### PR TITLE
Fix mocha attempting to load irrelevant .js files

### DIFF
--- a/packages/full-stack-tests/.mocharc.json
+++ b/packages/full-stack-tests/.mocharc.json
@@ -6,5 +6,5 @@
   "file": ["./lib/setup.js"],
   "reporter": ["node_modules/@itwin/build-tools/mocha-reporter"],
   "reporterOptions": ["mochaFile=lib/test/junit_results.xml"],
-  "spec": ["./lib/**/*.js"]
+  "spec": ["./lib/**/*.test.js"]
 }


### PR DESCRIPTION
Similar to https://github.com/iTwin/itwinjs-core/pull/5638:
> The first run causes core-frontend to copy some .js files to /lib/public/scripts. Then on the second run mocha attempted to load them and failed...