### PR TITLE
Add performance tests for all grouping types

### DIFF
--- a/apps/performance-tests/.mocharc.json
+++ b/apps/performance-tests/.mocharc.json
@@ -1,5 +1,5 @@
 {
-  "timeout": 60000,
+  "timeout": 120000,
   "file": "./lib/main.js",
   "reporter": ["./lib/util/TestReporter.js"]
 }

--- a/apps/performance-tests/package.json
+++ b/apps/performance-tests/package.json
@@ -20,6 +20,7 @@
     "@itwin/presentation-models-tree": "workspace:*",
     "as-table": "^1.0.55",
     "blocked": "^1.3.0",
+    "chai": "^4.4.1",
     "mocha": "^10.3.0",
     "presentation-test-utilities": "workspace:^",
     "rxjs": "^7.8.1"
@@ -27,6 +28,7 @@
   "devDependencies": {
     "@itwin/eslint-plugin": "4.0.0-dev.48",
     "@types/blocked": "^1.3.4",
+    "@types/chai": "^4.3.11",
     "@types/mocha": "^10.0.6",
     "@types/node": "^18.17.7",
     "cross-env": "^7.0.3",

--- a/apps/performance-tests/package.json
+++ b/apps/performance-tests/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "cross-env NODE_OPTIONS=\"--enable-source-maps\" mocha --config ./.mocharc.json ./lib/*test.js",
     "test:recreate": "cross-env RECREATE=true npm run test",
-    "benchmark": "test -- -O BENCHMARK_OUTPUT_PATH=./benchmark.json",
+    "benchmark": "npm run test -- -O BENCHMARK_OUTPUT_PATH=./benchmark.json",
     "build": "tsc",
     "clean": "rimraf lib temp",
     "lint": "eslint \"./src/**/*.ts\""

--- a/apps/performance-tests/package.json
+++ b/apps/performance-tests/package.json
@@ -3,8 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "test": "NODE_OPTIONS=\"--enable-source-maps\" mocha --config ./.mocharc.json ./lib/*test.js",
-    "benchmark": "npm run test -- -O BENCHMARK_OUTPUT_PATH=./benchmark.json",
+    "test": "cross-env NODE_OPTIONS=\"--enable-source-maps\" mocha --config ./.mocharc.json ./lib/*test.js",
+    "test:recreate": "cross-env RECREATE=true npm run test",
+    "benchmark": "test -- -O BENCHMARK_OUTPUT_PATH=./benchmark.json",
     "build": "tsc",
     "clean": "rimraf lib temp",
     "lint": "eslint \"./src/**/*.ts\""
@@ -28,6 +29,7 @@
     "@types/blocked": "^1.3.4",
     "@types/mocha": "^10.0.6",
     "@types/node": "^18.17.7",
+    "cross-env": "^7.0.3",
     "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
     "typescript": "~5.0.4"

--- a/apps/performance-tests/src/Datasets.ts
+++ b/apps/performance-tests/src/Datasets.ts
@@ -119,7 +119,7 @@ export class Datasets {
             userLabel: `${defaultUserLabel}_${groupIdx}`,
             modelId,
             categoryId,
-            propX: `${defaultPropertyValue}_${groupIdx}`,
+            [customPropName]: `${defaultPropertyValue}_${groupIdx}`,
           });
         }
       }

--- a/apps/performance-tests/src/Datasets.ts
+++ b/apps/performance-tests/src/Datasets.ts
@@ -6,6 +6,7 @@
 import fs from "fs";
 import path from "path";
 import { insertPhysicalElement, insertPhysicalModelWithPartition, insertSpatialCategory } from "presentation-test-utilities";
+import { Logger, LogLevel } from "@itwin/core-bentley";
 import { createIModel } from "./util/IModelUtilities";
 
 export const IMODEL_NAMES = ["baytown", "50k elements"] as const;
@@ -22,17 +23,25 @@ export class Datasets {
   }
 
   public static async initialize(datasetsDirPath: string) {
+    Logger.initializeToConsole();
+    Logger.setLevelDefault(LogLevel.Error);
+
     await fs.promises.mkdir(datasetsDirPath, { recursive: true });
     const promises = IMODEL_NAMES.map(async (key) => {
       if (key === "baytown") {
-        this._iModels[key] = await createIfMissing(key, datasetsDirPath, async (name: string, localPath: string) =>
+        this._iModels[key] = await this.createIModel(key, datasetsDirPath, async (name: string, localPath: string) =>
           downloadDataset(name, BAYTOWN_DOWNLOAD_URL, localPath),
         );
         return;
       }
 
       const count = 1000 * Number.parseInt(/(\d+)k elements/.exec(key)![1], 10);
-      const iModelPath = await createIfMissing(key, datasetsDirPath, async (name: string, localPath: string) => createFlatIModel(name, localPath, count));
+      const iModelPath = await this.createIModel(
+        key,
+        datasetsDirPath,
+        async (name: string, localPath: string) => createFlatIModel(name, localPath, count),
+        !process.env.REUSE_DATASET,
+      );
       this._iModels[key] = iModelPath;
     });
     await Promise.all(promises);
@@ -44,16 +53,21 @@ export class Datasets {
     }
     return arg;
   }
-}
 
-async function createIfMissing(name: string, folderPath: string, provider: (name: string, localPath: string) => void | Promise<void>) {
-  const localPath = path.join(folderPath, `${name}.bim`);
-  try {
-    await fs.promises.access(localPath, fs.constants.F_OK);
-  } catch {
-    await provider(name, localPath);
+  private static async createIModel(name: string, folderPath: string, provider: (name: string, localPath: string) => void | Promise<void>, force?: boolean) {
+    const localPath = path.join(folderPath, `${name}.bim`);
+    if (force) {
+      await provider(name, localPath);
+      return path.resolve(localPath);
+    }
+
+    try {
+      await fs.promises.access(localPath, fs.constants.F_OK);
+    } catch {
+      await provider(name, localPath);
+    }
+    return path.resolve(localPath);
   }
-  return path.resolve(localPath);
 }
 
 async function downloadDataset(name: string, downloadUrl: string, localPath: string) {
@@ -69,17 +83,40 @@ async function downloadDataset(name: string, downloadUrl: string, localPath: str
 async function createFlatIModel(name: string, localPath: string, numElements: number) {
   console.log(`${numElements} elements: Creating...`);
 
-  await createIModel(name, localPath, (builder) => {
+  const elementsPerGroup = 100;
+  const numGroups = numElements / elementsPerGroup;
+  const customPropName = "PropX";
+  const schemaName = "PerformanceTests";
+  const defaultClassName = schemaName;
+  const defaultUserLabel = "Element";
+  const defaultPropertyValue = "Property";
+  // prettier-ignore
+  const schema = `
+    <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
+    ${[...Array(numGroups).keys()].map((i) => `
+      <ECEntityClass typeName="${defaultClassName}_${i}">
+        <BaseClass>bis:PhysicalElement</BaseClass>
+        <ECProperty propertyName="${customPropName}" typeName="string" />
+      </ECEntityClass>
+    `).join("")}
+  `;
+
+  await createIModel(name, localPath, async (builder) => {
+    await builder.importSchema(schema, schemaName);
     const { id: categoryId } = insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
     const { id: modelId } = insertPhysicalModelWithPartition({ builder, fullClassNameSeparator: ":", codeValue: "My Model" });
-    for (let i = 0; i < numElements; ++i) {
-      insertPhysicalElement({
-        builder,
-        fullClassNameSeparator: ":",
-        userLabel: `Element_${i}`,
-        modelId,
-        categoryId,
-      });
+    for (let groupIdx = 0; groupIdx < numGroups; ++groupIdx) {
+      for (let j = 0; j < elementsPerGroup; ++j) {
+        insertPhysicalElement({
+          builder,
+          classFullName: `${schemaName}:${defaultClassName}_${groupIdx}`,
+          fullClassNameSeparator: ":",
+          userLabel: `${defaultUserLabel}_${groupIdx}`,
+          modelId,
+          categoryId,
+          propX: `${defaultPropertyValue}_${groupIdx}`,
+        });
+      }
     }
   });
 

--- a/apps/performance-tests/src/Datasets.ts
+++ b/apps/performance-tests/src/Datasets.ts
@@ -17,7 +17,6 @@ const BAYTOWN_DOWNLOAD_URL = "https://github.com/imodeljs/desktop-starter/raw/ma
 export class Datasets {
   private static readonly _iModels: IModelPathsMap = {};
 
-  public static readonly ITEMS_PER_GROUP = 100;
   public static readonly CUSTOM_SCHEMA = {
     schemaName: "PerformanceTests",
     defaultClassName: "PerformanceTests",
@@ -25,6 +24,7 @@ export class Datasets {
     defaultUserLabel: "Element",
     customPropName: "PropX",
     defaultPropertyValue: "PropertyValue",
+    itemsPerGroup: 100,
   };
 
   public static getIModelPath(name: IModelName): string {

--- a/apps/performance-tests/src/Datasets.ts
+++ b/apps/performance-tests/src/Datasets.ts
@@ -32,7 +32,7 @@ export class Datasets {
   }
 
   public static async initialize(datasetsDirPath: string) {
-    await fs.promises.mkdir(datasetsDirPath, { recursive: true });
+    fs.mkdirSync(datasetsDirPath, { recursive: true });
     const promises = IMODEL_NAMES.map(async (key) => {
       if (key === "baytown") {
         this._iModels[key] = await this.createIModel(key, datasetsDirPath, async (name: string, localPath: string) =>
@@ -60,18 +60,18 @@ export class Datasets {
     return arg;
   }
 
-  private static async createIModel(name: string, folderPath: string, provider: (name: string, localPath: string) => void | Promise<void>, force?: boolean) {
+  private static async createIModel(
+    name: string,
+    folderPath: string,
+    iModelFactory: (name: string, localPath: string) => void | Promise<void>,
+    force?: boolean,
+  ) {
     const localPath = path.join(folderPath, `${name}.bim`);
-    if (force) {
-      await provider(name, localPath);
-      return path.resolve(localPath);
+
+    if (force || !fs.existsSync(localPath)) {
+      await iModelFactory(name, localPath);
     }
 
-    try {
-      await fs.promises.access(localPath, fs.constants.F_OK);
-    } catch {
-      await provider(name, localPath);
-    }
     return path.resolve(localPath);
   }
 

--- a/apps/performance-tests/src/Datasets.ts
+++ b/apps/performance-tests/src/Datasets.ts
@@ -17,6 +17,16 @@ const BAYTOWN_DOWNLOAD_URL = "https://github.com/imodeljs/desktop-starter/raw/ma
 export class Datasets {
   private static readonly _iModels: IModelPathsMap = {};
 
+  public static readonly ITEMS_PER_GROUP = 100;
+  public static readonly CUSTOM_SCHEMA = {
+    schemaName: "PerformanceTests",
+    defaultClassName: "PerformanceTests",
+    baseClassName: "Base_PerformanceTests",
+    defaultUserLabel: "Element",
+    customPropName: "PropX",
+    defaultPropertyValue: "PropertyValue",
+  };
+
   public static getIModelPath(name: IModelName): string {
     return this.verifyInitialized(this._iModels[name]);
   }
@@ -26,7 +36,7 @@ export class Datasets {
     const promises = IMODEL_NAMES.map(async (key) => {
       if (key === "baytown") {
         this._iModels[key] = await this.createIModel(key, datasetsDirPath, async (name: string, localPath: string) =>
-          downloadDataset(name, BAYTOWN_DOWNLOAD_URL, localPath),
+          this.downloadDataset(name, BAYTOWN_DOWNLOAD_URL, localPath),
         );
         return;
       }
@@ -35,7 +45,7 @@ export class Datasets {
       const iModelPath = await this.createIModel(
         key,
         datasetsDirPath,
-        async (name: string, localPath: string) => createFlatIModel(name, localPath, count),
+        async (name: string, localPath: string) => this.createFlatIModel(name, localPath, count),
         !!process.env.RECREATE,
       );
       this._iModels[key] = iModelPath;
@@ -64,60 +74,57 @@ export class Datasets {
     }
     return path.resolve(localPath);
   }
-}
 
-async function downloadDataset(name: string, downloadUrl: string, localPath: string) {
-  console.log(`Downloading "${name}" iModel from "${downloadUrl}"...`);
-  const response = await fetch(downloadUrl);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch ${name} iModel: ${response.statusText}`);
+  private static async downloadDataset(name: string, downloadUrl: string, localPath: string) {
+    console.log(`Downloading "${name}" iModel from "${downloadUrl}"...`);
+    const response = await fetch(downloadUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${name} iModel: ${response.statusText}`);
+    }
+
+    await response.body!.pipeTo(fs.WriteStream.toWeb(fs.createWriteStream(localPath)));
   }
 
-  await response.body!.pipeTo(fs.WriteStream.toWeb(fs.createWriteStream(localPath)));
-}
+  private static async createFlatIModel(name: string, localPath: string, numElements: number) {
+    console.log(`${numElements} elements: Creating...`);
 
-async function createFlatIModel(name: string, localPath: string, numElements: number) {
-  console.log(`${numElements} elements: Creating...`);
+    const elementsPerGroup = 100;
+    const numGroups = numElements / elementsPerGroup;
+    const { defaultClassName, customPropName, schemaName, defaultUserLabel, defaultPropertyValue, baseClassName } = this.CUSTOM_SCHEMA;
 
-  const elementsPerGroup = 100;
-  const numGroups = numElements / elementsPerGroup;
-  const customPropName = "PropX";
-  const schemaName = "PerformanceTests";
-  const defaultClassName = schemaName;
-  const defaultUserLabel = "Element";
-  const defaultPropertyValue = "Property";
-  // prettier-ignore
-  const schema = `
-    <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
-    <ECEntityClass typeName="Base_${defaultClassName}">
-      <BaseClass>bis:PhysicalElement</BaseClass>
-      <ECProperty propertyName="${customPropName}" typeName="string" />
-    </ECEntityClass>
-    ${[...Array(numGroups).keys()].map((i) => `
-      <ECEntityClass typeName="${defaultClassName}_${i}">
-        <BaseClass>Base_${defaultClassName}</BaseClass>
+    // prettier-ignore
+    const schema = `
+      <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
+      <ECEntityClass typeName="${baseClassName}">
+        <BaseClass>bis:PhysicalElement</BaseClass>
+        <ECProperty propertyName="${customPropName}" typeName="string" />
       </ECEntityClass>
-    `).join("")}
-  `;
+      ${[...Array(numGroups).keys()].map((i) => `
+        <ECEntityClass typeName="${defaultClassName}_${i}">
+          <BaseClass>${baseClassName}</BaseClass>
+        </ECEntityClass>
+      `).join("")}
+    `;
 
-  await createIModel(name, localPath, async (builder) => {
-    await builder.importSchema(schema, schemaName);
-    const { id: categoryId } = insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
-    const { id: modelId } = insertPhysicalModelWithPartition({ builder, fullClassNameSeparator: ":", codeValue: "My Model" });
-    for (let groupIdx = 0; groupIdx < numGroups; ++groupIdx) {
-      for (let j = 0; j < elementsPerGroup; ++j) {
-        insertPhysicalElement({
-          builder,
-          classFullName: `${schemaName}:${defaultClassName}_${groupIdx}`,
-          fullClassNameSeparator: ":",
-          userLabel: `${defaultUserLabel}_${groupIdx}`,
-          modelId,
-          categoryId,
-          propX: `${defaultPropertyValue}_${groupIdx}`,
-        });
+    await createIModel(name, localPath, async (builder) => {
+      await builder.importSchema(schema, schemaName);
+      const { id: categoryId } = insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
+      const { id: modelId } = insertPhysicalModelWithPartition({ builder, fullClassNameSeparator: ":", codeValue: "My Model" });
+      for (let groupIdx = 0; groupIdx < numGroups; ++groupIdx) {
+        for (let j = 0; j < elementsPerGroup; ++j) {
+          insertPhysicalElement({
+            builder,
+            classFullName: `${schemaName}:${defaultClassName}_${groupIdx}`,
+            fullClassNameSeparator: ":",
+            userLabel: `${defaultUserLabel}_${groupIdx}`,
+            modelId,
+            categoryId,
+            propX: `${defaultPropertyValue}_${groupIdx}`,
+          });
+        }
       }
-    }
-  });
+    });
 
-  console.log(`${numElements} elements: Done.`);
+    console.log(`${numElements} elements: Done.`);
+  }
 }

--- a/apps/performance-tests/src/Datasets.ts
+++ b/apps/performance-tests/src/Datasets.ts
@@ -107,7 +107,7 @@ export class Datasets {
     `;
 
     await createIModel(name, localPath, async (builder) => {
-      await builder.importSchema(schema, schemaName);
+      await builder.importSchema(schemaName, schema);
       const { id: categoryId } = insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
       const { id: modelId } = insertPhysicalModelWithPartition({ builder, fullClassNameSeparator: ":", codeValue: "My Model" });
       for (let groupIdx = 0; groupIdx < numGroups; ++groupIdx) {

--- a/apps/performance-tests/src/main.ts
+++ b/apps/performance-tests/src/main.ts
@@ -3,13 +3,17 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import "chai";
 import { IModelHost } from "@itwin/core-backend";
 import { Logger, LogLevel } from "@itwin/core-bentley";
+import { createLogger } from "@itwin/presentation-core-interop";
+import { setLogger } from "@itwin/presentation-hierarchy-builder";
 import { Datasets } from "./Datasets";
 
 before(async () => {
   Logger.initializeToConsole();
   Logger.setLevelDefault(LogLevel.Error);
+  setLogger(createLogger());
   await IModelHost.startup({
     profileName: "presentation-performance-tests",
   });

--- a/apps/performance-tests/src/main.ts
+++ b/apps/performance-tests/src/main.ts
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import "chai";
 import { IModelHost } from "@itwin/core-backend";
 import { Logger, LogLevel } from "@itwin/core-bentley";
 import { createLogger } from "@itwin/presentation-core-interop";

--- a/apps/performance-tests/src/main.ts
+++ b/apps/performance-tests/src/main.ts
@@ -4,9 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IModelHost } from "@itwin/core-backend";
+import { Logger, LogLevel } from "@itwin/core-bentley";
 import { Datasets } from "./Datasets";
 
 before(async () => {
+  Logger.initializeToConsole();
+  Logger.setLevelDefault(LogLevel.Error);
   await IModelHost.startup({
     profileName: "presentation-performance-tests",
   });

--- a/apps/performance-tests/src/stateless.test.ts
+++ b/apps/performance-tests/src/stateless.test.ts
@@ -9,7 +9,7 @@ import { IMetadataProvider, NodeSelectClauseProps, NodeSelectQueryFactory } from
 import { ModelsTreeDefinition } from "@itwin/presentation-models-tree";
 import { Datasets, IModelName } from "./Datasets";
 import { ProviderOptions, StatelessHierarchyProvider } from "./StatelessHierarchyProvider";
-import { AdvancedRunProps, run } from "./util/TestUtilities";
+import { run } from "./util/TestUtilities";
 
 describe("models tree", () => {
   const getHierarchyFactory = (metadataProvider: IMetadataProvider) => new ModelsTreeDefinition({ metadataProvider });
@@ -81,19 +81,33 @@ describe("grouping", () => {
       },
     },
   });
+
+  runQueryTest({
+    testName: "by everything",
+    iModelName: "50k elements",
+    fullClassName: baseFullClassName,
+    nodeSelectProps: {
+      grouping: {
+        byBaseClasses: { fullClassNames: ["BisCore.PhysicalElement"] },
+        byClass: true,
+        byLabel: true,
+        byProperties: {
+          propertiesClassName: baseFullClassName,
+          propertyGroups: [{ propertyName: customPropName, propertyClassAlias: "this" }],
+        },
+      },
+    },
+  });
 });
 
-function runQueryTest(
-  testProps: {
-    testName: string;
-    iModelName: IModelName;
-    fullClassName?: string;
-    nodeSelectProps?: Partial<NodeSelectClauseProps>;
-    expectedNodeCount?: number;
-    limit?: number;
-    nodeRequestLimit?: number;
-  } & Omit<AdvancedRunProps<unknown>, "setup" | "test" | "cleanup">,
-) {
+function runQueryTest(testProps: {
+  testName: string;
+  iModelName: IModelName;
+  fullClassName?: string;
+  nodeSelectProps?: Partial<NodeSelectClauseProps>;
+  expectedNodeCount?: number;
+  limit?: number;
+}) {
   const { testName, iModelName, nodeSelectProps, limit } = testProps;
   run(testName + (limit ? ` (${limit / 1000}k limit)` : ""), {
     ...testProps,
@@ -103,7 +117,7 @@ function runQueryTest(
       return {
         iModel,
         rowLimit: "unbounded",
-        nodeRequestLimit: testProps.nodeRequestLimit ?? "unbounded",
+        nodeRequestLimit: "unbounded",
         getHierarchyFactory: (metadataProvider) => ({
           async defineHierarchyLevel(props) {
             if (props.parentNode) {

--- a/apps/performance-tests/src/stateless.test.ts
+++ b/apps/performance-tests/src/stateless.test.ts
@@ -81,7 +81,6 @@ describe("grouping", () => {
     ...[...Array(baseClassQueryLimit).keys()].map((i) => `${schemaName}.${defaultClassName}_${i}`),
   ];
   runHierarchyTest({
-    only: true,
     testName: `by base class (${baseClassQueryLimit} classes)`,
     iModelName: "50k elements",
     fullClassName: baseFullClassName,

--- a/apps/performance-tests/src/stateless.test.ts
+++ b/apps/performance-tests/src/stateless.test.ts
@@ -73,13 +73,19 @@ describe("grouping", () => {
     },
   });
 
+  const physicalElementFullClassName = "BisCore.PhysicalElement";
   const baseClassQueryLimit = 10;
-  const fullClassNames = [...Array(baseClassQueryLimit).keys()].map((i) => `${schemaName}.${defaultClassName}_${i}`);
+  const fullClassNames = [
+    physicalElementFullClassName,
+    baseFullClassName,
+    ...[...Array(baseClassQueryLimit).keys()].map((i) => `${schemaName}.${defaultClassName}_${i}`),
+  ];
   runHierarchyTest({
+    only: true,
     testName: `by base class (${baseClassQueryLimit} classes)`,
     iModelName: "50k elements",
     fullClassName: baseFullClassName,
-    expectedNodeCount: baseClassQueryLimit,
+    expectedNodeCount: fullClassNames.length,
     nodeSelectProps: {
       grouping: {
         byBaseClasses: { fullClassNames },
@@ -93,7 +99,7 @@ describe("grouping", () => {
     fullClassName: baseFullClassName,
     nodeSelectProps: {
       grouping: {
-        byBaseClasses: { fullClassNames: ["BisCore.PhysicalElement"] },
+        byBaseClasses: { fullClassNames: [physicalElementFullClassName] },
         byClass: true,
         byLabel: true,
         byProperties: {

--- a/apps/performance-tests/src/util/IModelUtilities.ts
+++ b/apps/performance-tests/src/util/IModelUtilities.ts
@@ -40,7 +40,7 @@ class BackendTestIModelBuilder implements TestIModelBuilder {
     return new Code({ scope: scopeModelId, spec, value: codeValue });
   }
 
-  public async importSchema(schemaContentXml: string, schemaName: string): Promise<void> {
+  public async importSchema(schemaName: string, schemaContentXml: string): Promise<void> {
     const fullXml = getFullSchemaXml({ schemaName, schemaContentXml });
     await this._iModel.importSchemaStrings([fullXml]);
   }

--- a/apps/performance-tests/src/util/IModelUtilities.ts
+++ b/apps/performance-tests/src/util/IModelUtilities.ts
@@ -9,7 +9,7 @@ import { IModelDb, SnapshotDb } from "@itwin/core-backend";
 import { BisCodeSpec, Code, ElementAspectProps, ElementProps, ModelProps } from "@itwin/core-common";
 
 export async function createIModel(name: string, localPath: string, cb: (builder: BackendTestIModelBuilder) => void | Promise<void>) {
-  await fs.promises.rm(localPath, { force: true });
+  fs.rmSync(localPath, { force: true });
   const iModel = SnapshotDb.createEmpty(localPath, { rootSubject: { name } });
   const builder = new BackendTestIModelBuilder(iModel);
   try {

--- a/apps/performance-tests/src/util/IModelUtilities.ts
+++ b/apps/performance-tests/src/util/IModelUtilities.ts
@@ -3,11 +3,11 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { TestIModelBuilder } from "presentation-test-utilities";
+import { getFullSchemaXml, TestIModelBuilder } from "presentation-test-utilities";
 import { IModelDb, SnapshotDb } from "@itwin/core-backend";
 import { BisCodeSpec, Code, ElementAspectProps, ElementProps, ModelProps } from "@itwin/core-common";
 
-export async function createIModel(name: string, localPath: string, cb: (builder: TestIModelBuilder) => void | Promise<void>) {
+export async function createIModel(name: string, localPath: string, cb: (builder: BackendTestIModelBuilder) => void | Promise<void>) {
   const iModel = SnapshotDb.createEmpty(localPath, { rootSubject: { name } });
   const builder = new BackendTestIModelBuilder(iModel);
   try {
@@ -36,5 +36,10 @@ class BackendTestIModelBuilder implements TestIModelBuilder {
   public createCode(scopeModelId: string, codeSpecName: BisCodeSpec, codeValue: string): Code {
     const spec = this._iModel.codeSpecs.getByName(codeSpecName).id;
     return new Code({ scope: scopeModelId, spec, value: codeValue });
+  }
+
+  public async importSchema(schemaContentXml: string): Promise<void> {
+    const fullXml = getFullSchemaXml({ schemaName: "PerformanceTestsSchema", schemaContentXml });
+    await this._iModel.importSchemaStrings([fullXml]);
   }
 }

--- a/apps/performance-tests/src/util/IModelUtilities.ts
+++ b/apps/performance-tests/src/util/IModelUtilities.ts
@@ -3,11 +3,13 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import fs from "fs";
 import { getFullSchemaXml, TestIModelBuilder } from "presentation-test-utilities";
 import { IModelDb, SnapshotDb } from "@itwin/core-backend";
 import { BisCodeSpec, Code, ElementAspectProps, ElementProps, ModelProps } from "@itwin/core-common";
 
 export async function createIModel(name: string, localPath: string, cb: (builder: BackendTestIModelBuilder) => void | Promise<void>) {
+  await fs.promises.rm(localPath, { force: true });
   const iModel = SnapshotDb.createEmpty(localPath, { rootSubject: { name } });
   const builder = new BackendTestIModelBuilder(iModel);
   try {
@@ -38,8 +40,8 @@ class BackendTestIModelBuilder implements TestIModelBuilder {
     return new Code({ scope: scopeModelId, spec, value: codeValue });
   }
 
-  public async importSchema(schemaContentXml: string): Promise<void> {
-    const fullXml = getFullSchemaXml({ schemaName: "PerformanceTestsSchema", schemaContentXml });
+  public async importSchema(schemaContentXml: string, schemaName: string): Promise<void> {
+    const fullXml = getFullSchemaXml({ schemaName, schemaContentXml });
     await this._iModel.importSchemaStrings([fullXml]);
   }
 }

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -15,6 +15,9 @@ interface AdvancedRunProps<TContext> {
 
   /** Whether or not to run exclusively this test. */
   only?: boolean;
+
+  /** Whether or not to skip this test. */
+  skip?: boolean;
 }
 
 /** Runs a test and passes information about it to the TestReporter. */
@@ -26,6 +29,10 @@ export function run<T>(desc: string, callbackOrProps: (() => void | Promise<void
       this.test!.ctx!.reporter.onTestStart();
       await callbackOrProps();
     });
+    return;
+  }
+
+  if (callbackOrProps.skip) {
     return;
   }
 

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-interface AdvancedRunProps<TContext> {
+export interface AdvancedRunProps<TContext> {
   /** Callback to run before the test that should produce the context required for the test. */
   setup(): TContext | Promise<TContext>;
 

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -3,7 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-export interface AdvancedRunProps<TContext> {
+export interface RunOptions<TContext> {
+  /** Name of the test. */
+  testName: string;
+
   /** Callback to run before the test that should produce the context required for the test. */
   setup(): TContext | Promise<TContext>;
 
@@ -21,40 +24,30 @@ export interface AdvancedRunProps<TContext> {
 }
 
 /** Runs a test and passes information about it to the TestReporter. */
-export function run(desc: string, callback: () => void | Promise<void>): void;
-export function run<T>(desc: string, props: AdvancedRunProps<T>): void;
-export function run<T>(desc: string, callbackOrProps: (() => void | Promise<void>) | AdvancedRunProps<T>): void {
-  if (typeof callbackOrProps === "function") {
-    it(desc, async function () {
-      this.test!.ctx!.reporter.onTestStart();
-      await callbackOrProps();
-    });
-    return;
-  }
-
-  if (callbackOrProps.skip) {
+export function run<T>(props: RunOptions<T>): void {
+  if (props.skip) {
     return;
   }
 
   const testFunc = async function (this: Mocha.Context) {
     let value: T;
     try {
-      value = await callbackOrProps.setup();
+      value = await props.setup();
     } finally {
       this.test!.ctx!.reporter.onTestStart();
     }
 
     try {
-      await callbackOrProps.test(value);
+      await props.test(value);
     } finally {
       this.test!.ctx!.reporter.onTestEnd();
-      await callbackOrProps.cleanup?.(value);
+      await props.cleanup?.(value);
     }
   };
 
-  if (callbackOrProps.only) {
-    it.only(desc, testFunc);
+  if (props.only) {
+    it.only(props.testName, testFunc);
   } else {
-    it(desc, testFunc);
+    it(props.testName, testFunc);
   }
 }

--- a/packages/full-stack-tests/src/IModelUtils.ts
+++ b/packages/full-stack-tests/src/IModelUtils.ts
@@ -8,6 +8,7 @@ import * as fs from "fs";
 import hash from "object-hash";
 import { tmpdir } from "os";
 import path from "path";
+import { getFullSchemaXml } from "presentation-test-utilities";
 import { ECDb, ECSqlStatement, IModelJsFs } from "@itwin/core-backend";
 import { BentleyError, DbResult, Id64, Id64String, OrderedId64Iterable } from "@itwin/core-bentley";
 import { LocalFileName } from "@itwin/core-common";
@@ -206,14 +207,7 @@ export async function buildIModel<TResult extends {} | undefined>(
 export function importSchema(mochaContext: Mocha.Context, imodel: { importSchema: (xml: string) => void }, schemaContentXml: string) {
   const schemaName = `SCHEMA_${mochaContext.test!.fullTitle()}`.replace(/[^\w\d_]/gi, "_").replace(/_+/g, "_");
   const schemaAlias = `test`;
-  const schemaXml = `
-    <?xml version="1.0" encoding="UTF-8"?>
-    <ECSchema schemaName="${schemaName}" alias="${schemaAlias}" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
-      <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
-      <ECSchemaReference name="ECDbMap" version="02.00.01" alias="ecdbmap" />
-      ${schemaContentXml}
-    </ECSchema>
-  `;
+  const schemaXml = getFullSchemaXml({ schemaName, schemaAlias, schemaContentXml });
   imodel.importSchema(schemaXml);
 
   const parsedSchema = new XMLParser({

--- a/packages/test-utilities/src/test-utilities/IModelUtils.ts
+++ b/packages/test-utilities/src/test-utilities/IModelUtils.ts
@@ -303,3 +303,24 @@ export function insertExternalSourceAspect(
 
   return { className, id };
 }
+
+export interface GetFullSchemaXmlProps {
+  schemaName: string;
+  schemaAlias?: string;
+  schemaContentXml: string;
+}
+
+/**
+ * Adds boilerplate to the XML schema.
+ */
+export function getFullSchemaXml(props: GetFullSchemaXmlProps) {
+  const schemaAlias = props.schemaAlias ?? `test`;
+  return `
+    <?xml version="1.0" encoding="UTF-8"?>
+    <ECSchema schemaName="${props.schemaName}" alias="${schemaAlias}" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+      <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
+      <ECSchemaReference name="ECDbMap" version="02.00.01" alias="ecdbmap" />
+      ${props.schemaContentXml}
+    </ECSchema>
+  `;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,6 +233,9 @@ importers:
       '@types/node':
         specifier: ^18.17.7
         version: 18.17.7
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -6828,7 +6831,6 @@ packages:
     hasBin: true
     dependencies:
       cross-spawn: 7.0.3
-    dev: false
 
   /cross-fetch@3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       blocked:
         specifier: ^1.3.0
         version: 1.3.0
+      chai:
+        specifier: ^4.4.1
+        version: 4.4.1
       mocha:
         specifier: ^10.3.0
         version: 10.3.0
@@ -227,6 +230,9 @@ importers:
       '@types/blocked':
         specifier: ^1.3.4
         version: 1.3.4
+      '@types/chai':
+        specifier: ^4.3.11
+        version: 4.3.11
       '@types/mocha':
         specifier: ^10.0.6
         version: 10.0.6


### PR DESCRIPTION
Closes #424

- Add a custom schema to the 50k element iModel.
- Make elements of the 50k iModel groupable by user label, class and properties.
- Add support for assertions.
- Add `only` and `skip` parameters for the `run` function.
- Add logging of iTwin.js errors.