### PR TITLE
Use node 18.16.0 in pipelines that run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.16.0 #TODO Change back to 18.x once segfault on 18.16.1? is resolved.
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.16.0 #TODO Change back to 18.x once segfault on 18.16.1? is resolved.
           cache: 'pnpm'
 
       - name: Install workspace dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.16.0 #TODO Change back to 18.x once segfault on 18.16.1? is resolved.
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies


### PR DESCRIPTION
full-stack-tests might segfault on node 18.16.1 because of an issue in `core-backend` https://github.com/iTwin/itwinjs-core/issues/5663#issuecomment-1600764489. Use 18.16.0 in pipelines that run test to avoid bloking PRs and releases.