### PR TITLE
Disable onMouseDown propagation for hierarchy filter buttons

### DIFF
--- a/.changeset/gorgeous-crabs-rhyme.md
+++ b/.changeset/gorgeous-crabs-rhyme.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-components": patch
 ---
 
-Disabled event propagation for hierarchy filtering buttons.
+Disabled `onMouseDown` event propagation for hierarchy filtering buttons.

--- a/.changeset/gorgeous-crabs-rhyme.md
+++ b/.changeset/gorgeous-crabs-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Disabled event propagation for hierarchy filtering buttons.

--- a/packages/components/src/presentation-components/tree/controlled/PresentationTreeNodeRenderer.tsx
+++ b/packages/components/src/presentation-components/tree/controlled/PresentationTreeNodeRenderer.tsx
@@ -109,6 +109,7 @@ function PresentationTreeNodeActions(props: PresentationTreeNodeActionsProps) {
             className="presentation-components-node-action-button"
             styleType="borderless"
             size="small"
+            onMouseDown={(e) => e.stopPropagation()}
             onClick={(e) => {
               e.stopPropagation();
               onClearFilterClick();
@@ -122,6 +123,7 @@ function PresentationTreeNodeActions(props: PresentationTreeNodeActionsProps) {
           className="presentation-components-node-action-button"
           styleType="borderless"
           size="small"
+          onMouseDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
             onFilterClick();


### PR DESCRIPTION
Disabled `onMouseDown` propagation for hierarchy filter buttons as they were causing duplicate `use-{tree}` feature reports in `TreeWidget`.