### PR TITLE
`PresentationInstanceFilterDialog`: Make API more convienent

### DIFF
--- a/.changeset/green-windows-cry.md
+++ b/.changeset/green-windows-cry.md
@@ -1,0 +1,34 @@
+---
+"@itwin/presentation-components": major
+---
+
+Merged `PresentationInstanceFilterDialogProps.descriptor` and `PresentationInstanceFilterDialogProps.descriptorInputKeys` into single property `PresentationInstanceFilterDialogProps.propertiesSource`. This explicitly associates `Descriptor` with input keys. It provides more convenient API in case `Descriptor` is lazy loaded and input keys are known only after loading.
+
+Before:
+
+```tsx
+const [inputKey, setInputKeys] = useState([]);
+
+<PresentationInstanceFilterDialog
+    descriptor={async () => {
+        const { descriptor, keys } = loadDescriptorAndKeys();
+        setInputKeys(keys);
+        return descriptor;
+    }}
+    descriptorInputKeys={inputKeys}
+/>
+```
+
+After:
+
+```tsx
+<PresentationInstanceFilterDialog
+    propertiesSource={async () => {
+        const { descriptor, keys } = loadDescriptorAndKeys();
+        return {
+            descriptor,
+            inputKeys: keys,
+        };
+    }}
+/>
+```

--- a/packages/components/api/presentation-components.api.md
+++ b/packages/components/api/presentation-components.api.md
@@ -425,8 +425,6 @@ export function PresentationInstanceFilterDialog(props: PresentationInstanceFilt
 
 // @beta
 export interface PresentationInstanceFilterDialogProps {
-    descriptor: (() => Promise<Descriptor>) | Descriptor;
-    descriptorInputKeys?: Keys;
     filterResultsCountRenderer?: (filter: PresentationInstanceFilterInfo) => ReactNode;
     imodel: IModelConnection;
     initialFilter?: PresentationInstanceFilterInfo;
@@ -434,6 +432,8 @@ export interface PresentationInstanceFilterDialogProps {
     onApply: (filter?: PresentationInstanceFilterInfo) => void;
     onClose?: () => void;
     onReset?: () => void;
+    propertiesSource: (() => Promise<PropertiesSource>) | PropertiesSource | undefined;
+    // @deprecated
     ruleGroupDepthLimit?: number;
     title?: React.ReactNode;
     toolbarButtonsRenderer?: (toolbarHandlers: FilteringDialogToolbarHandlers) => ReactNode;
@@ -622,6 +622,12 @@ export function PresentationTreeRenderer(props: PresentationTreeRendererProps): 
 export interface PresentationTreeRendererProps extends Omit<TreeRendererProps, "nodeRenderer"> {
     // (undocumented)
     nodeLoader: AbstractTreeNodeLoaderWithProvider<IPresentationTreeDataProvider>;
+}
+
+// @beta
+export interface PropertiesSource {
+    descriptor: Descriptor;
+    inputKeys?: Keys;
 }
 
 // @public

--- a/packages/components/api/presentation-components.api.md
+++ b/packages/components/api/presentation-components.api.md
@@ -432,7 +432,7 @@ export interface PresentationInstanceFilterDialogProps {
     onApply: (filter?: PresentationInstanceFilterInfo) => void;
     onClose?: () => void;
     onReset?: () => void;
-    propertiesSource: (() => Promise<PropertiesSource>) | PropertiesSource | undefined;
+    propertiesSource: (() => Promise<PresentationInstanceFilterPropertiesSource>) | PresentationInstanceFilterPropertiesSource | undefined;
     // @deprecated
     ruleGroupDepthLimit?: number;
     title?: React.ReactNode;
@@ -443,6 +443,12 @@ export interface PresentationInstanceFilterDialogProps {
 export interface PresentationInstanceFilterInfo {
     filter: PresentationInstanceFilter | undefined;
     usedClasses: ClassInfo[];
+}
+
+// @beta
+export interface PresentationInstanceFilterPropertiesSource {
+    descriptor: Descriptor;
+    inputKeys?: Keys;
 }
 
 // @beta
@@ -622,12 +628,6 @@ export function PresentationTreeRenderer(props: PresentationTreeRendererProps): 
 export interface PresentationTreeRendererProps extends Omit<TreeRendererProps, "nodeRenderer"> {
     // (undocumented)
     nodeLoader: AbstractTreeNodeLoaderWithProvider<IPresentationTreeDataProvider>;
-}
-
-// @beta
-export interface PropertiesSource {
-    descriptor: Descriptor;
-    inputKeys?: Keys;
 }
 
 // @public

--- a/packages/components/api/presentation-components.exports.csv
+++ b/packages/components/api/presentation-components.exports.csv
@@ -53,6 +53,7 @@ beta;PresentationInstanceFilterConditionGroup
 beta;PresentationInstanceFilterDialog(props: PresentationInstanceFilterDialogProps): JSX_2.Element
 beta;PresentationInstanceFilterDialogProps
 beta;PresentationInstanceFilterInfo
+beta;PresentationInstanceFilterPropertiesSource
 beta;PresentationInstanceFilterPropertyInfo
 public;PresentationLabelsProvider 
 public;PresentationLabelsProviderProps
@@ -74,7 +75,6 @@ beta;PresentationTreeNodeRendererProps
 public;PresentationTreeProps
 beta;PresentationTreeRenderer(props: PresentationTreeRendererProps): JSX_2.Element
 beta;PresentationTreeRendererProps 
-beta;PropertiesSource
 public;PropertyDataProviderWithUnifiedSelectionProps
 public;PropertyRecordsBuilder 
 beta;SchemaMetadataContext

--- a/packages/components/api/presentation-components.exports.csv
+++ b/packages/components/api/presentation-components.exports.csv
@@ -74,6 +74,7 @@ beta;PresentationTreeNodeRendererProps
 public;PresentationTreeProps
 beta;PresentationTreeRenderer(props: PresentationTreeRendererProps): JSX_2.Element
 beta;PresentationTreeRendererProps 
+beta;PropertiesSource
 public;PropertyDataProviderWithUnifiedSelectionProps
 public;PropertyRecordsBuilder 
 beta;SchemaMetadataContext

--- a/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterDialog.tsx
+++ b/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterDialog.tsx
@@ -24,7 +24,7 @@ import { filterRuleValidator, isFilterNonEmpty } from "./Utils";
  * Data structure that describes source to gather properties from.
  * @beta
  */
-export interface PropertiesSource {
+export interface PresentationInstanceFilterPropertiesSource {
   /**
    * [Descriptor]($presentation-common) that will be used to get properties.
    */
@@ -59,11 +59,11 @@ export interface PresentationInstanceFilterDialogProps {
   /** Renderer that will be used to render a custom toolbar instead of the default one. */
   toolbarButtonsRenderer?: (toolbarHandlers: FilteringDialogToolbarHandlers) => ReactNode;
   /**
-   * [[PropertiesSource]] that will be used in [[InstanceFilterBuilder]] component to populate properties.
+   * [[PresentationInstanceFilterPropertiesSource]] that will be used in [[InstanceFilterBuilder]] component to populate properties.
    *
-   * This property can be set to function in order to lazy load [[PropertiesSource]] when dialog is opened.
+   * This property can be set to function in order to lazy load [[PresentationInstanceFilterPropertiesSource]] when dialog is opened.
    */
-  propertiesSource: (() => Promise<PropertiesSource>) | PropertiesSource | undefined;
+  propertiesSource: (() => Promise<PresentationInstanceFilterPropertiesSource>) | PresentationInstanceFilterPropertiesSource | undefined;
   /** Renders filter results count. */
   filterResultsCountRenderer?: (filter: PresentationInstanceFilterInfo) => ReactNode;
   /** Dialog title. */
@@ -127,8 +127,10 @@ function FilterDialogContent({ propertiesSource, ...restProps }: FilterDialogCon
   return <LoadedFilterDialogContent {...restProps} descriptor={loadedPropertiesSource.descriptor} descriptorInputKeys={loadedPropertiesSource.inputKeys} />;
 }
 
-function useDelayLoadedPropertiesSource(sourceOrGetter: PropertiesSource | (() => Promise<PropertiesSource>) | undefined): {
-  propertiesSource: PropertiesSource | undefined;
+function useDelayLoadedPropertiesSource(
+  sourceOrGetter: PresentationInstanceFilterPropertiesSource | (() => Promise<PresentationInstanceFilterPropertiesSource>) | undefined,
+): {
+  propertiesSource: PresentationInstanceFilterPropertiesSource | undefined;
   isLoading: boolean;
 } {
   const [{ source, isLoading }, setState] = useState(() =>

--- a/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterDialog.tsx
+++ b/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterDialog.tsx
@@ -21,13 +21,32 @@ import { PresentationInstanceFilter } from "./PresentationInstanceFilter";
 import { filterRuleValidator, isFilterNonEmpty } from "./Utils";
 
 /**
+ * Data structure that describes source to gather properties from.
+ * @beta
+ */
+export interface PropertiesSource {
+  /**
+   * [Descriptor]($presentation-common) that will be used to get properties.
+   */
+  descriptor: Descriptor;
+  /**
+   * [Keys]($presentation-common) of filterables on which the filter was called.
+   * These keys should match the keys that were used to create the descriptor.
+   */
+  inputKeys?: Keys;
+}
+
+/**
  * Props for [[PresentationInstanceFilterDialog]] component.
  * @beta
  */
 export interface PresentationInstanceFilterDialogProps {
   /** iModel connection to pull data from. */
   imodel: IModelConnection;
-  /** Specifies how deep rule groups can be nested. */
+  /**
+   * Specifies how deep rule groups can be nested.
+   * @deprecated in 5.0. Rule groups nesting was removed from [PropertyFilterBuilderRenderer]($components-react)
+   */
   ruleGroupDepthLimit?: number;
   /** Specifies whether dialog is open or not. */
   isOpen: boolean;
@@ -40,19 +59,13 @@ export interface PresentationInstanceFilterDialogProps {
   /** Renderer that will be used to render a custom toolbar instead of the default one. */
   toolbarButtonsRenderer?: (toolbarHandlers: FilteringDialogToolbarHandlers) => ReactNode;
   /**
-   * [Descriptor]($presentation-common) that will be used in [[InstanceFilterBuilder]] component rendered inside this dialog.
+   * [[PropertiesSource]] that will be used in [[InstanceFilterBuilder]] component to populate properties.
    *
-   * This property can be set to function in order to lazy load [Descriptor]($presentation-common) when dialog is opened.
+   * This property can be set to function in order to lazy load [[PropertiesSource]] when dialog is opened.
    */
-  descriptor: (() => Promise<Descriptor>) | Descriptor;
+  propertiesSource: (() => Promise<PropertiesSource>) | PropertiesSource | undefined;
   /** Renders filter results count. */
   filterResultsCountRenderer?: (filter: PresentationInstanceFilterInfo) => ReactNode;
-  /**
-   * [Keys]($presentation-common) of filterables on which the filter was called.
-   *
-   * These keys should match the keys that were used to create the descriptor.
-   */
-  descriptorInputKeys?: Keys;
   /** Dialog title. */
   title?: React.ReactNode;
   /** Initial filter that will be show when component is mounted. */
@@ -101,70 +114,82 @@ export function PresentationInstanceFilterDialog(props: PresentationInstanceFilt
 
 type FilterDialogContentProps = Omit<PresentationInstanceFilterDialogProps, "isOpen" | "title">;
 
-function FilterDialogContent({ descriptor, ...restProps }: FilterDialogContentProps) {
-  const loadedDescriptor = useDelayLoadedDescriptor(descriptor);
-  if (!loadedDescriptor) {
+function FilterDialogContent({ propertiesSource, ...restProps }: FilterDialogContentProps) {
+  const { propertiesSource: loadedPropertiesSource, isLoading } = useDelayLoadedPropertiesSource(propertiesSource);
+  if (isLoading) {
     return <DelayedCenteredProgressRadial />;
   }
 
-  return <LoadedFilterDialogContent {...restProps} descriptor={loadedDescriptor} />;
+  if (!loadedPropertiesSource) {
+    return null;
+  }
+
+  return <LoadedFilterDialogContent {...restProps} descriptor={loadedPropertiesSource.descriptor} descriptorInputKeys={loadedPropertiesSource.inputKeys} />;
 }
 
-function useDelayLoadedDescriptor(descriptorOrGetter: Descriptor | (() => Promise<Descriptor>)) {
-  const [descriptor, setDescriptor] = useState<Descriptor | undefined>(() => (descriptorOrGetter instanceof Descriptor ? descriptorOrGetter : undefined));
+function useDelayLoadedPropertiesSource(sourceOrGetter: PropertiesSource | (() => Promise<PropertiesSource>) | undefined): {
+  propertiesSource: PropertiesSource | undefined;
+  isLoading: boolean;
+} {
+  const [{ source, isLoading }, setState] = useState(() =>
+    typeof sourceOrGetter === "function"
+      ? {
+          source: undefined,
+          isLoading: false,
+        }
+      : {
+          source: sourceOrGetter,
+          isLoading: false,
+        },
+  );
 
   useEffect(() => {
     let disposed = false;
 
-    if (descriptorOrGetter instanceof Descriptor) {
-      setDescriptor(descriptorOrGetter);
-    } else {
-      const updateState = (...params: Parameters<typeof setDescriptor>) => {
-        // istanbul ignore else
-        if (!disposed) {
-          setDescriptor(...params);
-        }
-      };
-
-      void (async () => {
-        try {
-          const newDescriptor = await descriptorOrGetter();
-          updateState(newDescriptor);
-        } catch (error) {
-          updateState(() => {
-            // throw error in setSate callback for it to be caught by ErrorBoundary
-            throw error;
-          });
-        }
-      })();
+    if (typeof sourceOrGetter !== "function") {
+      setState({ source: sourceOrGetter, isLoading: false });
+      return;
     }
+
+    const updateState = (...params: Parameters<typeof setState>) => {
+      // istanbul ignore else
+      if (!disposed) {
+        setState(...params);
+      }
+    };
+
+    updateState({ source: undefined, isLoading: true });
+
+    void (async () => {
+      try {
+        const newDescriptor = await sourceOrGetter();
+        updateState({
+          source: newDescriptor,
+          isLoading: false,
+        });
+      } catch (error) {
+        updateState(() => {
+          // throw error in setSate callback for it to be caught by ErrorBoundary
+          throw error;
+        });
+      }
+    })();
 
     return () => {
       disposed = true;
     };
-  }, [descriptorOrGetter]);
+  }, [sourceOrGetter]);
 
-  return descriptor;
+  return { propertiesSource: source, isLoading };
 }
 
-interface LoadedFilterDialogContentProps extends Omit<PresentationInstanceFilterDialogProps, "isOpen" | "title" | "descriptor"> {
+interface LoadedFilterDialogContentProps extends Omit<PresentationInstanceFilterDialogProps, "isOpen" | "title" | "propertiesSource"> {
   descriptor: Descriptor;
   descriptorInputKeys?: Keys;
 }
 
 function LoadedFilterDialogContent(props: LoadedFilterDialogContentProps) {
-  const {
-    initialFilter,
-    descriptor,
-    imodel,
-    ruleGroupDepthLimit,
-    filterResultsCountRenderer,
-    descriptorInputKeys,
-    onApply,
-    onReset,
-    onClose,
-    toolbarButtonsRenderer,
-  } = props;
+  const { initialFilter, descriptor, imodel, filterResultsCountRenderer, descriptorInputKeys, onApply, onReset, onClose, toolbarButtonsRenderer } = props;
   const [initialPropertyFilter] = useState(() => {
     if (!initialFilter?.filter) {
       return undefined;
@@ -232,7 +257,6 @@ function LoadedFilterDialogContent(props: LoadedFilterDialogContentProps) {
           onSelectedClassesChanged={onSelectedClassesChanged}
           rootGroup={rootGroup}
           actions={actions}
-          ruleGroupDepthLimit={ruleGroupDepthLimit}
           imodel={imodel}
           descriptor={descriptor}
           descriptorInputKeys={descriptorInputKeys}

--- a/packages/components/src/presentation-components/tree/controlled/PresentationTreeRenderer.tsx
+++ b/packages/components/src/presentation-components/tree/controlled/PresentationTreeRenderer.tsx
@@ -120,17 +120,33 @@ interface TreeNodeFilterBuilderDialogProps {
 function TreeNodeFilterBuilderDialog(props: TreeNodeFilterBuilderDialogProps) {
   const { filterNode, dataProvider, ...restProps } = props;
   const filteringInfo = filterNode.filtering;
-  const descriptorInputKeys = useMemo(() => [filterNode.key], [filterNode.key]);
   const imodel = dataProvider.imodel;
+
+  const propertiesSource = useMemo(() => {
+    if (typeof filteringInfo.descriptor === "function") {
+      const descriptorGetter = filteringInfo.descriptor;
+      return async () => {
+        const descriptor = await descriptorGetter();
+        return {
+          descriptor,
+          inputKeys: [filterNode.key],
+        };
+      };
+    }
+
+    return {
+      descriptor: filteringInfo.descriptor,
+      inputKeys: [filterNode.key],
+    };
+  }, [filteringInfo.descriptor, filterNode.key]);
 
   return (
     <PresentationInstanceFilterDialog
       {...restProps}
       isOpen={true}
       imodel={imodel}
-      descriptor={filteringInfo.descriptor}
+      propertiesSource={propertiesSource}
       initialFilter={filteringInfo.active}
-      descriptorInputKeys={descriptorInputKeys}
       filterResultsCountRenderer={(filter) => <MatchingInstancesCount dataProvider={dataProvider} filter={filter} parentKey={filterNode.key} />}
     />
   );

--- a/packages/components/src/test/instance-filter-builder/PresentationInstanceFilterDialog.test.tsx
+++ b/packages/components/src/test/instance-filter-builder/PresentationInstanceFilterDialog.test.tsx
@@ -15,7 +15,10 @@ import { translate } from "../../presentation-components/common/Utils";
 import { ECClassInfo, getIModelMetadataProvider } from "../../presentation-components/instance-filter-builder/ECMetadataProvider";
 import { PresentationInstanceFilterInfo } from "../../presentation-components/instance-filter-builder/PresentationFilterBuilder";
 import { PresentationInstanceFilter } from "../../presentation-components/instance-filter-builder/PresentationInstanceFilter";
-import { PresentationInstanceFilterDialog, PropertiesSource } from "../../presentation-components/instance-filter-builder/PresentationInstanceFilterDialog";
+import {
+  PresentationInstanceFilterDialog,
+  PresentationInstanceFilterPropertiesSource,
+} from "../../presentation-components/instance-filter-builder/PresentationInstanceFilterDialog";
 import { createTestECClassInfo, stubDOMMatrix, stubRaf } from "../_helpers/Common";
 import { createTestCategoryDescription, createTestContentDescriptor, createTestPropertiesContentField } from "../_helpers/Content";
 import { ResolvablePromise } from "../_helpers/Promises";
@@ -406,9 +409,9 @@ describe("PresentationInstanceFilterDialog", () => {
   });
 
   it("renders spinner while loading descriptor", async () => {
-    const propertieSourcePromise = new ResolvablePromise<PropertiesSource>();
+    const propertiesSourcePromise = new ResolvablePromise<PresentationInstanceFilterPropertiesSource>();
     // simulate long loading descriptor
-    const propertiesSourceGetter = async () => propertieSourcePromise;
+    const propertiesSourceGetter = async () => propertiesSourcePromise;
 
     const { container } = render(
       <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSourceGetter} onApply={() => {}} isOpen={true} />,
@@ -420,7 +423,7 @@ describe("PresentationInstanceFilterDialog", () => {
     await waitFor(() => {
       expect(container.querySelector(".presentation-instance-filter-dialog-progress")).to.not.be.null;
     });
-    await propertieSourcePromise.resolve(propertiesSource);
+    await propertiesSourcePromise.resolve(propertiesSource);
 
     await waitFor(() => {
       expect(container.querySelector(".presentation-instance-filter-dialog-progress")).to.be.null;

--- a/packages/components/src/test/instance-filter-builder/PresentationInstanceFilterDialog.test.tsx
+++ b/packages/components/src/test/instance-filter-builder/PresentationInstanceFilterDialog.test.tsx
@@ -10,15 +10,15 @@ import { UiComponents } from "@itwin/components-react";
 import { BeEvent } from "@itwin/core-bentley";
 import { EmptyLocalization } from "@itwin/core-common";
 import { IModelApp, IModelConnection } from "@itwin/core-frontend";
-import { Descriptor } from "@itwin/presentation-common";
 import { Presentation } from "@itwin/presentation-frontend";
 import { translate } from "../../presentation-components/common/Utils";
 import { ECClassInfo, getIModelMetadataProvider } from "../../presentation-components/instance-filter-builder/ECMetadataProvider";
 import { PresentationInstanceFilterInfo } from "../../presentation-components/instance-filter-builder/PresentationFilterBuilder";
 import { PresentationInstanceFilter } from "../../presentation-components/instance-filter-builder/PresentationInstanceFilter";
-import { PresentationInstanceFilterDialog } from "../../presentation-components/instance-filter-builder/PresentationInstanceFilterDialog";
+import { PresentationInstanceFilterDialog, PropertiesSource } from "../../presentation-components/instance-filter-builder/PresentationInstanceFilterDialog";
 import { createTestECClassInfo, stubDOMMatrix, stubRaf } from "../_helpers/Common";
 import { createTestCategoryDescription, createTestContentDescriptor, createTestPropertiesContentField } from "../_helpers/Content";
+import { ResolvablePromise } from "../_helpers/Promises";
 import { render, waitFor, waitForElement } from "../TestUtils";
 
 describe("PresentationInstanceFilterDialog", () => {
@@ -37,6 +37,11 @@ describe("PresentationInstanceFilterDialog", () => {
     categories: [category],
     fields: [stringField],
   });
+
+  const propertiesSource = {
+    descriptor,
+  };
+
   const initialFilter: PresentationInstanceFilterInfo = {
     filter: {
       field: stringField,
@@ -75,7 +80,7 @@ describe("PresentationInstanceFilterDialog", () => {
 
   it("displays warning message on class selector opening if filtering rules are set ", async () => {
     const { container, getByTitle, queryByDisplayValue, user, queryByText, getByPlaceholderText } = render(
-      <PresentationInstanceFilterDialog imodel={imodel} descriptor={descriptor} onApply={() => {}} isOpen={true} />,
+      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={() => {}} isOpen={true} />,
       {
         addThemeProvider: true,
       },
@@ -101,7 +106,7 @@ describe("PresentationInstanceFilterDialog", () => {
 
   it("hides warning message when class selection dropdown is hidden ", async () => {
     const { container, getByTitle, queryByDisplayValue, user, queryByText, getByPlaceholderText, getByTestId } = render(
-      <PresentationInstanceFilterDialog imodel={imodel} descriptor={descriptor} onApply={() => {}} isOpen={true} />,
+      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={() => {}} isOpen={true} />,
       {
         addThemeProvider: true,
       },
@@ -135,7 +140,7 @@ describe("PresentationInstanceFilterDialog", () => {
 
   it("clears all filtering options on class list changing ", async () => {
     const { container, getByTitle, user, queryByDisplayValue, getByPlaceholderText } = render(
-      <PresentationInstanceFilterDialog imodel={imodel} descriptor={descriptor} onApply={() => {}} isOpen={true} />,
+      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={() => {}} isOpen={true} />,
       {
         addThemeProvider: true,
       },
@@ -167,7 +172,7 @@ describe("PresentationInstanceFilterDialog", () => {
   it("invokes 'onApply' with string property filter rule", async () => {
     const spy = sinon.spy();
     const { container, getByTitle, queryByDisplayValue, user } = render(
-      <PresentationInstanceFilterDialog imodel={imodel} descriptor={descriptor} onApply={spy} isOpen={true} />,
+      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />,
       {
         addThemeProvider: true,
       },
@@ -207,9 +212,12 @@ describe("PresentationInstanceFilterDialog", () => {
 
   it("does not invoke `onApply` when there two empty rules", async () => {
     const spy = sinon.spy();
-    const { container, user, getByText } = render(<PresentationInstanceFilterDialog imodel={imodel} descriptor={descriptor} onApply={spy} isOpen={true} />, {
-      addThemeProvider: true,
-    });
+    const { container, user, getByText } = render(
+      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />,
+      {
+        addThemeProvider: true,
+      },
+    );
 
     await user.click(getByText(/filterBuilder.add/));
 
@@ -221,9 +229,12 @@ describe("PresentationInstanceFilterDialog", () => {
 
   it("does not invoke `onApply` when filter is invalid", async () => {
     const spy = sinon.spy();
-    const { container, getByTitle, user } = render(<PresentationInstanceFilterDialog imodel={imodel} descriptor={descriptor} onApply={spy} isOpen={true} />, {
-      addThemeProvider: true,
-    });
+    const { container, getByTitle, user } = render(
+      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />,
+      {
+        addThemeProvider: true,
+      },
+    );
 
     // open property selector
     const propertySelector = await getRulePropertySelector(container);
@@ -239,7 +250,7 @@ describe("PresentationInstanceFilterDialog", () => {
 
   it("invokes `onApply` when there are no items selected", async () => {
     const spy = sinon.spy();
-    const { container, user } = render(<PresentationInstanceFilterDialog imodel={imodel} descriptor={descriptor} onApply={spy} isOpen={true} />, {
+    const { container, user } = render(<PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />, {
       addThemeProvider: true,
     });
 
@@ -252,7 +263,7 @@ describe("PresentationInstanceFilterDialog", () => {
   it("invokes `onApply` with only selected classes", async () => {
     const spy = sinon.spy();
     const { container, getByRole, getByPlaceholderText, user } = render(
-      <PresentationInstanceFilterDialog imodel={imodel} descriptor={descriptor} onApply={spy} isOpen={true} />,
+      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />,
       {
         addThemeProvider: true,
       },
@@ -275,7 +286,7 @@ describe("PresentationInstanceFilterDialog", () => {
   it("invokes `onReset` when reset is clicked.", async () => {
     const spy = sinon.spy();
     const { container, user } = render(
-      <PresentationInstanceFilterDialog imodel={imodel} descriptor={descriptor} onReset={spy} onApply={() => {}} isOpen={true} />,
+      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onReset={spy} onApply={() => {}} isOpen={true} />,
       {
         addThemeProvider: true,
       },
@@ -291,7 +302,7 @@ describe("PresentationInstanceFilterDialog", () => {
     const fromComponentsPropertyFilterStub = sinon.stub(PresentationInstanceFilter, "fromComponentsPropertyFilter").throws(new Error("Some Error"));
     const spy = sinon.spy();
     const { container, getByText, queryByText, user, getByTitle } = render(
-      <PresentationInstanceFilterDialog imodel={imodel} descriptor={descriptor} onApply={spy} isOpen={true} />,
+      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />,
       {
         addThemeProvider: true,
       },
@@ -324,7 +335,7 @@ describe("PresentationInstanceFilterDialog", () => {
     const { queryByText } = render(
       <PresentationInstanceFilterDialog
         imodel={imodel}
-        descriptor={descriptor}
+        propertiesSource={propertiesSource}
         title={<div>{title}</div>}
         onApply={spy}
         isOpen={true}
@@ -339,7 +350,7 @@ describe("PresentationInstanceFilterDialog", () => {
     const { queryByText } = render(
       <PresentationInstanceFilterDialog
         imodel={imodel}
-        descriptor={descriptor}
+        propertiesSource={propertiesSource}
         onApply={() => {}}
         isOpen={true}
         initialFilter={initialFilter}
@@ -354,20 +365,22 @@ describe("PresentationInstanceFilterDialog", () => {
   });
 
   it("renders error boundary if error is thrown", async () => {
-    const descriptorGetter = async () => {
+    const propertiesSourceGetter = async () => {
       throw new Error("Cannot load descriptor");
     };
 
-    const { queryByText } = render(<PresentationInstanceFilterDialog imodel={imodel} descriptor={descriptorGetter} onApply={() => {}} isOpen={true} />);
+    const { queryByText } = render(
+      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSourceGetter} onApply={() => {}} isOpen={true} />,
+    );
 
     await waitFor(() => expect(queryByText("general.error")).to.not.be.null);
   });
 
   it("renders with lazy-loaded descriptor", async () => {
     const spy = sinon.spy();
-    const descriptorGetter = async () => descriptor;
+    const propertiesSourceGetter = async () => ({ descriptor });
 
-    const { container } = render(<PresentationInstanceFilterDialog imodel={imodel} descriptor={descriptorGetter} onApply={spy} isOpen={true} />, {
+    const { container } = render(<PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSourceGetter} onApply={spy} isOpen={true} />, {
       addThemeProvider: true,
     });
 
@@ -382,7 +395,7 @@ describe("PresentationInstanceFilterDialog", () => {
     const { queryByText } = render(
       <PresentationInstanceFilterDialog
         imodel={imodel}
-        descriptor={descriptor}
+        propertiesSource={propertiesSource}
         onApply={() => {}}
         isOpen={true}
         toolbarButtonsRenderer={toolbarButtonsRenderer}
@@ -393,15 +406,24 @@ describe("PresentationInstanceFilterDialog", () => {
   });
 
   it("renders spinner while loading descriptor", async () => {
+    const propertieSourcePromise = new ResolvablePromise<PropertiesSource>();
     // simulate long loading descriptor
-    const descriptorGetter = async () => undefined as unknown as Descriptor;
+    const propertiesSourceGetter = async () => propertieSourcePromise;
 
-    const { container } = render(<PresentationInstanceFilterDialog imodel={imodel} descriptor={descriptorGetter} onApply={() => {}} isOpen={true} />, {
-      addThemeProvider: true,
-    });
+    const { container } = render(
+      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSourceGetter} onApply={() => {}} isOpen={true} />,
+      {
+        addThemeProvider: true,
+      },
+    );
 
     await waitFor(() => {
       expect(container.querySelector(".presentation-instance-filter-dialog-progress")).to.not.be.null;
+    });
+    await propertieSourcePromise.resolve(propertiesSource);
+
+    await waitFor(() => {
+      expect(container.querySelector(".presentation-instance-filter-dialog-progress")).to.be.null;
     });
   });
 


### PR DESCRIPTION
Updated `PresentationInstanceFilterDialogProps` to make `PresentationInstanceFilterDialog` more convenient to use in case input keys are not now before loading `Descriptore`.