### PR TITLE
Add white background to the chevron

### DIFF
--- a/change/@itwin-presentation-components-3a7cdc71-44dc-493e-b5bc-d508816e64e9.json
+++ b/change/@itwin-presentation-components-3a7cdc71-44dc-493e-b5bc-d508816e64e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "`NavigationPropertyTargetSelector`: add white background to the chevron",
+  "packageName": "@itwin/presentation-components",
+  "email": "124659623+simasjar@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/src/presentation-components/properties/NavigationPropertyTargetSelector.tsx
+++ b/packages/components/src/presentation-components/properties/NavigationPropertyTargetSelector.tsx
@@ -159,7 +159,7 @@ function TargetSelectIndicatorsContainer<TOption extends OptionTypeBase>({ child
 }
 
 function TargetSelectDropdownIndicator<TOption extends OptionTypeBase>(_: IndicatorProps<TOption>) {
-  return <span className="iui-end-icon iui-actionable" >
+  return <span className="iui-end-icon iui-actionable" style={{ backgroundColor: "white", height: "22px" }} >
     <SvgCaretDownSmall />
   </span>;
 }

--- a/packages/components/src/presentation-components/properties/NavigationPropertyTargetSelector.tsx
+++ b/packages/components/src/presentation-components/properties/NavigationPropertyTargetSelector.tsx
@@ -88,6 +88,7 @@ export const NavigationPropertyTargetSelector = forwardRef<NavigationPropertyTar
         menu: () => ({ position: "absolute", zIndex: 9999, width }),
         option: () => ({ whiteSpace: "nowrap" }),
         placeholder: (style: any) => ({ ...style, position: "relative", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }),
+        dropdownIndicator: () => ({ backgroundColor: "var(--iui-color-background)" }),
       }}
       components={{
         Control: TargetSelectControl,
@@ -158,8 +159,8 @@ function TargetSelectIndicatorsContainer<TOption extends OptionTypeBase>({ child
   return Children.toArray(children).pop();
 }
 
-function TargetSelectDropdownIndicator<TOption extends OptionTypeBase>(_: IndicatorProps<TOption>) {
-  return <span className="iui-end-icon iui-actionable" style={{ backgroundColor: "var(--iui-color-background)", height: "22px" }} >
+function TargetSelectDropdownIndicator<TOption extends OptionTypeBase>(props: IndicatorProps<TOption>) {
+  return <components.DropdownIndicator {...props} className="iui-end-icon iui-actionable" >
     <SvgCaretDownSmall />
-  </span>;
+  </components.DropdownIndicator>;
 }

--- a/packages/components/src/presentation-components/properties/NavigationPropertyTargetSelector.tsx
+++ b/packages/components/src/presentation-components/properties/NavigationPropertyTargetSelector.tsx
@@ -159,7 +159,7 @@ function TargetSelectIndicatorsContainer<TOption extends OptionTypeBase>({ child
 }
 
 function TargetSelectDropdownIndicator<TOption extends OptionTypeBase>(_: IndicatorProps<TOption>) {
-  return <span className="iui-end-icon iui-actionable" style={{ backgroundColor: "white", height: "22px" }} >
+  return <span className="iui-end-icon iui-actionable" style={{ backgroundColor: "var(--iui-color-background)", height: "22px" }} >
     <SvgCaretDownSmall />
   </span>;
 }


### PR DESCRIPTION
Navigation property value is displayed under the chevron when it's too long:
![image](https://user-images.githubusercontent.com/124659623/221648982-d3545ad8-389a-4186-a8de-66ab206c3e9e.png)

After this fix, property value would look like this:
![image](https://user-images.githubusercontent.com/124659623/221648864-bc215597-2418-4be4-afe1-0b26b56ff780.png)

closes #79 