### PR TITLE
Add missing dev dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,12 @@ registry=https://registry.npmjs.org/
 
 resolution-mode=lowest-direct
 auto-install-peers=false
+
+hoist-pattern[]=!*
+hoist-pattern[]=@types/react*
+hoist-pattern[]=*babel*
+hoist-pattern[]=ignore-styles
+hoist-pattern[]=global-jsdom
+hoist-pattern[]=source-map-support
+# TODO: remove after https://github.com/iTwin/itwinjs-core/pull/6612 is released
+hoist-pattern[]=@itwin/core-common

--- a/packages/core-interop/package.json
+++ b/packages/core-interop/package.json
@@ -67,6 +67,7 @@
     "eslint": "^8.56.0",
     "mocha": "^10.3.0",
     "nyc": "^15.1.0",
+    "rimraf": "^5.0.5",
     "rxjs-for-await": "^1.0.0",
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",

--- a/packages/hierarchies/package.json
+++ b/packages/hierarchies/package.json
@@ -63,6 +63,7 @@
     "mocha": "^10.3.0",
     "nyc": "^15.1.0",
     "presentation-test-utilities": "workspace:^",
+    "rimraf": "^5.0.5",
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.21",

--- a/packages/models-tree/package.json
+++ b/packages/models-tree/package.json
@@ -43,6 +43,7 @@
     "@itwin/presentation-hierarchies": "workspace:^",
     "cpx2": "^7.0.1",
     "eslint": "^8.56.0",
+    "rimraf": "^5.0.5",
     "source-map-support": "^0.5.21",
     "typescript": "~5.0.4"
   }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -75,6 +75,7 @@
     "@types/chai-as-promised": "^7.1.8",
     "@types/chai-jest-snapshot": "^1.3.8",
     "@types/mocha": "^10.0.6",
+    "@types/node": "^18.17.7",
     "@types/sinon": "^17.0.3",
     "@types/sinon-chai": "^3.2.12",
     "chai": "^4.4.1",

--- a/packages/unified-selection/package.json
+++ b/packages/unified-selection/package.json
@@ -55,6 +55,7 @@
     "mocha": "^10.3.0",
     "nyc": "^15.1.0",
     "presentation-test-utilities": "workspace:^",
+    "rimraf": "^5.0.5",
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -814,6 +814,9 @@ importers:
       nyc:
         specifier: ^15.1.0
         version: 15.1.0
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.5
       rxjs-for-await:
         specifier: ^1.0.0
         version: 1.0.0(rxjs@7.8.1)
@@ -1115,6 +1118,9 @@ importers:
       presentation-test-utilities:
         specifier: workspace:^
         version: link:../test-utilities
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.5
       sinon:
         specifier: ^17.0.1
         version: 17.0.1
@@ -1273,6 +1279,9 @@ importers:
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.5
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -1531,6 +1540,9 @@ importers:
       '@types/mocha':
         specifier: ^10.0.6
         version: 10.0.6
+      '@types/node':
+        specifier: ^18.17.7
+        version: 18.17.7
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -1646,6 +1658,9 @@ importers:
       presentation-test-utilities:
         specifier: workspace:^
         version: link:../test-utilities
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.5
       sinon:
         specifier: ^17.0.1
         version: 17.0.1


### PR DESCRIPTION
Added missing dev dependencies. Also disabled hoisting for majority of packages and left only those that are needed for things to work:
`ignore-styles`, `global-jsdom`, `source-map-support` for `mocha`
`@types/react*` for build
`*babel*` for `@loaders.gl/schema` used by `@itwin/core-frontend`