### PR TITLE
Load unique property values only of instances specified by the input keys

### DIFF
--- a/.changeset/empty-birds-fail.md
+++ b/.changeset/empty-birds-fail.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Load only unique property values of instances specified by input keys.

--- a/packages/components/src/test/properties/inputs/UniquePropertyValuesSelector.test.tsx
+++ b/packages/components/src/test/properties/inputs/UniquePropertyValuesSelector.test.tsx
@@ -1053,6 +1053,86 @@ describe("UniquePropertyValuesSelector", () => {
       ]);
     });
 
+    it("calls 'getDistinctValuesIterator' with ruleset containing `SelectedNodeInstances` specification when input instance keys are provided", async () => {
+      const testProperty = {
+        name: "#testField",
+        displayLabel: "testField",
+        typename: "number",
+      };
+
+      const testClassInfos = [createTestECClassInfo({ name: "testSchema1:testClass1" })];
+      const testField = createTestPropertiesContentField({
+        name: "testField",
+        properties: testClassInfos.map((c) => ({ property: createTestPropertyInfo({ classInfo: c }) })),
+      });
+
+      const testDescriptor = createTestContentDescriptor({
+        fields: [testField],
+      });
+
+      const keys = [{ id: "0x1", className: "testSchema1:testClass1" }];
+      const { queryByText, user } = render(
+        <UniquePropertyValuesSelector property={testProperty} onChange={() => {}} imodel={testImodel} descriptor={testDescriptor} descriptorInputKeys={keys} />,
+      );
+
+      // trigger loadTargets function
+      const selector = await waitFor(() => queryByText("unique-values-property-editor.select-values"));
+      await user.click(selector!);
+
+      expect(getDistinctValuesIteratorStub.firstCall.args[0].rulesetOrId).to.containSubset({
+        rules: [
+          {
+            ruleType: "Content",
+            specifications: [
+              {
+                specType: "SelectedNodeInstances",
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it("calls 'getDistinctValuesIterator' with ruleset containing `SelectedNodeInstances` specification when input `KeySet` is provided", async () => {
+      const testProperty = {
+        name: "#testField",
+        displayLabel: "testField",
+        typename: "number",
+      };
+
+      const testClassInfos = [createTestECClassInfo({ name: "testSchema1:testClass1" })];
+      const testField = createTestPropertiesContentField({
+        name: "testField",
+        properties: testClassInfos.map((c) => ({ property: createTestPropertyInfo({ classInfo: c }) })),
+      });
+
+      const testDescriptor = createTestContentDescriptor({
+        fields: [testField],
+      });
+
+      const keys = new KeySet([{ id: "0x1", className: "testSchema1:testClass1" }]);
+      const { queryByText, user } = render(
+        <UniquePropertyValuesSelector property={testProperty} onChange={() => {}} imodel={testImodel} descriptor={testDescriptor} descriptorInputKeys={keys} />,
+      );
+
+      // trigger loadTargets function
+      const selector = await waitFor(() => queryByText("unique-values-property-editor.select-values"));
+      await user.click(selector!);
+
+      expect(getDistinctValuesIteratorStub.firstCall.args[0].rulesetOrId).to.containSubset({
+        rules: [
+          {
+            ruleType: "Content",
+            specifications: [
+              {
+                specType: "SelectedNodeInstances",
+              },
+            ],
+          },
+        ],
+      });
+    });
+
     it("does not create ruleset when field is a 'NestedContentField' with no parent, thus 'getDistinctValuesIterator' is not called", async () => {
       const testProperty = {
         name: "#testField",


### PR DESCRIPTION
When content descriptor does not contain ruleset we use `ContentInstancesOfSpecificClasses` specification to load unique property values. This specification loads content for all instances and does not take into account supplied input keys. In case input keys are provided use `SelectedNodeInstances` specification to load property only for the instances specified by the input keys.