### PR TITLE
Fix Table rows loading

### DIFF
--- a/apps/test-app/frontend/src/components/table-widget/TableWidget.tsx
+++ b/apps/test-app/frontend/src/components/table-widget/TableWidget.tsx
@@ -46,7 +46,7 @@ function PresentationTable(props: PresentationTableProps) {
     sort(sortBy?.id, sortBy?.desc);
   }, [sort]);
 
-  if (!columns) {
+  if (columns === undefined) {
     return <ProgressRadial indeterminate={true} />;
   }
 

--- a/change/@itwin-presentation-components-135dfcc8-0368-4c3e-ad09-f88ae6f749ce.json
+++ b/change/@itwin-presentation-components-135dfcc8-0368-4c3e-ad09-f88ae6f749ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed Table rows not loading with latest `presentation-frontend` version",
+  "packageName": "@itwin/presentation-components",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/src/test/table/UsePresentationTable.test.tsx
+++ b/packages/components/src/test/table/UsePresentationTable.test.tsx
@@ -52,7 +52,7 @@ describe("usePresentationTable", () => {
       displayValues: { [propertiesField.name]: "Test value" },
     });
     presentationManagerMock.setup(async (x) => x.getContentDescriptor(moq.It.isAny())).returns(async () => descriptor);
-    presentationManagerMock.setup(async (x) => x.getContent(moq.It.isAny())).returns(async () => new Content(descriptor, [item]));
+    presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.isAny())).returns(async () => ({ content: new Content(descriptor, [item]), size: 1 }));
 
     const { result } = renderHook(
       (props: UsePresentationTableProps<TableColumnDefinition, TableRowDefinition>) => usePresentationTable(props),
@@ -109,7 +109,7 @@ describe("usePresentationTableWithUnifiedSelection", () => {
     sinon.stub(Presentation.selection, "getSelection").returns(keys);
 
     presentationManagerMock.setup(async (x) => x.getContentDescriptor(moq.It.is((options) => options.keys.size === keys.size))).returns(async () => descriptor);
-    presentationManagerMock.setup(async (x) => x.getContent(moq.It.is((options) => options.keys.size === keys.size))).returns(async () => new Content(descriptor, [item]));
+    presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.is((options) => options.keys.size === keys.size))).returns(async () => ({ content: new Content(descriptor, [item]), size: 1 }));
 
     const { result } = renderHook(
       () => usePresentationTableWithUnifiedSelection(initialProps),
@@ -130,7 +130,7 @@ describe("usePresentationTableWithUnifiedSelection", () => {
 
   it("loads columns and rows with no keys unified selection context is not available", async () => {
     presentationManagerMock.setup(async (x) => x.getContentDescriptor(moq.It.is((options) => options.keys.isEmpty))).returns(async () => undefined);
-    presentationManagerMock.setup(async (x) => x.getContent(moq.It.is((options) => options.keys.isEmpty))).returns(async () => undefined);
+    presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.is((options) => options.keys.isEmpty))).returns(async () => undefined);
 
     const { result } = renderHook(
       () => usePresentationTableWithUnifiedSelection(initialProps),


### PR DESCRIPTION
Previous versions of `presentation-frontend` did not throw error when requesting content with page options out of bound so rows loader sometimes attempted to load one more page even if all content items are already loaded. This PR fixes this behavior and now rows loader check available content items count and do not make request with page options out of bounds

Closes #113 