### PR TITLE
Apply a hack to get `core-react` styles working in our test app

### DIFF
--- a/apps/test-app/frontend/src/components/app/App.tsx
+++ b/apps/test-app/frontend/src/components/app/App.tsx
@@ -226,7 +226,7 @@ export default class App extends Component<{}, State> {
     }
 
     return (
-      <ThemeProvider theme="os">
+      <ThemeProvider theme="os" data-root-container="iui-root-id">
         <div className="app">
           <div className="app-header">
             <h2>{IModelApp.localization.getLocalizedString("Sample:welcome-message")}</h2>


### PR DESCRIPTION
Without `data-root-container="iui-root-id"` on the root container, none of the `--buic-*` variables work.