### PR TITLE
Run dev publish on push

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -2,14 +2,15 @@ name: Publish dev pre-release NPM packages
 
 on:
   workflow_dispatch:
+  push:
+    branches: ["master"]
+    paths:
+      - 'packages/**'
+      - '!packages/full-stack-test/**'
 
 jobs:
   release-packages:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [18]
 
     name: Release packages
     steps:
@@ -23,10 +24,10 @@ jobs:
       with:
         version: 7.27.0
 
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 18
         registry-url: https://registry.npmjs.org/
 
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,6 @@ jobs:
   release-packages:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18]
-
     name: Release packages
     steps:
     - name: Checkout
@@ -23,10 +19,10 @@ jobs:
       with:
         version: 7.27.0
 
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 18
         registry-url: https://registry.npmjs.org/
 
     - name: Install dependencies

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -22,6 +22,7 @@ module.exports = {
     "pnpm-lock.yaml",
   ],
   changehint: "Run 'pnpm change' to generate a change file",
+  message: "Version bump [skip actions]",
   changelog: {
     customRenderers: {
       renderEntry: (entry) => {


### PR DESCRIPTION
Run dev prerelease publishing workflow on each push to default branch if changes were made to any of publishable packages. Added `[skip actions]` to version bump commit message to avoid recursively running this workflow.