### PR TITLE
Improve unified selection table

### DIFF
--- a/.changeset/blue-ligers-clap.md
+++ b/.changeset/blue-ligers-clap.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Updated `usePresentationTableWithUnifiedSelection` to work outside `UnifiedSelectionContextProvider`

--- a/packages/components/src/presentation-components/table/UsePresentationTable.ts
+++ b/packages/components/src/presentation-components/table/UsePresentationTable.ts
@@ -172,7 +172,8 @@ function useUnifiedSelectionKeys(imodel: IModelConnection) {
       if (imodel !== args.imodel) {
         return;
       }
-      setKeys(Presentation.selection.getSelection(imodel, 0));
+      // make copy in case getSelection return mutated key set
+      setKeys(new KeySet(Presentation.selection.getSelection(imodel, 0)));
     });
   }, [imodel]);
   return keys;

--- a/packages/components/src/presentation-components/table/UsePresentationTable.ts
+++ b/packages/components/src/presentation-components/table/UsePresentationTable.ts
@@ -91,8 +91,6 @@ export function usePresentationTable<TColumn, TRow>(props: UsePresentationTableP
 /**
  * Custom hook that load data for generic table component. It uses [Unified Selection]($docs/presentation/unified-selection/index.md) to get keys defining what to load rows for.
  *
- * **Note**: Should be used within [[UnifiedSelectionContextProvider]].
- *
  * @throws on failure to get table data. The error is thrown in the React's render loop, so it can be caught using an error boundary.
  * @beta
  */

--- a/packages/components/src/presentation-components/table/UsePresentationTable.ts
+++ b/packages/components/src/presentation-components/table/UsePresentationTable.ts
@@ -137,7 +137,7 @@ export function usePresentationTableWithUnifiedSelection<TColumn, TRow>(
     updateSelectedRows();
 
     return disposeListener;
-  }, [rows]);
+  }, [rows, imodel]);
 
   const onSelect = (selectedKeys: string[]) => {
     const parsedKeys: Key[] = [];

--- a/packages/components/src/presentation-components/table/UsePresentationTable.ts
+++ b/packages/components/src/presentation-components/table/UsePresentationTable.ts
@@ -10,7 +10,6 @@ import { useEffect, useMemo, useState } from "react";
 import { IModelConnection } from "@itwin/core-frontend";
 import { Key, KeySet, Ruleset } from "@itwin/presentation-common";
 import { Presentation } from "@itwin/presentation-frontend";
-import { useUnifiedSelectionContext } from "../unified-selection/UnifiedSelectionContext";
 import { TableColumnDefinition, TableRowDefinition } from "./Types";
 import { useColumns } from "./UseColumns";
 import { useRows } from "./UseRows";
@@ -100,20 +99,19 @@ export function usePresentationTable<TColumn, TRow>(props: UsePresentationTableP
 export function usePresentationTableWithUnifiedSelection<TColumn, TRow>(
   props: Omit<UsePresentationTableProps<TColumn, TRow>, "keys">,
 ): UsePresentationTableWithUnifiedSelectionResult<TColumn, TRow> {
-  const unifiedSelection = useUnifiedSelectionContext();
-  const keys = unifiedSelection?.getSelection() ?? emptyKeySet;
+  const { imodel, ruleset, pageSize, columnMapper, rowMapper } = props;
+  const [tableName] = useState(() => `UnifiedSelectionTable_${counter++}`);
+
   const [selectedRows, setSelectedRows] = useState<TableRowDefinition[]>();
 
-  const { imodel, ruleset, pageSize, columnMapper, rowMapper } = props;
+  const keys = useUnifiedSelectionKeys(imodel);
   const columns = useColumns({ imodel, ruleset, keys });
   const { options, sort, filter } = useTableOptions({ columns });
   const { rows, isLoading, loadMoreRows } = useRows({ imodel, ruleset, keys, pageSize, options });
 
-  const unifiedSelectionLevel = (unifiedSelection?.selectionLevel ?? 0) + 1;
-
   useEffect(() => {
     const updateSelectedRows = () => {
-      const toggledRowKeys = unifiedSelection?.getSelection(unifiedSelectionLevel);
+      const toggledRowKeys = Presentation.selection.getSelection(imodel, 1);
 
       const rowsToAddToSelection: TableRowDefinition[] = [];
       toggledRowKeys?.forEach((key) => {
@@ -128,17 +126,18 @@ export function usePresentationTableWithUnifiedSelection<TColumn, TRow>(
       setSelectedRows(rowsToAddToSelection);
     };
 
-    const disposeListener = Presentation.selection.selectionChange.addListener(({ level }) => {
-      if (level !== unifiedSelectionLevel) {
+    const disposeListener = Presentation.selection.selectionChange.addListener(({ imodel: selectionIModel, level }) => {
+      if (selectionIModel !== imodel || level > 1) {
         return;
       }
-      updateSelectedRows();
+
+      return level === 1 ? updateSelectedRows() : setSelectedRows([]);
     });
 
     updateSelectedRows();
 
     return disposeListener;
-  }, [rows, unifiedSelectionLevel, unifiedSelection]);
+  }, [rows]);
 
   const onSelect = (selectedKeys: string[]) => {
     const parsedKeys: Key[] = [];
@@ -153,7 +152,7 @@ export function usePresentationTableWithUnifiedSelection<TColumn, TRow>(
       }
     }
 
-    unifiedSelection?.replaceSelection(parsedKeys, unifiedSelectionLevel);
+    Presentation.selection.replaceSelection(tableName, props.imodel, parsedKeys, 1);
   };
 
   return {
@@ -168,4 +167,17 @@ export function usePresentationTableWithUnifiedSelection<TColumn, TRow>(
   };
 }
 
-const emptyKeySet = new KeySet();
+function useUnifiedSelectionKeys(imodel: IModelConnection) {
+  const [keys, setKeys] = useState(Presentation.selection.getSelection(imodel, 0));
+  useEffect(() => {
+    return Presentation.selection.selectionChange.addListener((args) => {
+      if (imodel !== args.imodel) {
+        return;
+      }
+      setKeys(Presentation.selection.getSelection(imodel, 0));
+    });
+  }, [imodel]);
+  return keys;
+}
+
+let counter = 0;

--- a/packages/components/src/test/table/UsePresentationTable.test.tsx
+++ b/packages/components/src/test/table/UsePresentationTable.test.tsx
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import { PropsWithChildren } from "react";
 import sinon from "sinon";
 import { BeUiEvent } from "@itwin/core-bentley";
 import { FormattingUnitSystemChangedArgs, IModelApp, IModelConnection } from "@itwin/core-frontend";
@@ -16,7 +15,6 @@ import {
   UsePresentationTableProps,
   usePresentationTableWithUnifiedSelection,
 } from "../../presentation-components/table/UsePresentationTable";
-import { UnifiedSelectionContextProvider } from "../../presentation-components/unified-selection/UnifiedSelectionContext";
 import { createTestECInstanceKey, createTestPropertyInfo } from "../_helpers/Common";
 import { createTestContentDescriptor, createTestContentItem, createTestPropertiesContentField } from "../_helpers/Content";
 import { act, renderHook, waitFor } from "../TestUtils";
@@ -115,14 +113,6 @@ describe("usePresentationTableWithUnifiedSelection", () => {
     sinon.stub(Presentation, "selection").get(() => selectionManager);
   });
 
-  function Wrapper({ children }: PropsWithChildren<{}>) {
-    return (
-      <UnifiedSelectionContextProvider imodel={imodel} selectionLevel={0}>
-        {children}
-      </UnifiedSelectionContextProvider>
-    );
-  }
-
   it("loads columns and rows with keys from unified selection", async () => {
     const propertiesField = createTestPropertiesContentField({
       name: "first_field",
@@ -141,7 +131,7 @@ describe("usePresentationTableWithUnifiedSelection", () => {
     presentationManager.getContentDescriptor.resolves(descriptor);
     presentationManager.getContentAndSize.resolves({ content: new Content(descriptor, [item]), size: 1 });
 
-    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps), { wrapper: Wrapper });
+    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
 
     await waitFor(() => expect(result.current.isLoading).to.be.false);
     expect(result.current.columns)
@@ -193,7 +183,7 @@ describe("usePresentationTableWithUnifiedSelection", () => {
 
     setupPresentationManager();
 
-    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps), { wrapper: Wrapper });
+    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
 
     const replaceSpy = sinon.stub(Presentation.selection, "replaceSelection");
     await waitFor(() => expect(result.current.isLoading).to.be.false);
@@ -212,7 +202,7 @@ describe("usePresentationTableWithUnifiedSelection", () => {
 
   it("gets invalid keys and does not pass any to the selection with onSelect", async () => {
     const keys = ["this is not a valid key", ""];
-    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps), { wrapper: Wrapper });
+    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
     await waitFor(() => expect(result.current.isLoading).to.be.false);
 
     const replaceSpy = sinon.stub(Presentation.selection, "replaceSelection");
@@ -231,7 +221,7 @@ describe("usePresentationTableWithUnifiedSelection", () => {
   it("gets valid keys for rows that are not loaded and does not pass any to the selection with onSelect", async () => {
     const stringifiedKeys = [createTestECInstanceKey()].map((key) => JSON.stringify(key));
 
-    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps), { wrapper: Wrapper });
+    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
     await waitFor(() => expect(result.current.isLoading).to.be.false);
 
     const replaceSpy = sinon.stub(Presentation.selection, "replaceSelection");
@@ -262,7 +252,7 @@ describe("usePresentationTableWithUnifiedSelection", () => {
       expect(Presentation.selection.getSelection(imodel, 1).size).to.be.eq(keys.size);
     });
 
-    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps), { wrapper: Wrapper });
+    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
 
     await waitFor(() => {
       expect(result.current.isLoading).to.be.false;
@@ -288,7 +278,7 @@ describe("usePresentationTableWithUnifiedSelection", () => {
       expect(Presentation.selection.getSelection(imodel, 1).size).to.be.eq(1);
     });
 
-    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps), { wrapper: Wrapper });
+    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
 
     await waitFor(() => {
       expect(result.current.isLoading).to.be.false;
@@ -324,7 +314,7 @@ describe("usePresentationTableWithUnifiedSelection", () => {
       expect(Presentation.selection.getSelection(imodel, 1).size).to.be.eq(1);
     });
 
-    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps), { wrapper: Wrapper });
+    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
 
     await waitFor(() => {
       expect(result.current.isLoading).to.be.false;
@@ -361,7 +351,7 @@ describe("usePresentationTableWithUnifiedSelection", () => {
       expect(Presentation.selection.getSelection(imodel, 1).size).to.be.eq(2);
     });
 
-    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps), { wrapper: Wrapper });
+    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
 
     await waitFor(() => {
       expect(result.current.isLoading).to.be.false;
@@ -397,7 +387,7 @@ describe("usePresentationTableWithUnifiedSelection", () => {
       expect(Presentation.selection.getSelection(imodel, 1).size).to.be.eq(2);
     });
 
-    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps), { wrapper: Wrapper });
+    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
 
     await waitFor(() => {
       expect(result.current.isLoading).to.be.false;
@@ -417,7 +407,7 @@ describe("usePresentationTableWithUnifiedSelection", () => {
   });
 
   it("returns an empty array of selectedRows when keys are passed from the wrong level on selectionChange event", async () => {
-    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps), { wrapper: Wrapper });
+    const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
 
     await waitFor(() => expect(result.current.isLoading).to.be.false);
 

--- a/packages/components/src/test/table/UsePresentationTable.test.tsx
+++ b/packages/components/src/test/table/UsePresentationTable.test.tsx
@@ -88,7 +88,7 @@ describe("usePresentationTable", () => {
   });
 });
 
-describe.only("usePresentationTableWithUnifiedSelection", () => {
+describe("usePresentationTableWithUnifiedSelection", () => {
   const imodel = {
     key: "imodel_key",
   } as IModelConnection;


### PR DESCRIPTION
Removed `useUnifiedSelectionContext` usage from `usePresentationTableWithUnifiedSelection`. It does not work with multiple levels which resulted in some selection handling done through `useUnifiedSelectionContext` and some through `Presentation.selection`. Now unified selection in all cases are handled through `Presentation.selection`.