### PR TITLE
hierarchies: Reference APIs using backticks rather than double-brackets

### DIFF
--- a/packages/hierarchies/src/hierarchies/HierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyDefinition.ts
@@ -39,7 +39,7 @@ export interface InstanceNodesQueryDefinition {
   fullClassName: string;
   /**
    * An ECSQL query that selects nodes from an iModel. `SELECT` clause of the query is expected
-   * to be built using [[NodeSelectQueryFactory.createSelectClause]].
+   * to be built using `NodeSelectQueryFactory.createSelectClause`.
    */
   query: ECSqlQueryDef;
 }
@@ -67,7 +67,7 @@ export namespace HierarchyNodesDefinition {
 export type HierarchyLevelDefinition = HierarchyNodesDefinition[];
 
 /**
- * A type for a function that parses a [[ParsedInstanceHierarchyNode]] from provided ECSQL `row` object.
+ * A type for a function that parses a `ParsedInstanceHierarchyNode` from provided ECSQL `row` object.
  * @beta
  */
 export type INodeParser = (row: { [columnName: string]: any }) => ParsedInstanceHierarchyNode;
@@ -90,16 +90,16 @@ export type INodePreProcessor = <TNode extends ProcessedCustomHierarchyNode | Pr
 export type INodePostProcessor = (node: ProcessedHierarchyNode) => Promise<ProcessedHierarchyNode>;
 
 /**
- * A type of node that can be passed to [[IHierarchyLevelDefinitionsFactory.defineHierarchyLevel]]. This basically means
- * a [[HierarchyNode]] that:
+ * A type of node that can be passed to `IHierarchyLevelDefinitionsFactory.defineHierarchyLevel`. This basically means
+ * a `HierarchyNode` that:
  * - knows nothing about its children,
- * - is either an instances node (key is of [[InstancesNodeKey]] type) or a custom node (key is of `string` type).
+ * - is either an instances node (key is of `InstancesNodeKey` type) or a custom node (key is of `string` type).
  * @beta
  */
 export type HierarchyDefinitionParentNode = Omit<HierarchyNode, "children" | "key"> & { key: InstancesNodeKey | string };
 
 /**
- * Props for [[IHierarchyLevelDefinitionsFactory.defineHierarchyLevel]].
+ * Props for `IHierarchyLevelDefinitionsFactory.defineHierarchyLevel`.
  * @beta
  */
 export interface DefineHierarchyLevelProps {
@@ -117,19 +117,19 @@ export interface IHierarchyLevelDefinitionsFactory {
   /**
    * An optional function for parsing ECInstance node from ECSQL row.
    *
-   * Should be used in situations when the [[IHierarchyLevelDefinitionsFactory]] implementation
+   * Should be used in situations when the `IHierarchyLevelDefinitionsFactory` implementation
    * introduces additional ECSQL columns into the select clause and wants to assign additional
    * data to the nodes it produces.
    *
-   * Defaults to a function that parses all [[HierarchyNode]] attributes.
+   * Defaults to a function that parses all `HierarchyNode` attributes.
    */
   parseNode?: INodeParser;
 
   /**
    * An optional function for pre-processing nodes.
    *
-   * Pre-processing happens immediately after the nodes are loaded based on [[HierarchyLevelDefinition]]
-   * returned by this [[IHierarchyLevelDefinitionsFactory]]. The step allows assigning nodes additional data
+   * Pre-processing happens immediately after the nodes are loaded based on `HierarchyLevelDefinition`
+   * returned by this `IHierarchyLevelDefinitionsFactory`. The step allows assigning nodes additional data
    * or excluding them from the hierarchy based on some attributes.
    */
   preProcessNode?: INodePreProcessor;
@@ -138,7 +138,7 @@ export interface IHierarchyLevelDefinitionsFactory {
    * An optional function for post-processing nodes.
    *
    * Post-processing happens after the loaded nodes go through all the merging, hiding, sorting and grouping
-   * steps. This step allows [[IHierarchyLevelDefinitionsFactory]] implementations to assign additional data
+   * steps. This step allows `IHierarchyLevelDefinitionsFactory` implementations to assign additional data
    * to nodes after they're processed. This is especially true for grouping nodes as they're only created during
    * processing.
    */
@@ -149,7 +149,7 @@ export interface IHierarchyLevelDefinitionsFactory {
 }
 
 /**
- * Props for [[InstancesNodeChildHierarchyLevelDefinition.definitions]] call.
+ * Props for `InstancesNodeChildHierarchyLevelDefinition.definitions` call.
  * @beta
  */
 export type DefineInstanceNodeChildHierarchyLevelProps = DefineHierarchyLevelProps & {
@@ -172,7 +172,7 @@ export interface InstancesNodeChildHierarchyLevelDefinition {
   parentNodeClassName: string;
 
   /**
-   * Called to create a hierarchy level definition when the class check passes (see [[parentNodeClassName]]).
+   * Called to create a hierarchy level definition when the class check passes (see `parentNodeClassName`).
    * @param requestProps Props for creating the hierarchy level definition.
    */
   definitions: (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => Promise<HierarchyLevelDefinition>;
@@ -188,7 +188,7 @@ export interface CustomNodeChildHierarchyLevelDefinition {
    */
   customParentNodeKey: string;
   /**
-   * Called to create a hierarchy level definition when the node key check passes (see [[customParentNodeKey]]).
+   * Called to create a hierarchy level definition when the node key check passes (see `customParentNodeKey`).
    * @param requestProps Props for creating the hierarchy level definition.
    */
   definitions: (requestProps: DefineHierarchyLevelProps) => Promise<HierarchyLevelDefinition>;
@@ -203,7 +203,7 @@ export interface CustomNodeChildHierarchyLevelDefinition {
 export type ClassBasedHierarchyLevelDefinition = InstancesNodeChildHierarchyLevelDefinition | CustomNodeChildHierarchyLevelDefinition;
 
 /**
- * Props for [[ClassBasedHierarchyDefinition.rootNodes]] call.
+ * Props for `ClassBasedHierarchyDefinition.rootNodes` call.
  * @beta
  */
 export type DefineRootHierarchyLevelProps = Omit<DefineHierarchyLevelProps, "parentNode">;
@@ -224,7 +224,7 @@ export interface ClassBasedHierarchyDefinition {
 }
 
 /**
- * Props for [[ClassBasedHierarchyLevelDefinitionsFactory]].
+ * Props for `ClassBasedHierarchyLevelDefinitionsFactory`.
  * @beta
  */
 export interface ClassBasedHierarchyDefinitionsFactoryProps {

--- a/packages/hierarchies/src/hierarchies/HierarchyNode.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyNode.ts
@@ -137,39 +137,39 @@ export namespace HierarchyNodeKey {
   export function isCustom(key: HierarchyNodeKey): key is string {
     return typeof key === "string";
   }
-  /** Checks whether the given node key is a [[StandardHierarchyNodeKey]]. */
+  /** Checks whether the given node key is a `StandardHierarchyNodeKey`. */
   export function isStandard(key: HierarchyNodeKey): key is StandardHierarchyNodeKey {
     return !!(key as StandardHierarchyNodeKey).type;
   }
-  /** Checks whether the given node key is an [[InstancesNodeKey]]. */
+  /** Checks whether the given node key is an `InstancesNodeKey`. */
   export function isInstances(key: HierarchyNodeKey): key is InstancesNodeKey {
     return isStandard(key) && key.type === "instances";
   }
-  /** Checks whether the given node key is a [[GroupingNodeKey]]. */
+  /** Checks whether the given node key is a `GroupingNodeKey`. */
   export function isGrouping(key: HierarchyNodeKey): key is GroupingNodeKey {
     return isStandard(key) && !isInstances(key);
   }
-  /** Checks whether the given node key is a [[ClassGroupingNodeKey]]. */
+  /** Checks whether the given node key is a `ClassGroupingNodeKey`. */
   export function isClassGrouping(key: HierarchyNodeKey): key is ClassGroupingNodeKey {
     return isStandard(key) && key.type === "class-grouping";
   }
-  /** Checks whether the given node key is a [[LabelGroupingNodeKey]]. */
+  /** Checks whether the given node key is a `LabelGroupingNodeKey`. */
   export function isLabelGrouping(key: HierarchyNodeKey): key is LabelGroupingNodeKey {
     return isStandard(key) && key.type === "label-grouping";
   }
-  /** Checks whether the given node key is a [[PropertyOtherValuesGroupingNodeKey]]. */
+  /** Checks whether the given node key is a `PropertyOtherValuesGroupingNodeKey`. */
   export function isPropertyOtherValuesGrouping(key: HierarchyNodeKey): key is PropertyOtherValuesGroupingNodeKey {
     return isStandard(key) && key.type === "property-grouping:other";
   }
-  /** Checks whether the given node key is a [[PropertyValueRangeGroupingNodeKey]]. */
+  /** Checks whether the given node key is a `PropertyValueRangeGroupingNodeKey`. */
   export function isPropertyValueRangeGrouping(key: HierarchyNodeKey): key is PropertyValueRangeGroupingNodeKey {
     return isStandard(key) && key.type === "property-grouping:range";
   }
-  /** Checks whether the given node key is a [[PropertyValueGroupingNodeKey]]. */
+  /** Checks whether the given node key is a `PropertyValueGroupingNodeKey`. */
   export function isPropertyValueGrouping(key: HierarchyNodeKey): key is PropertyValueGroupingNodeKey {
     return isStandard(key) && key.type === "property-grouping:value";
   }
-  /** Checks whether the given node key is a [[PropertyGroupingNodeKey]]. */
+  /** Checks whether the given node key is a `PropertyGroupingNodeKey`. */
   export function isPropertyGrouping(key: HierarchyNodeKey): key is PropertyGroupingNodeKey {
     return isPropertyOtherValuesGrouping(key) || isPropertyValueRangeGrouping(key) || isPropertyValueGrouping(key);
   }
@@ -330,8 +330,8 @@ export interface GroupingHierarchyNode extends BaseHierarchyNode {
 export type HierarchyNode = NonGroupingHierarchyNode | GroupingHierarchyNode;
 
 /**
- * A type of [[HierarchyNode]] that doesn't know about its children and is an input when requesting
- * them using [[HierarchyProvider.getNodes]].
+ * A type of `HierarchyNode` that doesn't know about its children and is an input when requesting
+ * them using `HierarchyProvider.getNodes`.
  *
  * @beta
  */
@@ -479,7 +479,7 @@ export interface HierarchyNodeGroupingParamsBase {
   autoExpand?: HierarchyNodeAutoExpandProp;
 }
 /**
- * Defines possible values for [[BaseGroupingParams.autoExpand]] attribute:
+ * Defines possible values for `BaseGroupingParams.autoExpand` attribute:
  * - `single-child` - set the grouping node to auto-expand if it groups a single node.
  * - `always` - always set the grouping node to auto-expand.
  * @beta
@@ -571,7 +571,7 @@ export interface HierarchyNodePropertyValueRange {
   fromValue: number;
   /** Defines the upper bound of the range. */
   toValue: number;
-  /** Defines the range label. Will be used as [[PropertyValueRangeGroupingNode]] node's display label. */
+  /** Defines the range label. Will be used as `PropertyValueRangeGroupingNode` node's display label. */
   rangeLabel?: string;
 }
 
@@ -609,27 +609,27 @@ export type ProcessedGroupingHierarchyNode = Omit<GroupingHierarchyNode, "childr
   children: Array<ProcessedGroupingHierarchyNode | ProcessedInstanceHierarchyNode>;
 };
 /**
- * A [[HierarchyNode]] that may have processing parameters defining whether it should be hidden under some conditions,
+ * A `HierarchyNode` that may have processing parameters defining whether it should be hidden under some conditions,
  * how it should be grouped, sorted, etc.
  * @beta
  */
 export type ProcessedHierarchyNode = ProcessedCustomHierarchyNode | ProcessedInstanceHierarchyNode | ProcessedGroupingHierarchyNode;
 
 /**
- * A [[ProcessedHierarchyNode]] that has an unformatted label in a form of [[ConcatenatedValue]]. Generally this is
+ * A `ProcessedHierarchyNode` that has an unformatted label in a form of `ConcatenatedValue`. Generally this is
  * returned when the node is just parsed from query results.
  * @beta
  */
 export type ParsedHierarchyNode = ParsedCustomHierarchyNode | ParsedInstanceHierarchyNode;
 /**
- * A kind of [[ProcessedCustomHierarchyNode]] that has unformatted label and doesn't know about its ancestors.
+ * A kind of `ProcessedCustomHierarchyNode` that has unformatted label and doesn't know about its ancestors.
  * @beta
  */
 export type ParsedCustomHierarchyNode = Omit<ProcessedCustomHierarchyNode, "label" | "parentKeys"> & {
   label: string | ConcatenatedValue;
 };
 /**
- * A kind of [[ProcessedInstanceHierarchyNode]] that has unformatted label and doesn't know about its ancestors.
+ * A kind of `ProcessedInstanceHierarchyNode` that has unformatted label and doesn't know about its ancestors.
  * @beta
  */
 export type ParsedInstanceHierarchyNode = Omit<ProcessedInstanceHierarchyNode, "label" | "parentKeys"> & {
@@ -639,9 +639,9 @@ export type ParsedInstanceHierarchyNode = Omit<ProcessedInstanceHierarchyNode, "
 /**
  * An identifier that can be used to identify either an ECInstance or a custom node.
  *
- * This is different from [[HierarchyNodeKey]] - the key can represent more types of nodes and,
- * in case of [[InstancesNodeKey]], contains information about all instances the node represents.
- * [[HierarchyNodeIdentifier]], on the other hand, is used for matching a node, so it only needs
+ * This is different from `HierarchyNodeKey` - the key can represent more types of nodes and,
+ * in case of `InstancesNodeKey`, contains information about all instances the node represents.
+ * `HierarchyNodeIdentifier`, on the other hand, is used for matching a node, so it only needs
  * to contain information about a single instance or custom node key.
  *
  * @beta

--- a/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
@@ -98,7 +98,7 @@ export interface HierarchyProviderLocalizedStrings {
 }
 
 /**
- * Props for [[HierarchyProvider]].
+ * Props for `HierarchyProvider`.
  * @beta
  */
 export interface HierarchyProviderProps {
@@ -125,7 +125,7 @@ export interface HierarchyProviderProps {
 
   /**
    * A values formatter for formatting node labels. Defaults to the
-   * result of [[createDefaultValueFormatter]] called with default parameters.
+   * result of `createDefaultValueFormatter` called with default parameters.
    */
   formatter?: IPrimitiveValueFormatter;
 
@@ -140,14 +140,14 @@ export interface HierarchyProviderProps {
 }
 
 /**
- * Props for [[HierarchyProvider.getNodes]] call.
+ * Props for `HierarchyProvider.getNodes` call.
  * @beta
  */
 export interface GetHierarchyNodesProps {
   /** Parent node to get children for. Pass `undefined` to get root nodes. */
   parentNode: ParentHierarchyNode | undefined;
 
-  /** Optional hierarchy level filter. Has no effect if `parentNode` is a [[GroupingNode]]. */
+  /** Optional hierarchy level filter. Has no effect if `parentNode` is a `GroupingNode`. */
   instanceFilter?: GenericInstanceFilter;
 
   /**
@@ -155,7 +155,7 @@ export interface GetHierarchyNodesProps {
    * by this provider to override query rows limit per hierarchy level. If not provided, defaults to whatever
    * is used by the limiting query executor.
    *
-   * Has no effect if `parentNode` is a [[GroupingNode]].
+   * Has no effect if `parentNode` is a `GroupingNode`.
    */
   hierarchyLevelSizeLimit?: number | "unbounded";
 
@@ -220,8 +220,8 @@ export class HierarchyProvider {
   }
 
   /**
-   * Sets [[HierarchyProvider]] values formatter that formats nodes' labels. If provided `undefined`, then defaults to the
-   * result of [[createDefaultValueFormatter]] called with default parameters.
+   * Sets `HierarchyProvider` values formatter that formats nodes' labels. If provided `undefined`, then defaults to the
+   * result of `createDefaultValueFormatter` called with default parameters.
    */
   public setFormatter(formatter: IPrimitiveValueFormatter | undefined) {
     this._valuesFormatter = formatter ?? createDefaultValueFormatter();

--- a/packages/hierarchies/src/hierarchies/Logging.ts
+++ b/packages/hierarchies/src/hierarchies/Logging.ts
@@ -18,7 +18,7 @@ export function setLogger(logger: ILogger | undefined) {
 
 /**
  * Get logger used by this package.
- * @see [[setLogger]]
+ * @see `setLogger`
  * @beta
  */
 export function getLogger(): ILogger {

--- a/packages/hierarchies/src/hierarchies/NodeSelectQueryFactory.ts
+++ b/packages/hierarchies/src/hierarchies/NodeSelectQueryFactory.ts
@@ -25,7 +25,7 @@ import {
 } from "@itwin/presentation-shared";
 
 /**
- * Column names of the SELECT clause created by [[NodeSelectClauseFactory]]. Order of the names matches the order of columns
+ * Column names of the SELECT clause created by `NodeSelectClauseFactory`. Order of the names matches the order of columns
  * created by the factory.
  *
  * @beta
@@ -67,7 +67,7 @@ export interface ECSqlValueSelector {
 }
 
 /**
- * Props for [[NodeSelectClauseFactory.createSelectClause]].
+ * Props for `NodeSelectClauseFactory.createSelectClause`.
  * @beta
  */
 export interface NodeSelectClauseProps {


### PR DESCRIPTION
We're not publishing out docs to iTwin.js doc site, so it makes no sense to use double-brackets to reference APIs - use backticks instead.