### PR TITLE
Fix `PresentationInstanceFilter.toGenericInstanceFilter` conversion with numeric string values

### DIFF
--- a/.changeset/smooth-fans-listen.md
+++ b/.changeset/smooth-fans-listen.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-components": patch
 ---
 
-Fixed `PresentationInstanceFilter.toGenericInstanceFilter` convertion with conditions using numeric string values.
+Fixed `PresentationInstanceFilter.toGenericInstanceFilter` conversion when condition is using numeric string values.

--- a/.changeset/smooth-fans-listen.md
+++ b/.changeset/smooth-fans-listen.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Fixed `PresentationInstanceFilter.toGenericInstanceFilter` convertion with conditions using numeric string values.

--- a/packages/components/src/presentation-components/common/Utils.ts
+++ b/packages/components/src/presentation-components/common/Utils.ts
@@ -279,7 +279,7 @@ export function deserializeUniqueValues(serializedDisplayValues: string, seriali
   const displayValues = tryParseJSON(serializedDisplayValues);
   const groupedRawValues = tryParseJSON(serializedGroupedRawValues);
 
-  if (!displayValues || !groupedRawValues) {
+  if (!displayValues || !groupedRawValues || !Array.isArray(displayValues) || Object.keys(groupedRawValues).length !== displayValues.length) {
     return undefined;
   }
 

--- a/packages/components/src/test/common/Utils.test.ts
+++ b/packages/components/src/test/common/Utils.test.ts
@@ -15,6 +15,7 @@ import { Presentation } from "@itwin/presentation-frontend";
 import {
   AsyncTasksTracker,
   createLabelRecord,
+  deserializeUniqueValues,
   findField,
   getDisplayName,
   initializeLocalization,
@@ -168,5 +169,23 @@ describe("AsyncTasksTracker", () => {
       expect(tracker.pendingAsyncs.size).to.eq(1);
     });
     expect(tracker.pendingAsyncs.size).to.eq(0);
+  });
+});
+
+describe("deserializeUniqueValues", () => {
+  it("returns undefined for non serialized numeric string values", () => {
+    const deserialized = deserializeUniqueValues("50", "50");
+    expect(deserialized).to.be.undefined;
+  });
+
+  it("returns undefined for non serialized string values", () => {
+    const deserialized = deserializeUniqueValues("some value", "some value");
+    expect(deserialized).to.be.undefined;
+  });
+
+  it("returns undefined if display value count does not match raw values count", () => {
+    const deserialized = deserializeUniqueValues(`[1, 2]`, `{"1": [1], "2": [2]}`);
+    expect(deserialized).to.have.lengthOf(2);
+    expect(deserializeUniqueValues(`[1, 2]`, `{"1": [1]}`)).to.be.undefined;
   });
 });

--- a/packages/components/src/test/instance-filter-builder/PresentationInstanceFilter.test.ts
+++ b/packages/components/src/test/instance-filter-builder/PresentationInstanceFilter.test.ts
@@ -429,6 +429,39 @@ describe("PresentationInstanceFilter", () => {
       expect(actual).to.be.deep.eq(expectedFilter);
     });
 
+    it("converts string unique value condition", () => {
+      const { displayValues, groupedRawValues } = serializeUniqueValues([
+        {
+          displayValue: "10",
+          groupedRawValues: ["10"],
+        },
+      ]);
+      const filter: PresentationInstanceFilter = {
+        operator: "is-equal",
+        field: propertyField1,
+        value: { valueFormat: PropertyValueFormat.Primitive, value: groupedRawValues, displayValue: displayValues },
+      };
+      const actual = PresentationInstanceFilter.toGenericInstanceFilter(filter);
+      const expectedFilter: GenericInstanceFilter = {
+        rules: {
+          operator: "or",
+          rules: [
+            {
+              operator: "is-equal",
+              propertyName: propertyField1.properties[0].property.name,
+              sourceAlias: "this",
+              propertyTypeName: propertyField1.type.typeName,
+              value: { displayValue: "10", rawValue: "10" },
+            },
+          ],
+        },
+        propertyClassNames: ["Schema:A"],
+        relatedInstances: [],
+        filteredClassNames: undefined,
+      };
+      expect(actual).to.be.deep.eq(expectedFilter);
+    });
+
     it("converts condition group", () => {
       const filter: PresentationInstanceFilter = {
         operator: "or",


### PR DESCRIPTION
`PresentationInstanceFilter.toGenericInstanceFilter` was throwing error when condition contains numeric string `UniqueValue`. Fixed `deserializeUniqueValues` to correctly handle string values that are valid JSON but it not serialized `UniqueValue`s.