### PR TITLE
core-interop: API cleanup, README, LICENSE

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,17 @@
 {
   "cSpell.words": [
+    "ecschema",
     "hilite",
     "hilited",
     "hilites",
     "imodel",
     "itwin",
+    "itwinjs",
+    "ruleset",
     "selectable",
     "selectables",
+    "txns",
+    "unregisters"
   ],
 
   "editor.insertSpaces": true,

--- a/apps/performance-tests/src/main.ts
+++ b/apps/performance-tests/src/main.ts
@@ -12,7 +12,7 @@ import { Datasets } from "./util/Datasets";
 before(async () => {
   Logger.initializeToConsole();
   Logger.setLevelDefault(LogLevel.Error);
-  setLogger(createLogger());
+  setLogger(createLogger(Logger));
   await IModelHost.startup({
     profileName: "presentation-performance-tests",
   });

--- a/packages/core-interop/LICENSE.md
+++ b/packages/core-interop/LICENSE.md
@@ -1,0 +1,9 @@
+# MIT License
+
+Copyright © 2017-2024 Bentley Systems, Incorporated. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/core-interop/README.md
+++ b/packages/core-interop/README.md
@@ -1,0 +1,99 @@
+# @itwin/presentation-core-interop
+
+Copyright © Bentley Systems, Incorporated. All rights reserved. See LICENSE.md for license terms and full copyright notice.
+
+The `@itwin/presentation-core-interop` package acts as a layer between [`itwinjs-core` packages](https://www.itwinjs.org/reference/) and `presentation` packages:
+
+- `@itwin/presentation-hierarchies`
+- `@itwin/unified-selection`
+
+Having this interop layer helps us evolve both sides without affecting one another in a major way.
+
+## API
+
+### `createECSqlQueryExecutor`
+
+Maps an iModel in the form of `itwinjs-core` [IModelDb](https://www.itwinjs.org/reference/core-backend/imodels/imodeldb/) or [IModelConnection](https://www.itwinjs.org/reference/core-frontend/imodelconnection/imodelconnection/) to an instance of `IECSqlQueryExecutor`, used in `@itwin/presentation-hierarchies` and `@itwin/unified-selection` packages.
+
+Example:
+
+```ts
+import { IModelDb } from "@itwin/core-backend";
+import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+
+const iModel: IModelDb = getIModelDb();
+const executor = createECSqlQueryExecutor(iModel);
+for await (const row of executor.createQueryReader(MY_QUERY)) {
+  // TODO: do something with `row`
+}
+```
+
+### `createMetadataProvider`
+
+Maps an instance of `itwinjs-core` [SchemaContext](https://www.itwinjs.org/reference/ecschema-metadata/context/schemacontext/) class to an instance of `IMetadataProvider`, used in `@itwin/presentation-hierarchies` and `@itwin/unified-selection` packages.
+
+Example:
+
+```ts
+import { SchemaContext } from "@itwin/ecschema-metadata";
+import { createMetadataProvider } from "@itwin/presentation-core-interop";
+
+const schemas = new SchemaContext();
+const metadata = createMetadataProvider(schemas);
+// the created metadata provider may be used in `@itwin/presentation-hierarchies` or `@itwin/unified-selection` packages
+```
+
+### `createValueFormatter`
+
+Creates an instance of `IPrimitiveValueFormatter` that knows how to format primitive property values using their units' information. That information is retrieved from an iModel through `itwinjs-core` [SchemaContext](https://www.itwinjs.org/reference/ecschema-metadata/context/schemacontext/).
+
+Example:
+
+```ts
+import { SchemaContext } from "@itwin/ecschema-metadata";
+import { createValueFormatter } from "@itwin/presentation-core-interop";
+
+const schemaContext = new SchemaContext();
+const formatter = createValueFormatter({ schemaContext, unitSystem: "metric" });
+const formattedValue = await formatter({ type: "Double", value: 1.234, koqName: "MySchema.LengthKindOfQuantity" });
+```
+
+### `registerTxnListeners`
+
+Registers a number of transaction listeners on either the backend [TxnManager](https://www.itwinjs.org/reference/core-backend/imodels/txnmanager/) or the frontend [BriefcaseTxns](https://www.itwinjs.org/reference/core-frontend/imodelconnection/briefcasetxns/) and calls the given `onChange` function whenever there's a change in an iModel holding the transaction manager.
+
+Example:
+
+```ts
+import { BriefcaseDb } from "@itwin/core-backend";
+import { registerTxnListeners } from "@itwin/presentation-core-interop";
+import { HierarchyProvider } from "@itwin/presentation-hierarchies";
+
+// get iModel and hierarchy provider from arbitrary sources
+const db: BriefcaseDb = getIModel();
+const provider: HierarchyProvider = getHierarchyProvider();
+
+// register the listeners
+const unregister = registerTxnListeners(db.txns, () => {
+  // notify provided about the changed data
+  provider.notifyDataSourceChanged();
+  // TODO: force the components using `provider` to reload
+});
+
+// clean up on iModel close
+db.onClosed.addOnce(() => unregister());
+```
+
+### `createLogger`
+
+Maps the `itwinjs-core` [Logger](https://www.itwinjs.org/reference/core-bentley/logging/logger/) class to an `ILogger` interface used by Presentation packages.
+
+Example:
+
+```ts
+import { Logger as CoreLogger } from "@itwin/core-bentley";
+import { createLogger as createPresentationLogger } from "@itwin/presentation-core-interop";
+import { setLogger as setPresentationLogger } from "@itwin/presentation-hierarchies";
+
+setPresentationLogger(createPresentationLogger(CoreLogger));
+```

--- a/packages/core-interop/api/presentation-core-interop.api.md
+++ b/packages/core-interop/api/presentation-core-interop.api.md
@@ -11,67 +11,33 @@ import { HierarchyProvider } from '@itwin/presentation-hierarchies';
 import { IECSqlQueryExecutor } from '@itwin/presentation-hierarchies';
 import { ILogger } from '@itwin/presentation-hierarchies';
 import { IMetadataProvider } from '@itwin/presentation-hierarchies';
+import { IModel } from '@itwin/core-common';
 import { IPrimitiveValueFormatter } from '@itwin/presentation-hierarchies';
 import { KeySet } from '@itwin/presentation-common';
+import { LogLevel } from '@itwin/core-bentley';
 import { NonGroupingHierarchyNode } from '@itwin/presentation-hierarchies';
 import { QueryBinder } from '@itwin/core-common';
 import { QueryOptions } from '@itwin/core-common';
 import { RulesetVariable } from '@itwin/presentation-common';
+import { Schema } from '@itwin/ecschema-metadata';
 import { SchemaContext } from '@itwin/ecschema-metadata';
+import { SchemaKey } from '@itwin/ecschema-metadata';
 import { UnitSystemKey } from '@itwin/core-quantity';
 
 // @beta
 export function createECSqlQueryExecutor(imodel: ICoreECSqlReaderFactory): IECSqlQueryExecutor;
 
 // @beta
-export function createHierarchyLevelDescriptor<TIModel extends ICoreECSqlReaderFactory>(props: CreateHierarchyLevelDescriptorProps<TIModel>): Promise<CreateHierarchyLevelDescriptorResult | undefined>;
+export function createHierarchyLevelDescriptor<TIModel extends IModel>(props: CreateHierarchyLevelDescriptorProps<TIModel>): Promise<CreateHierarchyLevelDescriptorResult | undefined>;
 
 // @beta
-export interface CreateHierarchyLevelDescriptorProps<TIModel extends ICoreECSqlReaderFactory> {
-    descriptorBuilder: {
-        getContentDescriptor: (requestOptions: ContentDescriptorRequestOptions<TIModel, KeySet, RulesetVariable>) => Promise<Descriptor | undefined>;
-    };
-    hierarchyProvider: HierarchyProvider;
-    imodel: TIModel;
-    parentNode: Omit<NonGroupingHierarchyNode, "children"> | undefined;
-}
+export function createLogger(coreLogger: ICoreLogger): ILogger;
 
 // @beta
-export interface CreateHierarchyLevelDescriptorResult {
-    descriptor: Descriptor;
-    inputKeys: KeySet;
-}
+export function createMetadataProvider(schemaContext: ICoreSchemaContext): IMetadataProvider;
 
 // @beta
-export function createLogger(): ILogger;
-
-// @beta
-export function createMetadataProvider(schemaContext: SchemaContext): IMetadataProvider;
-
-// @beta
-export function createValueFormatter(schemaContext: SchemaContext, unitSystem?: UnitSystemKey, baseFormatter?: IPrimitiveValueFormatter): IPrimitiveValueFormatter;
-
-// @beta
-interface Event_2<TListener extends () => void = () => void> {
-    // (undocumented)
-    addListener(listener: TListener): () => void;
-    // (undocumented)
-    removeListener(listener: TListener): void;
-}
-export { Event_2 as Event }
-
-// @beta
-export interface ICoreECSqlReaderFactory {
-    // (undocumented)
-    createQueryReader(ecsql: string, binder?: QueryBinder, options?: QueryOptions): ECSqlReader;
-}
-
-// @beta
-export interface ICoreTxnManager {
-    onChangesApplied: Event_2;
-    onCommit: Event_2;
-    onCommitted: Event_2;
-}
+export function createValueFormatter(props: CreateValueFormatterProps): IPrimitiveValueFormatter;
 
 // @beta
 export function registerTxnListeners(txns: ICoreTxnManager, onChanged: () => void): () => void;

--- a/packages/core-interop/api/presentation-core-interop.exports.csv
+++ b/packages/core-interop/api/presentation-core-interop.exports.csv
@@ -2,11 +2,7 @@ sep=;
 Release Tag;API Item
 beta;createECSqlQueryExecutor(imodel: ICoreECSqlReaderFactory): IECSqlQueryExecutor
 beta;createHierarchyLevelDescriptor
-beta;CreateHierarchyLevelDescriptorProps
-beta;CreateHierarchyLevelDescriptorResult
-beta;createLogger(): ILogger
-beta;createMetadataProvider(schemaContext: SchemaContext): IMetadataProvider
-beta;createValueFormatter(schemaContext: SchemaContext, unitSystem?: UnitSystemKey, baseFormatter?: IPrimitiveValueFormatter): IPrimitiveValueFormatter
-beta;ICoreECSqlReaderFactory
-beta;ICoreTxnManager
+beta;createLogger(coreLogger: ICoreLogger): ILogger
+beta;createMetadataProvider(schemaContext: ICoreSchemaContext): IMetadataProvider
+beta;createValueFormatter(props: CreateValueFormatterProps): IPrimitiveValueFormatter
 beta;registerTxnListeners(txns: ICoreTxnManager, onChanged: () => void): () => void

--- a/packages/core-interop/src/core-interop/Formatting.ts
+++ b/packages/core-interop/src/core-interop/Formatting.ts
@@ -18,17 +18,49 @@ import {
 import { createDefaultValueFormatter, IPrimitiveValueFormatter, parseFullClassName, TypedPrimitiveValue } from "@itwin/presentation-hierarchies";
 
 /**
- * Creates a formatter that knows how to format values of properties with assigned kind of quantity. In case the property
- * does not have an assigned kind of quantity, the base formatter is used.
+ * Props for `createValueFormatter` function.
+ */
+interface CreateValueFormatterProps {
+  /**
+   * An instance of [SchemaContext](https://www.itwinjs.org/reference/ecschema-metadata/context/schemacontext/) for
+   * getting units information.
+   */
+  schemaContext: SchemaContext;
+
+  /**
+   * An optional unit system to use for formatting property values. If not provided, default presentation units are used. If a property
+   * doesn't have a default presentation unit, then persistence unit is used. Finally, if a property doesn't have a unit assigned at all,
+   * `baseFormatter` is used to format the property value.
+   */
+  unitSystem?: UnitSystemKey;
+
+  /**
+   * Base primitive value formatter for cases when a property doesn't have any units' information. Defaults to the result of `createDefaultValueFormatter`
+   * from `@itwin/presentation-hierarchies` package.
+   */
+  baseFormatter?: IPrimitiveValueFormatter;
+}
+
+/**
+ * Creates an instance of `IPrimitiveValueFormatter` that knows how to format values of properties with assigned kind of quantity. In
+ * case the property does not have an assigned kind of quantity, the base formatter is used.
+ *
+ * Usage example:
+ *
+ * ```ts
+ * import { SchemaContext } from "@itwin/ecschema-metadata";
+ * import { createValueFormatter } from "@itwin/presentation-core-interop";
+ *
+ * const schemaContext = new SchemaContext();
+ * const formatter = createValueFormatter({ schemaContext, unitSystem: "metric" });
+ * const formattedValue = await formatter({ type: "Double", value: 1.234, koqName: "MySchema.LengthKindOfQuantity" });
+ * ```
  *
  * @beta
  */
-export function createValueFormatter(
-  schemaContext: SchemaContext,
-  unitSystem?: UnitSystemKey,
-  // istanbul ignore next
-  baseFormatter = createDefaultValueFormatter(),
-): IPrimitiveValueFormatter {
+export function createValueFormatter(props: CreateValueFormatterProps): IPrimitiveValueFormatter {
+  const { schemaContext, unitSystem } = props;
+  const baseFormatter = props.baseFormatter ?? /* istanbul ignore next */ createDefaultValueFormatter();
   const unitsProvider = new SchemaUnitProvider(schemaContext);
   return async function (value: TypedPrimitiveValue): Promise<string> {
     if (value.type === "Double" && !!value.koqName) {

--- a/packages/core-interop/src/core-interop/HierarchyLevelDescriptor.ts
+++ b/packages/core-interop/src/core-interop/HierarchyLevelDescriptor.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { filter, from, map, merge, mergeAll, mergeMap, Observable, partition, reduce, shareReplay } from "rxjs";
+import { IModel } from "@itwin/core-common";
 import { ContentDescriptorRequestOptions, DefaultContentDisplayTypes, Descriptor, KeySet, Ruleset, RulesetVariable } from "@itwin/presentation-common";
 import {
   ECSqlQueryDef,
@@ -17,13 +18,12 @@ import {
   NodeSelectClauseColumnNames,
   NonGroupingHierarchyNode,
 } from "@itwin/presentation-hierarchies";
-import { ICoreECSqlReaderFactory } from "./QueryExecutor";
 
 /**
  * Props for [[createHierarchyLevelDescriptor]].
  * @beta
  */
-export interface CreateHierarchyLevelDescriptorProps<TIModel extends ICoreECSqlReaderFactory> {
+export interface CreateHierarchyLevelDescriptorProps<TIModel extends IModel> {
   /**
    * An iModel to use for creating the descriptor. Typically, this is either [IModelDb]($core-backend)
    * or [IModelConnection]($core-frontend).
@@ -71,7 +71,7 @@ export interface CreateHierarchyLevelDescriptorResult {
  *
  * @beta
  */
-export async function createHierarchyLevelDescriptor<TIModel extends ICoreECSqlReaderFactory>(
+export async function createHierarchyLevelDescriptor<TIModel extends IModel>(
   props: CreateHierarchyLevelDescriptorProps<TIModel>,
 ): Promise<CreateHierarchyLevelDescriptorResult | undefined> {
   // convert instance keys stream into a KeySet

--- a/packages/core-interop/src/core-interop/Logging.ts
+++ b/packages/core-interop/src/core-interop/Logging.ts
@@ -3,20 +3,43 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { Logger as CoreLogger, LogLevel as CoreLogLevel } from "@itwin/core-bentley";
+import { LogLevel as CoreLogLevel } from "@itwin/core-bentley";
 import { ILogger, LogLevel } from "@itwin/presentation-hierarchies";
 
 /**
- * Create an `ILogger` that uses [Logger]($core-bentley) API to log messages.
+ * Defines input for `createLogger`. Generally, this is the [Logger](https://www.itwinjs.org/reference/core-bentley/logging/logger/)
+ * class from `@itwin/core-bentley` package.
+ */
+interface ICoreLogger {
+  isEnabled(category: string, level: CoreLogLevel): boolean;
+  logError(category: string, message: string): void;
+  logWarning(category: string, message: string): void;
+  logInfo(category: string, message: string): void;
+  logTrace(category: string, message: string): void;
+}
+
+/**
+ * Create an `ILogger` that uses [Logger](https://www.itwinjs.org/reference/core-bentley/logging/logger/) API to log messages.
+ *
+ * Usage example:
+ *
+ * ```ts
+ * import { Logger } from "@itwin/core-bentley";
+ * import { createLogger } from "@itwin/presentation-core-interop";
+ * import { setLogger } from "@itwin/presentation-hierarchies";
+ *
+ * setLogger(createLogger(Logger));
+ * ```
+ *
  * @beta
  */
-export function createLogger(): ILogger {
+export function createLogger(coreLogger: ICoreLogger): ILogger {
   return {
-    isEnabled: (category, level) => CoreLogger.isEnabled(category, getCoreLogLevel(level)),
-    logError: (category, msg) => CoreLogger.logError(category, msg),
-    logWarning: (category, msg) => CoreLogger.logWarning(category, msg),
-    logInfo: (category, msg) => CoreLogger.logInfo(category, msg),
-    logTrace: (category, msg) => CoreLogger.logTrace(category, msg),
+    isEnabled: (category, level) => coreLogger.isEnabled(category, getCoreLogLevel(level)),
+    logError: (category, msg) => coreLogger.logError(category, msg),
+    logWarning: (category, msg) => coreLogger.logWarning(category, msg),
+    logInfo: (category, msg) => coreLogger.logInfo(category, msg),
+    logTrace: (category, msg) => coreLogger.logTrace(category, msg),
   };
 }
 

--- a/packages/core-interop/src/core-interop/Logging.ts
+++ b/packages/core-interop/src/core-interop/Logging.ts
@@ -19,7 +19,8 @@ interface ICoreLogger {
 }
 
 /**
- * Create an `ILogger` that uses [Logger](https://www.itwinjs.org/reference/core-bentley/logging/logger/) API to log messages.
+ * Creates an `ILogger` that uses [Logger](https://www.itwinjs.org/reference/core-bentley/logging/logger/)
+ * API to log messages.
  *
  * Usage example:
  *

--- a/packages/core-interop/src/core-interop/Metadata.ts
+++ b/packages/core-interop/src/core-interop/Metadata.ts
@@ -16,7 +16,7 @@ interface ICoreSchemaContext {
 }
 
 /**
- * Create an `IMetadataProvider` for given [SchemaContext](https://www.itwinjs.org/reference/ecschema-metadata/context/schemacontext/).
+ * Creates an `IMetadataProvider` for given [SchemaContext](https://www.itwinjs.org/reference/ecschema-metadata/context/schemacontext/).
  *
  * Usage example:
  *

--- a/packages/core-interop/src/core-interop/Metadata.ts
+++ b/packages/core-interop/src/core-interop/Metadata.ts
@@ -3,15 +3,35 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { SchemaContext, SchemaKey } from "@itwin/ecschema-metadata";
+import { Schema as CoreSchema, SchemaKey as CoreSchemaKey } from "@itwin/ecschema-metadata";
 import { ECSchema, IMetadataProvider } from "@itwin/presentation-hierarchies";
 import { createECSchema } from "./MetadataInternal";
 
 /**
- * Create an `IMetadataProvider` for given [SchemaContext]($ecschema-metadata).
+ * Defines input for `createMetadataProvider`. Generally, this is an instance of [SchemaContext](https://www.itwinjs.org/reference/ecschema-metadata/context/schemacontext/)
+ * class from `@itwin/ecschema-metadata` package.
+ */
+interface ICoreSchemaContext {
+  getSchema(key: CoreSchemaKey): Promise<CoreSchema | undefined>;
+}
+
+/**
+ * Create an `IMetadataProvider` for given [SchemaContext](https://www.itwinjs.org/reference/ecschema-metadata/context/schemacontext/).
+ *
+ * Usage example:
+ *
+ * ```ts
+ * import { SchemaContext } from "@itwin/ecschema-metadata";
+ * import { createMetadataProvider } from "@itwin/presentation-core-interop";
+ *
+ * const schemas = new SchemaContext();
+ * const metadata = createMetadataProvider(schemas);
+ * // the created metadata provider may be used in `@itwin/presentation-hierarchies` or `@itwin/unified-selection` packages
+ * ```
+ *
  * @beta
  */
-export function createMetadataProvider(schemaContext: SchemaContext): IMetadataProvider {
+export function createMetadataProvider(schemaContext: ICoreSchemaContext): IMetadataProvider {
   const schemaCache = new Map<string, Promise<ECSchema | undefined>>();
   return {
     async getSchema(name) {
@@ -19,7 +39,7 @@ export function createMetadataProvider(schemaContext: SchemaContext): IMetadataP
       let schema = schemaCache.get(name);
       // istanbul ignore else
       if (!schema) {
-        schema = schemaContext.getSchema(new SchemaKey(name)).then((coreSchema) => (coreSchema ? createECSchema(coreSchema) : undefined));
+        schema = schemaContext.getSchema(new CoreSchemaKey(name)).then((coreSchema) => (coreSchema ? createECSchema(coreSchema) : undefined));
         schema.catch(() => schemaCache.delete(name));
         schemaCache.set(name, schema);
       }

--- a/packages/core-interop/src/core-interop/QueryExecutor.ts
+++ b/packages/core-interop/src/core-interop/QueryExecutor.ts
@@ -17,7 +17,7 @@ interface ICoreECSqlReaderFactory {
 }
 
 /**
- * Create an `IECSqlQueryExecutor` from either [IModelDb](https://www.itwinjs.org/reference/core-backend/imodels/imodeldb/) or
+ * Creates an `IECSqlQueryExecutor` from either [IModelDb](https://www.itwinjs.org/reference/core-backend/imodels/imodeldb/) or
  * [IModelConnection](https://www.itwinjs.org/reference/core-frontend/imodelconnection/imodelconnection/).
  *
  * Usage example:

--- a/packages/core-interop/src/core-interop/QueryExecutor.ts
+++ b/packages/core-interop/src/core-interop/QueryExecutor.ts
@@ -9,18 +9,29 @@ import { Point2d, Point3d } from "@itwin/core-geometry";
 import { ECSqlBinding, ECSqlQueryReader, ECSqlQueryReaderOptions, ECSqlQueryRow, IECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
 
 /**
- * An interface for something that knows how to create an `ECSqlReader`. Generally, this represents either [IModelDb]($core-backend)
- * or [IModelConnection]($core-frontend).
- *
- * @beta
+ * Defines input for `createECSqlQueryExecutor`. Generally, this is an instance of either [IModelDb](https://www.itwinjs.org/reference/core-backend/imodels/imodeldb/)
+ * or [IModelConnection](https://www.itwinjs.org/reference/core-frontend/imodelconnection/imodelconnection/).
  */
-export interface ICoreECSqlReaderFactory {
+interface ICoreECSqlReaderFactory {
   createQueryReader(ecsql: string, binder?: QueryBinder, options?: QueryOptions): ECSqlReader;
 }
 
 /**
- * Create an `IECSqlQueryExecutor` using given `ICoreECSqlReaderFactory`, which, generally, is either [IModelDb]($core-backend)
- * or [IModelConnection]($core-frontend).
+ * Create an `IECSqlQueryExecutor` from either [IModelDb](https://www.itwinjs.org/reference/core-backend/imodels/imodeldb/) or
+ * [IModelConnection](https://www.itwinjs.org/reference/core-frontend/imodelconnection/imodelconnection/).
+ *
+ * Usage example:
+ *
+ * ```ts
+ * import { IModelDb } from "@itwin/core-backend";
+ * import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+ *
+ * const iModel: IModelDb = getIModelDb();
+ * const executor = createECSqlQueryExecutor(iModel);
+ * for await (const row of executor.createQueryReader(MY_QUERY)) {
+ *   // TODO: do something with `row`
+ * }
+ * ```
  *
  * @beta
  */

--- a/packages/core-interop/src/core-interop/Transactions.ts
+++ b/packages/core-interop/src/core-interop/Transactions.ts
@@ -4,12 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
- * An interface that allows subscribing and unsubscribing listeners that
- * are called upon an event.
- *
- * @beta
+ * An interface that allows subscribing and unsubscribing listeners that are called upon an event.
  */
-export interface Event<TListener extends () => void = () => void> {
+interface Event<TListener extends () => void = () => void> {
   addListener(listener: TListener): () => void;
   removeListener(listener: TListener): void;
 }
@@ -18,34 +15,65 @@ export interface Event<TListener extends () => void = () => void> {
  * An interface for a transaction manager that has 3 types of events fired before and after a commit
  * and when changes are applied on a briefcase.
  *
- * Generally, this either means [TxnManager]($core-backend), accessed through [IModelDb.txns], or
- * [BriefcaseTxns]($core-frontend), accessed through [BriefcaseConnection.txns]($core-frontend).
- *
- * @beta
+ * Generally, this either means [TxnManager](https://www.itwinjs.org/reference/core-backend/imodels/txnmanager/), accessed
+ * through [BriefcaseDb.txns](https://www.itwinjs.org/reference/core-backend/imodels/briefcasedb/#txns), or
+ * [BriefcaseTxns](https://www.itwinjs.org/reference/core-frontend/imodelconnection/briefcasetxns/), accessed
+ * through [BriefcaseConnection.txns](https://www.itwinjs.org/reference/core-frontend/imodelconnection/briefcaseconnection/#txns).
  */
-export interface ICoreTxnManager {
+interface ICoreTxnManager {
   /**
-   * Event raised before a commit operation is performed. Initiated by a call to either [IModelDb.saveChanges]($core-backend)
-   * or [BriefcaseConnection.saveChanges]($core-frontend), unless there are no changes to save.
+   * Event raised before a commit operation is performed. Initiated by a call to either
+   * [IModelDb.saveChanges](https://www.itwinjs.org/reference/core-backend/imodels/imodeldb/savechanges/)
+   * or [BriefcaseConnection.saveChanges](https://www.itwinjs.org/reference/core-frontend/imodelconnection/briefcaseconnection/savechanges/),
+   * unless there are no changes to save.
    */
   onCommit: Event;
   /**
-   * Event raised after a commit operation is performed. Initiated by a call to either [IModelDb.saveChanges]($core-backend)
-   * or [BriefcaseConnection.saveChanges]($core-frontend), even if there were no changes to save.
+   * Event raised after a commit operation is performed. Initiated by a call to either
+   * [IModelDb.saveChanges](https://www.itwinjs.org/reference/core-backend/imodels/imodeldb/savechanges/)
+   * or [BriefcaseConnection.saveChanges](https://www.itwinjs.org/reference/core-frontend/imodelconnection/briefcaseconnection/savechanges/),
+   * even if there were no changes to save.
    */
   onCommitted: Event;
   /**
    * Event raised after a changeset has been applied to the briefcase. Changesets may be applied as a result of
-   * [IModelDb.pullChanges]($core-backend) or [BriefcaseConnection.pullChanges]($core-frontend), or by undo/redo operations.
+   * [BriefcaseDb.pullChanges](https://www.itwinjs.org/reference/core-backend/imodels/briefcasedb/) or
+   * [BriefcaseConnection.pullChanges](https://www.itwinjs.org/reference/core-frontend/imodelconnection/briefcaseconnection/pullchanges/),
+   * or by undo/redo operations.
    */
   onChangesApplied: Event;
 }
 
 /**
- * Registers listeners to `txns` events and calls provided `onChanged` even when transaction manager
+ * Registers listeners to `txns` events and calls provided `onChanged` callback when transaction manager
  * reports there are iModel data changes.
  *
- * @param txns Either [TxnManager]($core-backend), accessed through [IModelDb.txns], or [BriefcaseTxns]($core-frontend), accessed through [BriefcaseConnection.txns]($core-frontend).
+ * Usage example:
+ *
+ * ```ts
+ * import { BriefcaseDb } from "@itwin/core-backend";
+ * import { registerTxnListeners } from "@itwin/presentation-core-interop";
+ * import { HierarchyProvider } from "@itwin/presentation-hierarchies";
+ *
+ * // get iModel and hierarchy provider from arbitrary sources
+ * const db: BriefcaseDb = getIModel();
+ * const provider: HierarchyProvider = getHierarchyProvider();
+ *
+ * // register the listeners
+ * const unregister = registerTxnListeners(db.txns, () => {
+ *   // notify provided about the changed data
+ *   provider.notifyDataSourceChanged();
+ *   // TODO: force the components using `provider` to reload
+ * });
+ *
+ * // clean up on iModel close
+ * db.onClosed.addOnce(() => unregister());
+ * ```
+ *
+ * @param txns Either [TxnManager](https://www.itwinjs.org/reference/core-backend/imodels/txnmanager/), accessed
+ * through [BriefcaseDb.txns](https://www.itwinjs.org/reference/core-backend/imodels/briefcasedb/#txns),
+ * or [BriefcaseTxns](https://www.itwinjs.org/reference/core-frontend/imodelconnection/briefcasetxns/), accessed
+ * through [BriefcaseConnection.txns](https://www.itwinjs.org/reference/core-frontend/imodelconnection/briefcaseconnection/#txns).
  * @param onChanged A function to call when transaction manager reports iModel data changes.
  * @returns A function that unregisters the transaction manager listeners.
  * @beta

--- a/packages/core-interop/src/presentation-core-interop.ts
+++ b/packages/core-interop/src/presentation-core-interop.ts
@@ -3,9 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-export * from "./core-interop/Formatting";
-export * from "./core-interop/HierarchyLevelDescriptor";
-export * from "./core-interop/Logging";
-export * from "./core-interop/Metadata";
-export * from "./core-interop/QueryExecutor";
-export * from "./core-interop/Transactions";
+export { createValueFormatter } from "./core-interop/Formatting";
+export { createHierarchyLevelDescriptor } from "./core-interop/HierarchyLevelDescriptor";
+export { createLogger } from "./core-interop/Logging";
+export { createMetadataProvider } from "./core-interop/Metadata";
+export { createECSqlQueryExecutor } from "./core-interop/QueryExecutor";
+export { registerTxnListeners } from "./core-interop/Transactions";

--- a/packages/core-interop/src/test/Formatting.test.ts
+++ b/packages/core-interop/src/test/Formatting.test.ts
@@ -30,7 +30,11 @@ describe("createValueFormatter", () => {
   let formatter: IPrimitiveValueFormatter;
 
   function initFormatter(unitSystem?: UnitSystemKey) {
-    formatter = createValueFormatter(schemaContext as unknown as SchemaContext, unitSystem, defaultFormatter);
+    formatter = createValueFormatter({
+      schemaContext: schemaContext as unknown as SchemaContext,
+      unitSystem,
+      baseFormatter: defaultFormatter,
+    });
   }
 
   beforeEach(() => {

--- a/packages/core-interop/src/test/Logging.test.ts
+++ b/packages/core-interop/src/test/Logging.test.ts
@@ -11,28 +11,28 @@ import { createLogger } from "../core-interop/Logging";
 describe("createLogger", () => {
   it("checks error severity using core `Logger`", async () => {
     const spy = sinon.stub(Logger, "isEnabled").returns(true);
-    const logger = createLogger();
+    const logger = createLogger(Logger);
     expect(logger.isEnabled("test category", "error")).to.be.true;
     expect(spy).to.be.calledOnceWith("test category", LogLevel.Error);
   });
 
   it("checks warning severity using core `Logger`", async () => {
     const spy = sinon.stub(Logger, "isEnabled").returns(true);
-    const logger = createLogger();
+    const logger = createLogger(Logger);
     expect(logger.isEnabled("test category", "warning")).to.be.true;
     expect(spy).to.be.calledOnceWith("test category", LogLevel.Warning);
   });
 
   it("checks info severity using core `Logger`", async () => {
     const spy = sinon.stub(Logger, "isEnabled").returns(true);
-    const logger = createLogger();
+    const logger = createLogger(Logger);
     expect(logger.isEnabled("test category", "info")).to.be.true;
     expect(spy).to.be.calledOnceWith("test category", LogLevel.Info);
   });
 
   it("checks trace severity using core `Logger`", async () => {
     const spy = sinon.stub(Logger, "isEnabled").returns(true);
-    const logger = createLogger();
+    const logger = createLogger(Logger);
     expect(logger.isEnabled("test category", "trace")).to.be.true;
     expect(spy).to.be.calledOnceWith("test category", LogLevel.Trace);
   });
@@ -44,7 +44,7 @@ describe("createLogger", () => {
       info: sinon.spy(Logger, "logInfo"),
       trace: sinon.spy(Logger, "logTrace"),
     };
-    const logger = createLogger();
+    const logger = createLogger(Logger);
 
     logger.logError("c1", "m1");
     logger.logWarning("c2", "m2");

--- a/packages/core-interop/src/test/QueryExecutor.test.ts
+++ b/packages/core-interop/src/test/QueryExecutor.test.ts
@@ -8,14 +8,14 @@ import sinon from "sinon";
 import { QueryBinder, QueryOptions, QueryRowFormat } from "@itwin/core-common";
 import { Point2d, Point3d } from "@itwin/core-geometry";
 import { ECSqlBinding } from "@itwin/presentation-hierarchies";
-import { createECSqlQueryExecutor, ICoreECSqlReaderFactory } from "../core-interop/QueryExecutor";
+import { createECSqlQueryExecutor } from "../core-interop/QueryExecutor";
 
 describe("createECSqlQueryExecutor", () => {
   describe("createQueryReader", () => {
     it("calls IModel's `createQueryReader` with default params", async () => {
       const imodel = {
         createQueryReader: sinon.stub().returns(createCoreECSqlReaderStub([{}, {}])),
-      } as unknown as ICoreECSqlReaderFactory;
+      };
 
       const executor = createECSqlQueryExecutor(imodel);
       const reader = executor.createQueryReader("ecsql");
@@ -33,7 +33,7 @@ describe("createECSqlQueryExecutor", () => {
     it("calls IModel's `createQueryReader` with ECSqlPropertyNames row format", async () => {
       const imodel = {
         createQueryReader: sinon.stub().returns(createCoreECSqlReaderStub([])),
-      } as unknown as ICoreECSqlReaderFactory;
+      };
 
       const executor = createECSqlQueryExecutor(imodel);
       const reader = executor.createQueryReader("ecsql", undefined, { rowFormat: "ECSqlPropertyNames" });
@@ -51,7 +51,7 @@ describe("createECSqlQueryExecutor", () => {
     it("calls IModel's `createQueryReader` with Indexes row format", async () => {
       const imodel = {
         createQueryReader: sinon.stub().returns(createCoreECSqlReaderStub([])),
-      } as unknown as ICoreECSqlReaderFactory;
+      };
 
       const executor = createECSqlQueryExecutor(imodel);
       const reader = executor.createQueryReader("ecsql", undefined, { rowFormat: "Indexes" });
@@ -69,7 +69,7 @@ describe("createECSqlQueryExecutor", () => {
     it("calls IModel's `createQueryReader` with different bindings", async () => {
       const imodel = {
         createQueryReader: sinon.stub().returns(createCoreECSqlReaderStub([])),
-      } as unknown as ICoreECSqlReaderFactory;
+      };
 
       const bindings: ECSqlBinding[] = [
         {
@@ -140,7 +140,7 @@ describe("createECSqlQueryExecutor", () => {
       const rows = [{ x: 1 }, { y: 2 }];
       const imodel = {
         createQueryReader: sinon.stub().returns(createCoreECSqlReaderStub(rows)),
-      } as unknown as ICoreECSqlReaderFactory;
+      };
 
       const executor = createECSqlQueryExecutor(imodel);
       const reader = executor.createQueryReader("ecsql", undefined, { rowFormat: "ECSqlPropertyNames" });
@@ -160,7 +160,7 @@ describe("createECSqlQueryExecutor", () => {
       ];
       const imodel = {
         createQueryReader: sinon.stub().returns(createCoreECSqlReaderStub(rows)),
-      } as unknown as ICoreECSqlReaderFactory;
+      };
 
       const executor = createECSqlQueryExecutor(imodel);
       const reader = executor.createQueryReader("ecsql", undefined, { rowFormat: "Indexes" });

--- a/packages/full-stack-tests/src/hierarchies/Formatting.test.ts
+++ b/packages/full-stack-tests/src/hierarchies/Formatting.test.ts
@@ -137,7 +137,11 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy, formatterFactory: (schemas) => createValueFormatter(schemas, "metric") }),
+          provider: createProvider({
+            imodel,
+            hierarchy,
+            formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "metric" }),
+          }),
           expect: [
             {
               node: (node) => expect(node.label).to.eq(`[123.5 m]`),
@@ -145,7 +149,11 @@ describe("Hierarchies", () => {
           ],
         });
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy, formatterFactory: (schemas) => createValueFormatter(schemas, "imperial") }),
+          provider: createProvider({
+            imodel,
+            hierarchy,
+            formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "imperial" }),
+          }),
           expect: [
             {
               node: (node) => expect(node.label).to.eq(`[405.0 ft]`),
@@ -153,7 +161,11 @@ describe("Hierarchies", () => {
           ],
         });
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy, formatterFactory: (schemas) => createValueFormatter(schemas, "usCustomary") }),
+          provider: createProvider({
+            imodel,
+            hierarchy,
+            formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "usCustomary" }),
+          }),
           expect: [
             {
               node: (node) => expect(node.label).to.eq(`[405.0 ft]`),
@@ -161,7 +173,11 @@ describe("Hierarchies", () => {
           ],
         });
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy, formatterFactory: (schemas) => createValueFormatter(schemas, "usSurvey") }),
+          provider: createProvider({
+            imodel,
+            hierarchy,
+            formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "usSurvey" }),
+          }),
           expect: [
             {
               node: (node) => expect(node.label).to.eq(`[405.04 ft (US Survey)]`),

--- a/packages/full-stack-tests/src/hierarchies/models-tree/ModelsTreeCompareWithNative.test.ts
+++ b/packages/full-stack-tests/src/hierarchies/models-tree/ModelsTreeCompareWithNative.test.ts
@@ -23,7 +23,7 @@ describe("Hierarchies", () => {
 
     Logger.initializeToConsole();
     // Logger.setLevel(`${LOGGING_NAMESPACE}.HierarchyProvider`, LogLevel.Trace);
-    setLogger(createLogger());
+    setLogger(createLogger(Logger));
 
     const imodelPath = process.env.TEST_IMODEL_PATH;
     if (!imodelPath) {


### PR DESCRIPTION
Part of https://github.com/iTwin/presentation/issues/422.

Going to remove `createHierarchyLevelDescriptor` altogether in a separate PR.