### PR TITLE
Cleanup release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-    inputs:
-      target:
-        description: "Branch that should be used to perform publish on"
-        required: true
-        type: string
 
 jobs:
   release-packages:
@@ -22,7 +17,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        ref: ${{ inputs.target }}
 
     - name: Install pnpm
       uses: pnpm/action-setup@v2.2.4
@@ -42,6 +36,9 @@ jobs:
       run: pnpm lage build lint cover
 
     - name: Publish packages
-      run: pnpm publish-packages -y --no-publish --branch ${{ inputs.target }}
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        pnpm publish-packages -y --no-publish --branch ${{ github.ref_name }}
       # env:
       #   NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}


### PR DESCRIPTION
No need to have input for target branch because there is a choice on which branch action should run when starting.
Added github config for `github-actions[bot]` for commiting version bump and changelog changes.