### PR TITLE
Add ability to load limited or filtered node instance keys

### DIFF
--- a/packages/hierarchies/api/presentation-hierarchies.api.md
+++ b/packages/hierarchies/api/presentation-hierarchies.api.md
@@ -401,9 +401,7 @@ export namespace HierarchyNodesDefinition {
 // @beta
 export class HierarchyProvider {
     constructor(props: HierarchyProviderProps);
-    getNodeInstanceKeys(props: {
-        parentNode: ParentHierarchyNode | undefined;
-    }): AsyncIterableIterator<InstanceKey>;
+    getNodeInstanceKeys(props: Omit<GetHierarchyNodesProps, "ignoreCache">): AsyncIterableIterator<InstanceKey>;
     getNodes(props: GetHierarchyNodesProps): AsyncIterableIterator<HierarchyNode>;
     readonly hierarchyDefinition: IHierarchyLevelDefinitionsFactory;
     notifyDataSourceChanged(): void;

--- a/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
@@ -479,8 +479,8 @@ export class HierarchyProvider {
     );
   }
 
-  private getNodeInstanceKeysObs(props: { parentNode: ParentHierarchyNode | undefined }): Observable<InstanceKey> {
-    const { parentNode } = props;
+  private getNodeInstanceKeysObs(props: Omit<GetHierarchyNodesProps, "ignoreCache">): Observable<InstanceKey> {
+    const { parentNode, instanceFilter, hierarchyLevelSizeLimit = "unbounded" } = props;
 
     if (parentNode && HierarchyNode.isGroupingNode(parentNode)) {
       return from(parentNode.groupedInstanceKeys);
@@ -490,7 +490,7 @@ export class HierarchyProvider {
 
     // split the definitions based on whether they're for custom nodes or for instance nodes
     const [customDefs, instanceDefs] = partition(
-      from(this.hierarchyDefinition.defineHierarchyLevel({ parentNode })).pipe(mergeAll(), shareReplay()),
+      from(this.hierarchyDefinition.defineHierarchyLevel({ parentNode, instanceFilter })).pipe(mergeAll(), shareReplay()),
       HierarchyNodesDefinition.isCustomNode,
     );
 
@@ -509,7 +509,7 @@ export class HierarchyProvider {
                   ${query.ecsql}
                 )
               `;
-              const reader = this.queryExecutor.createQueryReader({ ...query, ecsql }, { rowFormat: "Indexes", limit: "unbounded" });
+              const reader = this.queryExecutor.createQueryReader({ ...query, ecsql }, { rowFormat: "Indexes", limit: hierarchyLevelSizeLimit });
               return from(reader).pipe(
                 map((row) => ({
                   key: {
@@ -568,7 +568,7 @@ export class HierarchyProvider {
    * Creates an iterator for all child hierarchy level instance keys, taking into account any hidden hierarchy levels
    * that there may be under the given parent node.
    */
-  public getNodeInstanceKeys(props: { parentNode: ParentHierarchyNode | undefined }): AsyncIterableIterator<InstanceKey> {
+  public getNodeInstanceKeys(props: Omit<GetHierarchyNodesProps, "ignoreCache">): AsyncIterableIterator<InstanceKey> {
     const loggingCategory = `${LOGGING_NAMESPACE}.GetNodeInstanceKeys`;
     doLog({
       category: loggingCategory,

--- a/packages/hierarchies/src/test/HierarchyProvider.test.ts
+++ b/packages/hierarchies/src/test/HierarchyProvider.test.ts
@@ -8,7 +8,7 @@ import { collect, createAsyncIterator, ResolvablePromise, waitFor } from "presen
 import sinon from "sinon";
 import { omit } from "@itwin/core-bentley";
 import { GenericInstanceFilter } from "@itwin/core-common";
-import { ECSqlQueryDef, InstanceKey, trimWhitespace, TypedPrimitiveValue } from "@itwin/presentation-shared";
+import { ECSqlQueryDef, ECSqlQueryReaderOptions, InstanceKey, trimWhitespace, TypedPrimitiveValue } from "@itwin/presentation-shared";
 import { DefineHierarchyLevelProps, IHierarchyLevelDefinitionsFactory } from "../hierarchies/HierarchyDefinition";
 import { RowsLimitExceededError } from "../hierarchies/HierarchyErrors";
 import { GroupingHierarchyNode, GroupingNodeKey, HierarchyNode } from "../hierarchies/HierarchyNode";
@@ -690,6 +690,23 @@ describe("HierarchyProvider", () => {
   });
 
   describe("Hierarchy level instance keys", () => {
+    const instanceFilter: GenericInstanceFilter = {
+      propertyClassNames: ["x.y"],
+      relatedInstances: [],
+      rules: {
+        operator: "and",
+        rules: [
+          {
+            propertyName: "z",
+            propertyTypeName: "string",
+            sourceAlias: "this",
+            operator: "is-equal",
+            value: { rawValue: "test value", displayValue: "test value" },
+          },
+        ],
+      },
+    };
+
     it("returns grouped instance keys for parent grouping node", async () => {
       const groupingNode: GroupingHierarchyNode = {
         key: { type: "class-grouping", className: "x.y" },
@@ -940,6 +957,92 @@ describe("HierarchyProvider", () => {
           arg.parentNode.key.instanceKeys.length === 2 &&
           InstanceKey.equals(arg.parentNode.key.instanceKeys[0], { className: "a.b", id: "0x123" }) &&
           InstanceKey.equals(arg.parentNode.key.instanceKeys[1], { className: "a.b", id: "0x456" }),
+      );
+    });
+
+    it("applies instance filter", async () => {
+      queryExecutor.createQueryReader.returns(
+        createAsyncIterator([
+          {
+            [0]: "a.b",
+            [1]: "0x123",
+            [2]: false,
+          },
+          {
+            [0]: "a.b",
+            [1]: "0x456",
+            [2]: false,
+          },
+        ]),
+      );
+      const hierarchyDefinition = {
+        defineHierarchyLevel: sinon.fake(async ({ parentNode, instanceFilter: requestedInstanceFilter }: DefineHierarchyLevelProps) => {
+          if (parentNode === undefined && requestedInstanceFilter) {
+            return [
+              {
+                fullClassName: "x.y",
+                query: { ecsql: "root" },
+              },
+            ];
+          }
+          return [];
+        }),
+      };
+      const provider = new HierarchyProvider({
+        metadataProvider,
+        queryExecutor,
+        hierarchyDefinition,
+      });
+      const keys = await collect(provider.getNodeInstanceKeys({ parentNode: undefined, instanceFilter }));
+      expect(keys)
+        .to.have.lengthOf(2)
+        .and.to.containSubset([
+          { className: "a.b", id: "0x123" },
+          { className: "a.b", id: "0x456" },
+        ]);
+      expect(hierarchyDefinition.defineHierarchyLevel).to.be.calledOnce;
+      expect(hierarchyDefinition.defineHierarchyLevel.firstCall).to.be.calledWithMatch(
+        (arg: DefineHierarchyLevelProps) => arg.parentNode === undefined && arg.instanceFilter === instanceFilter,
+      );
+    });
+
+    it("applies hierarchy level size limit", async () => {
+      queryExecutor.createQueryReader.returns(
+        createAsyncIterator([
+          {
+            [0]: "a.b",
+            [1]: "0x123",
+            [2]: false,
+          },
+        ]),
+      );
+      const hierarchyDefinition = {
+        defineHierarchyLevel: sinon.fake(async ({ parentNode }: DefineHierarchyLevelProps) => {
+          if (parentNode === undefined) {
+            return [
+              {
+                fullClassName: "x.y",
+                query: { ecsql: "root" },
+              },
+            ];
+          }
+          return [];
+        }),
+      };
+      const provider = new HierarchyProvider({
+        metadataProvider,
+        queryExecutor,
+        hierarchyDefinition,
+      });
+      const keys = await collect(provider.getNodeInstanceKeys({ parentNode: undefined, hierarchyLevelSizeLimit: 1 }));
+      expect(keys)
+        .to.have.lengthOf(1)
+        .and.to.containSubset([{ className: "a.b", id: "0x123" }]);
+      expect(hierarchyDefinition.defineHierarchyLevel).to.be.calledOnce;
+      expect(queryExecutor.createQueryReader).to.be.calledOnce;
+      expect(queryExecutor.createQueryReader).to.be.calledWithMatch(
+        sinon.match.any,
+        (config?: ECSqlQueryReaderOptions & { limit?: number | "unbounded" }) => config?.limit === 1,
       );
     });
   });


### PR DESCRIPTION
Added support for `instanceFilter` and `hierarchyLevelSizeLimit` when loading node instance keys using `HierarchyProvider.getNodeInstanceKeys`