### PR TITLE
Expose hierarchy level size limit

### DIFF
--- a/apps/test-app/frontend/src/components/tree-widget/stateless-v2/Tree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/stateless-v2/Tree.tsx
@@ -20,7 +20,7 @@ import {
 import { createECSqlQueryExecutor, createMetadataProvider } from "@itwin/presentation-core-interop";
 import { Presentation } from "@itwin/presentation-frontend";
 import { createLimitingECSqlQueryExecutor, GenericInstanceFilter, HierarchyProvider, ILimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
-import { HierarchyLevelFilteringOptions, PresentationHierarchyNode, TreeRenderer, useUnifiedSelectionTree } from "@itwin/presentation-hierarchies-react";
+import { HierarchyLevelConfiguration, PresentationHierarchyNode, TreeRenderer, useUnifiedSelectionTree } from "@itwin/presentation-hierarchies-react";
 import { ModelsTreeDefinition } from "@itwin/presentation-models-tree";
 import { createCachingECClassHierarchyInspector, IECClassHierarchyInspector, IECMetadataProvider } from "@itwin/presentation-shared";
 
@@ -91,7 +91,7 @@ function Tree({ imodel, height, width }: { imodel: IModelConnection; height: num
     );
   }, [imodelAccess, filteredPaths]);
 
-  const { rootNodes, isLoading, getHierarchyLevelFilteringOptions, ...treeProps } = useUnifiedSelectionTree({
+  const { rootNodes, isLoading, getHierarchyLevelConfiguration, ...treeProps } = useUnifiedSelectionTree({
     imodelKey: imodel.key,
     sourceName: "StatelessTreeV2",
     hierarchyProvider,
@@ -108,13 +108,13 @@ function Tree({ imodel, height, width }: { imodel: IModelConnection; height: num
     treeProps.reloadTree();
   };
 
-  const [filteringOptions, setFilteringOptions] = useState<{ nodeId: string; options: HierarchyLevelFilteringOptions }>();
+  const [filteringOptions, setFilteringOptions] = useState<{ nodeId: string; options: HierarchyLevelConfiguration }>();
   const onFilterClick = useCallback(
     (nodeId: string) => {
-      const options = getHierarchyLevelFilteringOptions(nodeId);
+      const options = getHierarchyLevelConfiguration(nodeId);
       setFilteringOptions(options ? { nodeId, options } : undefined);
     },
-    [getHierarchyLevelFilteringOptions],
+    [getHierarchyLevelConfiguration],
   );
   const propertiesSource = useMemo<(() => Promise<PresentationInstanceFilterPropertiesSource>) | undefined>(() => {
     if (!hierarchyProvider || !filteringOptions) {

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -25,6 +25,8 @@ export interface HierarchyLevelFilteringOptions {
     // (undocumented)
     currentFilter?: GenericInstanceFilter;
     // (undocumented)
+    hierarchyLevelSizeLimit?: number | "unbounded";
+    // (undocumented)
     hierarchyNode: HierarchyNode;
 }
 

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -21,7 +21,7 @@ export function createTreeNode(node: PresentationTreeNode, isNodeSelected: (node
 export { GenericInstanceFilter }
 
 // @beta (undocumented)
-export interface HierarchyLevelFilteringOptions {
+export interface HierarchyLevelConfiguration {
     // (undocumented)
     currentFilter?: GenericInstanceFilter;
     // (undocumented)

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
@@ -1,7 +1,7 @@
 sep=;
 Release Tag;API Item
 beta;createTreeNode(node: PresentationTreeNode, isNodeSelected: (nodeId: string) => boolean): ReturnType
-beta;HierarchyLevelFilteringOptions
+beta;HierarchyLevelConfiguration
 beta;InfoNodeTypes = "ResultSetTooLarge" | "ChildrenPlaceholder" | "NoFilterMatchingNodes" | "Unknown"
 beta;isPresentationHierarchyNode(node: PresentationTreeNode): node is PresentationHierarchyNode
 beta;PresentationHierarchyNode

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
@@ -11,7 +11,7 @@ import { useUnifiedTreeSelection, UseUnifiedTreeSelectionProps } from "./interna
 import { PresentationHierarchyNode, PresentationTreeNode } from "./Types";
 
 /** @beta */
-export interface HierarchyLevelFilteringOptions {
+export interface HierarchyLevelConfiguration {
   hierarchyNode: HierarchyNode;
   hierarchyLevelSizeLimit?: number | "unbounded";
   currentFilter?: GenericInstanceFilter;
@@ -49,7 +49,7 @@ interface UseTreeResult {
   setHierarchyLevelLimit: (nodeId: string | undefined, limit: undefined | number | "unbounded") => void;
   setHierarchyLevelFilter: (nodeId: string | undefined, filter: GenericInstanceFilter | undefined) => void;
   isNodeSelected: (nodeId: string) => boolean;
-  getHierarchyLevelFilteringOptions: (nodeId: string) => HierarchyLevelFilteringOptions | undefined;
+  getHierarchyLevelConfiguration: (nodeId: string) => HierarchyLevelConfiguration | undefined;
 }
 
 interface TreeState {
@@ -107,8 +107,8 @@ function useTreeInternal({ hierarchyProvider }: UseTreeProps): UseTreeResult & {
 
   const isNodeSelected = useCallback((nodeId: string) => TreeModel.isNodeSelected(state.model, nodeId), [state]);
 
-  const getHierarchyLevelFilteringOptions = useCallback(
-    (nodeId: string): HierarchyLevelFilteringOptions | undefined => {
+  const getHierarchyLevelConfiguration = useCallback(
+    (nodeId: string): HierarchyLevelConfiguration | undefined => {
       const node = actions.getNode(nodeId);
       if (!node || !isTreeModelHierarchyNode(node)) {
         return undefined;
@@ -136,7 +136,7 @@ function useTreeInternal({ hierarchyProvider }: UseTreeProps): UseTreeResult & {
     selectNode,
     isNodeSelected,
     setHierarchyLevelLimit,
-    getHierarchyLevelFilteringOptions,
+    getHierarchyLevelConfiguration,
     getNode,
     setHierarchyLevelFilter,
   };

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
@@ -13,6 +13,7 @@ import { PresentationHierarchyNode, PresentationTreeNode } from "./Types";
 /** @beta */
 export interface HierarchyLevelFilteringOptions {
   hierarchyNode: HierarchyNode;
+  hierarchyLevelSizeLimit?: number | "unbounded";
   currentFilter?: GenericInstanceFilter;
 }
 
@@ -121,6 +122,7 @@ function useTreeInternal({ hierarchyProvider }: UseTreeProps): UseTreeResult & {
       return {
         hierarchyNode,
         currentFilter,
+        hierarchyLevelSizeLimit: node.hierarchyLimit,
       };
     },
     [actions],

--- a/packages/hierarchies-react/src/test/UseTree.test.tsx
+++ b/packages/hierarchies-react/src/test/UseTree.test.tsx
@@ -240,7 +240,7 @@ describe("useTree", () => {
     });
   });
 
-  it("`getHierarchyLevelFilteringOptions` returns undefined for invalid node", async () => {
+  it("`getHierarchyLevelConfiguration` returns undefined for invalid node", async () => {
     const rootNodes = [createTestHierarchyNode({ id: "root-1" })];
 
     hierarchyProvider.getNodes.callsFake((props) => {
@@ -252,11 +252,11 @@ describe("useTree", () => {
       expect(result.current.rootNodes).to.have.lengthOf(1);
     });
 
-    const filterOptions = result.current.getHierarchyLevelFilteringOptions("invalid");
+    const filterOptions = result.current.getHierarchyLevelConfiguration("invalid");
     expect(filterOptions).to.be.undefined;
   });
 
-  it("`getHierarchyLevelFilteringOptions` returns undefined for grouping node", async () => {
+  it("`getHierarchyLevelConfiguration` returns undefined for grouping node", async () => {
     const rootNodes = [createTestGroupingNode({ id: "grouping-node", children: true, autoExpand: true })];
     const childNodes = [createTestHierarchyNode({ id: "grouped-node-1" }), createTestHierarchyNode({ id: "grouped-node-1" })];
 
@@ -277,11 +277,11 @@ describe("useTree", () => {
       expect((result.current.rootNodes![0] as PresentationHierarchyNode).children).to.have.lengthOf(2);
     });
 
-    const filterOptions = result.current.getHierarchyLevelFilteringOptions(nodeId);
+    const filterOptions = result.current.getHierarchyLevelConfiguration(nodeId);
     expect(filterOptions).to.be.undefined;
   });
 
-  it("`getHierarchyLevelFilteringOptions` returns options for hierarchy node", async () => {
+  it("`getHierarchyLevelConfiguration` returns options for hierarchy node", async () => {
     const rootNodes = [createTestHierarchyNode({ id: "root-1" })];
 
     hierarchyProvider.getNodes.callsFake((props) => {
@@ -294,7 +294,7 @@ describe("useTree", () => {
       expect(result.current.rootNodes).to.have.lengthOf(1);
     });
 
-    const filterOptions = result.current.getHierarchyLevelFilteringOptions(nodeId);
+    const filterOptions = result.current.getHierarchyLevelConfiguration(nodeId);
     expect(filterOptions).to.not.be.undefined;
     expect(filterOptions?.hierarchyNode).to.be.eq(rootNodes[0]);
   });


### PR DESCRIPTION
Hierarchy level size limit might be overridden for specific hierarchy level. This might be necessary information when building instance filter and checking if filter reduces instance count to set limit.