### PR TITLE
Fix block handler showing incorrect results

### DIFF
--- a/apps/performance-tests/package.json
+++ b/apps/performance-tests/package.json
@@ -21,7 +21,6 @@
     "@itwin/presentation-hierarchies": "workspace:*",
     "@itwin/presentation-models-tree": "workspace:*",
     "as-table": "^1.0.55",
-    "blocked": "^1.3.0",
     "chai": "^4.4.1",
     "mocha": "^10.3.0",
     "presentation-test-utilities": "workspace:^",
@@ -29,7 +28,6 @@
   },
   "devDependencies": {
     "@itwin/eslint-plugin": "4.0.0-dev.48",
-    "@types/blocked": "^1.3.4",
     "@types/chai": "^4.3.11",
     "@types/mocha": "^10.0.6",
     "@types/node": "^18.17.7",

--- a/apps/performance-tests/src/util/BlockHandler.ts
+++ b/apps/performance-tests/src/util/BlockHandler.ts
@@ -33,7 +33,6 @@ export interface Summary {
  */
 export class BlockHandler {
   private readonly _samples = new SortedArray<number>((a, b) => a - b);
-  private _running = false;
   private _promise?: Promise<void>;
 
   public getSummary(): Summary {
@@ -57,7 +56,6 @@ export class BlockHandler {
    */
   public start(threshold: number = 20, interval: number = 10) {
     const runTimer = async () => {
-      this._running = true;
       this._samples.clear();
 
       let lastTime = new Date();
@@ -72,13 +70,13 @@ export class BlockHandler {
         }
         lastTime = new Date();
 
-        if (!this._running) {
+        if (!this._promise) {
           break;
         }
       }
     };
 
-    if (this._running) {
+    if (this._promise) {
       throw new Error("Block handler already running.");
     }
     this._promise = runTimer();
@@ -86,8 +84,9 @@ export class BlockHandler {
 
   /** Stops the blocking timer. */
   public async stop() {
-    this._running = false;
-    return this._promise;
+    const promise = this._promise;
+    this._promise = undefined;
+    return promise;
   }
 }
 

--- a/apps/performance-tests/src/util/TestReporter.ts
+++ b/apps/performance-tests/src/util/TestReporter.ts
@@ -31,7 +31,6 @@ export class TestReporter extends Base {
   private readonly _blockHandler = new BlockHandler();
   private readonly _outputPath?: string;
   private _indentLevel = 0;
-  private _blockHandlerPromise?: Promise<void>;
 
   constructor(runner: Mocha.Runner, options: Mocha.MochaOptions) {
     super(runner, options);
@@ -69,7 +68,7 @@ export class TestReporter extends Base {
 
   /** Run before each test starts. */
   private onTestStart(test: Mocha.Runnable) {
-    this._blockHandlerPromise = this._blockHandler.start();
+    this._blockHandler.start();
     this.print(`${test.title}...`, false);
     this._testStartTimes.set(test.fullTitle(), performance.now());
   }
@@ -84,8 +83,7 @@ export class TestReporter extends Base {
     }
 
     const duration = Math.round((endTime - startTime) * 100) / 100;
-    this._blockHandler.stop();
-    await this._blockHandlerPromise;
+    await this._blockHandler.stop();
 
     const blockingSummary = this._blockHandler.getSummary();
     this._testInfo.set(fullTitle, {

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -46,7 +46,7 @@ export function run<T>(props: RunOptions<T>): void {
     try {
       await props.test(value);
     } finally {
-      this.test!.ctx!.reporter.onTestEnd();
+      await this.test!.ctx!.reporter.onTestEnd();
       await props.cleanup?.(value);
     }
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,7 +192,7 @@ importers:
     dependencies:
       '@itwin/core-backend':
         specifier: ^4.4.0
-        version: 4.4.0(@itwin/core-bentley@4.4.0)(@itwin/core-common@4.4.0)(@itwin/core-geometry@4.4.0)(@opentelemetry/api@1.6.0)
+        version: 4.4.0(@itwin/core-bentley@4.4.0)(@itwin/core-common@4.4.0)(@itwin/core-geometry@4.4.0)
       '@itwin/core-bentley':
         specifier: ^4.4.0
         version: 4.4.0
@@ -220,9 +220,6 @@ importers:
       as-table:
         specifier: ^1.0.55
         version: 1.0.55
-      blocked:
-        specifier: ^1.3.0
-        version: 1.3.0
       chai:
         specifier: ^4.4.1
         version: 4.4.1
@@ -239,9 +236,6 @@ importers:
       '@itwin/eslint-plugin':
         specifier: 4.0.0-dev.48
         version: 4.0.0-dev.48(eslint@8.56.0)(typescript@5.0.4)
-      '@types/blocked':
-        specifier: ^1.3.4
-        version: 1.3.4
       '@types/chai':
         specifier: ^4.3.11
         version: 4.3.11
@@ -3232,6 +3226,42 @@ packages:
       shortid: 2.2.16
       ts-key-enum: 2.0.12
 
+  /@itwin/core-backend@4.4.0(@itwin/core-bentley@4.4.0)(@itwin/core-common@4.4.0)(@itwin/core-geometry@4.4.0):
+    resolution: {integrity: sha512-Mhytjjr5n5vDsjrz+8wpJz/tk76d4fqEaCGmmxwxvNmKFS1Mjy7aVOhMIdSabOnKUBYPWn+bZvBxWcv/3SJANw==}
+    engines: {node: ^18.0.0 || ^20.0.0}
+    peerDependencies:
+      '@itwin/core-bentley': ^4.4.0
+      '@itwin/core-common': ^4.4.0
+      '@itwin/core-geometry': ^4.4.0
+      '@opentelemetry/api': ^1.0.4
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+    dependencies:
+      '@bentley/imodeljs-native': 4.4.3
+      '@itwin/cloud-agnostic-core': 2.2.3(inversify@6.0.2)(reflect-metadata@0.1.14)
+      '@itwin/core-bentley': 4.4.0
+      '@itwin/core-common': 4.4.0(@itwin/core-bentley@4.4.0)(@itwin/core-geometry@4.4.0)
+      '@itwin/core-geometry': 4.4.0
+      '@itwin/core-telemetry': 4.4.0(@itwin/core-geometry@4.4.0)
+      '@itwin/object-storage-azure': 2.2.3(inversify@6.0.2)(reflect-metadata@0.1.14)
+      '@itwin/object-storage-core': 2.2.3(inversify@6.0.2)(reflect-metadata@0.1.14)
+      form-data: 2.5.1
+      fs-extra: 8.1.0
+      inversify: 6.0.2
+      json5: 2.2.3
+      multiparty: 4.2.3
+      reflect-metadata: 0.1.14
+      semver: 7.6.0
+      touch: 3.1.0
+      ws: 7.5.9
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - utf-8-validate
+    dev: false
+
   /@itwin/core-backend@4.4.0(@itwin/core-bentley@4.4.0)(@itwin/core-common@4.4.0)(@itwin/core-geometry@4.4.0)(@opentelemetry/api@1.6.0):
     resolution: {integrity: sha512-Mhytjjr5n5vDsjrz+8wpJz/tk76d4fqEaCGmmxwxvNmKFS1Mjy7aVOhMIdSabOnKUBYPWn+bZvBxWcv/3SJANw==}
     engines: {node: ^18.0.0 || ^20.0.0}
@@ -3567,7 +3597,7 @@ packages:
       reflect-metadata: ^0.1.13
     dependencies:
       '@itwin/cloud-agnostic-core': 2.2.3(inversify@6.0.2)(reflect-metadata@0.1.14)
-      axios: 1.6.8(debug@4.3.4)
+      axios: 1.6.8
       inversify: 6.0.2
       reflect-metadata: 0.1.14
     transitivePeerDependencies:
@@ -5309,12 +5339,6 @@ packages:
     resolution: {integrity: sha512-Q2Xn2/vQHRGLRXhQ5+BSLwhHkR3JVflxVKywH0Q6fVoAiUE8fFYL2pE5/l2ZiOiBDfA8qUqRnSxln4G/NFz1Sg==}
     dev: false
 
-  /@types/blocked@1.3.4:
-    resolution: {integrity: sha512-Jwn+iPAM0k8BsS9FgZUXmroYci+fT0nCySh8ReAxV3Khh1CEUh7jFXZhx5X509XGbbhfEj+8LoKZoPZiZw52uA==}
-    dependencies:
-      '@types/node': 18.17.7
-    dev: true
-
   /@types/cacheable-request@6.0.3:
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
     dependencies:
@@ -6305,6 +6329,15 @@ packages:
     resolution: {integrity: sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==}
     engines: {node: '>=4'}
 
+  /axios@1.6.8:
+    resolution: {integrity: sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==}
+    dependencies:
+      follow-redirects: 1.15.6
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   /axios@1.6.8(debug@4.3.4):
     resolution: {integrity: sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==}
     dependencies:
@@ -6313,6 +6346,7 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+    dev: false
 
   /axobject-query@3.2.1:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
@@ -6368,11 +6402,6 @@ packages:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-    dev: false
-
-  /blocked@1.3.0:
-    resolution: {integrity: sha512-tAb98b4F01wLnKIjCpp17hheKIKnd7j+SgxwgNHQNjQ+EcvOCRZ1HPVNZt3/XnpMjFymVdIZlBQysi+s7OltLw==}
-    engines: {node: '>= 0.9.1'}
     dev: false
 
   /body-parser@1.20.2:
@@ -8446,6 +8475,15 @@ packages:
   /flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
 
+  /follow-redirects@1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   /follow-redirects@1.15.6(debug@4.3.4):
     resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
     engines: {node: '>=4.0'}
@@ -8456,6 +8494,7 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
+    dev: false
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}


### PR DESCRIPTION
Currently performance tests do not account for long main thread blocks that last until the end of the test. 
Now, before stopping the block handler, we will wait until block handler's callback is run the last time before stopping it.

Block handler will now use a much more convenient node's `timers/promises/setInterval` function which returns an async iterator.
Since `blocked` library is very simple and doesn't provide anything of value,  the dependency will be removed in favor of custom blocking time measuring logic.

Additionally, new optional logging will be added which might help the debugging experience:
- Logging of start and end times of the blocks
- Ability to log "pings" of the main thread