### PR TITLE
Change unique value selector dropdown menu to be space aware

### DIFF
--- a/.changeset/proud-numbers-retire.md
+++ b/.changeset/proud-numbers-retire.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Updated UniqueValueSelector dropdown menu to open upwards when there is not enough space below.

--- a/packages/components/src/presentation-components/common/PortalTargetContext.tsx
+++ b/packages/components/src/presentation-components/common/PortalTargetContext.tsx
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Core
+ */
+
+import { createContext, PropsWithChildren, useContext } from "react";
+
+/**
+ * Context that stores a portal target.
+ */
+export interface PortalTargetContext {
+  portalTarget: HTMLElement | null;
+}
+
+const portalTargetContext = createContext<PortalTargetContext>({} as PortalTargetContext);
+
+/**
+ * Props for [[PortalTargetContextProvider]]
+ */
+export interface PortalTargetContextProviderProps {
+  portalTarget: HTMLElement | null;
+}
+
+/**
+ * Provides a portal target for components.
+ */
+export function PortalTargetContextProvider({ portalTarget, children }: PropsWithChildren<PortalTargetContextProviderProps>) {
+  return <portalTargetContext.Provider value={{ portalTarget }}>{children}</portalTargetContext.Provider>;
+}
+
+/**
+ * Returns context provided by [[PortalTargetContextProvider]].
+ */
+export function usePortalTargetContext() {
+  return useContext(portalTargetContext);
+}

--- a/packages/components/src/presentation-components/common/PortalTargetContext.tsx
+++ b/packages/components/src/presentation-components/common/PortalTargetContext.tsx
@@ -9,7 +9,8 @@
 import { createContext, PropsWithChildren, useContext } from "react";
 
 /**
- * Context that stores a portal target.
+ * Context that stores a portal target. It will be used to portal popovers opened by presentation components.
+ * @beta
  */
 export interface PortalTargetContext {
   portalTarget: HTMLElement | null;
@@ -19,6 +20,7 @@ const portalTargetContext = createContext<PortalTargetContext>({} as PortalTarge
 
 /**
  * Props for [[PortalTargetContextProvider]]
+ * @beta
  */
 export interface PortalTargetContextProviderProps {
   portalTarget: HTMLElement | null;
@@ -26,6 +28,7 @@ export interface PortalTargetContextProviderProps {
 
 /**
  * Provides a portal target for components.
+ * @beta
  */
 export function PortalTargetContextProvider({ portalTarget, children }: PropsWithChildren<PortalTargetContextProviderProps>) {
   return <portalTargetContext.Provider value={{ portalTarget }}>{children}</portalTargetContext.Provider>;
@@ -33,6 +36,7 @@ export function PortalTargetContextProvider({ portalTarget, children }: PropsWit
 
 /**
  * Returns context provided by [[PortalTargetContextProvider]].
+ * @beta
  */
 export function usePortalTargetContext() {
   return useContext(portalTargetContext);

--- a/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterDialog.tsx
+++ b/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterDialog.tsx
@@ -19,6 +19,7 @@ import { InstanceFilterBuilder, usePresentationInstanceFilteringProps } from "./
 import { PresentationInstanceFilterInfo } from "./PresentationFilterBuilder";
 import { PresentationInstanceFilter } from "./PresentationInstanceFilter";
 import { filterRuleValidator, isFilterNonEmpty } from "./Utils";
+import { PortalTargetContextProvider } from "../common/PortalTargetContext";
 
 /**
  * Data structure that describes source to gather properties from.
@@ -88,9 +89,11 @@ export interface FilteringDialogToolbarHandlers {
  */
 export function PresentationInstanceFilterDialog(props: PresentationInstanceFilterDialogProps) {
   const { isOpen, title, ...restProps } = props;
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
 
   return (
     <Dialog
+      ref={setPortalTarget}
       className="presentation-instance-filter-dialog"
       isOpen={isOpen}
       onClose={props.onClose}
@@ -101,13 +104,15 @@ export function PresentationInstanceFilterDialog(props: PresentationInstanceFilt
       isResizable
       portal={true}
     >
-      <Dialog.Backdrop />
-      <Dialog.Main className="presentation-instance-filter-dialog-content-container">
-        <Dialog.TitleBar className="presentation-instance-filter-title" titleText={title ? title : translate("instance-filter-builder.filter")} />
-        <ErrorBoundary fallback={<ErrorState />}>
-          <FilterDialogContent {...restProps} />
-        </ErrorBoundary>
-      </Dialog.Main>
+      <PortalTargetContextProvider portalTarget={portalTarget}>
+        <Dialog.Backdrop />
+        <Dialog.Main className="presentation-instance-filter-dialog-content-container">
+          <Dialog.TitleBar className="presentation-instance-filter-title" titleText={title ? title : translate("instance-filter-builder.filter")} />
+          <ErrorBoundary fallback={<ErrorState />}>
+            <FilterDialogContent {...restProps} />
+          </ErrorBoundary>
+        </Dialog.Main>
+      </PortalTargetContextProvider>
     </Dialog>
   );
 }

--- a/packages/components/src/presentation-components/properties/inputs/AsyncSelect.tsx
+++ b/packages/components/src/presentation-components/properties/inputs/AsyncSelect.tsx
@@ -7,8 +7,19 @@ import "./AsyncSelect.scss";
 import classnames from "classnames";
 import { useRef, useState } from "react";
 import {
-  ClearIndicatorProps, components, ContainerProps, ControlProps, DropdownIndicatorProps, GroupBase, IndicatorsContainerProps, MenuListProps,
-  MultiValueProps, NoticeProps, OptionProps, SelectInstance, ValueContainerProps,
+  ClearIndicatorProps,
+  components,
+  ContainerProps,
+  ControlProps,
+  DropdownIndicatorProps,
+  GroupBase,
+  IndicatorsContainerProps,
+  MenuListProps,
+  MultiValueProps,
+  NoticeProps,
+  OptionProps,
+  SelectInstance,
+  ValueContainerProps,
 } from "react-select";
 import { AsyncPaginate, AsyncPaginateProps } from "react-select-async-paginate";
 import { SvgCaretDownSmall, SvgCheckmarkSmall, SvgCloseSmall } from "@itwin/itwinui-icons-react";
@@ -131,7 +142,7 @@ export function AsyncSelect<OptionType, Group extends GroupBase<OptionType>, Add
     setIsLoading(true);
     setDropdownUp(false);
     menuObserver.current && menuObserver.current.disconnect();
-  }
+  };
 
   return (
     <div ref={useMergedRefs(divRef, resizeRef)}>

--- a/packages/components/src/test/properties/inputs/UniquePropertyValuesSelector.test.tsx
+++ b/packages/components/src/test/properties/inputs/UniquePropertyValuesSelector.test.tsx
@@ -9,15 +9,16 @@ import { PropertyDescription, PropertyValue, PropertyValueFormat } from "@itwin/
 import { omit } from "@itwin/core-bentley";
 import { EmptyLocalization } from "@itwin/core-common";
 import { IModelApp, IModelConnection } from "@itwin/core-frontend";
-import {
-  combineFieldNames, ContentInstancesOfSpecificClassesSpecification, ContentRule, KeySet, RelatedClassInfo, Ruleset,
-} from "@itwin/presentation-common";
+import { combineFieldNames, ContentInstancesOfSpecificClassesSpecification, ContentRule, KeySet, RelatedClassInfo, Ruleset } from "@itwin/presentation-common";
 import { Presentation } from "@itwin/presentation-frontend";
 import { serializeUniqueValues, UniqueValue } from "../../../presentation-components/common/Utils";
 import { UniquePropertyValuesSelector } from "../../../presentation-components/properties/inputs/UniquePropertyValuesSelector";
 import { createTestECClassInfo, createTestPropertyInfo, createTestRelatedClassInfo, createTestRelationshipPath } from "../../_helpers/Common";
 import {
-  createTestCategoryDescription, createTestContentDescriptor, createTestNestedContentField, createTestPropertiesContentField,
+  createTestCategoryDescription,
+  createTestContentDescriptor,
+  createTestNestedContentField,
+  createTestPropertiesContentField,
 } from "../../_helpers/Content";
 import { createTestECInstancesNodeKey } from "../../_helpers/Hierarchy";
 import { render, waitFor } from "../../TestUtils";
@@ -39,15 +40,20 @@ class IntersectionObserver {
   }
 
   public observe() {
-    this.callback([{
-      boundingClientRect: { height: isOffScreen ? 2 : 1, bottom: 0, top: 0, left: 0, right: 0, width: 0, x: 0, y: 0, toJSON: () => { }, },
-      intersectionRect: { height: isOffScreen ? 1 : 2, bottom: 0, top: 0, left: 0, right: 0, width: 0, x: 0, y: 0, toJSON: () => { }, },
-      intersectionRatio: 0,
-      isIntersecting: false,
-      rootBounds: null,
-      target: null as unknown as Element,
-      time: 0,
-    }], this);
+    this.callback(
+      [
+        {
+          boundingClientRect: { height: isOffScreen ? 2 : 1, bottom: 0, top: 0, left: 0, right: 0, width: 0, x: 0, y: 0, toJSON: () => {} },
+          intersectionRect: { height: isOffScreen ? 1 : 2, bottom: 0, top: 0, left: 0, right: 0, width: 0, x: 0, y: 0, toJSON: () => {} },
+          intersectionRatio: 0,
+          isIntersecting: false,
+          rootBounds: null,
+          target: null as unknown as Element,
+          time: 0,
+        },
+      ],
+      this,
+    );
   }
 
   public takeRecords() {


### PR DESCRIPTION
Closes [439](https://github.com/iTwin/presentation/issues/439)

- Modified `UniqueValueSelector` dropdown menu to open upwards when there is not enough space below.
- Changed the dropdown menu portal target to the filtering dialog instead of the body.