### PR TITLE
Avoid committing using personal email

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,17 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# validate email
+emailPattern="[^@]+@users\\.noreply\\.github\\.com"
+email=$(git config user.email)
+
+if ! [[ $email =~ $emailPattern ]]; then
+  echo "Git commits should be using an e-mail like this pattern: \"$emailPattern\""
+  echo "But yours is configured like this: $email"
+  echo "To fix it, you can use command like this:"
+  echo "git config --local user.email \"mrexample@users.noreply.github.com\""
+  exit 1;
+fi
+
+# lint staged files
 pnpm lint-staged


### PR DESCRIPTION
`itwinjs-core` has policy enforced by `rush` that requires developers to not use personal emails for commits and instead use `@users.noreply.github.com` email.

Added check to pre-commit hook to check if correct email is setup for commits.