### PR TITLE
Fix tree auto update

### DIFF
--- a/.changeset/nine-foxes-glow.md
+++ b/.changeset/nine-foxes-glow.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Fixed tree reloading when unit system, ruleset variables or data in iModel changes.

--- a/apps/full-stack-tests/src/components/tree/Update.test.tsx
+++ b/apps/full-stack-tests/src/components/tree/Update.test.tsx
@@ -17,7 +17,7 @@ import {
   TreeModelSource,
 } from "@itwin/components-react";
 import { IModelConnection, SnapshotConnection } from "@itwin/core-frontend";
-import { ChildNodeSpecificationTypes, RuleTypes } from "@itwin/presentation-common";
+import { ChildNodeSpecificationTypes, Ruleset, RuleTypes } from "@itwin/presentation-common";
 import { IPresentationTreeDataProvider, usePresentationTreeState, UsePresentationTreeStateProps } from "@itwin/presentation-components";
 import { Presentation } from "@itwin/presentation-frontend";
 import { renderHook, waitFor } from "@testing-library/react";
@@ -170,7 +170,7 @@ describe("Tree update", () => {
 
     describe("on ruleset variables' modification", () => {
       it("detects a change in rule condition", async () => {
-        const ruleset = await Presentation.presentation.rulesets().add({
+        const ruleset: Ruleset = {
           id: "test_ruleset_id",
           rules: [
             {
@@ -199,10 +199,10 @@ describe("Tree update", () => {
               ],
             },
           ],
-        });
+        };
         await Presentation.presentation.vars(ruleset.id).setBool("use_first", false);
         await Presentation.presentation.vars(ruleset.id).setBool("use_second", false);
-        const hierarchy = await verifyHierarchy({ ...defaultProps, ruleset: ruleset.id }, []);
+        const hierarchy = await verifyHierarchy({ ...defaultProps, ruleset }, []);
 
         await Presentation.presentation.vars(ruleset.id).setBool("use_first", true);
         await hierarchy.verifyChange(["test-1"]);
@@ -215,7 +215,7 @@ describe("Tree update", () => {
       });
 
       it("detects a change in instance filter", async () => {
-        const ruleset = await Presentation.presentation.rulesets().add({
+        const ruleset: Ruleset = {
           id: "test_ruleset_id",
           rules: [
             {
@@ -231,9 +231,9 @@ describe("Tree update", () => {
               ],
             },
           ],
-        });
+        };
         await Presentation.presentation.vars(ruleset.id).setBool("show_nodes", false);
-        const hierarchy = await verifyHierarchy({ ...defaultProps, ruleset: ruleset.id }, []);
+        const hierarchy = await verifyHierarchy({ ...defaultProps, ruleset }, []);
 
         await Presentation.presentation.vars(ruleset.id).setBool("show_nodes", true);
         await hierarchy.verifyChange(["Physical Object [0-38]", "Physical Object [0-39]"]);
@@ -243,7 +243,7 @@ describe("Tree update", () => {
       });
 
       it("detects a change in customization rule's condition", async () => {
-        const ruleset = await Presentation.presentation.rulesets().add({
+        const ruleset: Ruleset = {
           id: "test_ruleset_id",
           rules: [
             {
@@ -263,8 +263,8 @@ describe("Tree update", () => {
               foreColor: `"Red"`,
             },
           ],
-        });
-        const hierarchy = await verifyHierarchy({ ...defaultProps, ruleset: ruleset.id }, ["Physical Object [0-38]", "Physical Object [0-39]"]);
+        };
+        const hierarchy = await verifyHierarchy({ ...defaultProps, ruleset }, ["Physical Object [0-38]", "Physical Object [0-39]"]);
 
         await Presentation.presentation.vars(ruleset.id).setBool("should_customize", true);
         await hierarchy.verifyChange([
@@ -274,7 +274,7 @@ describe("Tree update", () => {
       });
 
       it("detects a change in customization rule's value", async () => {
-        const ruleset = await Presentation.presentation.rulesets().add({
+        const ruleset: Ruleset = {
           id: "test_ruleset_id",
           rules: [
             {
@@ -294,8 +294,8 @@ describe("Tree update", () => {
               foreColor: `GetVariableStringValue("custom_color")`,
             },
           ],
-        });
-        const hierarchy = await verifyHierarchy({ ...defaultProps, ruleset: ruleset.id }, ["Physical Object [0-38]", "Physical Object [0-39]"]);
+        };
+        const hierarchy = await verifyHierarchy({ ...defaultProps, ruleset }, ["Physical Object [0-38]", "Physical Object [0-39]"]);
 
         await Presentation.presentation.vars(ruleset.id).setString("custom_color", "Red");
         await hierarchy.verifyChange([
@@ -311,7 +311,7 @@ describe("Tree update", () => {
       });
 
       it("detects changes of root and expanded nodes", async () => {
-        const ruleset = await Presentation.presentation.rulesets().add({
+        const ruleset: Ruleset = {
           id: "test_ruleset_id",
           rules: [
             {
@@ -354,9 +354,9 @@ describe("Tree update", () => {
               ],
             },
           ],
-        });
+        };
         await Presentation.presentation.vars(ruleset.id).setBool("show_children", true);
-        const hierarchy = await verifyHierarchy({ ...defaultProps, ruleset: ruleset.id }, [{ ["root-1"]: ["child-1"] }, { ["root-2"]: ["child-2"] }]);
+        const hierarchy = await verifyHierarchy({ ...defaultProps, ruleset }, [{ ["root-1"]: ["child-1"] }, { ["root-2"]: ["child-2"] }]);
 
         hierarchy.getModelSource().modifyModel((model) => {
           // expand only the `root-1` node

--- a/packages/components/src/presentation-components/tree/controlled/UsePresentationTreeState.ts
+++ b/packages/components/src/presentation-components/tree/controlled/UsePresentationTreeState.ts
@@ -174,7 +174,7 @@ export function usePresentationTreeState<TEventHandler extends TreeEventHandler 
     pageSize: dataProviderProps.pagingSize,
     modelSource: state?.nodeLoader.modelSource,
     dataProviderProps: treeStateProps,
-    rulesetId: state?.dataProvider.rulesetId,
+    ruleset: dataProviderProps.ruleset,
     onReload,
     renderedItems,
   });

--- a/packages/components/src/presentation-components/tree/controlled/UseTreeReload.ts
+++ b/packages/components/src/presentation-components/tree/controlled/UseTreeReload.ts
@@ -6,10 +6,12 @@
  * @module Tree
  */
 
-import { useEffect } from "react";
+import { MutableRefObject, useEffect } from "react";
 import { RenderedItemsRange, Subscription, TreeModelSource } from "@itwin/components-react";
 import { IModelApp } from "@itwin/core-frontend";
+import { Ruleset } from "@itwin/presentation-common";
 import { IModelHierarchyChangeEventArgs, Presentation } from "@itwin/presentation-frontend";
+import { getRulesetId } from "../../common/Utils";
 import { PresentationTreeDataProvider, PresentationTreeDataProviderProps } from "../DataProvider";
 import { reloadTree } from "./TreeReloader";
 
@@ -23,10 +25,10 @@ export interface ReloadedTree {
 export interface TreeReloadParams {
   dataProviderProps: PresentationTreeDataProviderProps;
   pageSize: number;
-  rulesetId?: string;
+  ruleset: string | Ruleset;
   modelSource?: TreeModelSource;
   onReload: (params: ReloadedTree) => void;
-  renderedItems: React.MutableRefObject<RenderedItemsRange | undefined>;
+  renderedItems: MutableRefObject<RenderedItemsRange | undefined>;
 }
 
 /** @internal */
@@ -38,96 +40,97 @@ export function useTreeReload(params: TreeReloadParams & { enable: boolean }) {
 }
 
 function useModelSourceUpdateOnIModelHierarchyUpdate(params: TreeReloadParams & { enable: boolean }): void {
-  const { enable, dataProviderProps, rulesetId, pageSize, modelSource, onReload, renderedItems } = params;
+  const { enable, dataProviderProps, ruleset, pageSize, modelSource, onReload, renderedItems } = params;
 
   useEffect(() => {
-    if (!enable || !rulesetId || !modelSource) {
+    if (!enable || !modelSource) {
       return;
     }
 
     let subscription: Subscription | undefined;
     const removeListener = Presentation.presentation.onIModelHierarchyChanged.addListener((args: IModelHierarchyChangeEventArgs) => {
-      if (args.rulesetId !== rulesetId || args.imodelKey !== dataProviderProps.imodel.key) {
+      if (args.rulesetId !== ruleset || args.imodelKey !== dataProviderProps.imodel.key) {
         return;
       }
 
-      subscription = startTreeReload({ dataProviderProps, rulesetId, pageSize, modelSource, renderedItems, onReload });
+      subscription = startTreeReload({ dataProviderProps, ruleset, pageSize, modelSource, renderedItems, onReload });
     });
 
     return () => {
       removeListener();
       subscription?.unsubscribe();
     };
-  }, [modelSource, enable, pageSize, dataProviderProps, rulesetId, onReload, renderedItems]);
+  }, [modelSource, enable, pageSize, dataProviderProps, ruleset, onReload, renderedItems]);
 }
 
 function useModelSourceUpdateOnRulesetModification(params: TreeReloadParams & { enable: boolean }): void {
-  const { enable, dataProviderProps, rulesetId, pageSize, modelSource, onReload, renderedItems } = params;
+  const { enable, dataProviderProps, ruleset, pageSize, modelSource, onReload, renderedItems } = params;
 
   useEffect(() => {
-    if (!enable || !rulesetId || !modelSource) {
+    if (!enable || !modelSource) {
       return;
     }
 
     let subscription: Subscription | undefined;
-    const removeListener = Presentation.presentation.rulesets().onRulesetModified.addListener((ruleset) => {
-      if (ruleset.id !== rulesetId) {
+    const removeListener = Presentation.presentation.rulesets().onRulesetModified.addListener((modifiedRuleset) => {
+      if (modifiedRuleset.id !== getRulesetId(ruleset)) {
         return;
       }
 
-      subscription = startTreeReload({ dataProviderProps, rulesetId, pageSize, modelSource, renderedItems, onReload });
+      // use ruleset id as only registered rulesets can be modified.
+      subscription = startTreeReload({ dataProviderProps, ruleset: modifiedRuleset.id, pageSize, modelSource, renderedItems, onReload });
     });
 
     return () => {
       removeListener();
       subscription?.unsubscribe();
     };
-  }, [dataProviderProps, rulesetId, enable, modelSource, pageSize, onReload, renderedItems]);
+  }, [dataProviderProps, ruleset, enable, modelSource, pageSize, onReload, renderedItems]);
 }
 
 function useModelSourceUpdateOnRulesetVariablesChange(params: TreeReloadParams & { enable: boolean }): void {
-  const { enable, dataProviderProps, pageSize, rulesetId, modelSource, onReload, renderedItems } = params;
+  const { enable, dataProviderProps, pageSize, ruleset, modelSource, onReload, renderedItems } = params;
 
   useEffect(() => {
-    if (!enable || !rulesetId || !modelSource) {
+    if (!enable || !modelSource) {
       return;
     }
 
     let subscription: Subscription | undefined;
-    const removeListener = Presentation.presentation.vars(rulesetId).onVariableChanged.addListener(() => {
+    const removeListener = Presentation.presentation.vars(getRulesetId(ruleset)).onVariableChanged.addListener(() => {
       // note: we should probably debounce these events while accumulating changed variables in case multiple vars are changed
-      subscription = startTreeReload({ dataProviderProps, rulesetId, pageSize, modelSource, renderedItems, onReload });
+      subscription = startTreeReload({ dataProviderProps, ruleset, pageSize, modelSource, renderedItems, onReload });
     });
 
     return () => {
       removeListener();
       subscription?.unsubscribe();
     };
-  }, [dataProviderProps, enable, modelSource, pageSize, rulesetId, onReload, renderedItems]);
+  }, [dataProviderProps, enable, modelSource, pageSize, ruleset, onReload, renderedItems]);
 }
 
 function useModelSourceUpdateOnUnitSystemChange(params: TreeReloadParams): void {
-  const { dataProviderProps, pageSize, rulesetId, modelSource, onReload, renderedItems } = params;
+  const { dataProviderProps, pageSize, ruleset, modelSource, onReload, renderedItems } = params;
 
   useEffect(() => {
-    if (!rulesetId || !modelSource) {
+    if (!modelSource) {
       return;
     }
 
     let subscription: Subscription | undefined;
     const removeListener = IModelApp.quantityFormatter.onActiveFormattingUnitSystemChanged.addListener(() => {
-      subscription = startTreeReload({ dataProviderProps, rulesetId, pageSize, modelSource, renderedItems, onReload });
+      subscription = startTreeReload({ dataProviderProps, ruleset, pageSize, modelSource, renderedItems, onReload });
     });
 
     return () => {
       removeListener();
       subscription?.unsubscribe();
     };
-  }, [dataProviderProps, modelSource, pageSize, rulesetId, onReload, renderedItems]);
+  }, [dataProviderProps, modelSource, pageSize, ruleset, onReload, renderedItems]);
 }
 
-function startTreeReload({ dataProviderProps, rulesetId, modelSource, pageSize, renderedItems, onReload }: Required<TreeReloadParams>): Subscription {
-  const dataProvider = new PresentationTreeDataProvider({ ...dataProviderProps, ruleset: rulesetId });
+function startTreeReload({ dataProviderProps, ruleset, modelSource, pageSize, renderedItems, onReload }: Required<TreeReloadParams>): Subscription {
+  const dataProvider = new PresentationTreeDataProvider({ ...dataProviderProps, ruleset });
   return reloadTree(modelSource.getModel(), dataProvider, pageSize, renderedItems.current).subscribe({
     next: (newModelSource) =>
       onReload({


### PR DESCRIPTION
Need to pass ruleset instead of id to the data provider when reloading tree because that ruleset might not be registered on presentation-frontend.

Fixes https://github.com/iTwin/viewer-components-react/issues/827