### PR TITLE
[core-interop]: Returns input keys with hierarchy level descriptor

### DIFF
--- a/packages/core-interop/api/presentation-core-interop.api.md
+++ b/packages/core-interop/api/presentation-core-interop.api.md
@@ -25,7 +25,10 @@ import { UnitSystemKey } from '@itwin/core-quantity';
 export function createECSqlQueryExecutor(imodel: ICoreECSqlReaderFactory): IECSqlQueryExecutor;
 
 // @beta
-export function createHierarchyLevelDescriptor<TIModel extends ICoreECSqlReaderFactory>(props: CreateHierarchyLevelDescriptorProps<TIModel>): Promise<Descriptor | undefined>;
+export function createHierarchyLevelDescriptor<TIModel extends ICoreECSqlReaderFactory>(props: CreateHierarchyLevelDescriptorProps<TIModel>): Promise<{
+    descriptor: Descriptor;
+    inputKeys: KeySet;
+} | undefined>;
 
 // @beta
 export interface CreateHierarchyLevelDescriptorProps<TIModel extends ICoreECSqlReaderFactory> {

--- a/packages/core-interop/api/presentation-core-interop.api.md
+++ b/packages/core-interop/api/presentation-core-interop.api.md
@@ -25,10 +25,7 @@ import { UnitSystemKey } from '@itwin/core-quantity';
 export function createECSqlQueryExecutor(imodel: ICoreECSqlReaderFactory): IECSqlQueryExecutor;
 
 // @beta
-export function createHierarchyLevelDescriptor<TIModel extends ICoreECSqlReaderFactory>(props: CreateHierarchyLevelDescriptorProps<TIModel>): Promise<{
-    descriptor: Descriptor;
-    inputKeys: KeySet;
-} | undefined>;
+export function createHierarchyLevelDescriptor<TIModel extends ICoreECSqlReaderFactory>(props: CreateHierarchyLevelDescriptorProps<TIModel>): Promise<CreateHierarchyLevelDescriptorResult | undefined>;
 
 // @beta
 export interface CreateHierarchyLevelDescriptorProps<TIModel extends ICoreECSqlReaderFactory> {
@@ -40,6 +37,12 @@ export interface CreateHierarchyLevelDescriptorProps<TIModel extends ICoreECSqlR
     parentNode: (Omit<HierarchyNode, "children"> & {
         key: InstancesNodeKey | string;
     }) | undefined;
+}
+
+// @beta
+export interface CreateHierarchyLevelDescriptorResult {
+    descriptor: Descriptor;
+    inputKeys: KeySet;
 }
 
 // @beta

--- a/packages/core-interop/api/presentation-core-interop.exports.csv
+++ b/packages/core-interop/api/presentation-core-interop.exports.csv
@@ -1,7 +1,9 @@
 sep=;
 Release Tag;API Item
 beta;createECSqlQueryExecutor(imodel: ICoreECSqlReaderFactory): IECSqlQueryExecutor
+beta;createHierarchyLevelDescriptor
 beta;CreateHierarchyLevelDescriptorProps
+beta;CreateHierarchyLevelDescriptorResult
 beta;createLogger(): ILogger
 beta;createMetadataProvider(schemaContext: SchemaContext): IMetadataProvider
 beta;createValueFormatter(schemaContext: SchemaContext, unitSystem?: UnitSystemKey, baseFormatter?: IPrimitiveValueFormatter): IPrimitiveValueFormatter

--- a/packages/core-interop/api/presentation-core-interop.exports.csv
+++ b/packages/core-interop/api/presentation-core-interop.exports.csv
@@ -1,7 +1,6 @@
 sep=;
 Release Tag;API Item
 beta;createECSqlQueryExecutor(imodel: ICoreECSqlReaderFactory): IECSqlQueryExecutor
-beta;createHierarchyLevelDescriptor
 beta;CreateHierarchyLevelDescriptorProps
 beta;createLogger(): ILogger
 beta;createMetadataProvider(schemaContext: SchemaContext): IMetadataProvider

--- a/packages/core-interop/src/core-interop/HierarchyLevelDescriptor.ts
+++ b/packages/core-interop/src/core-interop/HierarchyLevelDescriptor.ts
@@ -51,6 +51,17 @@ export interface CreateHierarchyLevelDescriptorProps<TIModel extends ICoreECSqlR
 }
 
 /**
+ * Result of [[createHierarchyLevelDescriptor]].
+ * @beta
+ */
+export interface CreateHierarchyLevelDescriptorResult {
+  /** Child hierarchy level [[Descriptor]]. */
+  descriptor: Descriptor;
+  /** Input keys used to create [[Descriptor]]. */
+  inputKeys: KeySet;
+}
+
+/**
  * Creates a [[Descriptor]] for the child hierarchy level based on given parent node and hierarchy definitions factory. The descriptor
  * contains metadata about the hierarchy level and can be used to create a filtering dialog.
  *
@@ -61,7 +72,7 @@ export interface CreateHierarchyLevelDescriptorProps<TIModel extends ICoreECSqlR
  */
 export async function createHierarchyLevelDescriptor<TIModel extends ICoreECSqlReaderFactory>(
   props: CreateHierarchyLevelDescriptorProps<TIModel>,
-): Promise<{ descriptor: Descriptor; inputKeys: KeySet } | undefined> {
+): Promise<CreateHierarchyLevelDescriptorResult | undefined> {
   // convert instance keys stream into a KeySet
   const keys = new KeySet();
   await recursivelyGetInstanceKeys(props.parentNode, props.hierarchyProvider).forEach((key) => keys.add(key));

--- a/packages/core-interop/src/core-interop/HierarchyLevelDescriptor.ts
+++ b/packages/core-interop/src/core-interop/HierarchyLevelDescriptor.ts
@@ -61,7 +61,7 @@ export interface CreateHierarchyLevelDescriptorProps<TIModel extends ICoreECSqlR
  */
 export async function createHierarchyLevelDescriptor<TIModel extends ICoreECSqlReaderFactory>(
   props: CreateHierarchyLevelDescriptorProps<TIModel>,
-): Promise<Descriptor | undefined> {
+): Promise<{ descriptor: Descriptor; inputKeys: KeySet } | undefined> {
   // convert instance keys stream into a KeySet
   const keys = new KeySet();
   await recursivelyGetInstanceKeys(props.parentNode, props.hierarchyProvider).forEach((key) => keys.add(key));
@@ -86,7 +86,7 @@ export async function createHierarchyLevelDescriptor<TIModel extends ICoreECSqlR
     keys,
     displayType: DefaultContentDisplayTypes.PropertyPane,
   });
-  return descriptor ? new Descriptor({ ...descriptor, ruleset }) : undefined;
+  return descriptor ? { descriptor: new Descriptor({ ...descriptor, ruleset }), inputKeys: keys } : undefined;
 }
 
 function recursivelyGetInstanceKeys(

--- a/packages/core-interop/src/test/HierarchyLevelDescriptor.test.ts
+++ b/packages/core-interop/src/test/HierarchyLevelDescriptor.test.ts
@@ -44,7 +44,7 @@ describe("createHierarchyLevelDescriptor", () => {
     const descriptorBuilder = {
       getContentDescriptor: sinon.stub().resolves(undefined),
     };
-    const descriptor = await createHierarchyLevelDescriptor({
+    const result = await createHierarchyLevelDescriptor({
       imodel: {} as any,
       hierarchyProvider,
       descriptorBuilder,
@@ -61,7 +61,7 @@ describe("createHierarchyLevelDescriptor", () => {
         return props.keys.isEmpty;
       }),
     );
-    expect(descriptor).to.be.undefined;
+    expect(result).to.be.undefined;
   });
 
   it("requests descriptor for hierarchy level instances", async () => {
@@ -105,7 +105,7 @@ describe("createHierarchyLevelDescriptor", () => {
     };
     const imodel = {} as any;
     const parentNode = {} as HierarchyNode & { key: InstancesNodeKey };
-    const descriptor = await createHierarchyLevelDescriptor({
+    const result = await createHierarchyLevelDescriptor({
       imodel,
       hierarchyProvider,
       descriptorBuilder,
@@ -133,8 +133,14 @@ describe("createHierarchyLevelDescriptor", () => {
         );
       }),
     );
-    expect(descriptor).to.be.instanceOf(Descriptor);
-    expect(descriptor?.ruleset).to.eq(descriptorBuilder.getContentDescriptor.firstCall.args[0].rulesetOrId);
+    expect(result?.descriptor).to.be.instanceOf(Descriptor);
+    expect(result?.descriptor.ruleset).to.eq(descriptorBuilder.getContentDescriptor.firstCall.args[0].rulesetOrId);
+    expect(
+      result?.inputKeys.hasAll([
+        { className: "schema.class1", id: "0x123" },
+        { className: "schema.class2", id: "0x456" },
+      ]),
+    ).to.be.true;
   });
 
   it("requests descriptor for hierarchy level instances with hidden intermediate hierarchy levels", async () => {
@@ -183,7 +189,7 @@ describe("createHierarchyLevelDescriptor", () => {
       getContentDescriptor: sinon.stub().resolves(descriptorResponse),
     };
     const imodel = {} as any;
-    const descriptor = await createHierarchyLevelDescriptor({
+    const result = await createHierarchyLevelDescriptor({
       imodel,
       hierarchyProvider,
       descriptorBuilder,
@@ -214,8 +220,9 @@ describe("createHierarchyLevelDescriptor", () => {
         );
       }),
     );
-    expect(descriptor).to.be.instanceOf(Descriptor);
-    expect(descriptor?.ruleset).to.eq(descriptorBuilder.getContentDescriptor.firstCall.args[0].rulesetOrId);
+    expect(result?.descriptor).to.be.instanceOf(Descriptor);
+    expect(result?.descriptor.ruleset).to.eq(descriptorBuilder.getContentDescriptor.firstCall.args[0].rulesetOrId);
+    expect(result?.inputKeys.hasAll([{ className: "schema.class2", id: "0x999" }])).to.be.true;
   });
 
   it("merges instance keys of hidden hierarchy levels by class when requesting child instance keys", async () => {
@@ -273,7 +280,7 @@ describe("createHierarchyLevelDescriptor", () => {
       getContentDescriptor: sinon.stub().resolves(descriptorResponse),
     };
     const imodel = {} as any;
-    const descriptor = await createHierarchyLevelDescriptor({
+    const result = await createHierarchyLevelDescriptor({
       imodel,
       hierarchyProvider,
       descriptorBuilder,
@@ -320,8 +327,14 @@ describe("createHierarchyLevelDescriptor", () => {
         );
       }),
     );
-    expect(descriptor).to.be.instanceOf(Descriptor);
-    expect(descriptor?.ruleset).to.eq(descriptorBuilder.getContentDescriptor.firstCall.args[0].rulesetOrId);
+    expect(result?.descriptor).to.be.instanceOf(Descriptor);
+    expect(result?.descriptor.ruleset).to.eq(descriptorBuilder.getContentDescriptor.firstCall.args[0].rulesetOrId);
+    expect(
+      result?.inputKeys.hasAll([
+        { className: "schema.class3", id: "0x333" },
+        { className: "schema.class4", id: "0x444" },
+      ]),
+    ).to.be.true;
   });
 });
 

--- a/packages/full-stack-tests/src/hierarchy-builder/HierarchyLevelDescriptors.test.ts
+++ b/packages/full-stack-tests/src/hierarchy-builder/HierarchyLevelDescriptors.test.ts
@@ -68,13 +68,13 @@ describe("Stateless hierarchy builder", () => {
           }),
           expect: [NodeValidators.createForInstanceNode({ instanceKeys: [{ className: Subject.classFullName.replace(":", "."), id: "0x1" }] })],
         });
-        const descriptor = await createHierarchyLevelDescriptor({
+        const result = await createHierarchyLevelDescriptor({
           imodel,
           parentNode: undefined,
           hierarchyProvider: provider,
           descriptorBuilder: PresentationBackend.getManager(),
         });
-        expect(descriptor).to.containSubset({
+        expect(result?.descriptor).to.containSubset({
           selectClasses: [
             {
               selectClassInfo: { name: Subject.classFullName },
@@ -142,13 +142,13 @@ describe("Stateless hierarchy builder", () => {
           }),
           expect: [NodeValidators.createForInstanceNode({ instanceKeys: [{ className: Subject.classFullName.replace(":", "."), id: "0x1" }] })],
         });
-        const descriptor = await createHierarchyLevelDescriptor({
+        const result = await createHierarchyLevelDescriptor({
           imodel,
           parentNode: undefined,
           hierarchyProvider: provider,
           descriptorBuilder: PresentationFrontend.presentation,
         });
-        expect(descriptor).to.containSubset({
+        expect(result?.descriptor).to.containSubset({
           selectClasses: [
             {
               selectClassInfo: { name: Subject.classFullName },
@@ -222,13 +222,13 @@ describe("Stateless hierarchy builder", () => {
             NodeValidators.createForInstanceNode({ instanceKeys: [{ className: LinkModel.classFullName.replace(":", "."), id: "0xe" }] }),
           ],
         });
-        const descriptor = await createHierarchyLevelDescriptor({
+        const result = await createHierarchyLevelDescriptor({
           imodel,
           parentNode: rootSubjectNode,
           hierarchyProvider: provider,
           descriptorBuilder: PresentationFrontend.presentation,
         });
-        expect(descriptor).to.containSubset({
+        expect(result?.descriptor).to.containSubset({
           selectClasses: [
             {
               selectClassInfo: { name: DictionaryModel.classFullName },

--- a/packages/full-stack-tests/src/hierarchy-builder/models-tree/ModelsTreeHierarchyLevelFiltering.test.ts
+++ b/packages/full-stack-tests/src/hierarchy-builder/models-tree/ModelsTreeHierarchyLevelFiltering.test.ts
@@ -43,13 +43,13 @@ describe("Stateless hierarchy builder", () => {
         }),
         expect: [NodeValidators.createForInstanceNode({ instanceKeys: [{ className: Subject.classFullName.replace(":", "."), id: "0x1" }] })],
       });
-      const descriptor = await createHierarchyLevelDescriptor({
+      const result = await createHierarchyLevelDescriptor({
         imodel,
         parentNode: undefined,
         hierarchyProvider: provider,
         descriptorBuilder: Presentation.presentation,
       });
-      expect(descriptor).to.containSubset({
+      expect(result?.descriptor).to.containSubset({
         selectClasses: [
           {
             selectClassInfo: { name: Subject.classFullName },
@@ -114,13 +114,13 @@ describe("Stateless hierarchy builder", () => {
           NodeValidators.createForInstanceNode({ instanceKeys: [keys.model] }),
         ],
       });
-      const descriptor = await createHierarchyLevelDescriptor({
+      const result = await createHierarchyLevelDescriptor({
         imodel,
         parentNode,
         hierarchyProvider: provider,
         descriptorBuilder: Presentation.presentation,
       });
-      expect(descriptor).to.containSubset({
+      expect(result?.descriptor).to.containSubset({
         selectClasses: [
           {
             selectClassInfo: { name: Subject.classFullName },
@@ -163,13 +163,13 @@ describe("Stateless hierarchy builder", () => {
         nodes: await provider.getNodes({ parentNode }),
         expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.category] })],
       });
-      const descriptor = await createHierarchyLevelDescriptor({
+      const result = await createHierarchyLevelDescriptor({
         imodel,
         parentNode,
         hierarchyProvider: provider,
         descriptorBuilder: Presentation.presentation,
       });
-      expect(descriptor).to.containSubset({
+      expect(result?.descriptor).to.containSubset({
         selectClasses: [
           {
             selectClassInfo: { name: SpatialCategory.classFullName },
@@ -213,13 +213,13 @@ describe("Stateless hierarchy builder", () => {
         nodes: await provider.getNodes({ parentNode }),
         expect: [NodeValidators.createForClassGroupingNode({ className: keys.element.className })],
       });
-      const descriptor = await createHierarchyLevelDescriptor({
+      const result = await createHierarchyLevelDescriptor({
         imodel,
         parentNode,
         hierarchyProvider: provider,
         descriptorBuilder: Presentation.presentation,
       });
-      expect(descriptor).to.containSubset({
+      expect(result?.descriptor).to.containSubset({
         selectClasses: [
           {
             selectClassInfo: { name: keys.element.className.replace(".", ":") },
@@ -271,13 +271,13 @@ describe("Stateless hierarchy builder", () => {
         nodes: await provider.getNodes({ parentNode }),
         expect: [NodeValidators.createForClassGroupingNode({ className: keys.childElement.className })],
       });
-      const descriptor = await createHierarchyLevelDescriptor({
+      const result = await createHierarchyLevelDescriptor({
         imodel,
         parentNode,
         hierarchyProvider: provider,
         descriptorBuilder: Presentation.presentation,
       });
-      expect(descriptor).to.containSubset({
+      expect(result?.descriptor).to.containSubset({
         selectClasses: [
           {
             selectClassInfo: { name: keys.childElement.className.replace(".", ":") },
@@ -336,13 +336,13 @@ describe("Stateless hierarchy builder", () => {
         nodes: await provider.getNodes({ parentNode }),
         expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.category] })],
       });
-      const descriptor = await createHierarchyLevelDescriptor({
+      const result = await createHierarchyLevelDescriptor({
         imodel,
         parentNode,
         hierarchyProvider: provider,
         descriptorBuilder: Presentation.presentation,
       });
-      expect(descriptor).to.containSubset({
+      expect(result?.descriptor).to.containSubset({
         selectClasses: [
           {
             selectClassInfo: { name: SpatialCategory.classFullName },
@@ -387,13 +387,13 @@ describe("Stateless hierarchy builder", () => {
         nodes: await provider.getNodes({ parentNode }),
         expect: [NodeValidators.createForClassGroupingNode({ className: keys.element.className })],
       });
-      const descriptor = await createHierarchyLevelDescriptor({
+      const result = await createHierarchyLevelDescriptor({
         imodel,
         parentNode,
         hierarchyProvider: provider,
         descriptorBuilder: Presentation.presentation,
       });
-      expect(descriptor).to.containSubset({
+      expect(result?.descriptor).to.containSubset({
         selectClasses: [
           {
             selectClassInfo: { name: keys.element.className.replace(".", ":") },


### PR DESCRIPTION
Input keys are needed when loading distinct values using `Hierarchy level descriptor ruleset`