### PR TITLE
OpenTelemetry: Document recent API change

### DIFF
--- a/change/@itwin-presentation-opentelemetry-47692d53-3c7b-4de3-9960-a16572f3bf22.json
+++ b/change/@itwin-presentation-opentelemetry-47692d53-3c7b-4de3-9960-a16572f3bf22.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "**BREAKING CHANGE:** Remove `convertToReadableSpans` function in favor of `exportDiagnostics`.",
+  "packageName": "@itwin/presentation-opentelemetry",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/opentelemetry/src/presentation-opentelemetry/Diagnostics.ts
+++ b/packages/opentelemetry/src/presentation-opentelemetry/Diagnostics.ts
@@ -10,7 +10,8 @@ import { Diagnostics, DiagnosticsLogEntry, DiagnosticsScopeLogs } from "@itwin/p
 import { context, Context, HrTime, SpanKind, trace } from "@opentelemetry/api";
 
 /**
- * Convert diagnostics to readable span format that can be passed to OpenTelemetry exporter.
+ * Export Presentation diagnostics as OpenTelemetry traces to the given context.
+ * @see [Diagnostics and OpenTelemetry]($docs/presentation/advanced/Diagnostics.md#diagnostics-and-opentelemetry)
  * @beta
  */
 export function exportDiagnostics(diagnostics: Diagnostics, ctx: Context) {


### PR DESCRIPTION
Supplement https://github.com/iTwin/presentation/pull/130:
- Add a change log regarding the breaking change
- Improve docs of the new `exportDiagnostics` function