### PR TITLE
`onFilterApplied` and `onHierarchyLimitExceeded` callbacks

### DIFF
--- a/.changeset/great-eggs-leave.md
+++ b/.changeset/great-eggs-leave.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Added `onFilterApplied` and `onHierarchyLimitExceeded` callbacks.

--- a/.changeset/great-eggs-leave.md
+++ b/.changeset/great-eggs-leave.md
@@ -1,5 +1,5 @@
 ---
-"@itwin/presentation-components": patch
+"@itwin/presentation-components": minor
 ---
 
 Added `onFilterApplied` and `onHierarchyLimitExceeded` callbacks.

--- a/packages/components/api/presentation-components.api.md
+++ b/packages/components/api/presentation-components.api.md
@@ -586,6 +586,8 @@ export interface PresentationTreeDataProviderProps extends DiagnosticsProps {
     // @beta
     hierarchyLevelSizeLimit?: number;
     imodel: IModelConnection;
+    // @beta
+    onHierarchyLimitExceeded?: () => void;
     pagingSize?: number;
     ruleset: string | Ruleset;
 }
@@ -650,6 +652,8 @@ export function PresentationTreeRenderer(props: PresentationTreeRendererProps): 
 export interface PresentationTreeRendererProps extends Omit<TreeRendererProps, "nodeRenderer"> {
     // (undocumented)
     nodeLoader: AbstractTreeNodeLoaderWithProvider<IPresentationTreeDataProvider>;
+    // (undocumented)
+    onFilterApplied?: () => void;
 }
 
 // @public
@@ -799,12 +803,14 @@ export function useControlledPresentationTreeFiltering(props: ControlledPresenta
 };
 
 // @beta
-export function useFilterablePresentationTree({ nodeLoader }: useFilterablePresentationTreeProps): FilterableTreeProps;
+export function useFilterablePresentationTree({ nodeLoader, onFilterApplied }: useFilterablePresentationTreeProps): FilterableTreeProps;
 
 // @beta
 export interface useFilterablePresentationTreeProps {
     // (undocumented)
     nodeLoader: AbstractTreeNodeLoaderWithProvider<IPresentationTreeDataProvider>;
+    // (undocumented)
+    onFilterApplied?: () => void;
 }
 
 // @beta
@@ -871,7 +877,7 @@ export interface UsePresentationTableWithUnifiedSelectionResult<TColumns, TRow> 
 export function usePresentationTreeNodeLoader(props: PresentationTreeNodeLoaderProps): PresentationTreeNodeLoaderResult;
 
 // @public
-export function usePresentationTreeState<TEventHandler extends TreeEventHandler = TreeEventHandler>({ onNodeLoaded, eventHandlerFactory, seedTreeModel, enableHierarchyAutoUpdate, filteringParams, ...dataProviderProps }: UsePresentationTreeStateProps<TEventHandler>): UsePresentationTreeStateResult<TEventHandler> | undefined;
+export function usePresentationTreeState<TEventHandler extends TreeEventHandler = TreeEventHandler>({ onHierarchyLimitExceeded, onNodeLoaded, eventHandlerFactory, seedTreeModel, enableHierarchyAutoUpdate, filteringParams, ...dataProviderProps }: UsePresentationTreeStateProps<TEventHandler>): UsePresentationTreeStateResult<TEventHandler> | undefined;
 
 // @public
 export interface UsePresentationTreeStateProps<TEventHandler extends TreeEventHandler = TreeEventHandler> extends PresentationTreeDataProviderProps {
@@ -882,6 +888,7 @@ export interface UsePresentationTreeStateProps<TEventHandler extends TreeEventHa
         filter: string;
         activeMatchIndex?: number;
     };
+    onHierarchyLimitExceeded?: () => void;
     onNodeLoaded?: (props: {
         node: string;
         duration: number;

--- a/packages/components/api/presentation-components.exports.csv
+++ b/packages/components/api/presentation-components.exports.csv
@@ -94,7 +94,7 @@ beta;UnifiedSelectionState = (selectionLevel?: number) => Readonly
 public;UnifiedSelectionTreeEventHandler 
 public;UnifiedSelectionTreeEventHandlerParams
 public;useControlledPresentationTreeFiltering(props: ControlledPresentationTreeFilteringProps):
-beta;useFilterablePresentationTree({ nodeLoader }: useFilterablePresentationTreeProps): FilterableTreeProps
+beta;useFilterablePresentationTree({ nodeLoader, onFilterApplied }: useFilterablePresentationTreeProps): FilterableTreeProps
 beta;useFilterablePresentationTreeProps
 beta;useHierarchyLevelFiltering(props: UseHierarchyLevelFilteringProps):
 beta;UseHierarchyLevelFilteringProps

--- a/packages/components/src/presentation-components/tree/controlled/PresentationTreeRenderer.tsx
+++ b/packages/components/src/presentation-components/tree/controlled/PresentationTreeRenderer.tsx
@@ -35,6 +35,7 @@ import { useHierarchyLevelFiltering } from "./UseHierarchyLevelFiltering";
  */
 export interface PresentationTreeRendererProps extends Omit<TreeRendererProps, "nodeRenderer"> {
   nodeLoader: AbstractTreeNodeLoaderWithProvider<IPresentationTreeDataProvider>;
+  onFilterApplied?: () => void;
 }
 
 /**
@@ -53,13 +54,14 @@ export interface FilterableTreeProps {
  */
 export interface useFilterablePresentationTreeProps {
   nodeLoader: AbstractTreeNodeLoaderWithProvider<IPresentationTreeDataProvider>;
+  onFilterApplied?: () => void;
 }
 
 /**
  * Hook that enables hierarchy level filtering with action handlers for setting and clearing filters.
  * @beta
  */
-export function useFilterablePresentationTree({ nodeLoader }: useFilterablePresentationTreeProps): FilterableTreeProps {
+export function useFilterablePresentationTree({ nodeLoader, onFilterApplied }: useFilterablePresentationTreeProps): FilterableTreeProps {
   const { applyFilter, clearFilter } = useHierarchyLevelFiltering({ nodeLoader, modelSource: nodeLoader.modelSource });
   const [filterNode, setFilterNode] = useState<PresentationTreeNodeItem>();
 
@@ -70,6 +72,7 @@ export function useFilterablePresentationTree({ nodeLoader }: useFilterablePrese
         onApply={(info) => {
           info === undefined ? clearFilter(filterNode.id) : applyFilter(filterNode.id, info);
           setFilterNode(undefined);
+          onFilterApplied?.();
         }}
         onClose={() => {
           setFilterNode(undefined);
@@ -97,7 +100,10 @@ export function useFilterablePresentationTree({ nodeLoader }: useFilterablePrese
  * @beta
  */
 export function PresentationTreeRenderer(props: PresentationTreeRendererProps) {
-  const { onClearFilterClick, onFilterClick, filterDialog } = useFilterablePresentationTree({ nodeLoader: props.nodeLoader });
+  const { onClearFilterClick, onFilterClick, filterDialog } = useFilterablePresentationTree({
+    nodeLoader: props.nodeLoader,
+    onFilterApplied: props.onFilterApplied,
+  });
   const filterableNodeRenderer = (nodeProps: TreeNodeRendererProps) => {
     return <PresentationTreeNodeRenderer {...nodeProps} onFilterClick={onFilterClick} onClearFilterClick={onClearFilterClick} />;
   };

--- a/packages/components/src/test/tree/controlled/PresentationTreeRenderer.test.tsx
+++ b/packages/components/src/test/tree/controlled/PresentationTreeRenderer.test.tsx
@@ -281,6 +281,33 @@ describe("PresentationTreeRenderer", () => {
     subject.complete();
   });
 
+  it("calls `onFilterApplied` when filter is applied", async () => {
+    const onFilterAppliedSpy = sinon.spy();
+
+    const { visibleNodes, nodeLoader } = setupTreeModel((model) => {
+      model.setChildren(
+        undefined,
+        [
+          createTreeModelNodeInput({
+            id: "A",
+            item: { filtering: { descriptor: createTestContentDescriptor({ fields: [propertyField] }), ancestorFilters: [] } },
+          }),
+        ],
+        0,
+      );
+    });
+
+    const result = render(
+      <PresentationTreeRenderer {...baseTreeProps} visibleNodes={visibleNodes} nodeLoader={nodeLoader} onFilterApplied={onFilterAppliedSpy} />,
+    );
+
+    const { queryByText } = result;
+    await waitFor(() => expect(queryByText("A")).to.not.be.null);
+    await applyFilter(result, propertyField.label);
+
+    await waitFor(() => expect(onFilterAppliedSpy).to.be.calledOnce);
+  });
+
   it("renders results count when filtering dialog has valid filter", async () => {
     const { visibleNodes, nodeLoader } = setupTreeModel((model) => {
       model.setChildren(


### PR DESCRIPTION
Added callbacks necessary for [792](https://github.com/iTwin/viewer-components-react/issues/792).