### PR TITLE
Fix filtering with `Point` types

### DIFF
--- a/change/@itwin-presentation-components-a7459a0b-1a71-4419-82e9-7f87813fdab0.json
+++ b/change/@itwin-presentation-components-a7459a0b-1a71-4419-82e9-7f87813fdab0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix filtering with `Point` types.",
+  "packageName": "@itwin/presentation-components",
+  "email": "124659623+simasjar@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/src/presentation-components/instance-filter-builder/InstanceFilterBuilder.tsx
+++ b/packages/components/src/presentation-components/instance-filter-builder/InstanceFilterBuilder.tsx
@@ -12,7 +12,7 @@ import { ActionMeta, MultiValue, SingleValue } from "react-select";
 import { BehaviorSubject, from, of } from "rxjs";
 import { map } from "rxjs/internal/operators/map";
 import { switchAll } from "rxjs/internal/operators/switchAll";
-import { PropertyDescription, StandardTypeNames } from "@itwin/appui-abstract";
+import { PropertyDescription } from "@itwin/appui-abstract";
 import {
   PropertyFilterBuilderRenderer,
   PropertyFilterBuilderRendererProps,
@@ -329,10 +329,7 @@ async function computeClassesByProperty(classes: ClassInfo[], property: Instance
 }
 
 function UniqueValuesRenderer(props: PropertyFilterBuilderRuleValueRendererProps & { imodel: IModelConnection; descriptor: Descriptor }) {
-  if (
-    props.property.typename !== StandardTypeNames.Navigation &&
-    (props.operator === PropertyFilterRuleOperator.IsEqual || props.operator === PropertyFilterRuleOperator.IsNotEqual)
-  ) {
+  if (props.operator === PropertyFilterRuleOperator.IsEqual || props.operator === PropertyFilterRuleOperator.IsNotEqual) {
     return <UniquePropertyValuesSelector {...props} />;
   }
   return <PropertyFilterBuilderRuleValue {...props} />;

--- a/packages/components/src/presentation-components/instance-filter-builder/InstanceFilterConverter.ts
+++ b/packages/components/src/presentation-components/instance-filter-builder/InstanceFilterConverter.ts
@@ -160,6 +160,11 @@ function createComparison(propertyName: string, type: string, alias: string, ope
     case "number":
       valueExpression = value.toString();
       break;
+    case "object":
+      if (isPoint2d(value)) {
+        return createPointComparision(value, operatorExpression, propertyAccessor);
+      }
+      break;
   }
 
   if (type === "navigation") {
@@ -248,4 +253,18 @@ function handleStringifiedUniqueValues(filter: PresentationInstanceFilterConditi
     selectedValueIndex++;
   }
   return conditionGroup;
+}
+
+function createPointComparision(point: { x: number; y: number } | { x: number; y: number; z: number }, operatorExpression: string, propertyAccessor: string) {
+  return `(CompareDoubles(${propertyAccessor}.x, ${point.x}) ${operatorExpression} 0) AND (CompareDoubles(${propertyAccessor}.y, ${
+    point.y
+  }) ${operatorExpression} 0)${isPoint3d(point) ? ` AND (CompareDoubles(${propertyAccessor}.z, ${point.z}) ${operatorExpression} 0)` : ""}`;
+}
+
+function isPoint2d(obj: object): obj is { x: number; y: number } {
+  return (obj as any).x !== undefined && (obj as any).y !== undefined;
+}
+
+function isPoint3d(obj: object): obj is { x: number; y: number; z: number } {
+  return isPoint2d(obj) && (obj as any).z !== undefined;
 }

--- a/packages/components/src/presentation-components/properties/UniquePropertyValuesSelector.tsx
+++ b/packages/components/src/presentation-components/properties/UniquePropertyValuesSelector.tsx
@@ -76,7 +76,7 @@ export function UniquePropertyValuesSelector(props: UniquePropertyValuesSelector
       isSearchable={false}
       closeMenuOnSelect={false}
       getOptionLabel={(option) => option.displayValue?.toString() ?? ""}
-      getOptionValue={(option) => option.groupedRawValues[0]?.toString() ?? ""}
+      getOptionValue={(option) => option.displayValue?.toString() ?? ""}
     />
   );
 }

--- a/packages/components/src/test/instance-filter-builder/InstanceFilterConverter.test.ts
+++ b/packages/components/src/test/instance-filter-builder/InstanceFilterConverter.test.ts
@@ -6,7 +6,7 @@
 import { expect } from "chai";
 import sinon from "sinon";
 import * as moq from "typemoq";
-import { PropertyValue, PropertyValueFormat } from "@itwin/appui-abstract";
+import { PropertyValue, PropertyValueFormat, StandardTypeNames } from "@itwin/appui-abstract";
 import { PropertyFilterRuleGroupOperator, PropertyFilterRuleOperator } from "@itwin/components-react";
 import { BeEvent } from "@itwin/core-bentley";
 import { IModelConnection } from "@itwin/core-frontend";
@@ -183,6 +183,36 @@ describe("convertToInstanceFilterDefinition", () => {
       };
       const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
       expect(expression).to.be.eq(`CompareDateTimes(${propertyAccessor}, "2021-10-12T08:45:41") = 0`);
+    });
+
+    it("point2d value", async () => {
+      const propertyInfo = createTestPropertyInfo({ type: StandardTypeNames.Point2d });
+      const filter: PresentationInstanceFilterCondition = {
+        field: createTestPropertiesContentField({
+          properties: [{ property: propertyInfo }],
+          type: { valueFormat: TypeValueFormat.Primitive, typeName: StandardTypeNames.Point2d },
+        }),
+        operator: PropertyFilterRuleOperator.IsEqual,
+        value: { ...value, value: { x: 10, y: 20 } },
+      };
+      const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(expression).to.be.eq(`(CompareDoubles(${propertyAccessor}.x, 10) = 0) AND (CompareDoubles(${propertyAccessor}.y, 20) = 0)`);
+    });
+
+    it("point3d value", async () => {
+      const propertyInfo = createTestPropertyInfo({ type: StandardTypeNames.Point3d });
+      const filter: PresentationInstanceFilterCondition = {
+        field: createTestPropertiesContentField({
+          properties: [{ property: propertyInfo }],
+          type: { valueFormat: TypeValueFormat.Primitive, typeName: StandardTypeNames.Point3d },
+        }),
+        operator: PropertyFilterRuleOperator.IsEqual,
+        value: { ...value, value: { x: 10, y: 20, z: 5 } },
+      };
+      const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(expression).to.be.eq(
+        `(CompareDoubles(${propertyAccessor}.x, 10) = 0) AND (CompareDoubles(${propertyAccessor}.y, 20) = 0) AND (CompareDoubles(${propertyAccessor}.z, 5) = 0)`,
+      );
     });
 
     it("invalid operator", async () => {
@@ -538,7 +568,7 @@ describe("convertToInstanceFilterDefinition", () => {
     });
   });
 
-  describe("handles unqiue values", () => {
+  describe("handles unique values", () => {
     const testImodel = {} as IModelConnection;
     const property = createTestPropertyInfo();
     const field = createTestPropertiesContentField({ properties: [{ property }] });

--- a/packages/components/src/test/instance-filter-builder/IntanceFilterBuilder.test.tsx
+++ b/packages/components/src/test/instance-filter-builder/IntanceFilterBuilder.test.tsx
@@ -17,7 +17,7 @@ import {
 import { BeEvent } from "@itwin/core-bentley";
 import { EmptyLocalization } from "@itwin/core-common";
 import { IModelApp, IModelConnection } from "@itwin/core-frontend";
-import { ClassInfo, Descriptor, NavigationPropertyInfo, PropertiesField, PropertyValueFormat } from "@itwin/presentation-common";
+import { ClassInfo, Descriptor, NavigationPropertyInfo, PropertiesField } from "@itwin/presentation-common";
 import { Presentation } from "@itwin/presentation-frontend";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { renderHook } from "@testing-library/react-hooks";
@@ -464,17 +464,10 @@ describe("UniqueValuesRenderer", () => {
     label: "propertiesField",
     category,
   });
-  const navigationPropertyField = createTestPropertiesContentField({
-    properties: [{ property: { classInfo, name: "navField", type: "navigation" } }],
-    name: "navField",
-    label: "navigationField",
-    category,
-    type: { valueFormat: PropertyValueFormat.Primitive, typeName: "navigation" },
-  });
   const descriptor = createTestContentDescriptor({
     selectClasses: [{ selectClassInfo: classInfo, isSelectPolymorphic: false }],
     categories: [category],
-    fields: [propertiesField, navigationPropertyField],
+    fields: [propertiesField],
   });
 
   const testIModel = {} as IModelConnection;
@@ -545,13 +538,10 @@ describe("UniqueValuesRenderer", () => {
     await waitFor(() => expect(queryByText("unique-values-property-editor.select-values")).to.not.be.null);
   });
 
-  it("does not render <UniquePropertyValuesSelector /> when the property is equal to `navigation`", async () => {
+  it("does not render <UniquePropertyValuesSelector /> when the operator is not equal to `IsEqual` and `IsNotEqual`", async () => {
     const { result } = renderHook(() =>
       usePropertyFilterBuilder({
-        initialFilter: convertPresentationFilterToPropertyFilter(
-          descriptor,
-          createFilter(PropertyFilterRuleOperator.IsNotEqual, navigationPropertyField).filter,
-        ),
+        initialFilter: convertPresentationFilterToPropertyFilter(descriptor, createFilter(PropertyFilterRuleOperator.Like).filter),
       }),
     );
     const { actions, rootGroup } = result.current;


### PR DESCRIPTION
- Added filtering expression for `Point` types.
- Fixed unique values selector with `Point` and `Navigation` types
- Replaced navigation property target selector with unique values renderer in the filter dialog

closes #198 