### PR TITLE
Add missing css imports

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -40,6 +40,6 @@ jobs:
       run: |
         git config --local user.email imodeljs-admin@users.noreply.github.com
         git config --local user.name imodeljs-admin
-        pnpm publish-packages-dev -y --branch ${{ github.ref_name }}
+        pnpm publish-packages-dev -y --branch ${{ github.ref_name }} --message "Version bump [skip actions]"
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,6 @@ jobs:
       run: |
         git config --local user.email imodeljs-admin@users.noreply.github.com
         git config --local user.name imodeljs-admin
-        pnpm publish-packages -y --branch ${{ github.ref_name }}
+        pnpm publish-packages -y --branch ${{ github.ref_name }} --message "Version bump [skip actions]"
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -22,7 +22,6 @@ module.exports = {
     "pnpm-lock.yaml",
   ],
   changehint: "Run 'pnpm change' to generate a change file",
-  message: "Version bump [skip actions]",
   changelog: {
     customRenderers: {
       renderEntry: (entry) => {

--- a/change/@itwin-presentation-components-eba1d12a-c78c-48bb-8816-f7419b77f47e.json
+++ b/change/@itwin-presentation-components-eba1d12a-c78c-48bb-8816-f7419b77f47e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed styles in `PresentationInstanceFilterBuilder` component.",
+  "packageName": "@itwin/presentation-components",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/src/presentation-components/instance-filter-builder/MultiTagSelect.tsx
+++ b/packages/components/src/presentation-components/instance-filter-builder/MultiTagSelect.tsx
@@ -3,6 +3,10 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
+import "@itwin/itwinui-css/css/tag.css";
+import "@itwin/itwinui-css/css/inputs.css";
+import "@itwin/itwinui-css/css/button.css";
+import "@itwin/itwinui-css/css/menu.css";
 import classnames from "classnames";
 import Component, {
   components, ControlProps, IndicatorProps, MenuProps, MultiValueProps, OptionProps, OptionTypeBase, Props, ValueContainerProps,

--- a/packages/components/src/presentation-components/properties/NavigationPropertyTargetSelector.tsx
+++ b/packages/components/src/presentation-components/properties/NavigationPropertyTargetSelector.tsx
@@ -3,6 +3,9 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
+import "@itwin/itwinui-css/css/tag.css";
+import "@itwin/itwinui-css/css/inputs.css";
+import "@itwin/itwinui-css/css/menu.css";
 import classnames from "classnames";
 import { Children, forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import {


### PR DESCRIPTION
Added missing css imports in some `PresentationInstanceFilterBuilder` related components. Missing imports resulted in components being rendered without styling in cases when css classes used in those components where nor loaded globally.

Also updated beachball config. Looks like message property from config is used for both `publish` and `change` commands. This resulted in `pnpm change` script generating change files with same message.