### PR TITLE
Use private fields in `UnifiedSelectionTreeEventHandler`

### DIFF
--- a/.changeset/rare-hotels-bathe.md
+++ b/.changeset/rare-hotels-bathe.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Use private fields in `UnifiedSelectionTreeEventHandler` to avoid clashing private property names when extending it.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,7 +55,7 @@
   "importSorter.importStringConfiguration.trailingComma": "multiLine",
   "importSorter.generalConfiguration.sortOnBeforeSave": true,
   "importSorter.sortConfiguration.customOrderingRules.defaultNumberOfEmptyLinesAfterGroup": 0,
-  "importSorter.sortConfiguration.removeUnusedImports": true,
+  "importSorter.sortConfiguration.removeUnusedImports": false,
   "importSorter.sortConfiguration.importMembers.order": "unsorted",
   "importSorter.sortConfiguration.customOrderingRules.rules": [
     {

--- a/packages/components/api/presentation-components.api.md
+++ b/packages/components/api/presentation-components.api.md
@@ -759,8 +759,6 @@ export class UnifiedSelectionTreeEventHandler extends TreeEventHandler implement
     // @deprecated (undocumented)
     protected getNodeKey(node: TreeNodeItem): NodeKey;
     // (undocumented)
-    get modelSource(): TreeModelSource;
-    // (undocumented)
     onSelectionModified({ modifications }: TreeSelectionModificationEventArgs): Subscription | undefined;
     // (undocumented)
     onSelectionReplaced({ replacements }: TreeSelectionReplacementEventArgs): Subscription | undefined;

--- a/packages/components/src/presentation-components/tree/controlled/UseUnifiedSelection.ts
+++ b/packages/components/src/presentation-components/tree/controlled/UseUnifiedSelection.ts
@@ -7,9 +7,7 @@
  */
 
 import { useCallback } from "react";
-import { takeUntil } from "rxjs/internal/operators/takeUntil";
-import { tap } from "rxjs/internal/operators/tap";
-import { Subject } from "rxjs/internal/Subject";
+import { Subject, takeUntil, tap } from "rxjs";
 import {
   AbstractTreeNodeLoaderWithProvider,
   MutableTreeModel,
@@ -17,7 +15,6 @@ import {
   TreeEditingParams,
   TreeEventHandler,
   TreeModelChanges,
-  TreeModelSource,
   TreeNodeItem,
   TreeSelectionModificationEventArgs,
   TreeSelectionReplacementEventArgs,
@@ -66,39 +63,32 @@ export interface UnifiedSelectionTreeEventHandlerParams {
  * @public
  */
 export class UnifiedSelectionTreeEventHandler extends TreeEventHandler implements IDisposable {
-  private _dataProvider: IPresentationTreeDataProvider;
-  private _modelSource: TreeModelSource;
-  private _selectionSourceName: string;
-  private _listeners: Array<() => void> = [];
-
-  private _cancelled = new Subject<void>();
+  #dataProvider: IPresentationTreeDataProvider;
+  #selectionSourceName: string;
+  #listeners: Array<() => void> = [];
+  #cancelled = new Subject<void>();
 
   constructor(params: UnifiedSelectionTreeEventHandlerParams) {
     super({
       ...params,
       modelSource: params.nodeLoader.modelSource,
     });
-    this._dataProvider = params.nodeLoader.dataProvider;
-    this._modelSource = params.nodeLoader.modelSource;
-    this._selectionSourceName = params.name ?? `Tree_${this._dataProvider.rulesetId}_${Guid.createValue()}`;
-    this._listeners.push(Presentation.selection.selectionChange.addListener((args) => this.onSelectionChanged(args)));
-    this._listeners.push(this._modelSource.onModelChanged.addListener((args) => this.selectNodes(args[1])));
+    this.#dataProvider = params.nodeLoader.dataProvider;
+    this.#selectionSourceName = params.name ?? `Tree_${this.#dataProvider.rulesetId}_${Guid.createValue()}`;
+    this.#listeners.push(Presentation.selection.selectionChange.addListener((args) => this.onSelectionChanged(args)));
+    this.#listeners.push(this.modelSource.onModelChanged.addListener((args) => this.selectNodes(args[1])));
     this.selectNodes();
-  }
-
-  public override get modelSource() {
-    return this._modelSource;
   }
 
   public override dispose() {
     super.dispose();
-    this._cancelled.next();
-    this._listeners.forEach((dispose) => dispose());
+    this.#cancelled.next();
+    this.#listeners.forEach((dispose) => dispose());
   }
 
   public override onSelectionModified({ modifications }: TreeSelectionModificationEventArgs) {
     const withUnifiedSelection = toRxjsObservable(modifications).pipe(
-      takeUntil(this._cancelled),
+      takeUntil(this.#cancelled),
       tap({
         next: ({ selectedNodeItems, deselectedNodeItems }) => {
           if (selectedNodeItems.length !== 0) {
@@ -117,7 +107,7 @@ export class UnifiedSelectionTreeEventHandler extends TreeEventHandler implement
   public override onSelectionReplaced({ replacements }: TreeSelectionReplacementEventArgs) {
     let firstEmission = true;
     const withUnifiedSelection = toRxjsObservable(replacements).pipe(
-      takeUntil(this._cancelled),
+      takeUntil(this.#cancelled),
       tap({
         next: ({ selectedNodeItems }) => {
           if (selectedNodeItems.length === 0) {
@@ -149,7 +139,7 @@ export class UnifiedSelectionTreeEventHandler extends TreeEventHandler implement
   // istanbul ignore next
   protected getNodeKey(node: TreeNodeItem): NodeKey {
     // eslint-disable-next-line deprecation/deprecation
-    return this._dataProvider.getNodeKey(node);
+    return this.#dataProvider.getNodeKey(node);
   }
 
   /**
@@ -193,49 +183,49 @@ export class UnifiedSelectionTreeEventHandler extends TreeEventHandler implement
 
   private addToSelection(nodes: TreeNodeItem[]) {
     Presentation.selection.addToSelection(
-      this._selectionSourceName,
-      this._dataProvider.imodel,
+      this.#selectionSourceName,
+      this.#dataProvider.imodel,
       this.createKeysForSelection(nodes, SelectionChangeType.Add),
       0,
-      this._dataProvider.rulesetId,
+      this.#dataProvider.rulesetId,
     );
   }
 
   private removeFromSelection(nodes: TreeNodeItem[]) {
     Presentation.selection.removeFromSelection(
-      this._selectionSourceName,
-      this._dataProvider.imodel,
+      this.#selectionSourceName,
+      this.#dataProvider.imodel,
       this.createKeysForSelection(nodes, SelectionChangeType.Remove),
       0,
-      this._dataProvider.rulesetId,
+      this.#dataProvider.rulesetId,
     );
   }
 
   private replaceSelection(nodes: TreeNodeItem[]) {
     Presentation.selection.replaceSelection(
-      this._selectionSourceName,
-      this._dataProvider.imodel,
+      this.#selectionSourceName,
+      this.#dataProvider.imodel,
       this.createKeysForSelection(nodes, SelectionChangeType.Replace),
       0,
-      this._dataProvider.rulesetId,
+      this.#dataProvider.rulesetId,
     );
   }
 
   private onSelectionChanged(evt: SelectionChangeEventArgs) {
-    if (evt.imodel !== this._dataProvider.imodel) {
+    if (evt.imodel !== this.#dataProvider.imodel) {
       return;
     }
 
     if (evt.changeType === SelectionChangeType.Clear || evt.changeType === SelectionChangeType.Replace) {
-      this._cancelled.next();
+      this.#cancelled.next();
     }
 
     this.selectNodes();
   }
 
   private updateAllNodes() {
-    const selection = Presentation.selection.getSelection(this._dataProvider.imodel);
-    this._modelSource.modifyModel((model: MutableTreeModel) => {
+    const selection = Presentation.selection.getSelection(this.#dataProvider.imodel);
+    this.modelSource.modifyModel((model: MutableTreeModel) => {
       for (const node of model.iterateTreeModelNodes()) {
         this.updateNodeSelectionState(node, selection);
       }
@@ -248,8 +238,8 @@ export class UnifiedSelectionTreeEventHandler extends TreeEventHandler implement
       return;
     }
 
-    const selection = Presentation.selection.getSelection(this._dataProvider.imodel);
-    this._modelSource.modifyModel((model: MutableTreeModel) => {
+    const selection = Presentation.selection.getSelection(this.#dataProvider.imodel);
+    this.modelSource.modifyModel((model: MutableTreeModel) => {
       for (const nodeId of affectedNodeIds) {
         const node = model.getNode(nodeId);
         // istanbul ignore if


### PR DESCRIPTION
Switched `UnifiedSelectionTreeEventHandler` to use private fields to avoid clashed between private property names when extending it.