### PR TITLE
Avoid changing `selectionSet` unnecessary when unified selection change is caused by `Viewport`

### DIFF
--- a/.changeset/ten-ghosts-flow.md
+++ b/.changeset/ten-ghosts-flow.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Avoid removing and adding back elements from/to `selectionSet` when unified selection is changed when selecting something in the `Viewport`.

--- a/apps/test-app/frontend/src/components/app/App.tsx
+++ b/apps/test-app/frontend/src/components/app/App.tsx
@@ -109,6 +109,26 @@ export function App() {
     };
   }, []);
 
+  useEffect(() => {
+    if (!state.imodel) {
+      return;
+    }
+
+    const removeSelectionListener = Presentation.selection.selectionChange.addListener((args: SelectionChangeEventArgs) => {
+      // eslint-disable-next-line no-console
+      console.log("Unified selection changed", args);
+    });
+    const selectionSetListener = state.imodel.selectionSet.onChanged.addListener((args) => {
+      // eslint-disable-next-line no-console
+      console.log("Selection set changed", args);
+    });
+
+    return () => {
+      removeSelectionListener();
+      selectionSetListener();
+    };
+  }, [state.imodel]);
+
   return (
     <ThemeProvider theme="os">
       <div className="app">


### PR DESCRIPTION
Avoid remove/adding back elements from/to `selectionSet` when unified selection change is caused by selecting something in a viewport. Remove/adding elements causes tool buttons flicker if they are shown only when something is in `selectionSet`