### PR TITLE
Match all entries that contain given string by default in instance filter builder

### DIFF
--- a/.changeset/rich-worms-repair.md
+++ b/.changeset/rich-worms-repair.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Updated `InstanceFilterBuilder` to automatically append `%` to both ends of value when using `Contains` operator.

--- a/packages/components/src/presentation-components/instance-filter-builder/InstanceFilterConverter.ts
+++ b/packages/components/src/presentation-components/instance-filter-builder/InstanceFilterConverter.ts
@@ -109,7 +109,7 @@ function createComparison(
 
   const value = propValue.rawValue;
   if (operator === "like" && typeof value === "string") {
-    return `${propertyAccessor} ${operatorExpression} "%${escapeString(value)}%"`;
+    return `${propertyAccessor} ${operatorExpression} "${escapeString(value)}"`;
   }
 
   let valueExpression = "";

--- a/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilter.ts
+++ b/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilter.ts
@@ -228,7 +228,7 @@ function createGenericInstanceFilterRule(condition: PresentationInstanceFilterCo
 
   return {
     operator,
-    value: toGenericInstanceFilterRuleValue(value),
+    value: toGenericInstanceFilterRuleValue(operator, value),
     sourceAlias: propertyAlias,
     propertyName: property.name,
     propertyTypeName: field.type.typeName,
@@ -499,12 +499,27 @@ function toRelationshipStep(path: RelationshipPath): GenericInstanceFilterRelati
   }));
 }
 
-function toGenericInstanceFilterRuleValue(primitiveValue?: PrimitiveValue): GenericInstanceFilterRuleValue | undefined {
+function toGenericInstanceFilterRuleValue(
+  operator: `${PropertyFilterRuleOperator}`,
+  primitiveValue?: PrimitiveValue,
+): GenericInstanceFilterRuleValue | undefined {
   if (!primitiveValue || primitiveValue.value === undefined || !isGenericPrimitiveValueLike(primitiveValue.value)) {
     return undefined;
   }
 
-  return { displayValue: primitiveValue.displayValue ?? "", rawValue: primitiveValue.value };
+  const displayValue = primitiveValue.displayValue ?? "";
+  let rawValue = primitiveValue.value;
+
+  if (operator === "like" && typeof rawValue === "string") {
+    if (!rawValue.startsWith("%")) {
+      rawValue = `%${rawValue}`;
+    }
+    if (!rawValue.endsWith("%")) {
+      rawValue = `${rawValue}%`;
+    }
+  }
+
+  return { displayValue, rawValue };
 }
 
 function isGenericPrimitiveValueLike(value: Primitives.Value): value is GenericInstanceFilterRuleValue.Values {

--- a/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilter.ts
+++ b/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilter.ts
@@ -354,11 +354,22 @@ function parseGenericFilterRuleGroup(
 
 function parseGenericFilterRule(rule: GenericInstanceFilterRule, ctx: GenericFilterParsingContext): PresentationInstanceFilterCondition {
   const field = ctx.findField(rule.propertyName, rule.sourceAlias);
+  let value = rule.value ? rule.value.rawValue : undefined;
+
+  if (value && rule.operator === "like" && typeof value === "string") {
+    if (value.startsWith("%")) {
+      value = value.slice(1);
+    }
+
+    if (value.endsWith("%")) {
+      value = value.slice(0, -1);
+    }
+  }
 
   return {
     field,
     operator: rule.operator,
-    value: rule.value ? { valueFormat: PropertyValueFormat.Primitive, displayValue: rule.value.displayValue, value: rule.value.rawValue } : undefined,
+    value: rule.value ? { valueFormat: PropertyValueFormat.Primitive, displayValue: rule.value.displayValue, value } : undefined,
   };
 }
 

--- a/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilter.ts
+++ b/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilter.ts
@@ -522,12 +522,7 @@ function toGenericInstanceFilterRuleValue(
   let rawValue = primitiveValue.value;
 
   if (operator === "like" && typeof rawValue === "string") {
-    if (!rawValue.startsWith("%")) {
-      rawValue = `%${rawValue}`;
-    }
-    if (!rawValue.endsWith("%")) {
-      rawValue = `${rawValue}%`;
-    }
+    rawValue = `%${rawValue}%`;
   }
 
   return { displayValue, rawValue };

--- a/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilter.ts
+++ b/packages/components/src/presentation-components/instance-filter-builder/PresentationInstanceFilter.ts
@@ -357,13 +357,7 @@ function parseGenericFilterRule(rule: GenericInstanceFilterRule, ctx: GenericFil
   let value = rule.value ? rule.value.rawValue : undefined;
 
   if (value && rule.operator === "like" && typeof value === "string") {
-    if (value.startsWith("%")) {
-      value = value.slice(1);
-    }
-
-    if (value.endsWith("%")) {
-      value = value.slice(0, -1);
-    }
+    value = value.replace(/^%|%$/g, "");
   }
 
   return {

--- a/packages/components/src/test/instance-filter-builder/PresentationInstanceFilter.test.ts
+++ b/packages/components/src/test/instance-filter-builder/PresentationInstanceFilter.test.ts
@@ -632,7 +632,7 @@ describe("PresentationInstanceFilter", () => {
     it("parses direct property rule", () => {
       const filter: GenericInstanceFilter = {
         rules: {
-          operator: "is-equal",
+          operator: "like",
           sourceAlias: "this",
           propertyName: propertyField1.properties[0].property.name,
           propertyTypeName: propertyField1.properties[0].property.type,
@@ -645,7 +645,30 @@ describe("PresentationInstanceFilter", () => {
 
       const actual = PresentationInstanceFilter.fromGenericInstanceFilter(descriptor, filter);
       const expected: PresentationInstanceFilter = {
-        operator: "is-equal",
+        operator: "like",
+        field: propertyField1,
+        value: { valueFormat: PropertyValueFormat.Primitive, displayValue: "Value", value: "val" },
+      };
+      expect(actual).to.be.deep.eq(expected);
+    });
+
+    it("removes `%` around value when operator is `like`", () => {
+      const filter: GenericInstanceFilter = {
+        rules: {
+          operator: "like",
+          sourceAlias: "this",
+          propertyName: propertyField1.properties[0].property.name,
+          propertyTypeName: propertyField1.properties[0].property.type,
+          value: { displayValue: "Value", rawValue: "%val%" },
+        },
+        propertyClassNames: ["Schema:A"],
+        relatedInstances: [],
+        filteredClassNames: undefined,
+      };
+
+      const actual = PresentationInstanceFilter.fromGenericInstanceFilter(descriptor, filter);
+      const expected: PresentationInstanceFilter = {
+        operator: "like",
         field: propertyField1,
         value: { valueFormat: PropertyValueFormat.Primitive, displayValue: "Value", value: "val" },
       };

--- a/packages/components/src/test/instance-filter-builder/PresentationInstanceFilter.test.ts
+++ b/packages/components/src/test/instance-filter-builder/PresentationInstanceFilter.test.ts
@@ -378,28 +378,6 @@ describe("PresentationInstanceFilter", () => {
       expect(actual).to.be.deep.eq(expectedFilter);
     });
 
-    it("does not `%` around value a second time when `like` operator is used", () => {
-      const filter: PresentationInstanceFilter = {
-        operator: "like",
-        field: propertyField1,
-        value: { valueFormat: PropertyValueFormat.Primitive, value: "%val%", displayValue: "Value" },
-      };
-      const actual = PresentationInstanceFilter.toGenericInstanceFilter(filter, [propertyField1.properties[0].property.classInfo]);
-      const expectedFilter: GenericInstanceFilter = {
-        rules: {
-          operator: "like",
-          propertyName: propertyField1.properties[0].property.name,
-          sourceAlias: "this",
-          propertyTypeName: propertyField1.type.typeName,
-          value: { displayValue: "Value", rawValue: "%val%" },
-        },
-        propertyClassNames: ["Schema:A"],
-        relatedInstances: [],
-        filteredClassNames: [propertyField1.properties[0].property.classInfo.name],
-      };
-      expect(actual).to.be.deep.eq(expectedFilter);
-    });
-
     it("converts point3d condition", () => {
       const filter: PresentationInstanceFilter = {
         operator: "is-equal",

--- a/packages/components/src/test/instance-filter-builder/PresentationInstanceFilter.test.ts
+++ b/packages/components/src/test/instance-filter-builder/PresentationInstanceFilter.test.ts
@@ -356,6 +356,50 @@ describe("PresentationInstanceFilter", () => {
       expect(actual).to.be.deep.eq(expectedFilter);
     });
 
+    it("adds `%` around value when `like` operator is used", () => {
+      const filter: PresentationInstanceFilter = {
+        operator: "like",
+        field: propertyField1,
+        value: { valueFormat: PropertyValueFormat.Primitive, value: "val", displayValue: "Value" },
+      };
+      const actual = PresentationInstanceFilter.toGenericInstanceFilter(filter, [propertyField1.properties[0].property.classInfo]);
+      const expectedFilter: GenericInstanceFilter = {
+        rules: {
+          operator: "like",
+          propertyName: propertyField1.properties[0].property.name,
+          sourceAlias: "this",
+          propertyTypeName: propertyField1.type.typeName,
+          value: { displayValue: "Value", rawValue: "%val%" },
+        },
+        propertyClassNames: ["Schema:A"],
+        relatedInstances: [],
+        filteredClassNames: [propertyField1.properties[0].property.classInfo.name],
+      };
+      expect(actual).to.be.deep.eq(expectedFilter);
+    });
+
+    it("does not `%` around value a second time when `like` operator is used", () => {
+      const filter: PresentationInstanceFilter = {
+        operator: "like",
+        field: propertyField1,
+        value: { valueFormat: PropertyValueFormat.Primitive, value: "%val%", displayValue: "Value" },
+      };
+      const actual = PresentationInstanceFilter.toGenericInstanceFilter(filter, [propertyField1.properties[0].property.classInfo]);
+      const expectedFilter: GenericInstanceFilter = {
+        rules: {
+          operator: "like",
+          propertyName: propertyField1.properties[0].property.name,
+          sourceAlias: "this",
+          propertyTypeName: propertyField1.type.typeName,
+          value: { displayValue: "Value", rawValue: "%val%" },
+        },
+        propertyClassNames: ["Schema:A"],
+        relatedInstances: [],
+        filteredClassNames: [propertyField1.properties[0].property.classInfo.name],
+      };
+      expect(actual).to.be.deep.eq(expectedFilter);
+    });
+
     it("converts point3d condition", () => {
       const filter: PresentationInstanceFilter = {
         operator: "is-equal",


### PR DESCRIPTION
Closes [459](https://github.com/iTwin/presentation/issues/469)

Modified instance filter builder to automatically append `%` to both sides of the value, to match all entries that contain given string by default.