### PR TITLE
Testing: replace spaces in test name when creating test iModel

### DIFF
--- a/change/@itwin-presentation-testing-bf04a3a7-ea71-4dcf-9118-3329b2ce6594.json
+++ b/change/@itwin-presentation-testing-bf04a3a7-ea71-4dcf-9118-3329b2ce6594.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Replace all spaces in test name when creating test iModel.",
+  "packageName": "@itwin/presentation-testing",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/testing/src/presentation-testing/IModelUtilities.ts
+++ b/packages/testing/src/presentation-testing/IModelUtilities.ts
@@ -128,5 +128,5 @@ function setupOutputFileLocation(fileName: string): LocalFileName {
 
 /** @internal */
 export function createFileNameFromString(str: string) {
-  return sanitize(str.replace(" ", "-")).toLocaleLowerCase();
+  return sanitize(str.replace(/[ ]+/g, "-")).toLocaleLowerCase();
 }


### PR DESCRIPTION
Fixed `createFileNameFromString` to replace all spaces into `-` when building test iModel based on test name. Also made sure that consecutive spaces are replaced into one `-`