### PR TITLE
Ensure that the action buttons have the same background color as the parent node in the tree widget

### DIFF
--- a/change/@itwin-presentation-components-2a0eeff2-270a-4075-a4bf-8528d8bbb7de.json
+++ b/change/@itwin-presentation-components-2a0eeff2-270a-4075-a4bf-8528d8bbb7de.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "InstanceFilterDialog: ensure that the action buttons have the same background color as the parent node",
+  "comment": "Controlled tree: ensure that the action buttons have the same background color as the parent node",
   "packageName": "@itwin/presentation-components",
   "email": "124659623+simasjar@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-presentation-components-2a0eeff2-270a-4075-a4bf-8528d8bbb7de.json
+++ b/change/@itwin-presentation-components-2a0eeff2-270a-4075-a4bf-8528d8bbb7de.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "InstanceFilterDialog: ensure that action buttons have same background and parent node",
+  "comment": "InstanceFilterDialog: ensure that the action buttons have the same background color as the parent node",
   "packageName": "@itwin/presentation-components",
   "email": "124659623+simasjar@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-presentation-components-2a0eeff2-270a-4075-a4bf-8528d8bbb7de.json
+++ b/change/@itwin-presentation-components-2a0eeff2-270a-4075-a4bf-8528d8bbb7de.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "InstanceFilterDialog: ensure that action buttons have same background and parent node",
+  "packageName": "@itwin/presentation-components",
+  "email": "124659623+simasjar@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/src/presentation-components/tree/controlled/PresentationTreeNodeRenderer.scss
+++ b/packages/components/src/presentation-components/tree/controlled/PresentationTreeNodeRenderer.scss
@@ -33,4 +33,8 @@
   .presentation-components-node-action-buttons.filtered {
     visibility: visible;
   }
+
+  &:is(.is-selected) > .presentation-components-node-action-buttons.filtered {
+    background-color: inherit;
+  }
 }

--- a/packages/components/src/presentation-components/tree/controlled/PresentationTreeNodeRenderer.scss
+++ b/packages/components/src/presentation-components/tree/controlled/PresentationTreeNodeRenderer.scss
@@ -34,7 +34,7 @@
     visibility: visible;
   }
 
-  &:is(.is-selected) > .presentation-components-node-action-buttons.filtered {
+  &.is-selected > .presentation-components-node-action-buttons.filtered {
     background-color: inherit;
   }
 }


### PR DESCRIPTION
fixes #78 

Before:
![image](https://user-images.githubusercontent.com/124659623/221165072-3d47ca26-bd7a-4457-8141-8aa5b47d24f3.png)

After:
![image](https://user-images.githubusercontent.com/124659623/221165165-fa0b3941-0797-4044-8783-2e73b6673b9e.png)
