### PR TITLE
Add support for formatting dates in property value selector

### DIFF
--- a/.changeset/seven-ducks-warn.md
+++ b/.changeset/seven-ducks-warn.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": minor
+---
+
+Add formatting to dates that are displayed in the property value selector.

--- a/packages/components/src/presentation-components/instance-filter-builder/MultiTagSelect.tsx
+++ b/packages/components/src/presentation-components/instance-filter-builder/MultiTagSelect.tsx
@@ -86,12 +86,12 @@ function TagSelectOption<TOption, IsMulti extends boolean = boolean>({ children:
   const className = classnames("iui-menu-item", {
     "iui-focused": props.isFocused,
     "iui-active": props.isSelected,
-    "presentation-instance-filter-special-property-value": optionLabel === "",
+    "presentation-instance-filter-special-property-value": optionLabel === translate("unique-values-property-editor.empty-value"),
   });
 
   return (
     <components.Option {...props} className={className}>
-      <span>{optionLabel === "" ? translate("unique-values-property-editor.empty-value") : optionLabel}</span>
+      <span>{optionLabel}</span>
       {props.isSelected && (
         <span className="iui-icon" style={{ marginLeft: "auto" }}>
           <SvgCheckmarkSmall />
@@ -139,7 +139,7 @@ function TagLabel<TOption, IsMulti extends boolean = boolean>({ children, ...pro
 
   return (
     <components.MultiValueLabel {...props} innerProps={{ ...props.innerProps, className }}>
-      {children === "" ? translate("unique-values-property-editor.empty-value") : children}
+      {children}
     </components.MultiValueLabel>
   );
 }

--- a/packages/components/src/presentation-components/properties/UniquePropertyValuesSelector.tsx
+++ b/packages/components/src/presentation-components/properties/UniquePropertyValuesSelector.tsx
@@ -7,7 +7,17 @@ import { useCallback, useEffect, useState } from "react";
 import { ActionMeta, MultiValue, Options } from "react-select";
 import { PropertyDescription, PropertyValue, PropertyValueFormat } from "@itwin/appui-abstract";
 import { IModelConnection } from "@itwin/core-frontend";
-import { ContentSpecificationTypes, Descriptor, DisplayValueGroup, Field, FieldDescriptor, KeySet, Ruleset, RuleTypes } from "@itwin/presentation-common";
+import {
+  ContentSpecificationTypes,
+  Descriptor,
+  DisplayValue,
+  DisplayValueGroup,
+  Field,
+  FieldDescriptor,
+  KeySet,
+  Ruleset,
+  RuleTypes,
+} from "@itwin/presentation-common";
 import { Presentation } from "@itwin/presentation-frontend";
 import { deserializeDisplayValueGroupArray, findField, serializeDisplayValueGroupArray, translate } from "../common/Utils";
 import { AsyncMultiTagSelect } from "../instance-filter-builder/MultiTagSelect";
@@ -78,10 +88,26 @@ export function UniquePropertyValuesSelector(props: UniquePropertyValuesSelector
       hideSelectedOptions={false}
       isSearchable={false}
       closeMenuOnSelect={false}
-      getOptionLabel={(option) => option.displayValue!.toString()}
+      getOptionLabel={(option) => formatOptionLabel(option.displayValue, property.typename)}
       getOptionValue={(option) => option.groupedRawValues[0]!.toString()}
     />
   );
+}
+
+function formatOptionLabel(displayValue: DisplayValue, type: string): string {
+  const label = displayValue!.toString();
+  if (label === "") {
+    return translate("unique-values-property-editor.empty-value");
+  }
+
+  switch (type) {
+    case "dateTime":
+      return new Date(label).toLocaleString();
+    case "shortDate":
+      return new Date(label).toLocaleDateString();
+    default:
+      return label;
+  }
 }
 
 function getUniqueValueFromProperty(property: PropertyValue | undefined): DisplayValueGroup[] | undefined {

--- a/packages/components/src/test/instance-filter-builder/MultiTagSelect.test.tsx
+++ b/packages/components/src/test/instance-filter-builder/MultiTagSelect.test.tsx
@@ -4,10 +4,21 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
+import sinon from "sinon";
+import { EmptyLocalization } from "@itwin/core-common";
+import { IModelApp } from "@itwin/core-frontend";
+import { Presentation } from "@itwin/presentation-frontend";
 import { fireEvent, render } from "@testing-library/react";
 import { MultiTagSelect } from "../../presentation-components/instance-filter-builder/MultiTagSelect";
 
 describe("MultiTagSelect", () => {
+  beforeEach(async () => {
+    const localization = new EmptyLocalization();
+    sinon.stub(IModelApp, "initialized").get(() => true);
+    sinon.stub(IModelApp, "localization").get(() => localization);
+    await Presentation.initialize();
+  });
+
   const options = [
     {
       label: "Option1",

--- a/packages/components/src/test/properties/UniquePropertyValuesSelector.test.tsx
+++ b/packages/components/src/test/properties/UniquePropertyValuesSelector.test.tsx
@@ -294,6 +294,83 @@ describe("UniquePropertyValuesSelector", () => {
     await waitFor(() => expect(container.querySelectorAll(".iui-menu-item").length).to.be.equal(1));
   });
 
+  describe("Date formatting", () => {
+    it(`displays date in valid format when typename is 'shortDate'`, async () => {
+      sinon.stub(Presentation.presentation, "getPagedDistinctValues").resolves({
+        total: 1,
+        items: [{ displayValue: "1410-07-15", groupedRawValues: [""] }],
+      });
+      const datePropertyDescription = {
+        name: "#propertyName",
+        displayLabel: "property",
+        typename: "shortDate",
+        editor: undefined,
+      };
+
+      const { queryByText, container, user } = render(
+        <UniquePropertyValuesSelector property={datePropertyDescription} onChange={() => {}} imodel={testImodel} descriptor={descriptor} />,
+      );
+
+      // open menu
+      const selector = await waitFor(() => queryByText("unique-values-property-editor.select-values"));
+      await user.click(selector!);
+
+      // assert that row is displayed correctly
+      const option = await waitFor(() => container.querySelector(".iui-menu-item"));
+      expect(option?.innerHTML.indexOf(new Date("1410-07-15").toLocaleDateString())).to.not.be.equal(-1);
+    });
+
+    it(`displays empty value string when typename is 'dateTime' but date is set as empty string`, async () => {
+      sinon.stub(Presentation.presentation, "getPagedDistinctValues").resolves({
+        total: 1,
+        items: [{ displayValue: "", groupedRawValues: [""] }],
+      });
+      const datePropertyDescription = {
+        name: "#propertyName",
+        displayLabel: "property",
+        typename: "dateTime",
+        editor: undefined,
+      };
+
+      const { queryByText, container, user } = render(
+        <UniquePropertyValuesSelector property={datePropertyDescription} onChange={() => {}} imodel={testImodel} descriptor={descriptor} />,
+      );
+
+      // open menu
+      const selector = await waitFor(() => queryByText("unique-values-property-editor.select-values"));
+      await user.click(selector!);
+
+      // assert that row is displayed correctly
+      const option = await waitFor(() => container.querySelector(".iui-menu-item"));
+      expect(option?.innerHTML.indexOf(translate("unique-values-property-editor.empty-value"))).to.not.be.equal(-1);
+    });
+
+    it(`displays date in valid format when typename is 'dateTime'`, async () => {
+      sinon.stub(Presentation.presentation, "getPagedDistinctValues").resolves({
+        total: 1,
+        items: [{ displayValue: "1410-07-15", groupedRawValues: [""] }],
+      });
+      const datePropertyDescription = {
+        name: "#propertyName",
+        displayLabel: "property",
+        typename: "dateTime",
+        editor: undefined,
+      };
+
+      const { queryByText, container, user } = render(
+        <UniquePropertyValuesSelector property={datePropertyDescription} onChange={() => {}} imodel={testImodel} descriptor={descriptor} />,
+      );
+
+      // open menu
+      const selector = await waitFor(() => queryByText("unique-values-property-editor.select-values"));
+      await user.click(selector!);
+
+      // assert that row is displayed correctly
+      const option = await waitFor(() => container.querySelector(".iui-menu-item"));
+      expect(option?.innerHTML.indexOf(new Date("1410-07-15").toLocaleString())).to.not.be.equal(-1);
+    });
+  });
+
   describe("Ruleset Creation", () => {
     const getSchemaAndClassNameFromRuleset = (ruleset: Ruleset) => {
       expect(ruleset.rules.length).to.be.equal(1);


### PR DESCRIPTION
closes #252 

Besides adding formatting to dates, with this PR the logic of creating labels for the value selector is moved into the `getOptionLabel()` callback,