### PR TITLE
Update dev release pipeline

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -2,8 +2,8 @@ name: Publish dev pre-release NPM packages
 
 on:
   workflow_dispatch:
-  # push:
-  #   branches: [ "master" ]
+  push:
+    branches: [ "master" ]
 
 jobs:
   release-packages:
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
-        fetch-depth: 0
+        token: ${{ secrets.IMJS_ADMIN_GH_TOKEN }}
 
     - name: Install pnpm
       uses: pnpm/action-setup@v2.2.4


### PR DESCRIPTION
Updated dev release pipeline to use IMJS_ADMIN_GH_TOKEN for git commands. This should allow workflow to push version bump to master