### PR TITLE
Load more than one page in UniqueValueSelector

### DIFF
--- a/.changeset/large-hotels-fly.md
+++ b/.changeset/large-hotels-fly.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-components": patch
 ---
 
-Fixed UniqueValueSelector from loading only the first page of values.
+Fixed UniqueValueSelector loading only the first page of values.

--- a/.changeset/large-hotels-fly.md
+++ b/.changeset/large-hotels-fly.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-components": patch
 ---
 
-Fixed UniqueValueSelector loading only the first page of values.
+Fixed `UniqueValueSelector` loading only the first page of values.

--- a/.changeset/large-hotels-fly.md
+++ b/.changeset/large-hotels-fly.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Fixed UniqueValueSelector from loading only the first page of values.

--- a/packages/components/src/presentation-components/properties/inputs/AsyncSelect.tsx
+++ b/packages/components/src/presentation-components/properties/inputs/AsyncSelect.tsx
@@ -115,15 +115,15 @@ function ClearIndicator<TOption, IsMulti extends boolean = boolean>({ children: 
   );
 }
 
+// Wrap custom menu as a workaround for some internal bugs of react-select
+const MenuList = wrapMenuList(CustomMenuList);
+
 /** @internal */
 export function AsyncSelect<OptionType, Group extends GroupBase<OptionType>, Additional>(props: AsyncPaginateProps<OptionType, Group, Additional, true>) {
   const [dropdownUp, setDropdownUp] = useState(false);
   const { ref: resizeRef, width } = useResizeObserver();
   const { portalTarget } = usePortalTargetContext();
   const divRef = useRef<HTMLDivElement>(null);
-
-  // Wrap custom menu as a workaround for some internal bugs of react-select
-  const MenuList = wrapMenuList(CustomMenuList);
 
   const onMenuOpen = () => {
     const { top, height } = divRef.current!.getBoundingClientRect();

--- a/packages/components/src/presentation-components/properties/inputs/AsyncSelect.tsx
+++ b/packages/components/src/presentation-components/properties/inputs/AsyncSelect.tsx
@@ -20,7 +20,7 @@ import {
   OptionProps,
   ValueContainerProps,
 } from "react-select";
-import { AsyncPaginate, AsyncPaginateProps } from "react-select-async-paginate";
+import { AsyncPaginate, AsyncPaginateProps, wrapMenuList } from "react-select-async-paginate";
 import { SvgCaretDownSmall, SvgCheckmarkSmall, SvgCloseSmall } from "@itwin/itwinui-icons-react";
 import { List, ListItem, Tag, TagContainer } from "@itwin/itwinui-react";
 import { translate, useMergedRefs, useResizeObserver } from "../../common/Utils";
@@ -44,7 +44,7 @@ function Control<TOption, IsMulti extends boolean = boolean>({ children, ...prop
   );
 }
 
-function MenuList<TOption, IsMulti extends boolean = boolean>({ children, ...props }: MenuListProps<TOption, IsMulti>) {
+function CustomMenuList<TOption, IsMulti extends boolean = boolean>({ children, ...props }: MenuListProps<TOption, IsMulti>) {
   return (
     <List className="presentation-async-select-dropdown" ref={props.innerRef} {...props.innerProps} as="div">
       {children}
@@ -121,6 +121,9 @@ export function AsyncSelect<OptionType, Group extends GroupBase<OptionType>, Add
   const { ref: resizeRef, width } = useResizeObserver();
   const { portalTarget } = usePortalTargetContext();
   const divRef = useRef<HTMLDivElement>(null);
+
+  // Wrap custom menu as a workaround for some internal bugs of react-select
+  const MenuList = wrapMenuList(CustomMenuList);
 
   const onMenuOpen = () => {
     const { top, height } = divRef.current!.getBoundingClientRect();


### PR DESCRIPTION
Closes [442](https://github.com/iTwin/presentation/issues/442)

Fixed an issue with `UniqueValueSelector` only loading the first page of values.