### PR TITLE
Remove source-map-support dependency

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -8,6 +8,5 @@ hoist-pattern[]=@types/react*
 hoist-pattern[]=*babel*
 hoist-pattern[]=ignore-styles
 hoist-pattern[]=global-jsdom
-hoist-pattern[]=source-map-support
 # TODO: remove after https://github.com/iTwin/itwinjs-core/pull/6612 is released
 hoist-pattern[]=@itwin/core-common

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -87,7 +87,8 @@
         "${workspaceFolder}/packages/components/lib/**/*.js"
       ],
       "env": {
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
+        "NODE_OPTIONS": "--enable-source-maps"
       }
     },
     {
@@ -106,7 +107,8 @@
         "${workspaceFolder}/packages/opentelemetry/lib/**/*.js"
       ],
       "env": {
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
+        "NODE_OPTIONS": "--enable-source-maps"
       }
     },
     {
@@ -125,7 +127,8 @@
         "${workspaceFolder}/packages/testing/lib/**/*.js"
       ],
       "env": {
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
+        "NODE_OPTIONS": "--enable-source-maps"
       }
     },
     {
@@ -133,16 +136,15 @@
       "cwd": "${workspaceFolder}/apps/performance-tests",
       "type": "node",
       "request": "launch",
-      "runtimeExecutable": "npx",
+      "program": "${workspaceFolder}/apps/performance-tests/node_modules/mocha/bin/_mocha",
       "runtimeArgs": [
-        "mocha",
         "--config",
         "./.mocharc.json",
-        "--timeout",
-        "0",
+        "--no-timeouts",
         "./lib/*test.js"
       ],
       "env": {
+        "NODE_ENV": "development",
         "NODE_OPTIONS": "--enable-source-maps"
       }
     },
@@ -162,7 +164,8 @@
         "${workspaceFolder}/packages/shared/lib/**/*.js"
       ],
       "env": {
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
+        "NODE_OPTIONS": "--enable-source-maps"
       }
     },
     {
@@ -181,7 +184,8 @@
         "${workspaceFolder}/packages/hierarchies/lib/**/*.js"
       ],
       "env": {
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
+        "NODE_OPTIONS": "--enable-source-maps"
       }
     },
     {
@@ -200,7 +204,8 @@
         "${workspaceFolder}/packages/core-interop/lib/**/*.js"
       ],
       "env": {
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
+        "NODE_OPTIONS": "--enable-source-maps"
       }
     },
     {
@@ -223,7 +228,8 @@
         "${workspaceFolder}/packages/full-stack-tests/lib/**/*.js"
       ],
       "env": {
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
+        "NODE_OPTIONS": "--enable-source-maps"
       }
     },
     {
@@ -242,7 +248,8 @@
         "${workspaceFolder}/packages/unified-selection/lib/**/*.js"
       ],
       "env": {
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
+        "NODE_OPTIONS": "--enable-source-maps"
       }
     },
     {
@@ -261,7 +268,8 @@
         "${workspaceFolder}/packages/hierarchies-react/lib/**/*.js"
       ],
       "env": {
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
+        "NODE_OPTIONS": "--enable-source-maps"
       }
     }
   ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -137,7 +137,7 @@
       "type": "node",
       "request": "launch",
       "program": "${workspaceFolder}/apps/performance-tests/node_modules/mocha/bin/_mocha",
-      "runtimeArgs": [
+      "args": [
         "--config",
         "./.mocharc.json",
         "--no-timeouts",

--- a/apps/performance-tests/package.json
+++ b/apps/performance-tests/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "test": "cross-env NODE_OPTIONS=\"--enable-source-maps\" mocha --config ./.mocharc.json ./lib/*test.js",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json ./lib/*test.js",
     "test:recreate": "cross-env RECREATE=true npm run test",
     "benchmark": "npm run test -- -O BENCHMARK_OUTPUT_PATH=./benchmark.json",
     "build": "tsc",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -36,7 +36,7 @@
     "clean": "rimraf lib build",
     "cover": "nyc npm -s test",
     "lint": "eslint ./src/**/*.{ts,tsx}",
-    "test": "mocha --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
     "test:watch": "npm -s test -- --reporter min --watch-extensions ts,tsx --watch",
     "docs": "npm run -s docs:extract && npm run -s docs:reference && npm run -s docs:changelog",
     "docs:changelog": "cpx ./CHANGELOG.md ./build/docs/reference/presentation-components",

--- a/packages/core-interop/.mocharc.json
+++ b/packages/core-interop/.mocharc.json
@@ -1,5 +1,4 @@
 {
-  "require": ["source-map-support/register"],
   "checkLeaks": true,
   "timeout": 60000,
   "file": ["./lib/cjs/test/index.js"],

--- a/packages/core-interop/package.json
+++ b/packages/core-interop/package.json
@@ -31,7 +31,7 @@
     "clean": "rimraf lib",
     "cover": "nyc npm -s test",
     "lint": "eslint ./src/**/*.ts",
-    "test": "mocha --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
     "extract-api": "betools extract-api --entry=presentation-core-interop --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/presentation-core-interop.api.md"
   },
@@ -71,7 +71,6 @@
     "rxjs-for-await": "^1.0.0",
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
-    "source-map-support": "^0.5.21",
     "typescript": "~5.0.4"
   }
 }

--- a/packages/full-stack-tests/package.json
+++ b/packages/full-stack-tests/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf lib build",
     "cover": "npm run -s test",
     "lint": "eslint ./src/**/*.{ts,tsx}",
-    "test": "mocha --config ./.mocharc.json",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json",
     "docs": "betools extract --fileExt=ts,tsx --extractFrom=./src --recursive --out=./build/docs/extract"
   },
   "dependencies": {
@@ -58,7 +58,6 @@
     "@types/react-dom": "^18.2.18",
     "@types/sinon": "^17.0.3",
     "@types/sinon-chai": "^3.2.12",
-    "@types/source-map-support": "^0.5.6",
     "chai": "^4.4.1",
     "chai-jest-snapshot": "^2.0.0",
     "chai-subset": "^1.6.0",
@@ -80,7 +79,6 @@
     "rimraf": "^5.0.5",
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
-    "source-map-support": "^0.5.21",
     "typescript": "~5.0.4"
   }
 }

--- a/packages/full-stack-tests/src/setup.ts
+++ b/packages/full-stack-tests/src/setup.ts
@@ -14,15 +14,9 @@ import * as jsdom from "jsdom";
 import * as path from "path";
 import ResizeObserver from "resize-observer-polyfill";
 import sinonChai from "sinon-chai";
-import sourceMapSupport from "source-map-support";
 
 // eslint-disable-next-line no-console
 console.log(`Backend PID: ${process.pid}`);
-
-// see https://github.com/babel/babel/issues/4605
-sourceMapSupport.install({
-  environment: "node",
-});
 
 // get rid of various xhr errors in the console
 globalJsdom(undefined, {

--- a/packages/hierarchies-react/.mocharc.json
+++ b/packages/hierarchies-react/.mocharc.json
@@ -1,5 +1,5 @@
 {
-  "require": ["ignore-styles", "source-map-support/register"],
+  "require": ["ignore-styles"],
   "checkLeaks": true,
   "global": ["IS_REACT_ACT_ENVIRONMENT"],
   "timeout": 60000,

--- a/packages/hierarchies-react/package.json
+++ b/packages/hierarchies-react/package.json
@@ -35,7 +35,7 @@
     "clean": "rimraf lib build",
     "cover": "nyc npm -s test",
     "lint": "eslint ./src/**/*.{ts,tsx}",
-    "test": "mocha --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
     "test:watch": "npm -s test -- --reporter min --watch-extensions ts,tsx --watch",
     "extract-api": "betools extract-api --entry=presentation-hierarchies-react --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/presentation-hierarchies-react.api.md"
@@ -85,7 +85,6 @@
     "rimraf": "^5.0.5",
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
-    "source-map-support": "^0.5.21",
     "typescript": "~5.0.4"
   }
 }

--- a/packages/hierarchies/.mocharc.json
+++ b/packages/hierarchies/.mocharc.json
@@ -1,5 +1,4 @@
 {
-  "require": ["source-map-support/register"],
   "checkLeaks": true,
   "timeout": 60000,
   "file": ["./lib/cjs/test/index.js"],

--- a/packages/hierarchies/package.json
+++ b/packages/hierarchies/package.json
@@ -32,7 +32,7 @@
     "clean": "rimraf lib",
     "cover": "nyc npm -s test",
     "lint": "eslint ./src/**/*.ts",
-    "test": "mocha --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
     "extract-api": "betools extract-api --entry=presentation-hierarchies --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/presentation-hierarchies.api.md"
   },
@@ -66,7 +66,6 @@
     "rimraf": "^5.0.5",
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
-    "source-map-support": "^0.5.21",
     "typescript": "~5.0.4"
   }
 }

--- a/packages/models-tree/package.json
+++ b/packages/models-tree/package.json
@@ -44,7 +44,6 @@
     "cpx2": "^7.0.1",
     "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
-    "source-map-support": "^0.5.21",
     "typescript": "~5.0.4"
   }
 }

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -36,7 +36,7 @@
     "docs:reference": "betools docs --includes=./build/docs/extract --json=./build/docs/reference/presentation-opentelemetry/file.json --tsIndexFile=presentation-opentelemetry.ts --onlyJson",
     "docs:extract": "betools extract --fileExt=ts --extractFrom=./src/test --recursive --out=./build/docs/extract",
     "lint": "eslint \"./src/**/*.ts\"",
-    "test": "mocha --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
     "extract-api": "betools extract-api --entry=presentation-opentelemetry --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/presentation-opentelemetry.api.md"
   },
@@ -67,7 +67,6 @@
     "rimraf": "^5.0.5",
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
-    "source-map-support": "^0.5.21",
     "typescript": "~5.0.4"
   }
 }

--- a/packages/shared/.mocharc.json
+++ b/packages/shared/.mocharc.json
@@ -1,5 +1,4 @@
 {
-  "require": ["source-map-support/register"],
   "checkLeaks": true,
   "timeout": 60000,
   "file": ["./lib/cjs/test/index.js"],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,7 +10,7 @@
     "clean": "rimraf lib temp",
     "cover": "nyc npm -s test",
     "lint": "eslint \"./src/**/*.ts\"",
-    "test": "mocha --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
     "extract-api": "betools extract-api --entry=presentation-shared --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/presentation-shared.api.md"
   },
@@ -39,7 +39,6 @@
     "nyc": "^15.1.0",
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
-    "source-map-support": "^0.5.21",
     "rimraf": "^5.0.5",
     "typescript": "~5.0.4"
   }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -32,7 +32,7 @@
     "docs:changelog": "cpx ./CHANGELOG.md ./build/docs/reference/presentation-testing",
     "docs:reference": "betools docs --includes=./build/docs/extract --json=./build/docs/reference/presentation-testing/file.json --tsIndexFile=presentation-testing.ts --onlyJson --testExcludeGlob=./src/test/**",
     "lint": "eslint ./src/**/*.ts",
-    "test": "mocha --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
     "extract-api": "betools extract-api --entry=presentation-testing --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/presentation-testing.api.md"
   },

--- a/packages/unified-selection/package.json
+++ b/packages/unified-selection/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf lib build",
     "cover": "nyc npm -s test",
     "lint": "eslint ./src/**/*.ts",
-    "test": "mocha --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
     "test:watch": "npm -s test -- --reporter min --watch-extensions ts --watch",
     "extract-api": "betools extract-api --entry=unified-selection --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/unified-selection.api.md"
@@ -58,7 +58,6 @@
     "rimraf": "^5.0.5",
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
-    "source-map-support": "^0.5.21",
     "typescript": "~5.0.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -826,9 +826,6 @@ importers:
       sinon-chai:
         specifier: ^3.7.0
         version: 3.7.0(chai@4.4.1)(sinon@17.0.1)
-      source-map-support:
-        specifier: ^0.5.21
-        version: 0.5.21
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
@@ -970,9 +967,6 @@ importers:
       '@types/sinon-chai':
         specifier: ^3.2.12
         version: 3.2.12
-      '@types/source-map-support':
-        specifier: ^0.5.6
-        version: 0.5.6
       chai:
         specifier: ^4.4.1
         version: 4.4.1
@@ -1036,9 +1030,6 @@ importers:
       sinon-chai:
         specifier: ^3.7.0
         version: 3.7.0(chai@4.4.1)(sinon@17.0.1)
-      source-map-support:
-        specifier: ^0.5.21
-        version: 0.5.21
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
@@ -1127,9 +1118,6 @@ importers:
       sinon-chai:
         specifier: ^3.7.0
         version: 3.7.0(chai@4.4.1)(sinon@17.0.1)
-      source-map-support:
-        specifier: ^0.5.21
-        version: 0.5.21
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
@@ -1251,9 +1239,6 @@ importers:
       sinon-chai:
         specifier: ^3.7.0
         version: 3.7.0(chai@4.4.1)(sinon@17.0.1)
-      source-map-support:
-        specifier: ^0.5.21
-        version: 0.5.21
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
@@ -1282,9 +1267,6 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
-      source-map-support:
-        specifier: ^0.5.21
-        version: 0.5.21
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
@@ -1357,9 +1339,6 @@ importers:
       sinon-chai:
         specifier: ^3.7.0
         version: 3.7.0(chai@4.4.1)(sinon@17.0.1)
-      source-map-support:
-        specifier: ^0.5.21
-        version: 0.5.21
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
@@ -1427,9 +1406,6 @@ importers:
       sinon-chai:
         specifier: ^3.7.0
         version: 3.7.0(chai@4.4.1)(sinon@17.0.1)
-      source-map-support:
-        specifier: ^0.5.21
-        version: 0.5.21
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
@@ -1667,9 +1643,6 @@ importers:
       sinon-chai:
         specifier: ^3.7.0
         version: 3.7.0(chai@4.4.1)(sinon@17.0.1)
-      source-map-support:
-        specifier: ^0.5.21
-        version: 0.5.21
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
@@ -5612,12 +5585,6 @@ packages:
     resolution: {integrity: sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==}
     dev: false
 
-  /@types/source-map-support@0.5.6:
-    resolution: {integrity: sha512-b2nJ9YyXmkhGaa2b8VLM0kJ04xxwNyijcq12/kDoomCt43qbHBeK2SLNJ9iJmETaAj+bKUT05PQUu3Q66GvLhQ==}
-    dependencies:
-      source-map: 0.6.1
-    dev: false
-
   /@types/tough-cookie@4.0.5:
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
@@ -6572,9 +6539,6 @@ packages:
   /buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
     dev: false
-
-  /buffer-from@1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   /buffer@4.9.2:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
@@ -12171,12 +12135,6 @@ packages:
     dependencies:
       source-map: 0.1.32
     dev: false
-
-  /source-map-support@0.5.21:
-    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
-    dependencies:
-      buffer-from: 1.1.2
-      source-map: 0.6.1
 
   /source-map@0.1.32:
     resolution: {integrity: sha512-htQyLrrRLkQ87Zfrir4/yN+vAUd6DNjVayEjTSHXu29AYQJw57I4/xEL/M6p6E/woPNJwvZt6rVlzc7gFEJccQ==}


### PR DESCRIPTION
Looks like there is no need to use `source-map-support` with `mocha` since node v12.12.0. Updated scripts and debug config to use node's `--enable-source-maps` flag. https://mochajs.org/#-enable-source-maps