### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -41,8 +41,8 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm release
-          title: Release packages
-          commit: Release packages [skip actions][publish docs]
+          title: Release packages [skip actions][publish docs]
+          commit: Release packages
         env:
           GITHUB_TOKEN: ${{ secrets.IMJS_ADMIN_GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}


### PR DESCRIPTION
Updates release workflow using changesets to add `[skip actions][publish docs]` to PR title. This should make sure CI workflow is not run after release is merged and docs is tagged for docs site releases.