### PR TITLE
Unified selection: Readme and API future-proofing

### DIFF
--- a/packages/unified-selection/README.md
+++ b/packages/unified-selection/README.md
@@ -9,12 +9,14 @@ The `@itwin/unified-selection` package provides API for managing [unified select
 The API consists of a few very basic concepts:
 
 - A `Selectable` is something that can be selected and is associated with an [EC](https://www.itwinjs.org/bis/ec/) instance. There are 2 types of selectables:
+
   - `SelectableInstanceKey` uniquely identifies a single EC instance through a full class name and [ECInstanceId](https://www.itwinjs.org/learning/ecsql/#ecinstanceid-and-ecclassid).
   - `CustomSelectable` is identified by an arbitrary `identifier` string and knows how to get any number of `SelectableInstanceKey` associated with it.
 
 - `Selectables` is a container for multiple `Selectable` instances. The container is structured in a way that allows to quickly find specific selectables by their identifier.
 
 - `SelectionStorage` is an interface that manages `Selectables` for different [iModels](https://www.itwinjs.org/learning/imodels/). It allows:
+
   - Changing the selection (add, remove, replace, clear).
   - Get active selection.
   - Listen to selection changes.
@@ -31,33 +33,33 @@ const unifiedSelection = createStore();
 // the store should to be cleaned up when iModels are closed to free up memory, e.g.:
 import { IModelConnection } from "@itwin/core-frontend";
 IModelConnection.onClose.addListener((iModel) => {
-    unifiedSelection.clearStorage(iModel.key);
+  unifiedSelection.clearStorage(iModel.key);
 });
 
 // add a demo selection listener
 import { Selectables } from "@itwin/unified-selection";
 unifiedSelection.selectionChangeEvent.addListener(({ iModelKey, source, changeType, selectables }) => {
-    const suffix = `in ${iModelKey} iModel from ${source} component`;
-    const numSelectables = Selectables.size(selectables);
-    switch (changeType) {
-        case "add":
-            console.log(`Added ${numSelectables} items to selection ${suffix}.`);
-            break;
-        case "remove":
-            console.log(`Removed ${numSelectables} items from selection ${suffix}.`);
-            break;
-        case "replace":
-            console.log(`Replaced selection with ${numSelectables} items ${suffix}.`);
-            break;
-        case "clear":
-            console.log(`Cleared selection ${suffix}.`);
-            break;
-    }
+  const suffix = `in ${iModelKey} iModel from ${source} component`;
+  const numSelectables = Selectables.size(selectables);
+  switch (changeType) {
+    case "add":
+      console.log(`Added ${numSelectables} items to selection ${suffix}.`);
+      break;
+    case "remove":
+      console.log(`Removed ${numSelectables} items from selection ${suffix}.`);
+      break;
+    case "replace":
+      console.log(`Replaced selection with ${numSelectables} items ${suffix}.`);
+      break;
+    case "clear":
+      console.log(`Cleared selection ${suffix}.`);
+      break;
+  }
 });
 
 // in some component
-MyComponent.onECInstanceSelected((iModel: IModelConnection, key: { className: string, id: Id64String }) => {
-    unifiedSelection.addToSelection({ iModelKey: iModel.key, source: "MyComponent", selectables: [key] });
+MyComponent.onECInstanceSelected((iModel: IModelConnection, key: { className: string; id: Id64String }) => {
+  unifiedSelection.addToSelection({ iModelKey: iModel.key, source: "MyComponent", selectables: [key] });
 });
 ```
 
@@ -67,13 +69,13 @@ MyComponent.onECInstanceSelected((iModel: IModelConnection, key: { className: st
 
 By default, whenever a component changes unified selection, that happens at 0th (top) selection level. And similarly, whenever a component requests current selection from the storage, by default the top selection level is used. However, there are cases when we want to have multiple levels of selection.
 
-For example, let's say there're 3 components: *A*, *B* and *C*:
+For example, let's say there're 3 components: _A_, _B_ and _C_:
 
-- *Component A* shows a list of elements and allows selecting them.
-- *Component B* shows a list of elements selected in *Component A* and allows selecting them individually. Selecting an individual element should not change selection in *Component A* or content in *Component B* itself.
-- *Component C* shows properties of elements selected either in *Component A* or *Component B*.
+- _Component A_ shows a list of elements and allows selecting them.
+- _Component B_ shows a list of elements selected in _Component A_ and allows selecting them individually. Selecting an individual element should not change selection in _Component A_ or content in _Component B_ itself.
+- _Component C_ shows properties of elements selected either in _Component A_ or _Component B_.
 
-The behavior described above can't be achieved using just one level of selection, because as soon as selection is made in *Component B*, that selection would get represented in *Component A*, and *Component B* would change what it's displaying to the individual element.
+The behavior described above can't be achieved using just one level of selection, because as soon as selection is made in _Component B_, that selection would get represented in _Component A_, and _Component B_ would change what it's displaying to the individual element.
 
 That can be fixed by introducing another selection level, but before the components can be configured, here are a few key facts about selection levels:
 
@@ -81,8 +83,8 @@ That can be fixed by introducing another selection level, but before the compone
 - Changing higher level selection clears all lower level selections.
 - Lower level selection doesn't have to be a sub-set of higher level selection.
 
-With that in mind, the above components *A*, *B* and *C* can be configured as follows:
+With that in mind, the above components _A_, _B_ and _C_ can be configured as follows:
 
-- *Component A* only cares about top level selection. Whenever something is selected in the component, unified selection is updated at the top level. Similarly, whenever unified selection changes, the component only reacts if that happened at the top level.
-- *Component B* reloads its content if the selection changes at the top level. Row selection is handled using lower level, so selecting a row doesn't affect *Component A's* selection or *Component B's* content.
-- *Component C* reloads its content no matter the selection level.
+- _Component A_ only cares about top level selection. Whenever something is selected in the component, unified selection is updated at the top level. Similarly, whenever unified selection changes, the component only reacts if that happened at the top level.
+- _Component B_ reloads its content if the selection changes at the top level. Row selection is handled using lower level, so selecting a row doesn't affect _Component A's_ selection or _Component B's_ content.
+- _Component C_ reloads its content no matter the selection level.

--- a/packages/unified-selection/README.md
+++ b/packages/unified-selection/README.md
@@ -47,7 +47,7 @@ unifiedSelection.selectionChangeEvent.addListener(({ iModelKey, source, changeTy
             console.log(`Removed ${numSelectables} items from selection ${suffix}.`);
             break;
         case "replace":
-            console.log(`Selected ${numSelectables} items ${suffix}.`);
+            console.log(`Replaced selection with ${numSelectables} items ${suffix}.`);
             break;
         case "clear":
             console.log(`Cleared selection ${suffix}.`);
@@ -56,8 +56,8 @@ unifiedSelection.selectionChangeEvent.addListener(({ iModelKey, source, changeTy
 });
 
 // in some component
-MyComponent.onECInstanceSelected((key: { className: string, id: Id64String }) => {
-    unifiedSelection.addToSelection("MyComponent", [key], 0);
+MyComponent.onECInstanceSelected((iModel: IModelConnection, key: { className: string, id: Id64String }) => {
+    unifiedSelection.addToSelection({ iModelKey: iModel.key, source: "MyComponent", selectables: [key] });
 });
 ```
 

--- a/packages/unified-selection/README.md
+++ b/packages/unified-selection/README.md
@@ -2,6 +2,87 @@
 
 Copyright © Bentley Systems, Incorporated. All rights reserved. See LICENSE.md for license terms and full copyright notice.
 
-## Description
+The `@itwin/unified-selection` package provides API for managing [unified selection](https://www.itwinjs.org/presentation/unified-selection/).
 
-The **@itwin/unified-selection** package provides API for managing [unified selection](https://www.itwinjs.org/presentation/unified-selection/).
+## Basic concepts
+
+The API consists of a few very basic concepts:
+
+- A `Selectable` is something that can be selected and is associated with an [EC](https://www.itwinjs.org/bis/ec/) instance. There are 2 types of selectables:
+  - `SelectableInstanceKey` uniquely identifies a single EC instance through a full class name and [ECInstanceId](https://www.itwinjs.org/learning/ecsql/#ecinstanceid-and-ecclassid).
+  - `CustomSelectable` is identified by an arbitrary `identifier` string and knows how to get any number of `SelectableInstanceKey` associated with it.
+
+- `Selectables` is a container for multiple `Selectable` instances. The container is structured in a way that allows to quickly find specific selectables by their identifier.
+
+- `SelectionStorage` is an interface that manages `Selectables` for different [iModels](https://www.itwinjs.org/learning/imodels/). It allows:
+  - Changing the selection (add, remove, replace, clear).
+  - Get active selection.
+  - Listen to selection changes.
+
+  The package delivers the `createStorage()` function to create an instance of `SelectionStorage`. Consumers are also expected to call `SelectionStorage.clearStorage` whenever an iModel is closed to free up memory.
+
+## Basic usage
+
+```ts
+// create a global selection store (generally, somewhere in main.ts or similar)
+import { createStore } from "@itwin/unified-selection";
+const unifiedSelection = createStore();
+
+// the store should to be cleaned up when iModels are closed to free up memory, e.g.:
+import { IModelConnection } from "@itwin/core-frontend";
+IModelConnection.onClose.addListener((iModel) => {
+    unifiedSelection.clearStorage(iModel.key);
+});
+
+// add a demo selection listener
+import { Selectables } from "@itwin/unified-selection";
+unifiedSelection.selectionChangeEvent.addListener(({ iModelKey, source, changeType, selectables }) => {
+    const suffix = `in ${iModelKey} iModel from ${source} component`;
+    const numSelectables = Selectables.size(selectables);
+    switch (changeType) {
+        case "add":
+            console.log(`Added ${numSelectables} items to selection ${suffix}.`);
+            break;
+        case "remove":
+            console.log(`Removed ${numSelectables} items from selection ${suffix}.`);
+            break;
+        case "replace":
+            console.log(`Selected ${numSelectables} items ${suffix}.`);
+            break;
+        case "clear":
+            console.log(`Cleared selection ${suffix}.`);
+            break;
+    }
+});
+
+// in some component
+MyComponent.onECInstanceSelected((key: { className: string, id: Id64String }) => {
+    unifiedSelection.addToSelection("MyComponent", [key], 0);
+});
+```
+
+## Details
+
+### Selection levels
+
+By default, whenever a component changes unified selection, that happens at 0th (top) selection level. And similarly, whenever a component requests current selection from the storage, by default the top selection level is used. However, there are cases when we want to have multiple levels of selection.
+
+For example, let's say there're 3 components: *A*, *B* and *C*:
+
+- *Component A* shows a list of elements and allows selecting them.
+- *Component B* shows a list of elements selected in *Component A* and allows selecting them individually. Selecting an individual element should not change selection in *Component A* or content in *Component B* itself.
+- *Component C* shows properties of elements selected either in *Component A* or *Component B*.
+
+The behavior described above can't be achieved using just one level of selection, because as soon as selection is made in *Component B*, that selection would get represented in *Component A*, and *Component B* would change what it's displaying to the individual element.
+
+That can be fixed by introducing another selection level, but before the components can be configured, here are a few key facts about selection levels:
+
+- Higher level selection has lower index. So top level selection is 0, lower level is 1, and so on.
+- Changing higher level selection clears all lower level selections.
+- Lower level selection doesn't have to be a sub-set of higher level selection.
+
+With that in mind, the above components *A*, *B* and *C* can be configured as follows:
+
+- *Component A* only cares about top level selection. Whenever something is selected in the component, unified selection is updated at the top level. Similarly, whenever unified selection changes, the component only reacts if that happened at the top level.
+- *Component B* reloads its content if the selection changes at the top level. Row selection is handled using lower level, so selecting a row doesn't affect *Component A's* selection or *Component B's* content.
+- *Component C* reloads its content no matter the selection level.

--- a/packages/unified-selection/api/unified-selection.api.md
+++ b/packages/unified-selection/api/unified-selection.api.md
@@ -9,8 +9,7 @@ export function createStorage(): SelectionStorage;
 
 // @beta
 export interface CustomSelectable {
-    // @internal
-    data: any;
+    data: unknown;
     identifier: string;
     loadInstanceKeys: () => AsyncIterableIterator<SelectableInstanceKey>;
 }
@@ -59,13 +58,39 @@ export interface SelectionChangeEvent {
 
 // @beta
 export interface SelectionStorage {
-    addToSelection(source: string, iModelKey: string, selectables: Selectable[], level: number): void;
-    clearSelection(source: string, iModelKey: string, level: number): void;
-    clearStorage(iModelKey: string): void;
-    getSelection(iModelKey: string, level: number): Selectables;
-    getSelectionLevels(iModelKey: string): number[];
-    removeFromSelection(source: string, iModelKey: string, selectables: Selectable[], level: number): void;
-    replaceSelection(source: string, iModelKey: string, selectables: Selectable[], level: number): void;
+    addToSelection(props: {
+        iModelKey: string;
+        source: string;
+        selectables: Selectable[];
+        level?: number;
+    }): void;
+    clearSelection(props: {
+        iModelKey: string;
+        source: string;
+        level?: number;
+    }): void;
+    clearStorage(props: {
+        iModelKey: string;
+    }): void;
+    getSelection(props: {
+        iModelKey: string;
+        level?: number;
+    }): Selectables;
+    getSelectionLevels(props: {
+        iModelKey: string;
+    }): number[];
+    removeFromSelection(props: {
+        iModelKey: string;
+        source: string;
+        selectables: Selectable[];
+        level?: number;
+    }): void;
+    replaceSelection(props: {
+        iModelKey: string;
+        source: string;
+        selectables: Selectable[];
+        level?: number;
+    }): void;
     selectionChangeEvent: SelectionChangeEvent;
 }
 

--- a/packages/unified-selection/src/test/SelectionStorage.test.ts
+++ b/packages/unified-selection/src/test/SelectionStorage.test.ts
@@ -16,8 +16,8 @@ const generateSelection = (): SelectableInstanceKey[] => {
 describe("SelectionStorage", () => {
   let selectionStorage: SelectionStorage;
   let baseSelection: SelectableInstanceKey[];
-  const iModel = "iModelKey";
-  const source: string = "test";
+  const iModelKey = "iModelKey";
+  const source = "test";
 
   beforeEach(() => {
     selectionStorage = createStorage();
@@ -25,40 +25,40 @@ describe("SelectionStorage", () => {
   });
 
   describe("clearStorage", () => {
-    it("clears iModel selection", () => {
-      selectionStorage.addToSelection(source, iModel, [createSelectableInstanceKey()], 0);
-      expect(Selectables.isEmpty(selectionStorage.getSelection(iModel, 0))).to.be.false;
+    it("clears iModelKey selection", () => {
+      selectionStorage.addToSelection({ iModelKey, source, selectables: [createSelectableInstanceKey()] });
+      expect(Selectables.isEmpty(selectionStorage.getSelection({ iModelKey }))).to.be.false;
       const listenerSpy = sinon.spy(() => {});
       selectionStorage.selectionChangeEvent.addListener(listenerSpy);
-      selectionStorage.clearStorage(iModel);
-      expect(Selectables.isEmpty(selectionStorage.getSelection(iModel, 0))).to.be.true;
+      selectionStorage.clearStorage({ iModelKey });
+      expect(Selectables.isEmpty(selectionStorage.getSelection({ iModelKey }))).to.be.true;
       expect(listenerSpy, "Expected selectionChange.onSelectionChange to be called").to.have.callCount(1);
     });
   });
 
   describe("getSelectionLevels", () => {
     it("returns empty list when there're no selection levels", () => {
-      expect(selectionStorage.getSelectionLevels(iModel)).to.be.empty;
+      expect(selectionStorage.getSelectionLevels({ iModelKey })).to.be.empty;
     });
 
     it("returns available selection levels", () => {
-      selectionStorage.addToSelection("", iModel, [createSelectableInstanceKey(1, "class1")], 0);
-      selectionStorage.addToSelection("", iModel, [createSelectableInstanceKey(2, "class2")], 3);
-      expect(selectionStorage.getSelectionLevels(iModel)).to.deep.eq([0, 3]);
+      selectionStorage.addToSelection({ iModelKey, source: "", selectables: [createSelectableInstanceKey(1, "class1")] });
+      selectionStorage.addToSelection({ iModelKey, source: "", selectables: [createSelectableInstanceKey(2, "class2")], level: 3 });
+      expect(selectionStorage.getSelectionLevels({ iModelKey })).to.deep.eq([0, 3]);
     });
 
     it("doesn't include empty selection levels", () => {
-      selectionStorage.addToSelection("", iModel, [createSelectableInstanceKey(1, "class1")], 0);
-      selectionStorage.addToSelection("", iModel, [createSelectableInstanceKey(2, "class2")], 1);
-      selectionStorage.addToSelection("", iModel, [], 2);
-      expect(selectionStorage.getSelectionLevels(iModel)).to.deep.eq([0, 1]);
+      selectionStorage.addToSelection({ iModelKey, source: "", selectables: [createSelectableInstanceKey(1, "class1")] });
+      selectionStorage.addToSelection({ iModelKey, source: "", selectables: [createSelectableInstanceKey(2, "class2")], level: 1 });
+      selectionStorage.addToSelection({ iModelKey, source: "", selectables: [], level: 2 });
+      expect(selectionStorage.getSelectionLevels({ iModelKey })).to.deep.eq([0, 1]);
     });
   });
 
   describe("addToSelection", () => {
     it("adds selection on an empty selection", () => {
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      const selectables = selectionStorage.getSelection(iModel, 0);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection });
+      const selectables = selectionStorage.getSelection({ iModelKey });
       expect(Selectables.size(selectables)).to.be.equal(baseSelection.length);
 
       for (const selectable of baseSelection) {
@@ -67,9 +67,9 @@ describe("SelectionStorage", () => {
     });
 
     it("adds selection on non empty selection", () => {
-      selectionStorage.addToSelection(source, iModel, [baseSelection[0]], 0);
-      selectionStorage.addToSelection(source, iModel, [baseSelection[1], baseSelection[2]], 0);
-      const selectables = selectionStorage.getSelection(iModel, 0);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: [baseSelection[0]] });
+      selectionStorage.addToSelection({ iModelKey, source, selectables: [baseSelection[1], baseSelection[2]] });
+      const selectables = selectionStorage.getSelection({ iModelKey });
       expect(Selectables.size(selectables)).to.be.equal(baseSelection.length);
 
       for (const selectable of baseSelection) {
@@ -79,11 +79,11 @@ describe("SelectionStorage", () => {
 
     it("adds selection on different iModels", () => {
       const iModel2 = "iModel2";
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.addToSelection(source, iModel2, baseSelection, 0);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection });
+      selectionStorage.addToSelection({ iModelKey: iModel2, source, selectables: baseSelection });
 
-      for (const iModelToken of [iModel, iModel2]) {
-        const selectables = selectionStorage.getSelection(iModelToken, 0);
+      for (const iModelToken of [iModelKey, iModel2]) {
+        const selectables = selectionStorage.getSelection({ iModelKey: iModelToken });
         expect(Selectables.size(selectables)).to.be.equal(baseSelection.length);
 
         for (const selectable of baseSelection) {
@@ -93,10 +93,10 @@ describe("SelectionStorage", () => {
     });
 
     it("adds selection on different levels", () => {
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.addToSelection(source, iModel, baseSelection, 1);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection });
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection, level: 1 });
       for (let i = 0; i <= 1; i++) {
-        const selectables = selectionStorage.getSelection(iModel, i);
+        const selectables = selectionStorage.getSelection({ iModelKey, level: i });
         expect(Selectables.size(selectables)).to.be.equal(baseSelection.length);
         for (const selectable of baseSelection) {
           expect(Selectables.has(selectables, selectable)).true;
@@ -105,26 +105,26 @@ describe("SelectionStorage", () => {
     });
 
     it("clears higher level selection when adding items to lower level selection", () => {
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.addToSelection(source, iModel, [createSelectableInstanceKey(1, "class1")], 1);
-      selectionStorage.addToSelection(source, iModel, [createSelectableInstanceKey(2, "class2")], 0);
-      const selectables = selectionStorage.getSelection(iModel, 1);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection });
+      selectionStorage.addToSelection({ iModelKey, source, selectables: [createSelectableInstanceKey(1, "class1")], level: 1 });
+      selectionStorage.addToSelection({ iModelKey, source, selectables: [createSelectableInstanceKey(2, "class2")], level: 0 });
+      const selectables = selectionStorage.getSelection({ iModelKey, level: 1 });
       expect(Selectables.isEmpty(selectables)).to.be.true;
     });
 
     it("doesn't clear higher level selection when adding same items to lower level selection", () => {
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.addToSelection(source, iModel, [createSelectableInstanceKey(1)], 1);
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      const selectables = selectionStorage.getSelection(iModel, 1);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection, level: 0 });
+      selectionStorage.addToSelection({ iModelKey, source, selectables: [createSelectableInstanceKey(1)], level: 1 });
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection, level: 0 });
+      const selectables = selectionStorage.getSelection({ iModelKey, level: 1 });
       expect(Selectables.isEmpty(selectables)).to.be.false;
     });
   });
 
   describe("replaceSelection", () => {
     it("replaces selection on an empty selection", () => {
-      selectionStorage.replaceSelection(source, iModel, baseSelection, 0);
-      const selectables = selectionStorage.getSelection(iModel, 0);
+      selectionStorage.replaceSelection({ iModelKey, source, selectables: baseSelection });
+      const selectables = selectionStorage.getSelection({ iModelKey });
       expect(Selectables.size(selectables)).to.be.equal(baseSelection.length);
 
       for (const selectable of baseSelection) {
@@ -133,9 +133,9 @@ describe("SelectionStorage", () => {
     });
 
     it("replaces on an non empty selection", () => {
-      selectionStorage.addToSelection(source, iModel, [baseSelection[0]], 0);
-      selectionStorage.replaceSelection(source, iModel, [baseSelection[1], baseSelection[2]], 0);
-      const selectables = selectionStorage.getSelection(iModel, 0);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: [baseSelection[0]] });
+      selectionStorage.replaceSelection({ iModelKey, source, selectables: [baseSelection[1], baseSelection[2]] });
+      const selectables = selectionStorage.getSelection({ iModelKey });
       expect(Selectables.size(selectables)).to.be.equal(baseSelection.length - 1);
       expect(Selectables.has(selectables, baseSelection[0])).false;
       expect(Selectables.has(selectables, baseSelection[1])).true;
@@ -144,11 +144,11 @@ describe("SelectionStorage", () => {
 
     it("replaces on different iModels", () => {
       const iModel2 = "iModel2";
-      selectionStorage.replaceSelection(source, iModel, baseSelection, 0);
-      selectionStorage.replaceSelection(source, iModel2, baseSelection, 0);
+      selectionStorage.replaceSelection({ iModelKey, source, selectables: baseSelection });
+      selectionStorage.replaceSelection({ iModelKey: iModel2, source, selectables: baseSelection });
 
-      for (const iModelToken of [iModel, iModel2]) {
-        const selectables = selectionStorage.getSelection(iModelToken, 0);
+      for (const iModelToken of [iModelKey, iModel2]) {
+        const selectables = selectionStorage.getSelection({ iModelKey: iModelToken });
         expect(Selectables.size(selectables)).to.be.equal(baseSelection.length);
 
         for (const selectable of baseSelection) {
@@ -158,10 +158,10 @@ describe("SelectionStorage", () => {
     });
 
     it("replaces with different levels", () => {
-      selectionStorage.replaceSelection(source, iModel, baseSelection, 0);
-      selectionStorage.replaceSelection(source, iModel, baseSelection, 1);
+      selectionStorage.replaceSelection({ iModelKey, source, selectables: baseSelection, level: 0 });
+      selectionStorage.replaceSelection({ iModelKey, source, selectables: baseSelection, level: 1 });
       for (let i = 0; i <= 1; i++) {
-        const selectables = selectionStorage.getSelection(iModel, i);
+        const selectables = selectionStorage.getSelection({ iModelKey, level: i });
         expect(Selectables.size(selectables)).to.be.equal(baseSelection.length);
         for (const selectable of baseSelection) {
           expect(Selectables.has(selectables, selectable)).true;
@@ -170,46 +170,46 @@ describe("SelectionStorage", () => {
     });
 
     it("clears higher level selection when replacing lower level selection", () => {
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.addToSelection(source, iModel, [createSelectableInstanceKey(1, "class1")], 1);
-      selectionStorage.replaceSelection(source, iModel, [createSelectableInstanceKey(2, "class2")], 0);
-      const selectables = selectionStorage.getSelection(iModel, 1);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection, level: 0 });
+      selectionStorage.addToSelection({ iModelKey, source, selectables: [createSelectableInstanceKey(1, "class1")], level: 1 });
+      selectionStorage.replaceSelection({ iModelKey, source, selectables: [createSelectableInstanceKey(2, "class2")], level: 0 });
+      const selectables = selectionStorage.getSelection({ iModelKey, level: 1 });
       expect(Selectables.isEmpty(selectables)).to.be.true;
     });
 
     it("doesn't clear higher level selection when replacing lower level selection with same items", () => {
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.addToSelection(source, iModel, [createSelectableInstanceKey(1)], 1);
-      selectionStorage.replaceSelection(source, iModel, baseSelection, 0);
-      const selectables = selectionStorage.getSelection(iModel, 1);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection, level: 0 });
+      selectionStorage.addToSelection({ iModelKey, source, selectables: [createSelectableInstanceKey(1)], level: 1 });
+      selectionStorage.replaceSelection({ iModelKey, source, selectables: baseSelection, level: 0 });
+      const selectables = selectionStorage.getSelection({ iModelKey, level: 1 });
       expect(Selectables.isEmpty(selectables)).to.be.false;
     });
   });
 
   describe("clearSelection", () => {
     it("clears empty selection", () => {
-      selectionStorage.clearSelection(source, iModel, 0);
-      const selectables = selectionStorage.getSelection(iModel, 0);
+      selectionStorage.clearSelection({ iModelKey, source });
+      const selectables = selectionStorage.getSelection({ iModelKey });
       expect(Selectables.size(selectables)).to.be.equal(0);
     });
 
     it("clears non empty selection", () => {
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.clearSelection(source, iModel, 0);
-      expect(Selectables.isEmpty(selectionStorage.getSelection(iModel, 0))).to.be.true;
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection });
+      selectionStorage.clearSelection({ iModelKey, source });
+      expect(Selectables.isEmpty(selectionStorage.getSelection({ iModelKey }))).to.be.true;
     });
 
     it("clears on different iModels", () => {
       const iModel2 = "iModel2";
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.addToSelection(source, iModel2, baseSelection, 0);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection });
+      selectionStorage.addToSelection({ iModelKey: iModel2, source, selectables: baseSelection });
 
-      selectionStorage.clearSelection(source, iModel2, 0);
+      selectionStorage.clearSelection({ iModelKey: iModel2, source });
 
-      let selectables = selectionStorage.getSelection(iModel2, 0);
+      let selectables = selectionStorage.getSelection({ iModelKey: iModel2 });
       expect(Selectables.size(selectables)).to.be.equal(0);
 
-      selectables = selectionStorage.getSelection(iModel, 0);
+      selectables = selectionStorage.getSelection({ iModelKey });
       expect(Selectables.size(selectables)).to.be.equal(baseSelection.length);
 
       for (const selectable of baseSelection) {
@@ -218,42 +218,42 @@ describe("SelectionStorage", () => {
     });
 
     it("clears with different levels", () => {
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.addToSelection(source, iModel, baseSelection, 1);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection, level: 0 });
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection, level: 1 });
 
-      selectionStorage.clearSelection(source, iModel, 1);
-      let selectables = selectionStorage.getSelection(iModel, 1);
-      expect(Selectables.size(selectables)).to.be.equal(0);
+      selectionStorage.clearSelection({ iModelKey, source, level: 1 });
+      const selectablesAtLevel1 = selectionStorage.getSelection({ iModelKey, level: 1 });
+      expect(Selectables.size(selectablesAtLevel1)).to.be.equal(0);
 
-      selectables = selectionStorage.getSelection(iModel, 0);
-      expect(Selectables.size(selectables)).to.be.equal(baseSelection.length);
+      const selectablesAtLevel0 = selectionStorage.getSelection({ iModelKey, level: 0 });
+      expect(Selectables.size(selectablesAtLevel0)).to.be.equal(baseSelection.length);
 
       for (const selectable of baseSelection) {
-        expect(Selectables.has(selectables, selectable)).true;
+        expect(Selectables.has(selectablesAtLevel0, selectable)).to.be.true;
       }
     });
 
     it("clears higher level selection when clearing items in lower level selection", () => {
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.addToSelection(source, iModel, [createSelectableInstanceKey(1)], 1);
-      selectionStorage.clearSelection(source, iModel, 0);
-      const selectables = selectionStorage.getSelection(iModel, 1);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection, level: 0 });
+      selectionStorage.addToSelection({ iModelKey, source, selectables: [createSelectableInstanceKey(1)], level: 1 });
+      selectionStorage.clearSelection({ iModelKey, source, level: 0 });
+      const selectables = selectionStorage.getSelection({ iModelKey, level: 1 });
       expect(Selectables.isEmpty(selectables)).to.be.true;
     });
 
-    it("doesn't clears higher level selection when clearing empty lower level selection", () => {
-      selectionStorage.addToSelection(source, iModel, [createSelectableInstanceKey(1)], 1);
-      selectionStorage.clearSelection(source, iModel, 0);
-      const selectables = selectionStorage.getSelection(iModel, 1);
+    it("doesn't clear higher level selection when clearing empty lower level selection", () => {
+      selectionStorage.addToSelection({ iModelKey, source, selectables: [createSelectableInstanceKey(1)], level: 1 });
+      selectionStorage.clearSelection({ iModelKey, source, level: 0 });
+      const selectables = selectionStorage.getSelection({ iModelKey, level: 1 });
       expect(Selectables.isEmpty(selectables)).to.be.false;
     });
   });
 
   describe("removeFromSelection", () => {
     it("removes part of the selection", () => {
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.removeFromSelection(source, iModel, [baseSelection[1], baseSelection[2]], 0);
-      const selectables = selectionStorage.getSelection(iModel, 0);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection });
+      selectionStorage.removeFromSelection({ iModelKey, source, selectables: [baseSelection[1], baseSelection[2]] });
+      const selectables = selectionStorage.getSelection({ iModelKey });
       expect(Selectables.size(selectables)).to.be.equal(baseSelection.length - 2);
       expect(Selectables.has(selectables, baseSelection[0])).true;
       expect(Selectables.has(selectables, baseSelection[1])).false;
@@ -261,26 +261,26 @@ describe("SelectionStorage", () => {
     });
 
     it("removes whole selection", () => {
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.removeFromSelection(source, iModel, baseSelection, 0);
-      const selectables = selectionStorage.getSelection(iModel, 0);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection });
+      selectionStorage.removeFromSelection({ iModelKey, source, selectables: baseSelection });
+      const selectables = selectionStorage.getSelection({ iModelKey });
       expect(Selectables.size(selectables)).to.be.equal(0);
     });
 
     it("removes on different iModels", () => {
       const iModel2 = "iModel2";
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.addToSelection(source, iModel2, baseSelection, 0);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection });
+      selectionStorage.addToSelection({ iModelKey: iModel2, source, selectables: baseSelection });
 
-      selectionStorage.removeFromSelection(source, iModel, [baseSelection[0]], 0);
-      selectionStorage.removeFromSelection(source, iModel2, [baseSelection[1], baseSelection[2]], 0);
-      let selectables = selectionStorage.getSelection(iModel, 0);
+      selectionStorage.removeFromSelection({ iModelKey, source, selectables: [baseSelection[0]] });
+      selectionStorage.removeFromSelection({ iModelKey: iModel2, source, selectables: [baseSelection[1], baseSelection[2]] });
+      let selectables = selectionStorage.getSelection({ iModelKey });
       expect(Selectables.size(selectables)).to.be.equal(baseSelection.length - 1);
       expect(Selectables.has(selectables, baseSelection[0])).false;
       expect(Selectables.has(selectables, baseSelection[1])).true;
       expect(Selectables.has(selectables, baseSelection[2])).true;
 
-      selectables = selectionStorage.getSelection(iModel2, 0);
+      selectables = selectionStorage.getSelection({ iModelKey: iModel2 });
       expect(Selectables.size(selectables)).to.be.equal(baseSelection.length - 2);
       expect(Selectables.has(selectables, baseSelection[0])).true;
       expect(Selectables.has(selectables, baseSelection[1])).false;
@@ -288,58 +288,58 @@ describe("SelectionStorage", () => {
     });
 
     it("removes with different levels", () => {
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.addToSelection(source, iModel, baseSelection, 1);
-      selectionStorage.removeFromSelection(source, iModel, [baseSelection[0]], 1);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection, level: 0 });
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection, level: 1 });
+      selectionStorage.removeFromSelection({ iModelKey, source, selectables: [baseSelection[0]], level: 1 });
 
-      let selectables = selectionStorage.getSelection(iModel, 0);
-      expect(Selectables.size(selectables)).to.be.equal(baseSelection.length);
-      expect(Selectables.has(selectables, baseSelection[0])).true;
-      expect(Selectables.has(selectables, baseSelection[1])).true;
-      expect(Selectables.has(selectables, baseSelection[2])).true;
+      const selectablesAtLevel0 = selectionStorage.getSelection({ iModelKey, level: 0 });
+      expect(Selectables.size(selectablesAtLevel0)).to.be.equal(baseSelection.length);
+      expect(Selectables.has(selectablesAtLevel0, baseSelection[0])).true;
+      expect(Selectables.has(selectablesAtLevel0, baseSelection[1])).true;
+      expect(Selectables.has(selectablesAtLevel0, baseSelection[2])).true;
 
-      selectables = selectionStorage.getSelection(iModel, 1);
-      expect(Selectables.size(selectables)).to.be.equal(baseSelection.length - 1);
-      expect(Selectables.has(selectables, baseSelection[0])).false;
-      expect(Selectables.has(selectables, baseSelection[1])).true;
-      expect(Selectables.has(selectables, baseSelection[2])).true;
+      const selectablesAtLevel1 = selectionStorage.getSelection({ iModelKey, level: 1 });
+      expect(Selectables.size(selectablesAtLevel1)).to.be.equal(baseSelection.length - 1);
+      expect(Selectables.has(selectablesAtLevel1, baseSelection[0])).false;
+      expect(Selectables.has(selectablesAtLevel1, baseSelection[1])).true;
+      expect(Selectables.has(selectablesAtLevel1, baseSelection[2])).true;
     });
 
     it("clears higher level selection when removing items from lower level selection", () => {
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.addToSelection(source, iModel, [createSelectableInstanceKey(1)], 1);
-      selectionStorage.removeFromSelection(source, iModel, baseSelection, 0);
-      const selectables = selectionStorage.getSelection(iModel, 1);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection, level: 0 });
+      selectionStorage.addToSelection({ iModelKey, source, selectables: [createSelectableInstanceKey(1)], level: 1 });
+      selectionStorage.removeFromSelection({ iModelKey, source, selectables: baseSelection, level: 0 });
+      const selectables = selectionStorage.getSelection({ iModelKey, level: 1 });
       expect(Selectables.isEmpty(selectables)).to.be.true;
     });
 
     it("doesn't clear higher level selection when removing non-existing items from lower level selection", () => {
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.addToSelection(source, iModel, [createSelectableInstanceKey(1, "class1")], 1);
-      selectionStorage.removeFromSelection(source, iModel, [createSelectableInstanceKey(2, "class2")], 0);
-      const selectables = selectionStorage.getSelection(iModel, 1);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection, level: 0 });
+      selectionStorage.addToSelection({ iModelKey, source, selectables: [createSelectableInstanceKey(1, "class1")], level: 1 });
+      selectionStorage.removeFromSelection({ iModelKey, source, selectables: [createSelectableInstanceKey(2, "class2")] });
+      const selectables = selectionStorage.getSelection({ iModelKey, level: 1 });
       expect(Selectables.isEmpty(selectables)).to.be.false;
     });
   });
 
   describe("selectionChange", () => {
     it("fires `selectionChange` event after `addToSelection`, `replaceSelection`, `clearSelection`, `removeFromSelection`", () => {
-      const listenerSpy = sinon.spy(() => {});
+      const listenerSpy = sinon.stub();
       selectionStorage.selectionChangeEvent.addListener(listenerSpy);
-      selectionStorage.addToSelection(source, iModel, baseSelection, 0);
-      selectionStorage.removeFromSelection(source, iModel, baseSelection, 0);
-      selectionStorage.replaceSelection(source, iModel, baseSelection, 0);
-      selectionStorage.clearSelection(source, iModel, 0);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: baseSelection });
+      selectionStorage.removeFromSelection({ iModelKey, source, selectables: baseSelection });
+      selectionStorage.replaceSelection({ iModelKey, source, selectables: baseSelection });
+      selectionStorage.clearSelection({ iModelKey, source });
       expect(listenerSpy, "Expected selectionChange.raiseEvent to be called").to.have.callCount(4);
     });
 
     it("doesn't fire `selectionChange` event after addToSelection, replaceSelection, clearSelection, removeFromSelection if nothing changes", () => {
-      const listenerSpy = sinon.spy(() => {});
+      const listenerSpy = sinon.stub();
       selectionStorage.selectionChangeEvent.addListener(listenerSpy);
-      selectionStorage.addToSelection(source, iModel, [], 0);
-      selectionStorage.clearSelection(source, iModel, 0);
-      selectionStorage.removeFromSelection(source, iModel, baseSelection, 0);
-      selectionStorage.replaceSelection(source, iModel, [], 0);
+      selectionStorage.addToSelection({ iModelKey, source, selectables: [] });
+      selectionStorage.clearSelection({ iModelKey, source });
+      selectionStorage.removeFromSelection({ iModelKey, source, selectables: baseSelection });
+      selectionStorage.replaceSelection({ iModelKey, source, selectables: [] });
       expect(listenerSpy, "Expected selectionChange.raiseEvent to not be called").to.not.have.been.called;
     });
   });

--- a/packages/unified-selection/src/unified-selection/Selectable.ts
+++ b/packages/unified-selection/src/unified-selection/Selectable.ts
@@ -12,7 +12,7 @@
  * @beta
  */
 export interface SelectableInstanceKey {
-  /** Full class name in format `SchemaName:ClassName` or `SchemaName.ClassName` */
+  /** Full class name in format `SchemaName:ClassName` or `SchemaName.ClassName`. */
   className: string;
   /** ECInstance ID */
   id: string;
@@ -23,14 +23,12 @@ export interface SelectableInstanceKey {
  * @beta
  */
 export interface CustomSelectable {
-  /** Unique identifier of the selectable */
+  /** Unique identifier of the selectable. */
   identifier: string;
-  /** Asynchronous function for loading instance keys */
+  /** Asynchronous function for loading instance keys associated with this selectable. */
   loadInstanceKeys: () => AsyncIterableIterator<SelectableInstanceKey>;
-  /** Custom data of the selectable
-   * @internal
-   */
-  data: any;
+  /** Custom data associated with the selectable. */
+  data: unknown;
 }
 
 /**
@@ -60,11 +58,11 @@ export namespace Selectable {
  */
 export interface Selectables {
   /**
-   * Map between ECInstance className and instance IDs
+   * Map between `SelectableInstanceKey.className` and a set of selected element IDs.
    */
   instanceKeys: Map<string, Set<string>>;
   /**
-   * Map between unique identifier of `CustomSelectable` and the selectable itself
+   * Map between unique identifier of `CustomSelectable` and the selectable itself.
    */
   custom: Map<string, CustomSelectable>;
 }

--- a/packages/unified-selection/src/unified-selection/SelectionStorage.ts
+++ b/packages/unified-selection/src/unified-selection/SelectionStorage.ts
@@ -15,59 +15,78 @@ import { SelectionChangeEvent, SelectionChangeEventImpl, StorageSelectionChangeE
  * @beta
  */
 export interface SelectionStorage {
-  /** An event that is raised when selection changes */
+  /** An event that is raised when selection changes. */
   selectionChangeEvent: SelectionChangeEvent;
-  /**
-   * Get the selection levels currently stored for the specified imodel
-   * @param iModelKey iModel key to get selection levels for.
-   * */
-  getSelectionLevels(iModelKey: string): number[];
-  /** Get the selection stored in the storage.
-   * @param iModelKey iModel key which the selection is associated with.
-   * @param level Level of the selection
-   */
-  getSelection(iModelKey: string, level: number): Selectables;
-  /**
-   * Add keys to the selection
-   * @param source Name of the selection source
-   * @param iModelKey iModel associated with the selection
-   * @param selectables selectables to add
-   * @param level Selection level
-   */
-  addToSelection(source: string, iModelKey: string, selectables: Selectable[], level: number): void;
-  /**
-   * Remove keys from current selection
-   * @param source Name of the selection source
-   * @param iModelKey iModel associated with the selection
-   * @param selectables selectables to remove
-   * @param level Selection level
-   */
-  removeFromSelection(source: string, iModelKey: string, selectables: Selectable[], level: number): void;
-  /**
-   * Replace current selection
-   * @param source Name of the selection source
-   * @param iModelKey iModel associated with the selection
-   * @param selectables selectables to replace the current selection with
-   * @param level Selection level
-   */
-  replaceSelection(source: string, iModelKey: string, selectables: Selectable[], level: number): void;
-  /**
-   * Clear current selection
-   * @param source Name of the selection source
-   * @param iModelKey iModel associated with the selection
-   * @param level Selection level
-   */
-  clearSelection(source: string, iModelKey: string, level: number): void;
-  /**
-   * Clear storage for an iModel. This function should be called when iModel is closed.
-   * @param iModelKey iModel to clear storage for
-   */
-  clearStorage(iModelKey: string): void;
+
+  /** Get the selection levels currently stored for the specified iModel. */
+  getSelectionLevels(props: {
+    /** Key of the iModel to get selection levels for. */
+    iModelKey: string;
+  }): number[];
+
+  /** Get the selection stored in the storage. */
+  getSelection(props: {
+    /** Key of the iModel to get selection for. */
+    iModelKey: string;
+    /** Level of the selection. Defaults to `0`. */
+    level?: number;
+  }): Selectables;
+
+  /** Add keys to the selection. */
+  addToSelection(props: {
+    /** Key of the iModel to change selection for. */
+    iModelKey: string;
+    /** Name of the selection source. Generally, this identifies the component that makes the selection change. */
+    source: string;
+    /** The selectables to add to selection. */
+    selectables: Selectable[];
+    /** Level of the selection. Defaults to `0`. */
+    level?: number;
+  }): void;
+
+  /** Remove keys from current selection. */
+  removeFromSelection(props: {
+    /** Key of the iModel to change selection for. */
+    iModelKey: string;
+    /** Name of the selection source. Generally, this identifies the component that makes the selection change. */
+    source: string;
+    /** The selectables to remove from selection. */
+    selectables: Selectable[];
+    /** Level of the selection. Defaults to `0`. */
+    level?: number;
+  }): void;
+
+  /** Replace current selection. */
+  replaceSelection(props: {
+    /** Key of the iModel to change selection for. */
+    iModelKey: string;
+    /** Name of the selection source. Generally, this identifies the component that makes the selection change. */
+    source: string;
+    /** The selectables to add to selection. */
+    selectables: Selectable[];
+    /** Level of the selection. Defaults to `0`. */
+    level?: number;
+  }): void;
+
+  /** Clear current selection. */
+  clearSelection(props: {
+    /** Key of the iModel to change selection for. */
+    iModelKey: string;
+    /** Name of the selection source. Generally, this identifies the component that makes the selection change. */
+    source: string;
+    /** Level of the selection. Defaults to `0`. */
+    level?: number;
+  }): void;
+
+  /** Clear storage for an iModel. This function should be called when iModel is closed. */
+  clearStorage(props: {
+    /** Key of the iModel to change selection for. */
+    iModelKey: string;
+  }): void;
 }
 
 /**
- * Creates a selection storage which stores the overall selection.
- * When an iModel is closed `clearSelection` function should be called.
+ * Creates a selection storage. When an iModel is closed `SelectionStorage.clearSelection` function should be called.
  * @beta
  */
 export function createStorage(): SelectionStorage {
@@ -82,32 +101,33 @@ class SelectionStorageImpl implements SelectionStorage {
     this.selectionChangeEvent = new SelectionChangeEventImpl();
   }
 
-  public getSelectionLevels(iModelKey: string): number[] {
+  public getSelectionLevels({ iModelKey }: { iModelKey: string }): number[] {
     return this.getContainer(iModelKey).getSelectionLevels();
   }
 
-  public getSelection(iModelKey: string, level: number): Selectables {
-    return this.getContainer(iModelKey).getSelection(level);
+  public getSelection(props: { iModelKey: string; level?: number }): Selectables {
+    const { iModelKey, level } = props;
+    return this.getContainer(iModelKey).getSelection(level ?? 0);
   }
 
-  public addToSelection(source: string, iModelKey: string, selectables: Selectable[], level: number): void {
-    this.handleChange(source, iModelKey, level, "add", selectables);
+  public addToSelection(props: { source: string; iModelKey: string; selectables: Selectable[]; level?: number }): void {
+    this.handleChange({ ...props, changeType: "add" });
   }
 
-  public removeFromSelection(source: string, iModelKey: string, selectables: Selectable[], level: number): void {
-    this.handleChange(source, iModelKey, level, "remove", selectables);
+  public removeFromSelection(props: { source: string; iModelKey: string; selectables: Selectable[]; level?: number }): void {
+    this.handleChange({ ...props, changeType: "remove" });
   }
 
-  public replaceSelection(source: string, iModelKey: string, selectables: Selectable[], level: number): void {
-    this.handleChange(source, iModelKey, level, "replace", selectables);
+  public replaceSelection(props: { source: string; iModelKey: string; selectables: Selectable[]; level?: number }): void {
+    this.handleChange({ ...props, changeType: "replace" });
   }
 
-  public clearSelection(source: string, iModelKey: string, level: number): void {
-    this.handleChange(source, iModelKey, level, "clear", []);
+  public clearSelection(props: { source: string; iModelKey: string; level?: number }): void {
+    this.handleChange({ ...props, changeType: "clear", selectables: [] });
   }
 
-  public clearStorage(iModelKey: string): void {
-    this.clearSelection("Clear iModel storage", iModelKey, 0);
+  public clearStorage({ iModelKey }: { iModelKey: string }): void {
+    this.clearSelection({ source: "Clear iModel storage", iModelKey });
     this._storage.delete(iModelKey);
   }
 
@@ -120,8 +140,10 @@ class SelectionStorageImpl implements SelectionStorage {
     return selectionContainer;
   }
 
-  private handleChange(source: string, iModelKey: string, level: number, changeType: StorageSelectionChangeType, change: Selectable[]): void {
+  private handleChange(props: { source: string; iModelKey: string; level?: number; changeType: StorageSelectionChangeType; selectables: Selectable[] }) {
+    const { iModelKey, source, level: inLevel, changeType, selectables: change } = props;
     const container = this.getContainer(iModelKey);
+    const level = inLevel ?? 0;
     const selectables = container.getSelection(level);
     const selected = Selectables.create(change);
     switch (changeType) {


### PR DESCRIPTION
- Add README (part of https://github.com/iTwin/presentation/issues/452)
- Change `SelectionStorage` methods to take a props object rather than a list of arguments to make it more future-proof.

