### PR TITLE
Components should react to unit system change

### DIFF
--- a/apps/test-app/frontend/src/components/app/App.tsx
+++ b/apps/test-app/frontend/src/components/app/App.tsx
@@ -5,11 +5,11 @@
 
 import "./App.css";
 import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
-import { Component, createRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { IModelApp, IModelConnection } from "@itwin/core-frontend";
 import { Geometry } from "@itwin/core-geometry";
 import { UnitSystemKey } from "@itwin/core-quantity";
-import { ElementSeparator, Orientation, RatioChangeResult } from "@itwin/core-react";
+import { ElementSeparator, Orientation } from "@itwin/core-react";
 import { ThemeProvider, ToggleSwitch } from "@itwin/itwinui-react";
 import { UnifiedSelectionContextProvider } from "@itwin/presentation-components";
 import { Presentation, SelectionChangeEventArgs } from "@itwin/presentation-frontend";
@@ -17,230 +17,236 @@ import { MyAppFrontend, MyAppSettings } from "../../api/MyAppFrontend";
 import { IModelSelector } from "../imodel-selector/IModelSelector";
 import { PropertiesWidget } from "../properties-widget/PropertiesWidget";
 import { RulesetSelector } from "../ruleset-selector/RulesetSelector";
-import { ExperimentalModelsTree /* , TreeWidget */ } from "../tree-widget/TreeWidget";
+import { TableWidget } from "../table-widget/TableWidget";
+import { TreeWidget } from "../tree-widget/TreeWidget";
+// import { ExperimentalModelsTree } from "../tree-widget/TreeWidget";
 import { UnitSystemSelector } from "../unit-system-selector/UnitSystemSelector";
 import ViewportContentControl from "../viewport/ViewportContentControl";
-import { TableWidget } from "../table-widget/TableWidget";
 
 export interface State {
   imodel?: IModelConnection;
   imodelPath?: string;
-  currentRulesetId?: string;
-  rightPaneRatio: number;
-  rightPaneHeight?: number;
-  contentRatio: number;
-  contentWidth?: number;
-  activeUnitSystem?: UnitSystemKey;
+  rulesetId?: string;
+  activeUnitSystem: UnitSystemKey;
   persistSettings: boolean;
 }
 
-export default class App extends Component<{}, State> {
-  private readonly _minRightPaneRatio = 0.3;
-  private readonly _maxRightPaneRatio = 0.7;
-  private readonly _minContentRatio = 0.2;
-  private readonly _maxContentRatio = 0.9;
-  private _rightPaneRef = createRef<HTMLDivElement>();
-  private _contentRef = createRef<HTMLDivElement>();
-  private _selectionListener!: () => void;
+export function App() {
+  const [state, setState] = useAppState();
 
-  constructor() {
-    super({});
-    this.state = {
-      // eslint-disable-next-line deprecation/deprecation
-      activeUnitSystem: Presentation.presentation.activeUnitSystem,
-      rightPaneRatio: 0.5,
-      contentRatio: 0.7,
-      persistSettings: MyAppFrontend.settings.persistSettings,
-    };
-  }
+  const onIModelSelected = (imodel: IModelConnection | undefined, path?: string) => {
+    setState((prev) => ({
+      ...prev,
+      imodel,
+      imodelPath: path,
+    }));
+  };
 
-  private updateAppSettings() {
-    const settings: MyAppSettings = {
-      persistSettings: this.state.persistSettings,
-    };
-    if (this.state.persistSettings) {
-      settings.imodelPath = this.state.imodelPath;
-      settings.rulesetId = this.state.currentRulesetId;
-      settings.unitSystem = this.state.activeUnitSystem;
+  const onRulesetSelected = (rulesetId: string | undefined) => {
+    if (state.imodel) {
+      Presentation.selection.clearSelection("onRulesetChanged", state.imodel, 0);
     }
-    MyAppFrontend.settings = settings;
-  }
 
-  private loadAppSettings() {
+    setState((prev) => ({
+      ...prev,
+      rulesetId,
+    }));
+  };
+
+  const onUnitSystemSelected = async (unitSystem: UnitSystemKey) => {
+    await IModelApp.quantityFormatter.setActiveUnitSystem(unitSystem);
+  };
+
+  const onPersistSettingsValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setState((prev) => ({
+      ...prev,
+      persistSettings: e.target.checked,
+    }));
+  };
+
+  useEffect(() => {
+    return Presentation.selection.selectionChange.addListener(async (args: SelectionChangeEventArgs) => {
+      if (!IModelApp.viewManager.selectedView) {
+        // no viewport to zoom in
+        return;
+      }
+
+      if (args.source === "Tool") {
+        // selection originated from the viewport - don't change what it's displaying by zooming in
+        return;
+      }
+
+      // determine what the viewport is hiliting
+      const hiliteSet = await Presentation.selection.getHiliteSet(args.imodel);
+      if (hiliteSet.elements) {
+        // note: the hilite list may contain models and subcategories as well - we don't
+        // care about them at this moment
+        await IModelApp.viewManager.selectedView.zoomToElements(hiliteSet.elements);
+      }
+    });
+  }, []);
+
+  return (
+    <ThemeProvider theme="os" data-root-container="iui-root-id">
+      <div className="app">
+        <div className="app-header">
+          <h2>{IModelApp.localization.getLocalizedString("Sample:welcome-message")}</h2>
+        </div>
+        <div className="app-pickers">
+          <IModelSelector onIModelSelected={onIModelSelected} activeIModelPath={state.imodelPath} />
+          <RulesetSelector onRulesetSelected={onRulesetSelected} activeRulesetId={state.rulesetId} />
+          <UnitSystemSelector selectedUnitSystem={state.activeUnitSystem} onUnitSystemSelected={onUnitSystemSelected} />
+          <ToggleSwitch label="Persist settings" labelPosition="right" checked={state.persistSettings} onChange={onPersistSettingsValueChange} />
+        </div>
+        {state.imodel ? <IModelComponents imodel={state.imodel} rulesetId={state.rulesetId} /> : null}
+      </div>
+    </ThemeProvider>
+  );
+}
+
+function updateAppSettings(state: State) {
+  const settings: MyAppSettings = {
+    persistSettings: state.persistSettings,
+  };
+  if (state.persistSettings) {
+    settings.imodelPath = state.imodelPath;
+    settings.rulesetId = state.rulesetId;
+    settings.unitSystem = state.activeUnitSystem;
+  }
+  MyAppFrontend.settings = settings;
+}
+
+function useAppState(): [State, (produceState: (prev: State) => State) => void] {
+  const [state, setState] = useState<State>(() => {
     const settings = MyAppFrontend.settings;
     const update: Partial<State> = {
       persistSettings: settings.persistSettings,
+      activeUnitSystem: IModelApp.quantityFormatter.activeUnitSystem,
     };
-    if (settings.persistSettings) {
-      update.imodelPath = settings.imodelPath;
-      update.currentRulesetId = settings.rulesetId;
-      update.activeUnitSystem = settings.unitSystem;
-    }
-    this.setState(update as State);
-  }
-
-  private onIModelSelected = async (imodel: IModelConnection | undefined, path?: string) => {
-    this.setState({ imodel, imodelPath: path }, () => this.updateAppSettings());
-  };
-
-  private onRulesetSelected = (rulesetId: string | undefined) => {
-    if (this.state.imodel) {
-      Presentation.selection.clearSelection("onRulesetChanged", this.state.imodel, 0);
+    if (!settings.persistSettings) {
+      return update as State;
     }
 
-    this.setState({ currentRulesetId: rulesetId }, () => this.updateAppSettings());
-  };
-
-  private onUnitSystemSelected = (unitSystem: UnitSystemKey | undefined) => {
-    // eslint-disable-next-line deprecation/deprecation
-    Presentation.presentation.activeUnitSystem = unitSystem;
-    this.setState({ activeUnitSystem: unitSystem }, () => this.updateAppSettings());
-  };
-
-  private onPersistSettingsValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ persistSettings: e.target.checked }, () => this.updateAppSettings());
-  };
-
-  private _onTreePaneRatioChanged = (ratio: number): RatioChangeResult => {
-    ratio = Geometry.clamp(ratio, this._minRightPaneRatio, this._maxRightPaneRatio);
-    if (this.state.rightPaneRatio === ratio) {
-      return { ratio };
+    if (settings.unitSystem) {
+      void IModelApp.quantityFormatter.setActiveUnitSystem(settings.unitSystem);
     }
 
-    this.setState({ rightPaneRatio: ratio });
-    return { ratio };
+    update.imodelPath = settings.imodelPath;
+    update.rulesetId = settings.rulesetId;
+    update.activeUnitSystem = settings.unitSystem;
+    return update as State;
+  });
+
+  const updateState = (produceState: (prev: State) => State) => {
+    setState((prev) => {
+      const newState = produceState(prev);
+      updateAppSettings(newState);
+      return newState;
+    });
   };
 
-  private _onContentRatioChanged = (ratio: number): RatioChangeResult => {
-    ratio = Geometry.clamp(ratio, this._minContentRatio, this._maxContentRatio);
-    if (this.state.contentRatio === ratio) {
-      return { ratio };
-    }
+  useEffect(() => {
+    return IModelApp.quantityFormatter.onActiveFormattingUnitSystemChanged.addListener(({ system }) => {
+      updateState((prev) => ({
+        ...prev,
+        activeUnitSystem: system,
+      }));
+    });
+  }, []);
 
-    this.setState({ contentRatio: ratio });
-    return { ratio };
-  };
+  return [state, updateState];
+}
 
-  private _onSelectionChanged = async (args: SelectionChangeEventArgs) => {
-    if (!IModelApp.viewManager.selectedView) {
-      // no viewport to zoom in
-      return;
-    }
+interface IModelComponentsProps {
+  imodel: IModelConnection;
+  rulesetId?: string;
+}
 
-    if (args.source === "Tool") {
-      // selection originated from the viewport - don't change what it's displaying by zooming in
-      return;
-    }
+function IModelComponents(props: IModelComponentsProps) {
+  const { imodel, rulesetId } = props;
 
-    // determine what the viewport is hiliting
-    const hiliteSet = await Presentation.selection.getHiliteSet(args.imodel);
-    if (hiliteSet.elements) {
-      // note: the hilite list may contain models and subcategories as well - we don't
-      // care about them at this moment
-      await IModelApp.viewManager.selectedView.zoomToElements(hiliteSet.elements);
-    }
-  };
+  const {
+    ref: contentRef,
+    ratio: contentRatio,
+    onResize: onContentResize,
+    width: contentWidth,
+  } = useResizableElement<HTMLDivElement>({ min: 0.2, max: 0.9, initial: 0.7 }); // content
+  const {
+    ref: panelRef,
+    ratio: panelRatio,
+    onResize: onPanelResize,
+    height: panelHeight,
+  } = useResizableElement<HTMLDivElement>({ min: 0.3, max: 0.7, initial: 0.5 }); // rightPanel
 
-  private renderIModelComponents(imodel: IModelConnection, rulesetId?: string) {
-    return (
-      <div
-        className="app-content"
-        ref={this._contentRef}
-        style={{
-          gridTemplateColumns: `${this.state.contentRatio * 100}% 1px calc(${(1 - this.state.contentRatio) * 100}% - 1px)`,
-        }}
-      >
-        <UnifiedSelectionContextProvider imodel={imodel} selectionLevel={0}>
-          <div className="app-content-left">
-            <div className="app-content-left-top">
-              <ViewportContentControl imodel={imodel} />
-            </div>
-            <div className="app-content-left-bottom">
-              <TableWidget imodel={imodel} rulesetId={rulesetId} />
-            </div>
+  return (
+    <div
+      className="app-content"
+      ref={contentRef}
+      style={{
+        gridTemplateColumns: `${contentRatio * 100}% 1px calc(${(1 - contentRatio) * 100}% - 1px)`,
+      }}
+    >
+      <UnifiedSelectionContextProvider imodel={imodel} selectionLevel={0}>
+        <div className="app-content-left">
+          <div className="app-content-left-top">
+            <ViewportContentControl imodel={imodel} />
           </div>
-          <ElementSeparator
-            orientation={Orientation.Horizontal}
-            ratio={this.state.contentRatio}
-            movableArea={this.state.contentWidth}
-            separatorSize={10}
-            onRatioChanged={this._onContentRatioChanged}
-          />
-          <div
-            ref={this._rightPaneRef}
-            className="app-content-right"
-            style={{
-              gridTemplateRows: `${this.state.rightPaneRatio * 100}% 30px calc(${(1 - this.state.rightPaneRatio) * 100}% - 30px)`,
-            }}
-          >
-            {/* <TreeWidget imodel={imodel} rulesetId={rulesetId} /> */}
-            <ExperimentalModelsTree imodel={imodel} />
-            <div className="app-content-right-separator">
-              <hr />
-              <ElementSeparator
-                orientation={Orientation.Vertical}
-                ratio={this.state.rightPaneRatio}
-                movableArea={this.state.rightPaneHeight}
-                onRatioChanged={this._onTreePaneRatioChanged}
-              />
-            </div>
-            <PropertiesWidget imodel={imodel} rulesetId={rulesetId} />
+          <div className="app-content-left-bottom">
+            <TableWidget imodel={imodel} rulesetId={rulesetId} />
           </div>
-        </UnifiedSelectionContextProvider>
-      </div>
-    );
-  }
-
-  private afterRender() {
-    if (this._rightPaneRef.current) {
-      const height = this._rightPaneRef.current.getBoundingClientRect().height;
-      if (height !== this.state.rightPaneHeight) {
-        this.setState({ rightPaneHeight: height });
-      }
-    }
-    if (this._contentRef.current) {
-      const width = this._contentRef.current.getBoundingClientRect().width;
-      if (width !== this.state.contentWidth) {
-        this.setState({ contentWidth: width });
-      }
-    }
-  }
-
-  public override componentDidMount() {
-    this.loadAppSettings();
-    this.afterRender();
-    this._selectionListener = Presentation.selection.selectionChange.addListener(this._onSelectionChanged);
-  }
-
-  public override componentDidUpdate() {
-    this.afterRender();
-  }
-
-  public override componentWillUnmount() {
-    Presentation.selection.selectionChange.removeListener(this._selectionListener);
-  }
-
-  public override render() {
-    let imodelComponents = null;
-    if (this.state.imodel) {
-      imodelComponents = this.renderIModelComponents(this.state.imodel, this.state.currentRulesetId);
-    }
-
-    return (
-      <ThemeProvider theme="os" data-root-container="iui-root-id">
-        <div className="app">
-          <div className="app-header">
-            <h2>{IModelApp.localization.getLocalizedString("Sample:welcome-message")}</h2>
-          </div>
-          <div className="app-pickers">
-            <IModelSelector onIModelSelected={this.onIModelSelected} activeIModelPath={this.state.imodelPath} />
-            <RulesetSelector onRulesetSelected={this.onRulesetSelected} activeRulesetId={this.state.currentRulesetId} />
-            <UnitSystemSelector selectedUnitSystem={this.state.activeUnitSystem} onUnitSystemSelected={this.onUnitSystemSelected} />
-            <ToggleSwitch label="Persist settings" labelPosition="right" checked={this.state.persistSettings} onChange={this.onPersistSettingsValueChange} />
-          </div>
-          {imodelComponents}
         </div>
-      </ThemeProvider>
-    );
-  }
+        <ElementSeparator
+          orientation={Orientation.Horizontal}
+          ratio={contentRatio}
+          movableArea={contentWidth}
+          separatorSize={10}
+          onRatioChanged={onContentResize}
+        />
+        <div
+          ref={panelRef}
+          className="app-content-right"
+          style={{
+            gridTemplateRows: `${panelRatio * 100}% 30px calc(${(1 - panelRatio) * 100}% - 30px)`,
+          }}
+        >
+          <TreeWidget imodel={imodel} rulesetId={rulesetId} />
+          {/* <ExperimentalModelsTree imodel={imodel} /> */}
+          <div className="app-content-right-separator">
+            <hr />
+            <ElementSeparator orientation={Orientation.Vertical} ratio={panelRatio} movableArea={panelHeight} onRatioChanged={onPanelResize} />
+          </div>
+          <PropertiesWidget imodel={imodel} rulesetId={rulesetId} />
+        </div>
+      </UnifiedSelectionContextProvider>
+    </div>
+  );
+}
+
+function useResizableElement<T extends Element>({ min, max, initial }: { min: number; max: number; initial: number }) {
+  const ref = useRef<T>(null);
+  const [ratio, setRatio] = useState(initial);
+  const [height, setHeight] = useState(0);
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    const rect = ref.current.getBoundingClientRect();
+    setHeight(rect.height);
+    setWidth(rect.width);
+  }, []);
+
+  const onResize = (newRatio: number) => {
+    setRatio(Geometry.clamp(newRatio, min, max));
+  };
+
+  return {
+    ref,
+    ratio,
+    height,
+    width,
+    onResize,
+  };
 }

--- a/apps/test-app/frontend/src/components/unit-system-selector/UnitSystemSelector.tsx
+++ b/apps/test-app/frontend/src/components/unit-system-selector/UnitSystemSelector.tsx
@@ -8,8 +8,8 @@ import { UnitSystemKey } from "@itwin/core-quantity";
 import { Select, SelectOption } from "@itwin/itwinui-react";
 
 export interface UnitSystemSelectorProps {
-  selectedUnitSystem: UnitSystemKey | undefined;
-  onUnitSystemSelected: (unitSystem: UnitSystemKey | undefined) => void;
+  selectedUnitSystem: UnitSystemKey;
+  onUnitSystemSelected: (unitSystem: UnitSystemKey) => void;
 }
 
 export function UnitSystemSelector(props: UnitSystemSelectorProps) {
@@ -28,11 +28,7 @@ export function UnitSystemSelector(props: UnitSystemSelectorProps) {
   );
 }
 
-const availableUnitSystems: SelectOption<UnitSystemKey | undefined>[] = [
-  {
-    value: undefined,
-    label: "",
-  },
+const availableUnitSystems: SelectOption<UnitSystemKey>[] = [
   {
     value: "metric",
     label: "Metric",

--- a/apps/test-app/frontend/src/index.tsx
+++ b/apps/test-app/frontend/src/index.tsx
@@ -16,7 +16,7 @@ import { ITwinLocalization } from "@itwin/core-i18n";
 import { createFavoritePropertiesStorage, DefaultFavoritePropertiesStorageTypes, Presentation } from "@itwin/presentation-frontend";
 // __PUBLISH_EXTRACT_END__
 import { rpcInterfaces } from "@test-app/common";
-import App from "./components/app/App";
+import { App } from "./components/app/App";
 
 // initialize logging
 Logger.initializeToConsole();
@@ -54,6 +54,7 @@ async function initializeApp() {
 
   readyPromises.push(initializePresentation());
   readyPromises.push(UiComponents.initialize(IModelApp.localization));
+  readyPromises.push(IModelApp.quantityFormatter.setActiveUnitSystem("metric"));
   await Promise.all(readyPromises);
 }
 
@@ -63,9 +64,6 @@ async function initializePresentation() {
     presentation: {
       // specify locale for localizing presentation data, it can be changed afterwards
       activeLocale: IModelApp.localization.getLanguageList()[0],
-
-      // specify the preferred unit system
-      activeUnitSystem: "metric",
     },
     favorites: {
       storage: createFavoritePropertiesStorage(DefaultFavoritePropertiesStorageTypes.UserPreferencesStorage),

--- a/change/@itwin-presentation-components-ec605eb6-b9a2-4f57-a2f5-749645a2b60a.json
+++ b/change/@itwin-presentation-components-ec605eb6-b9a2-4f57-a2f5-749645a2b60a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Reload content and hierarchies when active unit system is changed.",
+  "packageName": "@itwin/presentation-components",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/src/presentation-components/propertygrid/DataProvider.ts
+++ b/packages/components/src/presentation-components/propertygrid/DataProvider.ts
@@ -129,13 +129,9 @@ export class PresentationPropertyDataProvider extends ContentDataProvider implem
    */
   protected override invalidateCache(props: CacheInvalidationProps): void {
     super.invalidateCache(props);
-    if (this.getMemoizedData) {
-      this.getMemoizedData.cache.keys.length = 0;
-      this.getMemoizedData.cache.values.length = 0;
-    }
-    if (this.onDataChanged) {
-      this.onDataChanged.raiseEvent();
-    }
+    this.getMemoizedData.cache.keys.length = 0;
+    this.getMemoizedData.cache.values.length = 0;
+    this.onDataChanged.raiseEvent();
   }
 
   /**

--- a/packages/components/src/presentation-components/table/UseRows.ts
+++ b/packages/components/src/presentation-components/table/UseRows.ts
@@ -6,12 +6,10 @@
  * @module Internal
  */
 
-import { useEffect, useState } from "react";
-import { EMPTY, from, Subject } from "rxjs";
-import { distinct } from "rxjs/internal/operators/distinct";
-import { mergeMap } from "rxjs/internal/operators/mergeMap";
+import { useEffect, useRef, useState } from "react";
+import { EMPTY, from, mergeMap, Observable, Subject } from "rxjs";
 import { assert } from "@itwin/core-bentley";
-import { IModelConnection } from "@itwin/core-frontend";
+import { IModelApp, IModelConnection } from "@itwin/core-frontend";
 import { Content, DefaultContentDisplayTypes, KeySet, PageOptions, Ruleset, StartItemProps, traverseContent } from "@itwin/presentation-common";
 import { Presentation } from "@itwin/presentation-frontend";
 import { FieldHierarchyRecord, PropertyRecordsBuilder } from "../common/ContentBuilder";
@@ -37,59 +35,175 @@ export interface UseRowsResult {
 
 /** @internal */
 export function useRows(props: UseRowsProps): UseRowsResult {
+  interface State {
+    total: number;
+    isLoading: boolean;
+    rows: TableRowDefinition[];
+  }
+
   const { imodel, ruleset, keys, pageSize, options } = props;
   const setErrorState = useErrorState();
-  const [state, setState] = useState<UseRowsResult>({
+  const [state, setState] = useState<State>({
     isLoading: false,
     rows: [],
-    loadMoreRows: /* istanbul ignore next*/ () => {},
+    total: 0,
   });
+
+  const loaderRef = useRef<RowsLoader>(noopRowsLoader);
 
   useEffect(() => {
     setState((prev) => ({ ...prev, rows: [] }));
+    const { observable, ...loader } = createRowsLoader({
+      imodel,
+      ruleset,
+      keys,
+      pageSize,
+      options,
+      onPageLoadStart: () => setState((prev) => ({ ...prev, isLoading: true })),
+    });
+    loaderRef.current = loader;
 
-    const loader = new Subject<number>();
-    const subscription = loader
-      .pipe(
-        distinct(),
-        mergeMap((pageStart) => {
-          if (keys.isEmpty) {
-            return EMPTY;
-          }
-          setState((prev) => ({ ...prev, isLoading: true }));
-          return from(loadRows(imodel, ruleset, keys, { start: pageStart, size: pageSize }, options));
-        }, 1),
-      )
-      .subscribe({
-        next: (loadedRows) => {
-          setState((prev) => ({
+    const subscription = observable.subscribe({
+      next: ({ total, rowDefinitions, offset }) => {
+        setState((prev) => {
+          const newRows = [...prev.rows];
+          newRows.splice(offset, rowDefinitions.length, ...rowDefinitions);
+
+          return {
+            ...prev,
             isLoading: false,
-            rows: [...prev.rows, ...loadedRows.rowDefinitions],
-            loadMoreRows: () => {
-              const pageStart = prev.rows.length + loadedRows.rowDefinitions.length;
-              if (pageStart >= loadedRows.total) {
-                return;
-              }
-              loader.next(pageStart);
-            },
-          }));
-        },
-        error: (err) => {
-          setErrorState(err);
-          setState((prev) => ({ ...prev, rows: [], isLoading: false }));
-        },
-      });
+            rows: newRows,
+            total,
+          };
+        });
+      },
+      error: (err) => {
+        setErrorState(err);
+        setState((prev) => ({ ...prev, rows: [], isLoading: false, total: 0 }));
+      },
+    });
 
-    loader.next(0);
+    loaderRef.current.loadPage(0);
     return () => {
       subscription.unsubscribe();
+      loaderRef.current = noopRowsLoader;
     };
   }, [imodel, ruleset, keys, pageSize, options, setErrorState]);
 
-  return state;
+  useEffect(() => {
+    return IModelApp.quantityFormatter.onActiveFormattingUnitSystemChanged.addListener(() => {
+      loaderRef.current.reload(state.rows.length);
+    });
+  }, [state.rows]);
+
+  return {
+    rows: state.rows,
+    isLoading: state.isLoading,
+    loadMoreRows: () => {
+      if (state.rows.length === state.total) {
+        return;
+      }
+
+      loaderRef.current.loadPage(state.rows.length);
+    },
+  };
 }
 
-async function loadRows(imodel: IModelConnection, ruleset: Ruleset | string, keys: Readonly<KeySet>, paging: PageOptions, options: TableOptions) {
+interface LoadPageOptions {
+  action: "load-page";
+  pageStart: number;
+}
+
+interface ReloadOptions {
+  action: "reload";
+  loadedRowsCount: number;
+}
+
+type LoaderOptions = LoadPageOptions | ReloadOptions;
+
+interface RowsLoaderProps {
+  imodel: IModelConnection;
+  ruleset: Ruleset | string;
+  keys: Readonly<KeySet>;
+  pageSize: number;
+  options: TableOptions;
+  onPageLoadStart: () => void;
+}
+
+interface RowsLoader {
+  loadPage: (pageStart: number) => void;
+  reload: (loadedRowsCount: number) => void;
+}
+
+function createRowsLoader({
+  imodel,
+  ruleset,
+  keys,
+  pageSize,
+  options,
+  onPageLoadStart,
+}: RowsLoaderProps): RowsLoader & { observable: Observable<RowsLoadResult> } {
+  const loaderSubject = new Subject<LoaderOptions>();
+  const loaderObservable = loaderSubject.pipe(
+    mergeMap((loaderOptions) => {
+      if (keys.isEmpty) {
+        return EMPTY;
+      }
+
+      switch (loaderOptions.action) {
+        case "load-page": {
+          onPageLoadStart();
+          return from(loadRows(imodel, ruleset, keys, { start: loaderOptions.pageStart, size: pageSize }, options));
+        }
+        case "reload": {
+          return loaderOptions.loadedRowsCount === 0 ? EMPTY : createReloadObs(imodel, ruleset, keys, options, loaderOptions.loadedRowsCount);
+        }
+      }
+    }),
+  );
+
+  return {
+    observable: loaderObservable,
+    loadPage: (pageStart: number) => {
+      loaderSubject.next({ action: "load-page", pageStart });
+    },
+    reload: (rowsCount: number) => {
+      loaderSubject.next({ action: "reload", loadedRowsCount: rowsCount });
+    },
+  };
+}
+
+/** @internal */
+export const ROWS_RELOAD_PAGE_SIZE = 1000;
+
+function createReloadObs(imodel: IModelConnection, ruleset: Ruleset | string, keys: Readonly<KeySet>, options: TableOptions, loadedItemsCount: number) {
+  const lastPageIndex = Math.floor(loadedItemsCount / ROWS_RELOAD_PAGE_SIZE);
+  const lastPageSize = loadedItemsCount % ROWS_RELOAD_PAGE_SIZE;
+
+  const pages: Array<Required<PageOptions>> = [];
+  for (let i = 0; i <= lastPageIndex; i++) {
+    pages.push({
+      start: i * ROWS_RELOAD_PAGE_SIZE,
+      size: i === lastPageIndex ? lastPageSize : ROWS_RELOAD_PAGE_SIZE,
+    });
+  }
+
+  return from(pages).pipe(mergeMap((pageOptions) => from(loadRows(imodel, ruleset, keys, pageOptions, options))));
+}
+
+interface RowsLoadResult {
+  rowDefinitions: TableRowDefinition[];
+  total: number;
+  offset: number;
+}
+
+async function loadRows(
+  imodel: IModelConnection,
+  ruleset: Ruleset | string,
+  keys: Readonly<KeySet>,
+  paging: Required<PageOptions>,
+  options: TableOptions,
+): Promise<RowsLoadResult> {
   const result = await Presentation.presentation.getContentAndSize({
     imodel,
     keys: new KeySet(keys),
@@ -106,12 +220,14 @@ async function loadRows(imodel: IModelConnection, ruleset: Ruleset | string, key
     return {
       rowDefinitions: [],
       total: 0,
+      offset: 0,
     };
   }
 
   return {
     rowDefinitions: createRows(result.content),
     total: result.size,
+    offset: paging.start,
   };
 }
 
@@ -158,3 +274,9 @@ class RowsBuilder extends PropertyRecordsBuilder {
     super.finishItem();
   }
 }
+
+// istanbul ignore next
+const noopRowsLoader: RowsLoader = {
+  loadPage: () => {},
+  reload: () => {},
+};

--- a/packages/components/src/test/propertygrid/DataProvider.test.ts
+++ b/packages/components/src/test/propertygrid/DataProvider.test.ts
@@ -8,9 +8,9 @@ import * as sinon from "sinon";
 import * as moq from "typemoq";
 import { PropertyRecord } from "@itwin/appui-abstract";
 import { PropertyCategory } from "@itwin/components-react";
-import { BeEvent, using } from "@itwin/core-bentley";
+import { BeEvent, BeUiEvent, using } from "@itwin/core-bentley";
 import { EmptyLocalization } from "@itwin/core-common";
-import { IModelConnection } from "@itwin/core-frontend";
+import { FormattingUnitSystemChangedArgs, IModelApp, IModelConnection } from "@itwin/core-frontend";
 import {
   ArrayTypeDescription,
   CategoryDescription,
@@ -84,6 +84,9 @@ describe("PropertyDataProvider", () => {
     sinon.stub(Presentation, "presentation").get(() => presentationManagerMock.object);
     sinon.stub(Presentation, "favoriteProperties").get(() => favoritePropertiesManagerMock.object);
     sinon.stub(Presentation, "localization").get(() => new EmptyLocalization());
+    sinon.stub(IModelApp, "quantityFormatter").get(() => ({
+      onActiveFormattingUnitSystemChanged: new BeUiEvent<FormattingUnitSystemChangedArgs>(),
+    }));
 
     provider = new Provider({ imodel: imodelMock.object, ruleset: rulesetId });
   });

--- a/packages/components/src/test/table/UsePresentationTable.test.tsx
+++ b/packages/components/src/test/table/UsePresentationTable.test.tsx
@@ -7,7 +7,8 @@ import { expect } from "chai";
 import { PropsWithChildren } from "react";
 import sinon from "sinon";
 import * as moq from "typemoq";
-import { IModelConnection } from "@itwin/core-frontend";
+import { BeUiEvent } from "@itwin/core-bentley";
+import { FormattingUnitSystemChangedArgs, IModelApp, IModelConnection } from "@itwin/core-frontend";
 import { Content, KeySet } from "@itwin/presentation-common";
 import { Presentation, PresentationManager, SelectionManager } from "@itwin/presentation-frontend";
 import { waitFor } from "@testing-library/react";
@@ -40,6 +41,9 @@ describe("usePresentationTable", () => {
     const { presentationManager } = mockPresentationManager();
     presentationManagerMock = presentationManager;
     sinon.stub(Presentation, "presentation").get(() => presentationManagerMock.object);
+    sinon.stub(IModelApp, "quantityFormatter").get(() => ({
+      onActiveFormattingUnitSystemChanged: new BeUiEvent<FormattingUnitSystemChangedArgs>(),
+    }));
   });
 
   afterEach(() => {
@@ -103,6 +107,9 @@ describe("usePresentationTableWithUnifiedSelection", () => {
     const { presentationManager } = mockPresentationManager();
     presentationManagerMock = presentationManager;
     sinon.stub(Presentation, "presentation").get(() => presentationManagerMock.object);
+    sinon.stub(IModelApp, "quantityFormatter").get(() => ({
+      onActiveFormattingUnitSystemChanged: new BeUiEvent<FormattingUnitSystemChangedArgs>(),
+    }));
 
     const selectionManager = new SelectionManager({ scopes: undefined as any });
     sinon.stub(Presentation, "selection").get(() => selectionManager);

--- a/packages/testing/src/test/ContentBuilder.test.ts
+++ b/packages/testing/src/test/ContentBuilder.test.ts
@@ -7,9 +7,9 @@ import { expect } from "chai";
 import * as sinon from "sinon";
 import * as moq from "typemoq";
 import { ArrayValue, PrimitiveValue, StructValue } from "@itwin/appui-abstract";
-import { BeEvent, Guid, Id64String } from "@itwin/core-bentley";
+import { BeEvent, BeUiEvent, Guid, Id64String } from "@itwin/core-bentley";
 import { ECSqlReader } from "@itwin/core-common";
-import { IModelConnection } from "@itwin/core-frontend";
+import { FormattingUnitSystemChangedArgs, IModelApp, IModelConnection } from "@itwin/core-frontend";
 import {
   ArrayTypeDescription,
   CategoryDescription,
@@ -242,6 +242,9 @@ describe("ContentBuilder", () => {
       presentationManagerMock.setup(async (manager) => manager.getContent(moq.It.isAny())).returns(getEmptyContent);
       presentationManagerMock.setup((x) => x.onIModelContentChanged).returns(() => new BeEvent());
       sinon.stub(Presentation, "presentation").get(() => presentationManagerMock.object);
+      sinon.stub(IModelApp, "quantityFormatter").get(() => ({
+        onActiveFormattingUnitSystemChanged: new BeUiEvent<FormattingUnitSystemChangedArgs>(),
+      }));
     });
 
     afterEach(() => {


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/93

Reload Tree, Table and PropertyGrid data when active unit system is changed to make sure values format matches the new active unit system.