### PR TITLE
Filter Dialog: retain selected classes information on strict mode rerenders

### DIFF
--- a/.changeset/strange-shoes-cheer.md
+++ b/.changeset/strange-shoes-cheer.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-components": patch
 ---
 
-Add fix for retaining selected class info's in filter dialog when using strict mode
+Fix selected class information in filter dialog not being retained when using React 18 strict mode.

--- a/.changeset/strange-shoes-cheer.md
+++ b/.changeset/strange-shoes-cheer.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Add fix for retaining selected class info's in filter dialog when using strict mode

--- a/packages/components/src/presentation-components/instance-filter-builder/InstanceFilterBuilder.tsx
+++ b/packages/components/src/presentation-components/instance-filter-builder/InstanceFilterBuilder.tsx
@@ -199,12 +199,12 @@ function useActiveClasses({ imodel, availableClasses, initialActiveClasses }: Us
   const [activeClasses, setActiveClasses] = useState<ClassInfo[]>(initialActiveClasses ?? []);
   const [isFilteringClasses, setIsFilteringClasses] = useState(false);
 
-  const firstRender = useRef(true);
+  const availableClassesRef = useRef(availableClasses);
   useEffect(() => {
-    if (!firstRender.current) {
+    if (availableClassesRef.current !== availableClasses) {
       setActiveClasses([]);
+      availableClassesRef.current = availableClasses;
     }
-    firstRender.current = false;
   }, [availableClasses]);
 
   const filterClassesByProperty = useCallback(

--- a/packages/components/src/test/instance-filter-builder/IntanceFilterBuilder.test.tsx
+++ b/packages/components/src/test/instance-filter-builder/IntanceFilterBuilder.test.tsx
@@ -422,6 +422,18 @@ describe("usePresentationInstanceFilteringProps", () => {
     expect(result.current.selectedClasses).to.be.empty;
   });
 
+  it("does not clear selected classes on rerender descriptor does not change", async () => {
+    const { result, rerender } = renderHook((props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.imodel), { initialProps });
+
+    act(() => {
+      result.current.onSelectedClassesChanged([concreteClass1.id]);
+    });
+    await waitFor(() => expect(result.current.selectedClasses).to.have.lengthOf(1).and.to.containSubset([concreteClass1]));
+
+    rerender({ descriptor: initialProps.descriptor, imodel: initialProps.imodel });
+    expect(result.current.selectedClasses).to.have.lengthOf(1).and.to.containSubset([concreteClass1]);
+  });
+
   describe("properties filtering", () => {
     it("returns properties only of selected class", async () => {
       const { result } = renderHook((props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.imodel), { initialProps });

--- a/packages/components/src/test/instance-filter-builder/IntanceFilterBuilder.test.tsx
+++ b/packages/components/src/test/instance-filter-builder/IntanceFilterBuilder.test.tsx
@@ -422,7 +422,7 @@ describe("usePresentationInstanceFilteringProps", () => {
     expect(result.current.selectedClasses).to.be.empty;
   });
 
-  it("does not clear selected classes on rerender descriptor does not change", async () => {
+  it("does not clear selected classes on rerender when descriptor does not change", async () => {
     const { result, rerender } = renderHook((props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.imodel), { initialProps });
 
     act(() => {


### PR DESCRIPTION
Closes #368 

The previous implementation was not working correctly when everything is rendered twice (strict mode).  This fix is not necessary
when strict mode is disabled. 

