### PR TITLE
Cancel hilite set request on selection change

### DIFF
--- a/.changeset/dry-scissors-rule.md
+++ b/.changeset/dry-scissors-rule.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": minor
+---
+
+Cancel ongoing hilite set request when unified selection changes.

--- a/.changeset/dry-scissors-rule.md
+++ b/.changeset/dry-scissors-rule.md
@@ -1,5 +1,5 @@
 ---
-"@itwin/presentation-components": minor
+"@itwin/presentation-components": patch
 ---
 
 Cancel ongoing hilite set request when unified selection changes.

--- a/apps/test-app/frontend/package.json
+++ b/apps/test-app/frontend/package.json
@@ -55,6 +55,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-resize-detector": "^8.1.0",
+    "rxjs": "^7.8.1",
     "sass": "^1.66.1",
     "sass-loader": "^13.3.2",
     "style-loader": "^3.3.3",

--- a/packages/components/src/presentation-components/viewport/ViewportSelectionHandler.ts
+++ b/packages/components/src/presentation-components/viewport/ViewportSelectionHandler.ts
@@ -45,6 +45,7 @@ export class ViewportSelectionHandler implements IDisposable {
   }
 
   public dispose() {
+    this._cancelOngoingChanges.next();
     this._selectionHandler.manager.setSyncWithIModelToolSelection(this._imodel, false);
     this._selectionHandler.dispose();
   }

--- a/packages/components/src/presentation-components/viewport/WithUnifiedSelection.tsx
+++ b/packages/components/src/presentation-components/viewport/WithUnifiedSelection.tsx
@@ -37,7 +37,6 @@ export function viewWithUnifiedSelection<P extends ViewportProps>(
     const [viewportSelectionHandler, setViewportSelectionHandler] = useState<ViewportSelectionHandler>();
 
     // apply currentSelection when 'viewportSelectionHandler' is initialized (set to handler from props or new is created)
-    // 'viewportSelectionHandler' should never change because setter is not used.
     useEffect(() => {
       if (selectionHandler) {
         selectionHandler.applyCurrentSelection();

--- a/packages/components/src/presentation-components/viewport/WithUnifiedSelection.tsx
+++ b/packages/components/src/presentation-components/viewport/WithUnifiedSelection.tsx
@@ -34,19 +34,30 @@ export function viewWithUnifiedSelection<P extends ViewportProps>(
   const WithUnifiedSelection = memo<CombinedProps>((props) => {
     const { selectionHandler, ...restProps } = props;
     const imodel = restProps.imodel;
-    const [viewportSelectionHandler] = useState(() => selectionHandler ?? new ViewportSelectionHandler({ imodel }));
+    const [viewportSelectionHandler, setViewportSelectionHandler] = useState<ViewportSelectionHandler>();
 
     // apply currentSelection when 'viewportSelectionHandler' is initialized (set to handler from props or new is created)
     // 'viewportSelectionHandler' should never change because setter is not used.
     useEffect(() => {
-      void viewportSelectionHandler.applyCurrentSelection();
+      if (selectionHandler) {
+        selectionHandler.applyCurrentSelection();
+        setViewportSelectionHandler(selectionHandler);
+        return;
+      }
+
+      const handler = new ViewportSelectionHandler({ imodel });
+      handler.applyCurrentSelection();
+      setViewportSelectionHandler(handler);
       return () => {
-        viewportSelectionHandler.dispose();
+        handler.dispose();
       };
-    }, [viewportSelectionHandler]);
+    }, [selectionHandler, imodel]);
 
     // set new imodel on 'viewportSelectionHandler' when it changes
     useEffect(() => {
+      if (!viewportSelectionHandler) {
+        return;
+      }
       viewportSelectionHandler.imodel = imodel;
     }, [viewportSelectionHandler, imodel]);
 

--- a/packages/components/src/test/viewport/WithUnifiedSelection.test.tsx
+++ b/packages/components/src/test/viewport/WithUnifiedSelection.test.tsx
@@ -55,7 +55,7 @@ describe("Viewport withUnifiedSelection", () => {
     render(<PresentationViewport imodel={imodel} viewDefinitionId={viewDefinitionId} selectionHandler={selectionHandler} />);
   });
 
-  it("creates default ViewportSelectionHandler implementation when not provided through props", () => {
+  it("creates and disposes default ViewportSelectionHandler implementation when not provided through props", () => {
     const selectionChangeEvent = new SelectionChangeEvent();
     const selectionManagerMock = {
       selectionChange: selectionChangeEvent,
@@ -67,10 +67,14 @@ describe("Viewport withUnifiedSelection", () => {
 
     expect(selectionChangeEvent.numberOfListeners).to.be.eq(0);
 
-    render(<PresentationViewport imodel={imodel} viewDefinitionId={viewDefinitionId} />);
+    const { unmount } = render(<PresentationViewport imodel={imodel} viewDefinitionId={viewDefinitionId} />);
 
     // new 'ViewportSelectionHandler' should be listening to selection change event
     expect(selectionChangeEvent.numberOfListeners).to.be.eq(1);
+    unmount();
+
+    // 'ViewportSelectionHandler' should not be listening to selection change event anymore
+    expect(selectionChangeEvent.numberOfListeners).to.be.eq(0);
   });
 
   it("sets ViewportSelectionHandler.imodel property when rendered with new imodel", () => {

--- a/packages/components/src/test/viewport/WithUnifiedSelection.test.tsx
+++ b/packages/components/src/test/viewport/WithUnifiedSelection.test.tsx
@@ -286,7 +286,6 @@ describe("ViewportSelectionHandler", () => {
 
       // trigger the selection change and wait for event handler to finish
       triggerSelectionChange();
-      // await waitForAllAsyncs([handler]);
 
       await waitFor(() => {
         // verify hilite was changed with expected ids
@@ -310,7 +309,6 @@ describe("ViewportSelectionHandler", () => {
 
       // trigger the selection change and wait for event handler to finish
       triggerSelectionChange();
-      // await waitForAllAsyncs([handler]);
 
       await waitFor(() => {
         // verify hilite was changed with expected ids
@@ -334,7 +332,6 @@ describe("ViewportSelectionHandler", () => {
 
       // trigger the selection change and wait for event handler to finish
       triggerSelectionChange();
-      // await waitForAllAsyncs([handler]);
 
       await waitFor(() => {
         // verify hilite was changed with expected ids
@@ -362,7 +359,6 @@ describe("ViewportSelectionHandler", () => {
 
       // trigger the selection change and wait for event handler to finish
       triggerSelectionChange();
-      // await waitForAllAsyncs([handler]);
 
       await waitFor(() => {
         // verify hilite was changed with expected ids

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,6 +438,9 @@ importers:
       react-resize-detector:
         specifier: ^8.1.0
         version: 8.1.0(react-dom@18.2.0)(react@18.2.0)
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.1
       sass:
         specifier: ^1.66.1
         version: 1.66.1
@@ -1203,8 +1206,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.19
     dev: true
 
-  /@artilleryio/int-commons@2.0.2:
-    resolution: {integrity: sha512-IfdHOtprbuoLY8zlfdmJdEn/bt7NEJPTDc9tGjy2ya76uVdarU495E+nGG4PrDnzhDF8R56uUmEW66aRRzEoTA==}
+  /@artilleryio/int-commons@2.0.4:
+    resolution: {integrity: sha512-pi4hkKhpT7pyydH7GxZGWnYM+a2fM1WysCDlKsH7UJTy2xqlqmujd5iY+G/74NHsxQUxd8osAHFu+bnkbjMinw==}
     dependencies:
       async: 2.6.4
       cheerio: 1.0.0-rc.12
@@ -1213,14 +1216,15 @@ packages:
       espree: 9.6.1
       jsonpath-plus: 7.2.0
       lodash: 4.17.21
+      ms: 2.1.3
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@artilleryio/int-core@2.2.0:
-    resolution: {integrity: sha512-cZSSONpntDDwgRQUMe/6BryPiZRNoejT9nRSWsn2EDVqOaOkb4rNcEKuA0PqwGQM8ompBZsLBorf9UmYQ2b3Ow==}
+  /@artilleryio/int-core@2.2.2:
+    resolution: {integrity: sha512-BYbheLZb7m+DrQt2OTM4uaX6IWbjYf/D9ZVi49WW5QdDOTsnWCjOES46iR0lM2hWKf0qF2ESajkDVm1ithvXOw==}
     dependencies:
-      '@artilleryio/int-commons': 2.0.2
+      '@artilleryio/int-commons': 2.0.4
       '@artilleryio/sketches-js': 2.1.1
       agentkeepalive: 4.5.0
       arrivals: 2.1.2
@@ -1264,7 +1268,7 @@ packages:
       '@aws-sdk/credential-providers': 3.395.0
       '@oclif/core': 2.11.8(@types/node@18.17.7)(typescript@5.0.4)
       '@supercharge/promise-pool': 2.4.0
-      artillery-plugin-ensure: 1.2.0
+      artillery-plugin-ensure: 1.3.0
       async: 2.6.4
       aws-sdk: 2.1441.0
       chalk: 2.4.2
@@ -5691,8 +5695,8 @@ packages:
       - supports-color
     dev: false
 
-  /artillery-engine-playwright@1.0.0:
-    resolution: {integrity: sha512-TQo+IgdBSo8NBNuBDU4VLuOIu578o6NrI4I4QMCehVt0j/zS1gDwl6MOrJh9qsS1kwRSELk1W+KbOPPqZpPZ1Q==}
+  /artillery-engine-playwright@1.1.0:
+    resolution: {integrity: sha512-AZrM5FbETHcBBOgBDCCTOkpSBwT6r0LqqSwoZQx/X/fHvBcxintf/OrIK/VFarUH3cCEu3ZiCqoT6j/Ydy5dnA==}
     dependencies:
       '@playwright/browser-chromium': 1.39.0
       debug: 4.3.4(supports-color@8.1.1)
@@ -5705,8 +5709,8 @@ packages:
     resolution: {integrity: sha512-hXYHzkTv3RvapSBuO6YBjIvpsKhngrhBDLfiLuR9NoQhPpOO87K0TAKc9Tt73P36eOH1MOA/D5RCg5Bh1sbH8g==}
     dev: false
 
-  /artillery-plugin-ensure@1.2.0:
-    resolution: {integrity: sha512-o8P8amtnJDO/H7ZQJ/CIhLqsvw3UJaI4nTV7WSNpamQwb2Y8E4dt9r01dhKddzaBX7lwQvbhX5il9buw2NAwrg==}
+  /artillery-plugin-ensure@1.3.0:
+    resolution: {integrity: sha512-+y5Ha5pSsxSwYaeKnn33F8Za7Ol2WcLowzDn8pHiCLwPRPNWmiewDKRffRekqRDpAYHhwgOF0/kWoCwEYjbPAA==}
     dependencies:
       chalk: 2.4.2
       debug: 4.3.4(supports-color@8.1.1)
@@ -5715,8 +5719,8 @@ packages:
       - supports-color
     dev: false
 
-  /artillery-plugin-expect@2.3.2:
-    resolution: {integrity: sha512-LesFFTAZr1ncU0f16h4CCDVXBN9QSrilw8U1uITDV9GXQv2oPPtskFjcLRQTqErTmY+ZqdfQjY55kGcJAD3GbQ==}
+  /artillery-plugin-expect@2.3.3:
+    resolution: {integrity: sha512-vKA3WMjEwEGae29EWoZZjGPWX/hcLc1lRqEl/2xAcQXwDnF7nj2aiqMgeEBlpqr8XqAhbr9teQxblFxlf37yzQ==}
     engines: {node: '>= 14.17.6'}
     dependencies:
       chalk: 4.1.2
@@ -5735,8 +5739,8 @@ packages:
       - supports-color
     dev: false
 
-  /artillery-plugin-publish-metrics@2.8.0:
-    resolution: {integrity: sha512-EqC3S2fNNJeHmxGMblWSP3Cwc/R7EDTo96o2qO0TPWxztasDEJbQgxUgKXSgAY1dadZAZ5TJDrwPPBlQz3xMEQ==}
+  /artillery-plugin-publish-metrics@2.9.0:
+    resolution: {integrity: sha512-IKWoGrBdR5+XQ82W9HYUNuO89f8y4aCDiqFHLVqMYCq4avqS9WsBKr49mCmLV0lhbUWA3qMcVfNZnuTdZLnHew==}
     dependencies:
       '@aws-sdk/client-cloudwatch': 3.395.0
       '@opentelemetry/api': 1.4.1
@@ -5776,20 +5780,20 @@ packages:
     engines: {node: '>= 18.16.1'}
     hasBin: true
     dependencies:
-      '@artilleryio/int-commons': 2.0.2
-      '@artilleryio/int-core': 2.2.0
+      '@artilleryio/int-commons': 2.0.4
+      '@artilleryio/int-core': 2.2.2
       '@artilleryio/platform-fargate': 2.2.0(@types/node@18.17.7)(typescript@5.0.4)
       '@aws-sdk/credential-providers': 3.395.0
       '@oclif/core': 2.11.8(@types/node@18.17.7)(typescript@5.0.4)
       '@oclif/plugin-help': 5.2.17(@types/node@18.17.7)(typescript@5.0.4)
       '@oclif/plugin-not-found': 2.3.37(@types/node@18.17.7)(typescript@5.0.4)
       archiver: 5.3.2
-      artillery-engine-playwright: 1.0.0
+      artillery-engine-playwright: 1.1.0
       artillery-plugin-apdex: 1.0.1
-      artillery-plugin-ensure: 1.2.0
-      artillery-plugin-expect: 2.3.2
+      artillery-plugin-ensure: 1.3.0
+      artillery-plugin-expect: 2.3.3
       artillery-plugin-metrics-by-endpoint: 1.2.0
-      artillery-plugin-publish-metrics: 2.8.0
+      artillery-plugin-publish-metrics: 2.9.0
       async: 2.6.4
       aws-sdk: 2.1441.0
       chalk: 2.4.2


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/329

Use new `getHiliteSetIterator` API to highlight elements on unified selection change. This new implementation cancels ongoing hilite set request when unified selection changes again.