### PR TITLE
Signify Class Selector being Optional in the Filtering Dialog

### DIFF
--- a/.changeset/funny-feet-buy.md
+++ b/.changeset/funny-feet-buy.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Change placeholder value of class selector in `InstanceFilterDialog`.

--- a/packages/components/public/locales/en/PresentationComponents.json
+++ b/packages/components/public/locales/en/PresentationComponents.json
@@ -17,7 +17,8 @@
     "select-instance": "Select element"
   },
   "instance-filter-builder": {
-    "select-class": "Select class...",
+    "select-classes-optional": "Select classes (optional)",
+    "selected-classes": "Selected classes",
     "category": "Category:",
     "class": "Class:",
     "schema": "Schema:",

--- a/packages/components/src/presentation-components/instance-filter-builder/InstanceFilterBuilder.tsx
+++ b/packages/components/src/presentation-components/instance-filter-builder/InstanceFilterBuilder.tsx
@@ -58,7 +58,9 @@ export function InstanceFilterBuilder(props: InstanceFilterBuilderProps) {
         options={options}
         value={selectedOptions}
         inputProps={{
-          placeholder: translate("instance-filter-builder.select-class"),
+          placeholder: selectedClasses.length
+            ? translate("instance-filter-builder.selected-classes")
+            : translate("instance-filter-builder.select-classes-optional"),
         }}
         onChange={(selectedIds) => {
           onSelectedClassesChanged(selectedIds);

--- a/packages/components/src/test/instance-filter-builder/IntanceFilterBuilder.test.tsx
+++ b/packages/components/src/test/instance-filter-builder/IntanceFilterBuilder.test.tsx
@@ -21,6 +21,7 @@ import { SchemaContext } from "@itwin/ecschema-metadata";
 import { ClassInfo, Descriptor, KoqPropertyValueFormatter } from "@itwin/presentation-common";
 import { Presentation } from "@itwin/presentation-frontend";
 import { SchemaMetadataContextProvider } from "../../presentation-components/common/SchemaMetadataContext";
+import { translate } from "../../presentation-components/common/Utils";
 import { ECClassInfo, getIModelMetadataProvider } from "../../presentation-components/instance-filter-builder/ECMetadataProvider";
 import { InstanceFilterBuilder, usePresentationInstanceFilteringProps } from "../../presentation-components/instance-filter-builder/InstanceFilterBuilder";
 import { createTestECClassInfo, stubRaf } from "../_helpers/Common";
@@ -82,6 +83,40 @@ describe("InstanceFilterBuilder", () => {
     fireEvent.click(option);
 
     expect(spy).to.be.calledOnceWith([classInfos[0].id]);
+  });
+
+  it("renders appropriate text in class selector when no class is selected", async () => {
+    const { getByPlaceholderText } = render(
+      <InstanceFilterBuilder
+        classes={classInfos}
+        selectedClasses={[]}
+        properties={[]}
+        onSelectedClassesChanged={() => {}}
+        actions={testActions}
+        rootGroup={testRootGroup}
+        imodel={testImodel}
+        descriptor={testDescriptor}
+      />,
+    );
+
+    await waitFor(() => getByPlaceholderText(translate("instance-filter-builder.select-classes-optional")));
+  });
+
+  it("renders appropriate text in class selector when class is selected", async () => {
+    const { getByPlaceholderText } = render(
+      <InstanceFilterBuilder
+        classes={classInfos}
+        selectedClasses={[createTestECClassInfo()]}
+        properties={[]}
+        onSelectedClassesChanged={() => {}}
+        actions={testActions}
+        rootGroup={testRootGroup}
+        imodel={testImodel}
+        descriptor={testDescriptor}
+      />,
+    );
+
+    await waitFor(() => getByPlaceholderText(translate("instance-filter-builder.selected-classes")));
   });
 
   it("invokes 'onSelectedClassesChanged' when class is deselected", async () => {


### PR DESCRIPTION
This PR adds changes to the placeholder value displayed in class selector of the instance filtering dialog to try and signify that selecting a class is optional.

Also, added extra logic to display different text in class selector based on whether any classes are selected or not.