### PR TITLE
Reduce amount of tooltips property selector

### DIFF
--- a/.changeset/modern-hounds-pretend.md
+++ b/.changeset/modern-hounds-pretend.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Reduced amount of tooltips rendered in filter builder property selector.

--- a/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterProperty.scss
+++ b/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterProperty.scss
@@ -16,7 +16,6 @@
       max-width: 100%;
       display: inline-block;
 
-      .iui-badge,
       .property-category-badge {
         max-width: 100%;
         vertical-align: middle;

--- a/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterProperty.tsx
+++ b/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilterProperty.tsx
@@ -8,7 +8,7 @@
 
 import "./PresentationInstanceFilterProperty.scss";
 import { PropertyDescription } from "@itwin/appui-abstract";
-import { Badge, Tooltip } from "@itwin/itwinui-react";
+import { Badge, Text, Tooltip } from "@itwin/itwinui-react";
 import { translate } from "../common/Utils";
 
 /**
@@ -33,11 +33,7 @@ export function PresentationInstanceFilterProperty(props: PresentationInstanceFi
   const { propertyDescription, categoryLabel, fullClassName } = props;
   return (
     <div className="property-item-line">
-      <Tooltip className="property-item-tooltip" content={propertyDescription.displayLabel} placement="bottom">
-        <div className="property-display-label" title={propertyDescription.displayLabel}>
-          {propertyDescription.displayLabel}
-        </div>
-      </Tooltip>
+      <Text className="property-display-label" title={propertyDescription.displayLabel}>{propertyDescription.displayLabel}</Text>
       <div className="property-badge-container">
         {categoryLabel && (
           <Tooltip


### PR DESCRIPTION
Do not render tooltip for each property in selector. It should be enough setting `title` property. `Tooltip` component sometimes was blocking scroll action and made scrolling to dropdown difficult.