### PR TITLE
Prepare components to be used with React 18

### DIFF
--- a/apps/test-app/frontend/package.json
+++ b/apps/test-app/frontend/package.json
@@ -49,7 +49,7 @@
     "html-webpack-plugin": "^5.5.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
-    "react-resize-detector": "^6.7.6",
+    "react-resize-detector": "^8.0.4",
     "sass": "^1.58.3",
     "sass-loader": "^13.2.0",
     "source-map-loader": "^4.0.1",

--- a/apps/test-app/frontend/src/components/properties-widget/PropertiesWidget.tsx
+++ b/apps/test-app/frontend/src/components/properties-widget/PropertiesWidget.tsx
@@ -39,7 +39,7 @@ export function PropertiesWidget(props: Props) {
   const [activeMatchIndex, setActiveMatchIndex] = useState(0);
   const [activeHighlight, setActiveHighlight] = useState<HighlightInfo>();
 
-  const setFilter = useCallback((filter) => {
+  const setFilter = useCallback((filter: string) => {
     if (filter !== filterText)
       setFilterText(filter);
   }, [filterText]);

--- a/apps/test-app/frontend/src/components/table-widget/TableWidget.tsx
+++ b/apps/test-app/frontend/src/components/table-widget/TableWidget.tsx
@@ -41,7 +41,7 @@ function PresentationTable(props: PresentationTableProps) {
     rowMapper: mapTableRow,
   });
 
-  const onSort = useCallback((tableState) => {
+  const onSort = useCallback((tableState: any) => {
     const sortBy = tableState.sortBy[0];
     sort(sortBy?.id, sortBy?.desc);
   }, [sort]);

--- a/change/@itwin-presentation-components-8b5c2571-206b-4617-b563-8d4769b6eea2.json
+++ b/change/@itwin-presentation-components-8b5c2571-206b-4617-b563-8d4769b6eea2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Prepared package to be used with React 18. Updated React peerDependency to \"^17.0.0 || ^18.0.0\"",
+  "packageName": "@itwin/presentation-components",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -25,7 +25,7 @@
   "module": "lib/esm/presentation-components.js",
   "types": "lib/cjs/presentation-components.d.ts",
   "scripts": {
-    "build": "npm run -s copy:locale && npm run -s pseudolocalize && npm run -s build:cjs && npm run -s build:esm",
+    "build": "npm run -s copy:locale && npm run -s build:cjs && npm run -s build:esm",
     "build:cjs": "npm run -s copy:cjs && tsc -p tsconfig.cjs.json",
     "build:esm": "npm run -s copy:esm && tsc -p tsconfig.esm.json",
     "copy:locale": "cpx \"./public/**/*\" ./lib/public",
@@ -35,7 +35,6 @@
     "clean": "rimraf lib",
     "cover": "nyc npm -s test",
     "lint": "eslint ./src/**/*.{ts,tsx}",
-    "pseudolocalize": "betools pseudolocalize --englishDir ./lib/public/locales/en --out ./lib/public/locales/en-PSEUDO",
     "test": "mocha --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
     "test:watch": "npm -s test -- --reporter min --watch-extensions ts,tsx --watch",
     "docs": "npm run -s docs:extract && npm run -s docs:reference && npm run -s docs:changelog",
@@ -52,8 +51,8 @@
     "fast-deep-equal": "^3.1.3",
     "fast-sort": "^3.0.2",
     "micro-memoize": "^4.0.9",
-    "react-select": "3.2.0",
-    "react-select-async-paginate": "0.5.3",
+    "react-select": "5.7.0",
+    "react-select-async-paginate": "0.7.2",
     "rxjs": "^6.6.2"
   },
   "peerDependencies": {
@@ -66,8 +65,8 @@
     "@itwin/imodel-components-react": "^4.0.0-dev.11",
     "@itwin/presentation-common": "^3.6.0 || ^4.0.0-dev.37",
     "@itwin/presentation-frontend": "^3.6.0 || ^4.0.0-dev.37",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@itwin/appui-abstract": "^4.0.0-dev.37",
@@ -96,7 +95,6 @@
     "@types/mocha": "^8.2.2",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.0",
-    "@types/react-select": "3.0.26",
     "@types/sinon": "^9.0.0",
     "@types/sinon-chai": "^3.2.0",
     "chai": "^4.1.2",

--- a/packages/components/src/presentation-components/common/Utils.ts
+++ b/packages/components/src/presentation-components/common/Utils.ts
@@ -6,7 +6,7 @@
  * @module Core
  */
 
-import { LegacyRef, MutableRefObject, RefCallback, useCallback, useEffect, useRef, useState } from "react";
+import { LegacyRef, MutableRefObject, RefCallback, useCallback, useRef, useState } from "react";
 import { Primitives, PrimitiveValue, PropertyDescription, PropertyRecord, PropertyValueFormat } from "@itwin/appui-abstract";
 import { IPropertyValueRenderer, PropertyValueRendererManager } from "@itwin/components-react";
 import { assert, Guid, GuidString, IDisposable } from "@itwin/core-bentley";
@@ -163,8 +163,6 @@ export function useResizeObserver<T extends HTMLElement>() {
       observer.current.observe(element);
     }
   }, []);
-
-  useEffect(() => () => { observer.current?.disconnect(); }, []);
 
   return {
     ref,

--- a/packages/components/src/presentation-components/instance-filter-builder/MultiTagSelect.tsx
+++ b/packages/components/src/presentation-components/instance-filter-builder/MultiTagSelect.tsx
@@ -9,7 +9,8 @@ import "@itwin/itwinui-css/css/button.css";
 import "@itwin/itwinui-css/css/menu.css";
 import classnames from "classnames";
 import Component, {
-  components, ControlProps, IndicatorProps, MenuProps, MultiValueProps, OptionProps, OptionTypeBase, Props, ValueContainerProps,
+  ClearIndicatorProps, components, ControlProps, DropdownIndicatorProps, MenuProps, MultiValueGenericProps, MultiValueProps, MultiValueRemoveProps,
+  OptionProps, Props, ValueContainerProps,
 } from "react-select";
 import { SvgCaretDown, SvgCheckmarkSmall, SvgCloseSmall } from "@itwin/itwinui-icons-react";
 import { useResizeObserver } from "../common/Utils";
@@ -30,7 +31,8 @@ export function MultiTagSelect<Option>(props: Props<Option>) {
         input: (style) => ({ ...style, order: -1, flex: 0 }),
         valueContainer: (style) => ({ ...style, padding: 0, flexWrap: "nowrap" }),
         indicatorsContainer: () => ({ marginLeft: "auto", display: "flex" }),
-        multiValue: (style) => ({ ...style, margin: 0 }),
+        multiValue: () => ({ margin: 0 }),
+        multiValueLabel: () => ({}),
       }}
       components={{
         Control: TagSelectControl,
@@ -46,19 +48,19 @@ export function MultiTagSelect<Option>(props: Props<Option>) {
   </div>);
 }
 
-function TagSelectControl<Option extends OptionTypeBase>({ children, ...props }: ControlProps<Option>) {
+function TagSelectControl<TOption, IsMulti extends boolean = boolean>({ children, ...props }: ControlProps<TOption, IsMulti>) {
   return <components.Control {...props} className="iui-select-button">
     {children}
   </components.Control>;
 }
 
-function TagSelectMenu<Option extends OptionTypeBase>({ children, ...props }: MenuProps<Option>) {
+function TagSelectMenu<TOption, IsMulti extends boolean = boolean>({ children, ...props }: MenuProps<TOption, IsMulti>) {
   return <components.Menu {...props} className="iui-menu">
     {children}
   </components.Menu>;
 }
 
-function TagSelectOption<Option extends OptionTypeBase>({ children: _, ...props }: OptionProps<Option>) {
+function TagSelectOption<TOption, IsMulti extends boolean = boolean>({ children: _, ...props }: OptionProps<TOption, IsMulti>) {
   const className = classnames("iui-menu-item", {
     "iui-focused": props.isFocused,
     "iui-active": props.isSelected,
@@ -70,13 +72,13 @@ function TagSelectOption<Option extends OptionTypeBase>({ children: _, ...props 
   </components.Option>;
 }
 
-function TagSelectValueContainer<Option extends OptionTypeBase>({ children, ...props }: ValueContainerProps<Option>) {
+function TagSelectValueContainer<TOption, IsMulti extends boolean = boolean>({ children, ...props }: ValueContainerProps<TOption, IsMulti>) {
   return <components.ValueContainer {...props} className="iui-tag-container">
     {children}
   </components.ValueContainer>;
 }
 
-function TagMultiValue<Option extends OptionTypeBase>({ children, ...props }: MultiValueProps<Option>) {
+function TagMultiValue<TOption, IsMulti extends boolean = boolean>({ children, ...props }: MultiValueProps<TOption, IsMulti>) {
   return <components.MultiValue
     {...props}
     components={{
@@ -89,25 +91,31 @@ function TagMultiValue<Option extends OptionTypeBase>({ children, ...props }: Mu
   </components.MultiValue>;
 }
 
-function TagContainer({ children, ...props }: any) {
+function TagContainer<TOption, IsMulti extends boolean = boolean>({ children, ...props }: MultiValueGenericProps<TOption, IsMulti>) {
   return <components.MultiValueContainer {...props} innerProps={{ ...props.innerProps, className: "iui-tag" }}>
     {children}
   </components.MultiValueContainer>;
 }
 
-function TagLabel({ children, ...props }: any) {
+function TagLabel<TOption, IsMulti extends boolean = boolean>({ children, ...props }: MultiValueGenericProps<TOption, IsMulti>) {
   return <components.MultiValueLabel {...props} innerProps={{ ...props.innerProps, className: "iui-tag-label" }}>
     {children}
   </components.MultiValueLabel>;
 }
 
-function TagRemove(props: any) {
-  return <components.MultiValueRemove {...props} innerProps={{ ...props.innerProps, className: "iui-button iui-tag-button", ["data-iui-variant"]: "borderless", ["data-iui-size"]: "small" }}>
+function TagRemove<TOption, IsMulti extends boolean = boolean>(props: MultiValueRemoveProps<TOption, IsMulti>) {
+  const innerProps = {
+    ...props.innerProps,
+    className: "iui-button iui-tag-button",
+    ["data-iui-variant"]: "borderless",
+    ["data-iui-size"]: "small",
+  };
+  return <components.MultiValueRemove {...props} innerProps={innerProps}>
     <SvgCloseSmall className="iui-button-icon" aria-hidden />
   </components.MultiValueRemove>;
 }
 
-function TagSelectDropdownIndicator<Option extends OptionTypeBase>({ children: _, ...props }: IndicatorProps<Option>) {
+function TagSelectDropdownIndicator<TOption, IsMulti extends boolean = boolean>({ children: _, ...props }: DropdownIndicatorProps<TOption, IsMulti>) {
   return <components.DropdownIndicator {...props} >
     <span data-testid="multi-tag-select-dropdownIndicator" className="iui-end-icon iui-actionable" style={{ padding: 0 }}>
       <SvgCaretDown />
@@ -115,7 +123,7 @@ function TagSelectDropdownIndicator<Option extends OptionTypeBase>({ children: _
   </components.DropdownIndicator>;
 }
 
-function TagSelectClearIndicator<Option extends OptionTypeBase>({ children: _, ...props }: IndicatorProps<Option>) {
+function TagSelectClearIndicator<TOption, IsMulti extends boolean = boolean>({ children: _, ...props }: ClearIndicatorProps<TOption, IsMulti>) {
   return <components.ClearIndicator {...props} >
     <span data-testid="multi-tag-select-clearIndicator" className="iui-end-icon iui-actionable" style={{ padding: 0 }}>
       <SvgCloseSmall aria-hidden />

--- a/packages/components/src/presentation-components/properties/NavigationPropertyTargetSelector.tsx
+++ b/packages/components/src/presentation-components/properties/NavigationPropertyTargetSelector.tsx
@@ -9,7 +9,7 @@ import "@itwin/itwinui-css/css/menu.css";
 import classnames from "classnames";
 import { Children, forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import {
-  components, ControlProps, IndicatorContainerProps, IndicatorProps, MenuProps, OptionProps, OptionTypeBase, ValueContainerProps,
+  components, ControlProps, DropdownIndicatorProps, IndicatorsContainerProps, MenuProps, OptionProps, SingleValue, ValueContainerProps,
 } from "react-select";
 import { AsyncPaginate } from "react-select-async-paginate";
 import { PropertyDescription, PropertyRecord, PropertyValue, PropertyValueFormat } from "@itwin/appui-abstract";
@@ -43,8 +43,9 @@ export const NavigationPropertyTargetSelector = forwardRef<NavigationPropertyTar
 
   const [selectedTarget, setSelectedTarget] = useState(() => getNavigationTargetFromPropertyRecord(propertyRecord));
 
-  const onChange = useCallback((target?: NavigationPropertyTarget) => {
-    setSelectedTarget(target);
+  const onChange = useCallback((target: SingleValue<NavigationPropertyTarget>) => {
+    // istanbul ignore next
+    setSelectedTarget(target === null ? undefined : target);
     target && onCommit && onCommit({ propertyRecord, newValue: getPropertyValue(target) });
   }, [propertyRecord, onCommit]);
 
@@ -75,7 +76,7 @@ export const NavigationPropertyTargetSelector = forwardRef<NavigationPropertyTar
       getOptionValue={(option: NavigationPropertyTarget) => option.key.id}
       hideSelectedOptions={false}
       debounceTimeout={500}
-      loadOptions={loadTargets}
+      loadOptions={async (inputValue, options) => loadTargets(inputValue, options.length)}
       cacheUniqs={[loadTargets]}
       // eslint-disable-next-line jsx-a11y/no-autofocus
       autoFocus={setFocus}
@@ -127,25 +128,25 @@ function getNavigationTargetFromPropertyRecord(record: PropertyRecord): Navigati
   return { key: value.value as InstanceKey, label: LabelDefinition.fromLabelString(value.displayValue) };
 }
 
-function TargetSelectControl<TOption extends OptionTypeBase>({ children, ...props }: ControlProps<TOption>) {
+function TargetSelectControl<TOption, IsMulti extends boolean = boolean>({ children, ...props }: ControlProps<TOption, IsMulti>) {
   return <components.Control {...props} className="iui-input-with-icon" >
     {children}
   </components.Control>;
 }
 
-function TargetSelectValueContainer<TOption extends OptionTypeBase>({ children, ...props }: ValueContainerProps<TOption>) {
+function TargetSelectValueContainer<TOption, IsMulti extends boolean = boolean>({ children, ...props }: ValueContainerProps<TOption, IsMulti>) {
   return <components.ValueContainer {...props} className="iui-select-button">
     {children}
   </components.ValueContainer>;
 }
 
-function TargetSelectMenu<TOption extends OptionTypeBase>({ children, ...props }: MenuProps<TOption>) {
+function TargetSelectMenu<TOption, IsMulti extends boolean = boolean>({ children, ...props }: MenuProps<TOption, IsMulti>) {
   return <components.Menu {...props} className="iui-menu" >
     {children}
   </components.Menu>;
 }
 
-function TargetSelectOption<TOption extends OptionTypeBase>({ children: _, ...props }: OptionProps<TOption>) {
+function TargetSelectOption<TOption, IsMulti extends boolean = boolean>({ children: _, ...props }: OptionProps<TOption, IsMulti>) {
   const className = classnames("iui-menu-item", {
     "iui-focused": props.isFocused,
     "iui-active": props.isSelected,
@@ -156,11 +157,11 @@ function TargetSelectOption<TOption extends OptionTypeBase>({ children: _, ...pr
   </components.Option>;
 }
 
-function TargetSelectIndicatorsContainer<TOption extends OptionTypeBase>({ children }: IndicatorContainerProps<TOption>) {
-  return Children.toArray(children).pop();
+function TargetSelectIndicatorsContainer<TOption, IsMulti extends boolean = boolean>({ children }: IndicatorsContainerProps<TOption, IsMulti>) {
+  return <>{Children.toArray(children).pop()}</>;
 }
 
-function TargetSelectDropdownIndicator<TOption extends OptionTypeBase>(props: IndicatorProps<TOption>) {
+function TargetSelectDropdownIndicator<TOption, IsMulti extends boolean = boolean>(props: DropdownIndicatorProps<TOption, IsMulti>) {
   return <components.DropdownIndicator {...props} className="iui-end-icon iui-actionable" >
     <SvgCaretDownSmall />
   </components.DropdownIndicator>;

--- a/packages/components/src/presentation-components/properties/UseNavigationPropertyTargetsLoader.ts
+++ b/packages/components/src/presentation-components/properties/UseNavigationPropertyTargetsLoader.ts
@@ -35,7 +35,7 @@ export interface UseNavigationPropertyTargetsLoaderProps {
 /** @internal */
 export function useNavigationPropertyTargetsLoader(props: UseNavigationPropertyTargetsLoaderProps) {
   const { imodel, ruleset } = props;
-  const loadTargets = useCallback(async (filter: string, loadedOptions: NavigationPropertyTarget[]): Promise<NavigationPropertyTargetsResult> => {
+  const loadTargets = useCallback(async (filter: string, loadedOptionsCount: number): Promise<NavigationPropertyTargetsResult> => {
     if (!ruleset) {
       return { options: [], hasMore: false };
     }
@@ -48,7 +48,7 @@ export function useNavigationPropertyTargetsLoader(props: UseNavigationPropertyT
         contentFlags: ContentFlags.ShowLabels | ContentFlags.NoFields,
         fieldsFilterExpression: filter ? `/DisplayLabel/ ~ \"%${filter}%\"` : undefined,
       },
-      paging: { start: loadedOptions.length, size: NAVIGATION_PROPERTY_TARGETS_BATCH_SIZE },
+      paging: { start: loadedOptionsCount, size: NAVIGATION_PROPERTY_TARGETS_BATCH_SIZE },
     });
 
     return {

--- a/packages/components/src/presentation-components/table/UseColumns.ts
+++ b/packages/components/src/presentation-components/table/UseColumns.ts
@@ -13,7 +13,7 @@ import { TableColumnDefinition } from "./Types";
 export interface UseColumnsProps {
   imodel: IModelConnection;
   ruleset: Ruleset | string;
-  keys: KeySet;
+  keys: Readonly<KeySet>;
 }
 
 /** @internal */
@@ -41,12 +41,12 @@ export function useColumns(props: UseColumnsProps): TableColumnDefinition[] | un
   return columns;
 }
 
-async function loadColumns(imodel: IModelConnection, ruleset: Ruleset | string, keys: KeySet): Promise<TableColumnDefinition[] | undefined> {
+async function loadColumns(imodel: IModelConnection, ruleset: Ruleset | string, keys: Readonly<KeySet>): Promise<TableColumnDefinition[] | undefined> {
   const descriptor = await Presentation.presentation.getContentDescriptor({
     imodel,
     rulesetOrId: ruleset,
     displayType: DefaultContentDisplayTypes.Grid,
-    keys,
+    keys: new KeySet(keys),
   });
 
   return descriptor ? createColumns(descriptor) : undefined;

--- a/packages/components/src/presentation-components/table/UsePresentationTable.ts
+++ b/packages/components/src/presentation-components/table/UsePresentationTable.ts
@@ -25,7 +25,7 @@ export interface UsePresentationTableProps<TColumn, TRow> {
   /** Ruleset or ruleset id that should be used to load data. */
   ruleset: Ruleset | string;
   /** Keys defining what to request data for. */
-  keys: KeySet;
+  keys: Readonly<KeySet>;
   /** Paging size for obtaining rows. */
   pageSize: number;
   /** Function that maps one column from generic [[TableColumnDefinition]] to table component specific type. */
@@ -81,6 +81,8 @@ export function usePresentationTable<TColumn, TRow>(props: UsePresentationTableP
  */
 export function usePresentationTableWithUnifiedSelection<TColumn, TRow>(props: Omit<UsePresentationTableProps<TColumn, TRow>, "keys">): UsePresentationTableResult<TColumn, TRow> {
   const unifiedSelection = useUnifiedSelectionContext();
-  const keys = useMemo(() => unifiedSelection ? new KeySet(unifiedSelection.getSelection(0)) : new KeySet(), [unifiedSelection]);
+  const keys = unifiedSelection?.getSelection() ?? emptyKeySet;
   return usePresentationTable({ ...props, keys });
 }
+
+const emptyKeySet = new KeySet();

--- a/packages/components/src/presentation-components/table/UseRows.ts
+++ b/packages/components/src/presentation-components/table/UseRows.ts
@@ -10,7 +10,7 @@ import { mergeMap } from "rxjs/internal/operators/mergeMap";
 import { assert } from "@itwin/core-bentley";
 import { IModelConnection } from "@itwin/core-frontend";
 import {
-  Content, KeySet, PageOptions, PresentationError, PresentationStatus, Ruleset, StartItemProps, traverseContent,
+  Content, DefaultContentDisplayTypes, KeySet, PageOptions, PresentationError, PresentationStatus, Ruleset, StartItemProps, traverseContent,
 } from "@itwin/presentation-common";
 import { Presentation } from "@itwin/presentation-frontend";
 import { FieldHierarchyRecord, PropertyRecordsBuilder } from "../common/ContentBuilder";
@@ -21,7 +21,7 @@ import { TableOptions } from "./UseTableOptions";
 export interface UseRowsProps {
   imodel: IModelConnection;
   ruleset: Ruleset | string;
-  keys: KeySet;
+  keys: Readonly<KeySet>;
   pageSize: number;
   options: TableOptions;
 }
@@ -78,11 +78,12 @@ export function useRows(props: UseRowsProps): UseRowsResult {
   return state;
 }
 
-async function loadRows(imodel: IModelConnection, ruleset: Ruleset | string, keys: KeySet, paging: PageOptions, options: TableOptions): Promise<TableRowDefinition[]> {
+async function loadRows(imodel: IModelConnection, ruleset: Ruleset | string, keys: Readonly<KeySet>, paging: PageOptions, options: TableOptions): Promise<TableRowDefinition[]> {
   const content = await Presentation.presentation.getContent({
     imodel,
-    keys,
+    keys: new KeySet(keys),
     descriptor: {
+      displayType: DefaultContentDisplayTypes.Grid,
       sorting: options.sorting,
       fieldsFilterExpression: options.fieldsFilterExpression,
     },

--- a/packages/components/src/test/instance-filter-builder/MultiTagSelect.test.tsx
+++ b/packages/components/src/test/instance-filter-builder/MultiTagSelect.test.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import { fireEvent, render } from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { MultiTagSelect } from "../../presentation-components/instance-filter-builder/MultiTagSelect";
 
 describe("MultiTagSelect", () => {
@@ -19,7 +19,7 @@ describe("MultiTagSelect", () => {
     value: "option3",
   }];
 
-  it("renders with selected tags", () => {
+  it("renders with selected tags", async () => {
     const { container } = render(<MultiTagSelect
       options={options}
       getOptionLabel={(option) => option.label}
@@ -27,11 +27,13 @@ describe("MultiTagSelect", () => {
       value={[options[1], options[2]]}
     />);
 
-    const tags = container.querySelectorAll(".iui-tag");
-    expect(tags).to.have.lengthOf(2);
+    await waitFor(() => {
+      const tags = container.querySelectorAll(".iui-tag");
+      expect(tags).to.have.lengthOf(2);
+    });
   });
 
-  it("render dropdown menu", () => {
+  it("render dropdown menu", async () => {
     const { container, getByTestId } = render(<MultiTagSelect
       options={options}
       getOptionLabel={(option) => option.label}
@@ -40,10 +42,14 @@ describe("MultiTagSelect", () => {
       hideSelectedOptions={false}
     />);
 
-    const dropdownIndicator = getByTestId("multi-tag-select-dropdownIndicator");
-    fireEvent.mouseDown(dropdownIndicator);
+    const dropdownIndicator = await waitFor(() => getByTestId("multi-tag-select-dropdownIndicator"));
+    act(() => {
+      fireEvent.mouseDown(dropdownIndicator);
+    });
 
-    const dropdownMenu = container.querySelector(".iui-menu");
-    expect(dropdownMenu).to.not.be.null;
+    await waitFor(() => {
+      const dropdownMenu = container.querySelector(".iui-menu");
+      expect(dropdownMenu).to.not.be.null;
+    });
   });
 });

--- a/packages/components/src/test/propertygrid/UseUnifiedSelection.test.ts
+++ b/packages/components/src/test/propertygrid/UseUnifiedSelection.test.ts
@@ -15,10 +15,14 @@ import { createTestECInstanceKey, isKeySet } from "../_helpers/Common";
 describe("usePropertyDataProviderWithUnifiedSelection", () => {
   const selectionHandlerMock = moq.Mock.ofType<SelectionHandler>();
   const dataProviderMock = moq.Mock.ofType<IPresentationPropertyDataProvider>();
+  const testImodel = {} as IModelConnection;
 
   beforeEach(() => {
     selectionHandlerMock.reset();
     dataProviderMock.reset();
+
+    dataProviderMock.setup((x) => x.rulesetId).returns(() => "test_ruleset_id");
+    dataProviderMock.setup((x) => x.imodel).returns(() => testImodel);
   });
 
   it("doesn't set provider keys when handler returns no selection", () => {
@@ -117,9 +121,6 @@ describe("usePropertyDataProviderWithUnifiedSelection", () => {
     const setKeys = new KeySet([createTestECInstanceKey({ id: "0x1" }), createTestECInstanceKey({ id: "0x2" })]);
     selectionHandlerMock.setup((x) => x.getSelectionLevels()).returns(() => [0]);
     selectionHandlerMock.setup((x) => x.getSelection(0)).returns(() => setKeys);
-    const mockIModel = moq.Mock.ofType<IModelConnection>();
-    dataProviderMock.setup((x) => x.imodel).returns(() => mockIModel.object);
-    dataProviderMock.setup((x) => x.rulesetId).returns(() => "ruleset");
 
     const { unmount } = renderHook(
       usePropertyDataProviderWithUnifiedSelection,

--- a/packages/components/src/test/propertygrid/VirtualizedPropertyGrid.test.tsx
+++ b/packages/components/src/test/propertygrid/VirtualizedPropertyGrid.test.tsx
@@ -12,7 +12,8 @@ import {
   PropertyValueRendererManager, VirtualizedPropertyGridWithDataProvider,
 } from "@itwin/components-react";
 import { Orientation } from "@itwin/core-react";
-import { render } from "@testing-library/react";
+import { InstanceKey } from "@itwin/presentation-common";
+import { render, waitFor } from "@testing-library/react";
 import { renderHook } from "@testing-library/react-hooks";
 import { PresentationPropertyDataProvider } from "../../presentation-components/propertygrid/DataProvider";
 import { createTestCategoryDescription } from "../_helpers/Content";
@@ -72,7 +73,7 @@ describe("Category renderer customization", () => {
       // __PUBLISH_EXTRACT_END__
 
       const dataProvider = setupDataProvider();
-      const { findByText } = render(
+      const { queryByText } = render(
         <VirtualizedPropertyGridWithDataProvider
           dataProvider={dataProvider}
           width={500}
@@ -80,12 +81,12 @@ describe("Category renderer customization", () => {
           orientation={Orientation.Horizontal}
         />,
       );
-      expect(await findByText("rootCategory1Property")).not.to.be.null;
+      await waitFor(() => expect(queryByText("rootCategory1Property")).not.to.be.null);
     });
 
-    it("compiles PropertyRecord to InstanceKey sample", () => {
-      function useInstanceKeys(props: PropertyCategoryRendererProps): void {
-        const [_, setInstanceKeys] = useState<unknown>();
+    it("compiles PropertyRecord to InstanceKey sample", async () => {
+      function useInstanceKeys(props: PropertyCategoryRendererProps) {
+        const [keys, setInstanceKeys] = useState<InstanceKey[][] | undefined>();
         // __PUBLISH_EXTRACT_START__ Presentation.Customization.PropertyRecordToInstanceKey
         // <Somewhere within MyCustomRenderer component>
         useEffect(
@@ -101,13 +102,15 @@ describe("Category renderer customization", () => {
           [],
         );
         // __PUBLISH_EXTRACT_END__
+        return keys;
       }
 
       const stubProps = {
         categoryItem: { getChildren() { return []; } },
         gridContext: { dataProvider: { async getPropertyRecordInstanceKeys() { return []; } } },
       };
-      renderHook(() => useInstanceKeys(stubProps as any));
+      const { result } = renderHook(() => useInstanceKeys(stubProps as any));
+      await waitFor(() => { expect(result.current).to.not.be.undefined; });
     });
   });
 });

--- a/packages/components/src/test/table/UseColumns.test.ts
+++ b/packages/components/src/test/table/UseColumns.test.ts
@@ -9,6 +9,7 @@ import * as moq from "typemoq";
 import { IModelConnection } from "@itwin/core-frontend";
 import { KeySet } from "@itwin/presentation-common";
 import { Presentation, PresentationManager } from "@itwin/presentation-frontend";
+import { waitFor } from "@testing-library/react";
 import { renderHook } from "@testing-library/react-hooks";
 import { useColumns, UseColumnsProps } from "../../presentation-components/table/UseColumns";
 import { createTestECInstanceKey } from "../_helpers/Common";
@@ -39,17 +40,16 @@ describe("useColumns", () => {
     const contentField = createTestPropertiesContentField({ name: "first_field", label: "First Field", properties: [] });
     presentationManagerMock.setup(async (x) => x.getContentDescriptor(moq.It.isAny())).returns(async () => createTestContentDescriptor({ fields: [contentField] }));
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       (props) => useColumns(props),
       { initialProps }
     );
 
-    await waitFor(() => result.current !== undefined);
-    expect(result.current).to.have.lengthOf(1).and.containSubset([{
+    await waitFor(() => expect(result.current).to.have.lengthOf(1).and.containSubset([{
       name: contentField.name,
       label: contentField.label,
       field: contentField,
-    }]);
+    }]));
   });
 
   it("loads columns only for properties fields", async () => {
@@ -58,41 +58,38 @@ describe("useColumns", () => {
     const nestingField = createTestNestedContentField({ name: "nesting_field", label: "Nesting Field", nestedFields: [nestedField] });
     presentationManagerMock.setup(async (x) => x.getContentDescriptor(moq.It.isAny())).returns(async () => createTestContentDescriptor({ fields: [propertyField, nestingField] }));
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       (props) => useColumns(props),
       { initialProps }
     );
 
-    await waitFor(() => result.current !== undefined);
-    expect(result.current).to.have.lengthOf(1).and.containSubset([{
+    await waitFor(() => expect(result.current).to.have.lengthOf(1).and.containSubset([{
       name: propertyField.name,
       label: propertyField.label,
       field: propertyField,
-    }]);
+    }]));
   });
 
   it("returns empty column list if no keys provided", async () => {
     const propertyField = createTestPropertiesContentField({ name: "first_field", label: "First Field", properties: [] });
     presentationManagerMock.setup(async (x) => x.getContentDescriptor(moq.It.isAny())).returns(async () => createTestContentDescriptor({ fields: [propertyField] }));
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       (props) => useColumns(props),
       { initialProps: { ...initialProps, keys: new KeySet() } }
     );
 
-    await waitFor(() => result.current !== undefined);
-    expect(result.current).to.have.lengthOf(0);
+    await waitFor(() => expect(result.current).to.have.lengthOf(0));
   });
 
   it("returns empty column list if content descriptor was not loaded", async () => {
     presentationManagerMock.setup(async (x) => x.getContentDescriptor(moq.It.isAny())).returns(async () => undefined);
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       (props) => useColumns(props),
       { initialProps }
     );
 
-    await waitFor(() => result.current !== undefined);
-    expect(result.current).to.have.lengthOf(0);
+    await waitFor(() => expect(result.current).to.have.lengthOf(0));
   });
 });

--- a/packages/components/src/test/table/UsePresentationTable.test.tsx
+++ b/packages/components/src/test/table/UsePresentationTable.test.tsx
@@ -10,6 +10,7 @@ import * as moq from "typemoq";
 import { IModelConnection } from "@itwin/core-frontend";
 import { Content, KeySet } from "@itwin/presentation-common";
 import { Presentation, PresentationManager, SelectionManager } from "@itwin/presentation-frontend";
+import { waitFor } from "@testing-library/react";
 import { renderHook } from "@testing-library/react-hooks";
 import { TableColumnDefinition, TableRowDefinition } from "../../presentation-components/table/Types";
 import {
@@ -53,12 +54,12 @@ describe("usePresentationTable", () => {
     presentationManagerMock.setup(async (x) => x.getContentDescriptor(moq.It.isAny())).returns(async () => descriptor);
     presentationManagerMock.setup(async (x) => x.getContent(moq.It.isAny())).returns(async () => new Content(descriptor, [item]));
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       (props: UsePresentationTableProps<TableColumnDefinition, TableRowDefinition>) => usePresentationTable(props),
       { initialProps },
     );
 
-    await waitFor(() => result.current.columns !== undefined && !result.current.isLoading);
+    await waitFor(() => expect(result.current.isLoading).to.be.false);
     expect(result.current.columns).to.have.lengthOf(1).and.containSubset([{
       name: propertiesField.name,
       label: propertiesField.label,
@@ -110,12 +111,12 @@ describe("usePresentationTableWithUnifiedSelection", () => {
     presentationManagerMock.setup(async (x) => x.getContentDescriptor(moq.It.is((options) => options.keys.size === keys.size))).returns(async () => descriptor);
     presentationManagerMock.setup(async (x) => x.getContent(moq.It.is((options) => options.keys.size === keys.size))).returns(async () => new Content(descriptor, [item]));
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () => usePresentationTableWithUnifiedSelection(initialProps),
       { wrapper: Wrapper },
     );
 
-    await waitFor(() => result.current.columns !== undefined && !result.current.isLoading);
+    await waitFor(() => expect(result.current.isLoading).to.be.false);
     expect(result.current.columns).to.have.lengthOf(1).and.containSubset([{
       name: propertiesField.name,
       label: propertiesField.label,
@@ -131,11 +132,11 @@ describe("usePresentationTableWithUnifiedSelection", () => {
     presentationManagerMock.setup(async (x) => x.getContentDescriptor(moq.It.is((options) => options.keys.isEmpty))).returns(async () => undefined);
     presentationManagerMock.setup(async (x) => x.getContent(moq.It.is((options) => options.keys.isEmpty))).returns(async () => undefined);
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () => usePresentationTableWithUnifiedSelection(initialProps),
     );
 
-    await waitFor(() => result.current.columns !== undefined && !result.current.isLoading);
+    await waitFor(() => expect(result.current.isLoading).to.be.false);
     expect(result.current.columns).to.have.lengthOf(0);
     expect(result.current.rows).to.have.lengthOf(0);
   });

--- a/packages/components/src/test/table/UseRows.test.ts
+++ b/packages/components/src/test/table/UseRows.test.ts
@@ -9,6 +9,7 @@ import * as moq from "typemoq";
 import { IModelConnection } from "@itwin/core-frontend";
 import { Content, DescriptorOverrides, KeySet, SortDirection } from "@itwin/presentation-common";
 import { Presentation, PresentationManager } from "@itwin/presentation-frontend";
+import { act, waitFor } from "@testing-library/react";
 import { renderHook } from "@testing-library/react-hooks";
 import { useRows, UseRowsProps } from "../../presentation-components/table/UseRows";
 import { createTestECInstanceKey, createTestPropertyInfo } from "../_helpers/Common";
@@ -48,12 +49,12 @@ describe("useRows", () => {
     });
     presentationManagerMock.setup(async (x) => x.getContent(moq.It.isAny())).returns(async () => new Content(descriptor, [item]));
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       (props: UseRowsProps) => useRows(props),
       { initialProps }
     );
 
-    await waitFor(() => !result.current.isLoading);
+    await waitFor(() => expect(result.current.isLoading).to.be.false);
     expect(result.current.rows).to.have.lengthOf(1);
     const cell = result.current.rows[0].cells[0];
     expect(cell).to.containSubset({
@@ -86,12 +87,12 @@ describe("useRows", () => {
     });
     presentationManagerMock.setup(async (x) => x.getContent(moq.It.isAny())).returns(async () => new Content(descriptor, [item]));
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       (props: UseRowsProps) => useRows(props),
       { initialProps }
     );
 
-    await waitFor(() => !result.current.isLoading);
+    await waitFor(() => expect(result.current.isLoading).to.be.false);
     expect(result.current.rows).to.have.lengthOf(1);
     expect(result.current.rows[0].cells).to.have.lengthOf(1);
     const cell = result.current.rows[0].cells[0];
@@ -114,30 +115,30 @@ describe("useRows", () => {
     presentationManagerMock.setup(async (x) => x.getContent(moq.It.is((options) => options.paging?.start === 0))).returns(async () => new Content(descriptor, [item1]));
     presentationManagerMock.setup(async (x) => x.getContent(moq.It.is((options) => options.paging?.start === 1))).returns(async () => new Content(descriptor, [item2]));
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       (props: UseRowsProps) => useRows(props),
       { initialProps: { ...initialProps, pageSize: 1 } }
     );
 
-    await waitFor(() => !result.current.isLoading);
+    await waitFor(() => expect(result.current.isLoading).to.be.false);
     expect(result.current.rows).to.have.lengthOf(1);
 
-    result.current.loadMoreRows();
-    await waitFor(() => result.current.isLoading);
+    act(() => { result.current.loadMoreRows(); });
+    await waitFor(() => expect(result.current.isLoading).to.be.true);
 
-    await waitFor(() => !result.current.isLoading);
+    await waitFor(() => expect(result.current.isLoading).to.be.false);
     expect(result.current.rows).to.have.lengthOf(2);
   });
 
   it("returns empty rows list if content was not loaded", async () => {
     presentationManagerMock.setup(async (x) => x.getContent(moq.It.isAny())).returns(async () => undefined);
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       (props: UseRowsProps) => useRows(props),
       { initialProps }
     );
 
-    await waitFor(() => !result.current.isLoading);
+    await waitFor(() => expect(result.current.isLoading).to.be.false);
     expect(result.current.rows).to.have.lengthOf(0);
   });
 
@@ -148,12 +149,12 @@ describe("useRows", () => {
       .returns(async () => new Content(createTestContentDescriptor({ fields: [] }), []))
       .verifiable(moq.Times.once());
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       (props: UseRowsProps) => useRows(props),
       { initialProps: { ...initialProps, options: { fieldsFilterExpression: filterExpression } } }
     );
 
-    await waitFor(() => !result.current.isLoading);
+    await waitFor(() => expect(result.current.isLoading).to.be.false);
     presentationManagerMock.verifyAll();
   });
 
@@ -169,12 +170,12 @@ describe("useRows", () => {
       .returns(async () => new Content(createTestContentDescriptor({ fields: [] }), []))
       .verifiable(moq.Times.once());
 
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       (props: UseRowsProps) => useRows(props),
       { initialProps: { ...initialProps, options: { sorting } } }
     );
 
-    await waitFor(() => !result.current.isLoading);
+    await waitFor(() => expect(result.current.isLoading).to.be.false);
     presentationManagerMock.verifyAll();
   });
 });

--- a/packages/components/src/test/table/UseTableOptions.test.ts
+++ b/packages/components/src/test/table/UseTableOptions.test.ts
@@ -5,6 +5,7 @@
 
 import { expect } from "chai";
 import { FieldDescriptorType, SortDirection } from "@itwin/presentation-common";
+import { act } from "@testing-library/react";
 import { renderHook } from "@testing-library/react-hooks";
 import { useTableOptions, UseTableOptionsProps } from "../../presentation-components/table/UseTableOptions";
 import { createTestPropertyInfo } from "../_helpers/Common";
@@ -27,7 +28,7 @@ describe("useTableOptions", () => {
     );
 
     expect(result.current.options.sorting).to.be.undefined;
-    result.current.sort(propertiesField.name, false);
+    act(() => { result.current.sort(propertiesField.name, false); });
     expect(result.current.options.sorting?.direction).to.be.eq(SortDirection.Ascending);
     expect(result.current.options.sorting?.field.type).to.be.eq(FieldDescriptorType.Properties);
   });
@@ -39,7 +40,7 @@ describe("useTableOptions", () => {
     );
 
     expect(result.current.options.sorting).to.be.undefined;
-    result.current.sort(propertiesField.name, true);
+    act(() => { result.current.sort(propertiesField.name, true); });
     expect(result.current.options.sorting?.direction).to.be.eq(SortDirection.Descending);
     expect(result.current.options.sorting?.field.type).to.be.eq(FieldDescriptorType.Properties);
   });
@@ -51,9 +52,9 @@ describe("useTableOptions", () => {
     );
 
     expect(result.current.options.sorting).to.be.undefined;
-    result.current.sort(propertiesField.name, true);
+    act(() => { result.current.sort(propertiesField.name, true); });
     expect(result.current.options.sorting?.direction).to.be.eq(SortDirection.Descending);
-    result.current.sort();
+    act(() => { result.current.sort(); });
     expect(result.current.options.sorting).to.be.undefined;
   });
 
@@ -64,7 +65,7 @@ describe("useTableOptions", () => {
     );
 
     expect(result.current.options.sorting).to.be.undefined;
-    result.current.sort("invalid_name", true);
+    act(() => { result.current.sort("invalid_name", true); });
     expect(result.current.options.sorting).to.be.undefined;
   });
 
@@ -76,7 +77,7 @@ describe("useTableOptions", () => {
 
     const filterExpression = `${propertiesField.name} = 1`;
     expect(result.current.options.fieldsFilterExpression).to.be.undefined;
-    result.current.filter(filterExpression);
+    act(() => { result.current.filter(filterExpression); });
     expect(result.current.options.fieldsFilterExpression).to.be.eq(filterExpression);
   });
 
@@ -88,9 +89,9 @@ describe("useTableOptions", () => {
 
     const filterExpression = `${propertiesField.name} = 1`;
     expect(result.current.options.fieldsFilterExpression).to.be.undefined;
-    result.current.filter(filterExpression);
+    act(() => { result.current.filter(filterExpression); });
     expect(result.current.options.fieldsFilterExpression).to.be.eq(filterExpression);
-    result.current.filter();
+    act(() => { result.current.filter(); });
     expect(result.current.options.fieldsFilterExpression).to.be.undefined;
   });
 
@@ -102,7 +103,7 @@ describe("useTableOptions", () => {
 
     const filterExpression = `${propertiesField.name} = 1`;
     expect(result.current.options.fieldsFilterExpression).to.be.undefined;
-    result.current.filter(filterExpression);
+    act(() => { result.current.filter(filterExpression); });
     expect(result.current.options.fieldsFilterExpression).to.be.eq(filterExpression);
 
     const newField = createTestPropertiesContentField({ name: "new_field", label: "New Field", properties: [{ property: createTestPropertyInfo() }] });

--- a/packages/components/src/test/tree/controlled/PresentationTreeRenderer.test.tsx
+++ b/packages/components/src/test/tree/controlled/PresentationTreeRenderer.test.tsx
@@ -12,7 +12,7 @@ import { EmptyLocalization } from "@itwin/core-common";
 import { IModelApp, IModelConnection } from "@itwin/core-frontend";
 import { PropertyValueFormat } from "@itwin/presentation-common";
 import { Presentation } from "@itwin/presentation-frontend";
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { PresentationTreeRenderer, PresentationTreeRendererProps } from "../../../presentation-components/tree/controlled/PresentationTreeRenderer";
 import { createTestPropertyInfo } from "../../_helpers/Common";
 import { createTestContentDescriptor, createTestPropertiesContentField } from "../../_helpers/Content";
@@ -87,18 +87,22 @@ describe("PresentationTreeRenderer", () => {
     await waitFor(() => getByText(label));
     expect(container.querySelector(".presentation-components-node")).to.not.be.null;
 
-    const filterButton = container.querySelector(".presentation-components-node-action-buttons button");
-    expect(filterButton).to.not.be.null;
-    fireEvent.click(filterButton!);
+    act(() => {
+      const filterButton = container.querySelector(".presentation-components-node-action-buttons button");
+      expect(filterButton).to.not.be.null;
+      fireEvent.click(filterButton!);
+    });
 
     // wait for dialog to be visible
     await waitFor(() => {
       expect(baseElement.querySelector(".presentation-instance-filter-dialog")).to.not.be.null;
     });
 
-    const closeButton = baseElement.querySelector(".presentation-instance-filter-dialog-close-button");
-    expect(closeButton).to.not.be.null;
-    fireEvent.click(closeButton!);
+    act(() => {
+      const closeButton = baseElement.querySelector(".presentation-instance-filter-dialog-close-button");
+      expect(closeButton).to.not.be.null;
+      fireEvent.click(closeButton!);
+    });
 
     const dialog = baseElement.querySelector(".presentation-instance-filter-dialog");
     expect(dialog).to.be.null;
@@ -130,9 +134,11 @@ describe("PresentationTreeRenderer", () => {
 
     await waitFor(() => getByText(label));
 
-    const filterButton = container.querySelector(".presentation-components-node-action-buttons button");
-    expect(filterButton).to.not.be.null;
-    fireEvent.click(filterButton!);
+    act(() => {
+      const filterButton = container.querySelector(".presentation-components-node-action-buttons button");
+      expect(filterButton).to.not.be.null;
+      fireEvent.click(filterButton!);
+    });
 
     // wait for dialog to be visible
     await waitFor(() => {
@@ -140,10 +146,16 @@ describe("PresentationTreeRenderer", () => {
     });
 
     // select property in filter builder dialog
-    const propertySelector = baseElement.querySelector<HTMLInputElement>(".rule-property .iui-input");
-    expect(propertySelector).to.not.be.null;
-    propertySelector?.focus();
-    fireEvent.click(getByText(propertyField.label));
+    // open property selector
+    act(() => {
+      const propertySelector = baseElement.querySelector<HTMLInputElement>(".rule-property input");
+      expect(propertySelector).to.not.be.null;
+      fireEvent.focus(propertySelector!);
+    });
+    // select property
+    act(() => {
+      fireEvent.click(getByText(propertyField.label));
+    });
 
     // wait until apply button is enabled
     const applyButton = await waitFor(() => {
@@ -151,7 +163,7 @@ describe("PresentationTreeRenderer", () => {
       expect(button?.disabled).to.be.false;
       return button;
     });
-    fireEvent.click(applyButton!);
+    act(() => { fireEvent.click(applyButton!); });
 
     // wait until dialog closes
     await waitFor(() => {

--- a/packages/components/src/test/tree/controlled/UseControlledTreeFiltering.test.ts
+++ b/packages/components/src/test/tree/controlled/UseControlledTreeFiltering.test.ts
@@ -6,10 +6,11 @@
 import { expect } from "chai";
 import sinon from "sinon";
 import * as moq from "typemoq";
-import { AbstractTreeNodeLoaderWithProvider, TreeModelNode, TreeModelSource, UiComponents } from "@itwin/components-react";
+import { AbstractTreeNodeLoaderWithProvider, TreeModelNode, TreeModelSource, TreeNodeItem, UiComponents } from "@itwin/components-react";
 import { EmptyLocalization } from "@itwin/core-common";
 import { IModelConnection } from "@itwin/core-frontend";
 import { NodePathElement } from "@itwin/presentation-common";
+import { act, waitFor } from "@testing-library/react";
 import { renderHook } from "@testing-library/react-hooks";
 import {
   ControlledPresentationTreeFilteringProps, IPresentationTreeDataProvider, useControlledPresentationTreeFiltering,
@@ -49,7 +50,6 @@ describe("useControlledPresentationTreeFiltering", () => {
       useControlledPresentationTreeFiltering,
       { initialProps: { nodeLoader: nodeLoaderMock.object } },
     );
-    expect(result.current).to.not.be.undefined;
     expect(result.current.isFiltering).to.be.false;
   });
 
@@ -64,10 +64,9 @@ describe("useControlledPresentationTreeFiltering", () => {
     expect(result.current).to.not.be.undefined;
     expect(result.current.isFiltering).to.be.true;
 
-    await pathsResult1.resolve([]);
+    await act(async () => pathsResult1.resolve([]));
 
-    expect(result.current).to.not.be.undefined;
-    expect(result.current.isFiltering).to.be.false;
+    await waitFor(() => expect(result.current.isFiltering).to.be.false);
     expect(result.current.filteredNodeLoader).to.not.eq(nodeLoaderMock.object);
   });
 
@@ -88,7 +87,7 @@ describe("useControlledPresentationTreeFiltering", () => {
     );
 
     // give time to start request
-    await clock.tickAsync(1);
+    await act(async () => { await clock.tickAsync(1); });
     dataProviderMock.verify(async (x) => x.getFilteredNodePaths(moq.It.isAnyString()), moq.Times.once());
     expect(result.current).to.not.be.undefined;
     expect(result.current.isFiltering).to.be.true;
@@ -97,7 +96,7 @@ describe("useControlledPresentationTreeFiltering", () => {
     rerender({ ...initialProps, filter: "changed" });
 
     // give time to start request if necessary
-    await clock.tickAsync(1);
+    await act(async () => { await clock.tickAsync(1); });
     dataProviderMock.verify(async (x) => x.getFilteredNodePaths(moq.It.isAnyString()), moq.Times.once());
     expect(result.current).to.not.be.undefined;
     expect(result.current.isFiltering).to.be.true;
@@ -106,25 +105,25 @@ describe("useControlledPresentationTreeFiltering", () => {
     rerender({ ...initialProps, filter: "last" });
 
     // give time to start request if necessary
-    await clock.tickAsync(1);
+    await act(async () => { await clock.tickAsync(1); });
     dataProviderMock.verify(async (x) => x.getFilteredNodePaths(moq.It.isAnyString()), moq.Times.once());
     expect(result.current).to.not.be.undefined;
     expect(result.current.isFiltering).to.be.true;
 
     clock.restore();
     // resolve first request and verify that new filtering request started
-    await pathsResult1.resolve([]);
+    await act(async () => pathsResult1.resolve([]));
     dataProviderMock.verify(async (x) => x.getFilteredNodePaths(moq.It.isAnyString()), moq.Times.exactly(2));
     expect(result.current).to.not.be.undefined;
     expect(result.current.isFiltering).to.be.true;
 
     // resolve second request and verify state
-    await pathsResult2.resolve([]);
+    await act(async () => pathsResult2.resolve([]));
     dataProviderMock.verify(async (x) => x.getFilteredNodePaths(moq.It.isAnyString()), moq.Times.exactly(2));
     dataProviderMock.verify(async (x) => x.getFilteredNodePaths("test"), moq.Times.once());
     dataProviderMock.verify(async (x) => x.getFilteredNodePaths("last"), moq.Times.once());
-    expect(result.current).to.not.be.undefined;
-    expect(result.current.isFiltering).to.be.false;
+
+    await waitFor(() => expect(result.current.isFiltering).to.be.false);
     expect(result.current.filteredNodeLoader).to.not.be.undefined;
     const filteredProvider = result.current.filteredNodeLoader.dataProvider;
     expect(filteredProvider).to.be.instanceOf(FilteredPresentationTreeDataProvider);
@@ -146,7 +145,7 @@ describe("useControlledPresentationTreeFiltering", () => {
     );
 
     // give time to start request if necessary
-    await clock.tickAsync(1);
+    await act(async () => { await clock.tickAsync(1); });
     dataProviderMock.verify(async (x) => x.getFilteredNodePaths(moq.It.isAnyString()), moq.Times.once());
     expect(result.current).to.not.be.undefined;
     expect(result.current.isFiltering).to.be.true;
@@ -155,14 +154,14 @@ describe("useControlledPresentationTreeFiltering", () => {
     rerender({ ...initialProps, filter: "" });
 
     // give time to start request if necessary
-    await clock.tickAsync(1);
+    await act(async () => { await clock.tickAsync(1); });
     dataProviderMock.verify(async (x) => x.getFilteredNodePaths(moq.It.isAnyString()), moq.Times.once());
     expect(result.current).to.not.be.undefined;
     expect(result.current.isFiltering).to.be.false;
 
     clock.restore();
     // resolve first request verify that filtering was not applied
-    await pathsResult.resolve([]);
+    await act(async () => pathsResult.resolve([]));
     dataProviderMock.verify(async (x) => x.getFilteredNodePaths(moq.It.isAnyString()), moq.Times.exactly(1));
     expect(result.current).to.not.be.undefined;
     expect(result.current.isFiltering).to.be.false;
@@ -184,9 +183,8 @@ describe("useControlledPresentationTreeFiltering", () => {
       { initialProps },
     );
 
-    await pathsResult.resolve([]);
-    expect(result.current).to.not.be.undefined;
-    expect(result.current.isFiltering).to.be.false;
+    await act(async () => pathsResult.resolve([]));
+    await waitFor(() => expect(result.current.isFiltering).to.be.false);
     expect(result.current.filteredNodeLoader).to.not.be.undefined;
     dataProviderMock.verify(async (x) => x.getFilteredNodePaths(filter), moq.Times.once());
 
@@ -198,9 +196,8 @@ describe("useControlledPresentationTreeFiltering", () => {
 
     rerender({ ...initialProps, nodeLoader: newNodeLoader.object });
 
-    await newPathsResult.resolve([]);
-    expect(result.current).to.not.be.undefined;
-    expect(result.current.isFiltering).to.be.false;
+    await act(async () => newPathsResult.resolve([]));
+    await waitFor(() => expect(result.current.isFiltering).to.be.false);
     expect(result.current.filteredNodeLoader).to.not.be.undefined;
     newProvider.verify(async (x) => x.getFilteredNodePaths(filter), moq.Times.once());
   });
@@ -218,17 +215,15 @@ describe("useControlledPresentationTreeFiltering", () => {
       { initialProps },
     );
 
-    await pathsResult.resolve([]);
-    expect(result.current).to.not.be.undefined;
-    expect(result.current.isFiltering).to.be.false;
+    await act(async () => pathsResult.resolve([]));
+    await waitFor(() => expect(result.current.isFiltering).to.be.false);
 
     const filteredNodeLoader = result.current.filteredNodeLoader;
     expect(filteredNodeLoader.dataProvider).to.be.instanceOf(FilteredPresentationTreeDataProvider);
     rerender({ ...initialProps, filter: "changed", nodeLoader: filteredNodeLoader });
 
-    await pathsResult.resolve([]);
-    expect(result.current).to.not.be.undefined;
-    expect(result.current.isFiltering).to.be.false;
+    await act(async () => pathsResult.resolve([]));
+    await waitFor(() => expect(result.current.isFiltering).to.be.false);
     expect(result.current.filteredNodeLoader).to.not.eq(filteredNodeLoader);
 
     // make sure that FilteredPresentationTreeDataProvider was not wrapped into another FilteredPresentationTreeDataProvider
@@ -237,7 +232,7 @@ describe("useControlledPresentationTreeFiltering", () => {
     expect((provider as FilteredPresentationTreeDataProvider).parentDataProvider).to.not.be.instanceOf(FilteredPresentationTreeDataProvider);
   });
 
-  it("returns `filteredNodeLoader` with model whose root node's `numRootNodes` is undefined and `loadNode` method returns result with an empty `loadedNodes` array when filtering", (done) => {
+  it("returns `filteredNodeLoader` with model whose root node's `numRootNodes` is undefined and `loadNode` method returns result with an empty `loadedNodes` array when filtering", async () => {
     const testModelNode: TreeModelNode = {
       id: "test",
       checkbox: {
@@ -266,11 +261,13 @@ describe("useControlledPresentationTreeFiltering", () => {
     const nodeLoader = result.current.filteredNodeLoader;
     expect(result.current.isFiltering).to.be.true;
     expect(nodeLoader.modelSource.getModel().getRootNode().numChildren).to.be.undefined;
-    nodeLoader.loadNode(testModelNode, 0).subscribe((res) => {
-      expect(res).to.deep.eq({
-        loadedNodes: [],
+
+    let loadedNodes: TreeNodeItem[] | undefined;
+    act(() => {
+      nodeLoader.loadNode(testModelNode, 0).subscribe((res) => {
+        loadedNodes = res.loadedNodes;
       });
-      done();
     });
+    await waitFor(() => expect(loadedNodes).to.have.lengthOf(0));
   });
 });

--- a/packages/components/src/test/tree/controlled/UseHierarchyStateTracking.test.ts
+++ b/packages/components/src/test/tree/controlled/UseHierarchyStateTracking.test.ts
@@ -10,6 +10,7 @@ import { TreeModelNodeInput, TreeModelSource, UiComponents } from "@itwin/compon
 import { EmptyLocalization } from "@itwin/core-common";
 import { IModelConnection } from "@itwin/core-frontend";
 import { Presentation, StateTracker } from "@itwin/presentation-frontend";
+import { act, waitFor } from "@testing-library/react";
 import { cleanup, renderHook } from "@testing-library/react-hooks";
 import { createLabelRecord } from "../../../presentation-components/common/Utils";
 import {
@@ -72,7 +73,6 @@ describe("useHierarchyStateTracking", () => {
 
   afterEach(async () => {
     await cleanup();
-    Presentation.terminate();
     sinon.restore();
   });
 
@@ -99,7 +99,7 @@ describe("useHierarchyStateTracking", () => {
     expect(removeListenerSpy).to.be.calledOnce;
   });
 
-  it("calls 'onHierarchyClosed' when unmounted", () => {
+  it("calls 'onHierarchyClosed' when unmounted", async () => {
     const { unmount } = renderHook(
       useHierarchyStateTracking,
       { initialProps },
@@ -107,10 +107,10 @@ describe("useHierarchyStateTracking", () => {
 
     stateTrackerMock.setup(async (x) => x.onHierarchyClosed(imodelMock.object, rulesetId, moq.It.isAnyString())).verifiable(moq.Times.once()); // eslint-disable-line @itwin/no-internal
     unmount();
-    stateTrackerMock.verifyAll();
+    await waitFor(() => stateTrackerMock.verifyAll());
   });
 
-  it("calls 'onHierarchyStateChanged' with root node when expanded root node is added to model", () => {
+  it("calls 'onHierarchyStateChanged' with root node when expanded root node is added to model", async () => {
     const node = createNodeItem("root-1");
     renderHook(
       useHierarchyStateTracking,
@@ -121,13 +121,15 @@ describe("useHierarchyStateTracking", () => {
       node: { id: node.id, key: node.key },
       state: { isExpanded: true },
     }])).verifiable(moq.Times.once());
-    modelSource.modifyModel((model) => {
-      model.setChildren(undefined, [createTreeModelInput(node, true)], 0);
-    });
-    stateTrackerMock.verifyAll();
+    act(() =>
+      modelSource.modifyModel((model) => {
+        model.setChildren(undefined, [createTreeModelInput(node, true)], 0);
+      })
+    );
+    await waitFor(() => stateTrackerMock.verifyAll());
   });
 
-  it("call 'onHierarchyStateChanged' without nodes when non expanded root node is added to model", () => {
+  it("call 'onHierarchyStateChanged' without nodes when non expanded root node is added to model", async () => {
     const node = createNodeItem("root-1");
     renderHook(
       useHierarchyStateTracking,
@@ -135,13 +137,15 @@ describe("useHierarchyStateTracking", () => {
     );
     stateTrackerMock.reset();
     stateTrackerMock.setup(async (x) => x.onHierarchyStateChanged(imodelMock.object, rulesetId, moq.It.isAnyString(), [])).verifiable(moq.Times.once()); // eslint-disable-line @itwin/no-internal
-    modelSource.modifyModel((model) => {
-      model.setChildren(undefined, [createTreeModelInput(node, false)], 0);
-    });
-    stateTrackerMock.verifyAll();
+    act(() =>
+      modelSource.modifyModel((model) => {
+        model.setChildren(undefined, [createTreeModelInput(node, false)], 0);
+      })
+    );
+    await waitFor(() => stateTrackerMock.verifyAll());
   });
 
-  it("calls 'onHierarchyStateChanged' with existing node that was expanded", () => {
+  it("calls 'onHierarchyStateChanged' with existing node that was expanded", async () => {
     const node = createNodeItem("root-1");
     modelSource.modifyModel((model) => { model.setChildren(undefined, [createTreeModelInput(node)], 0); });
     renderHook(
@@ -153,13 +157,15 @@ describe("useHierarchyStateTracking", () => {
       node: { id: node.id, key: node.key },
       state: { isExpanded: true },
     }])).verifiable(moq.Times.once());
-    modelSource.modifyModel((model) => {
-      model.getNode(node.id)!.isExpanded = true;
-    });
-    stateTrackerMock.verifyAll();
+    act(() =>
+      modelSource.modifyModel((model) => {
+        model.getNode(node.id)!.isExpanded = true;
+      })
+    );
+    await waitFor(() => stateTrackerMock.verifyAll());
   });
 
-  it("calls 'onHierarchyStateChanged' with expanded children nodes and parent when parent is expanded", () => {
+  it("calls 'onHierarchyStateChanged' with expanded children nodes and parent when parent is expanded", async () => {
     const node = createNodeItem("root-1");
     const children = [createNodeItem("child-1"), createNodeItem("child-2")];
     modelSource.modifyModel((model) => {
@@ -178,13 +184,15 @@ describe("useHierarchyStateTracking", () => {
       node: { id: children[1].id, key: children[1].key },
       state: { isExpanded: true },
     }])).verifiable(moq.Times.once());
-    modelSource.modifyModel((model) => {
-      model.getNode(node.id)!.isExpanded = true;
-    });
-    stateTrackerMock.verifyAll();
+    act(() =>
+      modelSource.modifyModel((model) => {
+        model.getNode(node.id)!.isExpanded = true;
+      })
+    );
+    await waitFor(() => stateTrackerMock.verifyAll());
   });
 
-  it("calls 'onHierarchyStateChanged' without nodes when node is collapsed", () => {
+  it("calls 'onHierarchyStateChanged' without nodes when node is collapsed", async () => {
     const node = createNodeItem("root-1");
     modelSource.modifyModel((model) => { model.setChildren(undefined, [createTreeModelInput(node, true)], 0); });
     renderHook(
@@ -193,13 +201,15 @@ describe("useHierarchyStateTracking", () => {
     );
     stateTrackerMock.reset();
     stateTrackerMock.setup(async (x) => x.onHierarchyStateChanged(imodelMock.object, rulesetId, moq.It.isAnyString(), [])).verifiable(moq.Times.once()); // eslint-disable-line @itwin/no-internal
-    modelSource.modifyModel((model) => {
-      model.getNode(node.id)!.isExpanded = false;
-    });
-    stateTrackerMock.verifyAll();
+    act(() =>
+      modelSource.modifyModel((model) => {
+        model.getNode(node.id)!.isExpanded = false;
+      })
+    );
+    await waitFor(() => stateTrackerMock.verifyAll());
   });
 
-  it("calls 'onHierarchyStateChanged' without nodes when parent with expanded child nodes is collapsed", () => {
+  it("calls 'onHierarchyStateChanged' without nodes when parent with expanded child nodes is collapsed", async () => {
     const node = createNodeItem("root-1");
     const children = [createNodeItem("child-1"), createNodeItem("child-2")];
     modelSource.modifyModel((model) => {
@@ -212,9 +222,11 @@ describe("useHierarchyStateTracking", () => {
     );
     stateTrackerMock.reset();
     stateTrackerMock.setup(async (x) => x.onHierarchyStateChanged(imodelMock.object, rulesetId, moq.It.isAnyString(), [])).verifiable(moq.Times.once()); // eslint-disable-line @itwin/no-internal
-    modelSource.modifyModel((model) => {
-      model.getNode(node.id)!.isExpanded = false;
-    });
-    stateTrackerMock.verifyAll();
+    act(() =>
+      modelSource.modifyModel((model) => {
+        model.getNode(node.id)!.isExpanded = false;
+      })
+    );
+    await waitFor(() => stateTrackerMock.verifyAll());
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,7 +133,7 @@ importers:
       html-webpack-plugin: ^5.5.0
       react: ^17.0.0
       react-dom: ^17.0.0
-      react-resize-detector: ^6.7.6
+      react-resize-detector: ^8.0.4
       sass: ^1.58.3
       sass-loader: ^13.2.0
       source-map-loader: ^4.0.1
@@ -180,7 +180,7 @@ importers:
       html-webpack-plugin: 5.5.0_webpack@5.75.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-resize-detector: 6.7.8_sfoxds7t5ydpegc3knd667wn6m
+      react-resize-detector: 8.0.4_sfoxds7t5ydpegc3knd667wn6m
       sass: 1.58.3
       sass-loader: 13.2.0_sass@1.58.3+webpack@5.75.0
       source-map-loader: 4.0.1_webpack@5.75.0
@@ -224,7 +224,6 @@ importers:
       '@types/mocha': ^8.2.2
       '@types/react': ^17.0.37
       '@types/react-dom': ^17.0.0
-      '@types/react-select': 3.0.26
       '@types/sinon': ^9.0.0
       '@types/sinon-chai': ^3.2.0
       chai: ^4.1.2
@@ -245,8 +244,8 @@ importers:
       nyc: ^15.1.0
       react: ^17.0.0
       react-dom: ^17.0.0
-      react-select: 3.2.0
-      react-select-async-paginate: 0.5.3
+      react-select: 5.7.0
+      react-select-async-paginate: 0.7.2
       resize-observer-polyfill: 1.5.1
       rimraf: ^3.0.2
       rxjs: ^6.6.2
@@ -263,8 +262,8 @@ importers:
       fast-deep-equal: 3.1.3
       fast-sort: 3.2.0
       micro-memoize: 4.0.11
-      react-select: 3.2.0_sfoxds7t5ydpegc3knd667wn6m
-      react-select-async-paginate: 0.5.3_ybmczhbwvuxlsly3vqtlp7ghs4
+      react-select: 5.7.0_gzv7pa6nrbev3fs6gyzn7sadkq
+      react-select-async-paginate: 0.7.2_brvwyr73orxcrbyu3q724jvumu
       rxjs: 6.6.7
     devDependencies:
       '@itwin/appui-abstract': 4.0.0-dev.37_lsdsjuovpbdgtadtz7dj6lr77i
@@ -293,7 +292,6 @@ importers:
       '@types/mocha': 8.2.3
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
-      '@types/react-select': 3.0.26
       '@types/sinon': 9.0.11
       '@types/sinon-chai': 3.2.9
       chai: 4.3.7
@@ -960,73 +958,93 @@ packages:
       - supports-color
     dev: false
 
-  /@emotion/cache/10.0.29:
-    resolution: {integrity: sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==}
+  /@emotion/babel-plugin/11.10.6:
+    resolution: {integrity: sha512-p2dAqtVrkhSa7xz1u/m9eHYdLi+en8NowrmXeF/dKtJpU8lCWli8RUAati7NcSl0afsBott48pdnANuD0wh9QQ==}
     dependencies:
-      '@emotion/sheet': 0.9.4
-      '@emotion/stylis': 0.8.5
-      '@emotion/utils': 0.11.3
-      '@emotion/weak-memoize': 0.2.5
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/runtime': 7.20.1
+      '@emotion/hash': 0.9.0
+      '@emotion/memoize': 0.8.0
+      '@emotion/serialize': 1.1.1
+      babel-plugin-macros: 3.1.0
+      convert-source-map: 1.9.0
+      escape-string-regexp: 4.0.0
+      find-root: 1.1.0
+      source-map: 0.5.7
+      stylis: 4.1.3
     dev: false
 
-  /@emotion/core/10.3.1_react@17.0.2:
-    resolution: {integrity: sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==}
+  /@emotion/cache/11.10.5:
+    resolution: {integrity: sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==}
+    dependencies:
+      '@emotion/memoize': 0.8.0
+      '@emotion/sheet': 1.2.1
+      '@emotion/utils': 1.2.0
+      '@emotion/weak-memoize': 0.3.0
+      stylis: 4.1.3
+    dev: false
+
+  /@emotion/hash/0.9.0:
+    resolution: {integrity: sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==}
+    dev: false
+
+  /@emotion/memoize/0.8.0:
+    resolution: {integrity: sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==}
+    dev: false
+
+  /@emotion/react/11.10.6_q5o373oqrklnndq2vhekyuzhxi:
+    resolution: {integrity: sha512-6HT8jBmcSkfzO7mc+N1L9uwvOnlcGoix8Zn7srt+9ga0MjREo6lRpuVX0kzo6Jp6oTqDhREOFsygN6Ew4fEQbw==}
     peerDependencies:
-      react: '>=16.3.0'
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
     dependencies:
       '@babel/runtime': 7.20.1
-      '@emotion/cache': 10.0.29
-      '@emotion/css': 10.0.27
-      '@emotion/serialize': 0.11.16
-      '@emotion/sheet': 0.9.4
-      '@emotion/utils': 0.11.3
+      '@emotion/babel-plugin': 11.10.6
+      '@emotion/cache': 11.10.5
+      '@emotion/serialize': 1.1.1
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0_react@17.0.2
+      '@emotion/utils': 1.2.0
+      '@emotion/weak-memoize': 0.3.0
+      '@types/react': 17.0.52
+      hoist-non-react-statics: 3.3.2
       react: 17.0.2
     dev: false
 
-  /@emotion/css/10.0.27:
-    resolution: {integrity: sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==}
+  /@emotion/serialize/1.1.1:
+    resolution: {integrity: sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==}
     dependencies:
-      '@emotion/serialize': 0.11.16
-      '@emotion/utils': 0.11.3
-      babel-plugin-emotion: 10.2.2
+      '@emotion/hash': 0.9.0
+      '@emotion/memoize': 0.8.0
+      '@emotion/unitless': 0.8.0
+      '@emotion/utils': 1.2.0
+      csstype: 3.1.1
     dev: false
 
-  /@emotion/hash/0.8.0:
-    resolution: {integrity: sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==}
+  /@emotion/sheet/1.2.1:
+    resolution: {integrity: sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==}
     dev: false
 
-  /@emotion/memoize/0.7.4:
-    resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+  /@emotion/unitless/0.8.0:
+    resolution: {integrity: sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==}
     dev: false
 
-  /@emotion/serialize/0.11.16:
-    resolution: {integrity: sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==}
+  /@emotion/use-insertion-effect-with-fallbacks/1.0.0_react@17.0.2:
+    resolution: {integrity: sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==}
+    peerDependencies:
+      react: '>=16.8.0'
     dependencies:
-      '@emotion/hash': 0.8.0
-      '@emotion/memoize': 0.7.4
-      '@emotion/unitless': 0.7.5
-      '@emotion/utils': 0.11.3
-      csstype: 2.6.21
+      react: 17.0.2
     dev: false
 
-  /@emotion/sheet/0.9.4:
-    resolution: {integrity: sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==}
+  /@emotion/utils/1.2.0:
+    resolution: {integrity: sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==}
     dev: false
 
-  /@emotion/stylis/0.8.5:
-    resolution: {integrity: sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==}
-    dev: false
-
-  /@emotion/unitless/0.7.5:
-    resolution: {integrity: sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==}
-    dev: false
-
-  /@emotion/utils/0.11.3:
-    resolution: {integrity: sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==}
-    dev: false
-
-  /@emotion/weak-memoize/0.2.5:
-    resolution: {integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==}
+  /@emotion/weak-memoize/0.3.0:
+    resolution: {integrity: sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==}
     dev: false
 
   /@es-joy/jsdoccomment/0.8.0:
@@ -1070,6 +1088,16 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+
+  /@floating-ui/core/1.2.2:
+    resolution: {integrity: sha512-FaO9KVLFnxknZaGWGmNtjD2CVFuc0u4yeGEofoyXO2wgRA7fLtkngT6UB0vtWQWuhH3iMTZZ/Y89CMeyGfn8pA==}
+    dev: false
+
+  /@floating-ui/dom/1.2.3:
+    resolution: {integrity: sha512-lK9cZUrHSJLMVAdCvDqs6Ug8gr0wmqksYiaoj/bxj2gweRQkSuhg2/V6Jswz2KiQ0RAULbqw1oQDJIMpQ5GfGA==}
+    dependencies:
+      '@floating-ui/core': 1.2.2
+    dev: false
 
   /@humanwhocodes/config-array/0.5.0:
     resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==}
@@ -2139,14 +2167,6 @@ packages:
     dependencies:
       '@types/react': 17.0.52
 
-  /@types/react-select/3.0.26:
-    resolution: {integrity: sha512-rAaiD0SFkBi3PUwp1DrJV04CobPl2LuZXF+kv6MKw8kaeGo82xTOZzjM8DDi4lrdkqGbInZiE2QO9nIJm3bqgw==}
-    dependencies:
-      '@types/react': 17.0.52
-      '@types/react-dom': 17.0.18
-      '@types/react-transition-group': 4.4.5
-    dev: true
-
   /@types/react-table/7.7.12:
     resolution: {integrity: sha512-bRUent+NR/WwtDGwI/BqhZ8XnHghwHw0HUKeohzB5xN3K2qKWYE5w19e7GCuOkL1CXD9Gi1HFy7TIm2AvgWUHg==}
     dependencies:
@@ -2161,7 +2181,7 @@ packages:
     resolution: {integrity: sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==}
     dependencies:
       '@types/react': 17.0.52
-    dev: true
+    dev: false
 
   /@types/react/17.0.52:
     resolution: {integrity: sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==}
@@ -2169,10 +2189,6 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.1.1
-
-  /@types/resize-observer-browser/0.1.7:
-    resolution: {integrity: sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg==}
-    dev: false
 
   /@types/responselike/1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
@@ -2407,6 +2423,14 @@ packages:
     dependencies:
       '@typescript-eslint/types': 4.31.2
       eslint-visitor-keys: 2.1.0
+
+  /@vtaits/use-lazy-ref/0.1.0_react@17.0.2:
+    resolution: {integrity: sha512-/m5z3Df6I6i/B0lnv6pB2O1+X/nWVquqbnltq+irW1+Nhpv0PpeMzSNf9lTjzT/eHRZtH2fM1370AdYqc3FTyQ==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 17.0.2
+    dev: false
 
   /@webassemblyjs/ast/1.11.1:
     resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
@@ -2898,31 +2922,13 @@ packages:
   /axobject-query/2.2.0:
     resolution: {integrity: sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==}
 
-  /babel-plugin-emotion/10.2.2:
-    resolution: {integrity: sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==}
-    dependencies:
-      '@babel/helper-module-imports': 7.18.6
-      '@emotion/hash': 0.8.0
-      '@emotion/memoize': 0.7.4
-      '@emotion/serialize': 0.11.16
-      babel-plugin-macros: 2.8.0
-      babel-plugin-syntax-jsx: 6.18.0
-      convert-source-map: 1.9.0
-      escape-string-regexp: 1.0.5
-      find-root: 1.1.0
-      source-map: 0.5.7
-    dev: false
-
-  /babel-plugin-macros/2.8.0:
-    resolution: {integrity: sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==}
+  /babel-plugin-macros/3.1.0:
+    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
+    engines: {node: '>=10', npm: '>=6'}
     dependencies:
       '@babel/runtime': 7.20.1
-      cosmiconfig: 6.0.0
+      cosmiconfig: 7.1.0
       resolve: 1.22.1
-    dev: false
-
-  /babel-plugin-syntax-jsx/6.18.0:
-    resolution: {integrity: sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==}
     dev: false
 
   /backfill-cache/5.6.2:
@@ -3533,17 +3539,6 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: false
 
-  /cosmiconfig/6.0.0:
-    resolution: {integrity: sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@types/parse-json': 4.0.0
-      import-fresh: 3.3.0
-      parse-json: 5.2.0
-      path-type: 4.0.0
-      yaml: 1.10.2
-    dev: false
-
   /cosmiconfig/7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
@@ -3694,10 +3689,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       cssom: 0.3.8
-
-  /csstype/2.6.21:
-    resolution: {integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==}
-    dev: false
 
   /csstype/3.1.1:
     resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
@@ -5387,6 +5378,12 @@ packages:
   /highlight-words-core/1.2.2:
     resolution: {integrity: sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==}
 
+  /hoist-non-react-statics/3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+    dependencies:
+      react-is: 16.13.1
+    dev: false
+
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
@@ -6517,6 +6514,10 @@ packages:
   /memoize-one/5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
+  /memoize-one/6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
+    dev: false
+
   /memorystream/0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
     engines: {node: '>= 0.10.0'}
@@ -7528,76 +7529,56 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
 
-  /react-input-autosize/3.0.0_react@17.0.2:
-    resolution: {integrity: sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==}
-    peerDependencies:
-      react: ^16.3.0 || ^17.0.0
-    dependencies:
-      prop-types: 15.8.1
-      react: 17.0.2
-    dev: false
-
-  /react-is-mounted-hook/1.1.2_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-yjq3Tj34CiFcdVOS/h6JerWLOLdJqEGKMNpTHc4kWebzz2YtIpgqMRrqxdmQhewM1KJREojdAV2tsNvBsUWyhA==}
-    peerDependencies:
-      react: ^16.8.6 || ^17
-      react-dom: ^16.8.6 || ^17
-    dependencies:
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-    dev: false
-
   /react-is/16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   /react-is/17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  /react-resize-detector/6.7.8_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-0FaEcUBAbn+pq3PT5a9hHRebUfuS1SRLGLpIw8LydU7zX429I6XJgKerKAMPsJH0qWAl6o5bVKNqFJqr6tGPYw==}
+  /react-resize-detector/8.0.4_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-ln9pMAob8y8mc9UI4aZuuWFiyMqBjnTs/sxe9Vs9dPXUjwCTeKK1FP8I75ufnb/2mEEZXG6wOo/fjMcBRRuAXw==}
     peerDependencies:
-      react: ^16.0.0 || ^17.0.0
-      react-dom: ^16.0.0 || ^17.0.0
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@types/resize-observer-browser': 0.1.7
       lodash: 4.17.21
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      resize-observer-polyfill: 1.5.1
     dev: false
 
-  /react-select-async-paginate/0.5.3_ybmczhbwvuxlsly3vqtlp7ghs4:
-    resolution: {integrity: sha512-SWX1twi/jzViDpQa1nS+xyjrFtn9RBezbL4aIjcJXCABKMY+8JhH4iAKqAW3pryZbm439/DaMtQeZADH17v7bQ==}
+  /react-select-async-paginate/0.7.2_brvwyr73orxcrbyu3q724jvumu:
+    resolution: {integrity: sha512-NlF717+Kh/OgSC7YyEYuB0ebsqF2YhyEdcETH1lX6X4INgNKpKH269MI1H5soIThZdCPZl5xz2QSldcPKlPlew==}
     peerDependencies:
-      react: ^16.14.0 || ^17.0.0
-      react-select: ^2.0.0 || ^3.0.0 || ^4.0.0
+      react: ^16.14.0 || ^17.0.0 || ^18.0.0
+      react-select: ^5.0.0
     dependencies:
-      '@babel/runtime': 7.20.1
       '@seznam/compose-react-refs': 1.0.6
+      '@vtaits/use-lazy-ref': 0.1.0_react@17.0.2
       react: 17.0.2
-      react-is-mounted-hook: 1.1.2_sfoxds7t5ydpegc3knd667wn6m
-      react-select: 3.2.0_sfoxds7t5ydpegc3knd667wn6m
+      react-select: 5.7.0_gzv7pa6nrbev3fs6gyzn7sadkq
       sleep-promise: 9.1.0
-    transitivePeerDependencies:
-      - react-dom
+      use-is-mounted-ref: 1.5.0_react@17.0.2
     dev: false
 
-  /react-select/3.2.0_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-B/q3TnCZXEKItO0fFN/I0tWOX3WJvi/X2wtdffmwSQVRwg5BpValScTO1vdic9AxlUgmeSzib2hAZAwIUQUZGQ==}
+  /react-select/5.7.0_gzv7pa6nrbev3fs6gyzn7sadkq:
+    resolution: {integrity: sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.20.1
-      '@emotion/cache': 10.0.29
-      '@emotion/core': 10.3.1_react@17.0.2
-      '@emotion/css': 10.0.27
-      memoize-one: 5.2.1
+      '@emotion/cache': 11.10.5
+      '@emotion/react': 11.10.6_q5o373oqrklnndq2vhekyuzhxi
+      '@floating-ui/dom': 1.2.3
+      '@types/react-transition-group': 4.4.5
+      memoize-one: 6.0.0
       prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-input-autosize: 3.0.0_react@17.0.2
       react-transition-group: 4.4.5_sfoxds7t5ydpegc3knd667wn6m
+      use-isomorphic-layout-effect: 1.1.2_q5o373oqrklnndq2vhekyuzhxi
+    transitivePeerDependencies:
+      - '@types/react'
     dev: false
 
   /react-table/7.8.0_react@17.0.2:
@@ -8450,6 +8431,10 @@ packages:
       webpack: 5.75.0_webpack-cli@5.0.0
     dev: false
 
+  /stylis/4.1.3:
+    resolution: {integrity: sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==}
+    dev: false
+
   /subarg/1.0.0:
     resolution: {integrity: sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==}
     dependencies:
@@ -8878,6 +8863,27 @@ packages:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  /use-is-mounted-ref/1.5.0_react@17.0.2:
+    resolution: {integrity: sha512-p5FksHf/ospZUr5KU9ese6u3jp9fzvZ3wuSb50i0y6fdONaHWgmOqQtxR/PUcwi6hnhQDbNxWSg3eTK3N6m+dg==}
+    peerDependencies:
+      react: '>=16.0.0'
+    dependencies:
+      react: 17.0.2
+    dev: false
+
+  /use-isomorphic-layout-effect/1.1.2_q5o373oqrklnndq2vhekyuzhxi:
+    resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 17.0.52
+      react: 17.0.2
+    dev: false
 
   /username/5.1.0:
     resolution: {integrity: sha512-PCKbdWw85JsYMvmCv5GH3kXmM66rCd9m1hBEDutPNv94b/pqCMT4NtcKyeWYvLFiE8b+ha1Jdl8XAaUdPn5QTg==}


### PR DESCRIPTION
Tested `presentation-components` with React 18 and made necessary adjustments.
Updated tests to work better with React 18 and newest version of react-testing-library. This should make it easier to switch to newest version in the future.
Updated some dependencies that are used in `presentation-components`

Closes https://github.com/iTwin/presentation/issues/90