### PR TITLE
Add a workflow for labeling all issues with "presentation" label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+# Add 'presentation' label to any issue that gets opened in this repo
+presentation:
+  - '/.*/'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: "Issue Labeler"
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v3.1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/labeler.yml
+        enable-versioned-regex: 0


### PR DESCRIPTION
This should improve discoverability of newly filed issues in this repository.

Ideally, in our project board we'd like to see these issues:
- everything from the `presentation` repo
- with `presentation` label from all other repos

Sadly, github doesn't provide a way to filter with `OR` operator (`repository:"iTwin/presentation" OR label:"presentation"`)... So we need to make sure everything we want to see is labeled with `presentation` label.