### PR TITLE
Use correct env variable for npm authorization in release workflow

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -41,11 +41,11 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm release
-          title: Release packages [skip actions][publish docs]
+          title: Release packages [publish docs]
           commit: Release packages
         env:
           GITHUB_TOKEN: ${{ secrets.IMJS_ADMIN_GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}
           GIT_AUTHOR_NAME: imodeljs-admin
           GIT_AUTHOR_EMAIL: imodeljs-admin@users.noreply.github.com
           GIT_COMMITTER_NAME: imodeljs-admin


### PR DESCRIPTION
Using `actions/setup-node` action with `repository-url` creates `.npmrc` file that expect to get npm token from env variable `NODE_AUTH_TOKEN`