### PR TITLE
Tree filtering: reset `filteredNodeLoader` when filter string is changed

### DIFF
--- a/change/@itwin-presentation-components-a970de67-6464-44ae-b7bc-9e203c6b4a10.json
+++ b/change/@itwin-presentation-components-a970de67-6464-44ae-b7bc-9e203c6b4a10.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "`useControlledPresentationTreeFiltering`: Reset `filteredNodeLoader` after filter string is changed and filtering is in progress.",
+  "packageName": "@itwin/presentation-components",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/573

Reset `filteredNodeLoader` after filter string is changed in order for spinner to be shown while filtering is in progress.