### PR TITLE
Fix tooltip appearing under property selector

### DIFF
--- a/.changeset/smart-lobsters-hide.md
+++ b/.changeset/smart-lobsters-hide.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Fixed tooltip appearing under property selector in property filter builder.

--- a/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterProperty.scss
+++ b/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterProperty.scss
@@ -8,6 +8,10 @@
   grid-template-columns: minmax(50%, auto) minmax(auto, 50%);
   align-items: center;
 
+  .property-item-tooltip {
+    z-index: 999999;
+  }
+
   .property-badge-container {
     max-width: 100%;
     justify-self: end;

--- a/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterProperty.scss
+++ b/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterProperty.scss
@@ -8,10 +8,6 @@
   grid-template-columns: minmax(50%, auto) minmax(auto, 50%);
   align-items: center;
 
-  .property-item-tooltip {
-    z-index: 999999;
-  }
-
   .property-badge-container {
     max-width: 100%;
     justify-self: end;
@@ -39,6 +35,10 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
+}
+
+.property-item-tooltip {
+  z-index: 999999;
 }
 
 .tooltip-content-header {

--- a/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterProperty.tsx
+++ b/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterProperty.tsx
@@ -33,7 +33,7 @@ export function PresentationInstanceFilterProperty(props: PresentationInstanceFi
   const { propertyDescription, categoryLabel, fullClassName } = props;
   return (
     <div className="property-item-line">
-      <Tooltip content={propertyDescription.displayLabel} placement="bottom">
+      <Tooltip className="property-item-tooltip" content={propertyDescription.displayLabel} placement="bottom">
         <div className="property-display-label" title={propertyDescription.displayLabel}>
           {propertyDescription.displayLabel}
         </div>
@@ -41,6 +41,7 @@ export function PresentationInstanceFilterProperty(props: PresentationInstanceFi
       <div className="property-badge-container">
         {categoryLabel && (
           <Tooltip
+            className="property-item-tooltip"
             content={<CategoryTooltipContent categoryLabel={categoryLabel} fullClassName={fullClassName} />}
             placement="bottom"
             style={{ textAlign: "left" }}


### PR DESCRIPTION
Closes [450](https://github.com/iTwin/presentation/issues/450)

Fixed tooltip appearing under property selector.