### PR TITLE
Do not run dev release on push to master

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -2,8 +2,6 @@ name: Publish dev pre-release NPM packages
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ "master" ]
 
 jobs:
   release-packages:


### PR DESCRIPTION
After packages are published workflow bumps package versions and pushes changes to master. This causes workflow to run again.