### PR TITLE
Make sure nodes load duration is reported always

### DIFF
--- a/.changeset/odd-plums-marry.md
+++ b/.changeset/odd-plums-marry.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Report nodes load duration immediately after nodes are loaded.

--- a/.changeset/odd-plums-marry.md
+++ b/.changeset/odd-plums-marry.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-components": patch
 ---
 
-Report nodes load duration immediately after nodes are loaded.
+Fixed `usePresentationTreeState` callback prop `onNodeLoaded` not being called under certain race conditions.

--- a/packages/components/src/presentation-components/tree/ReportingTreeNodeLoader.ts
+++ b/packages/components/src/presentation-components/tree/ReportingTreeNodeLoader.ts
@@ -39,12 +39,20 @@ export class ReportingTreeNodeLoader<IPresentationTreeDataProvider extends TreeD
     this._trackedRequests.add(parentId);
     const tracked = toRxjsObservable(observable).pipe(
       tap({
-        subscribe: () => (time = performance.now()),
-        unsubscribe: () => this._trackedRequests.delete(parentId),
-        error: () => this._trackedRequests.delete(parentId),
+        subscribe: () => {
+          time = performance.now();
+        },
+        unsubscribe: () => {
+          this._trackedRequests.delete(parentId);
+        },
+        error: () => {
+          this._trackedRequests.delete(parentId);
+        },
+        next: () => {
+          this._onNodeLoaded({ node: parentId, duration: performance.now() - time });
+        },
         complete: () => {
           this._trackedRequests.delete(parentId);
-          this._onNodeLoaded({ node: parentId, duration: performance.now() - time });
         },
       }),
     );

--- a/packages/components/src/test/tree/ReportingTreeNodeLoader.test.ts
+++ b/packages/components/src/test/tree/ReportingTreeNodeLoader.test.ts
@@ -100,12 +100,12 @@ describe("ReportingTreeNodeLoader", () => {
       const observable = reportingNodeLoader.loadNode({ id: "id" } as TreeModelNode, 0);
       const subscription = observable.subscribe({ next: (result) => (loadedNodes = [...loadedNodes, ...result.loadedNodes]) });
 
-      loadNodeSubject.next({ loadedNodes: [{ id: "node 1" }] } as TreeNodeLoadResult);
       subscription.unsubscribe();
+      loadNodeSubject.next({ loadedNodes: [{ id: "node 1" }] } as TreeNodeLoadResult);
       loadNodeSubject.complete();
 
       await waitFor(() => {
-        expect(loadedNodes).to.have.lengthOf(1);
+        expect(loadedNodes).to.have.lengthOf(0);
         expect(reportStub).to.not.be.called;
       });
     });


### PR DESCRIPTION
Moved nodes load duration reporting into `next` callback to make sure it is reported immediately after nodes are loaded. Reporting from `complete` callback leaves open possibility to unsubscribe between `next` and `complete` without reporting duration.