### PR TITLE
Add explicit zIndex for tooltip

### DIFF
--- a/.changeset/big-weeks-refuse.md
+++ b/.changeset/big-weeks-refuse.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Fix bug where property tooltip appears to be covered by propertySelector.

--- a/.changeset/big-weeks-refuse.md
+++ b/.changeset/big-weeks-refuse.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-components": patch
 ---
 
-Fix bug where property tooltip appears to be covered by propertySelector.
+Fix property tooltip appearing behind the property selector.

--- a/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterProperty.tsx
+++ b/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterProperty.tsx
@@ -33,7 +33,7 @@ export function PresentationInstanceFilterProperty(props: PresentationInstanceFi
   const { propertyDescription, categoryLabel, fullClassName } = props;
   return (
     <div className="property-item-line">
-      <Tooltip content={propertyDescription.displayLabel} placement="bottom">
+      <Tooltip content={propertyDescription.displayLabel} placement="bottom" zIndex={999999}>
         <div className="property-display-label" title={propertyDescription.displayLabel}>
           {propertyDescription.displayLabel}
         </div>


### PR DESCRIPTION
Added specific `zIndex` property for the tooltip component. 

The `zIndex` value was chosen by checking what is the value of the parent element, which was _99999_, and adding one additional _9_ to it.