### PR TITLE
hierarchies: Performance tests adjustment

### DIFF
--- a/apps/performance-tests/.mocharc.json
+++ b/apps/performance-tests/.mocharc.json
@@ -1,5 +1,7 @@
 {
-  "timeout": 120000,
+  "timeout": 300000,
   "file": "./lib/main.js",
-  "reporter": ["./lib/util/TestReporter.js"]
+  "reporter": [
+    "./lib/util/TestReporter.js"
+  ]
 }

--- a/apps/performance-tests/.mocharc.json
+++ b/apps/performance-tests/.mocharc.json
@@ -1,7 +1,5 @@
 {
   "timeout": 300000,
   "file": "./lib/main.js",
-  "reporter": [
-    "./lib/util/TestReporter.js"
-  ]
+  "reporter": ["./lib/util/TestReporter.js"]
 }

--- a/apps/performance-tests/src/main.ts
+++ b/apps/performance-tests/src/main.ts
@@ -5,19 +5,11 @@
 
 import { IModelHost } from "@itwin/core-backend";
 import { setLogger } from "@itwin/presentation-hierarchies";
-import { LogLevel } from "@itwin/presentation-shared";
 import { Datasets } from "./util/Datasets";
+import { LOGGER } from "./util/Logging";
 
 before(async () => {
-  setLogger({
-    isEnabled: (_category: string, level: LogLevel) => {
-      return level === "error";
-    },
-    logError: (category: string, message: string) => console.log(createLogMessage("error", category, message)),
-    logWarning: (category: string, message: string) => console.log(createLogMessage("warning", category, message)),
-    logInfo: (category: string, message: string) => console.log(createLogMessage("info", category, message)),
-    logTrace: (category: string, message: string) => console.log(createLogMessage("trace", category, message)),
-  });
+  setLogger(LOGGER);
   await IModelHost.startup({
     profileName: "presentation-performance-tests",
   });
@@ -27,14 +19,3 @@ before(async () => {
 after(async () => {
   await IModelHost.shutdown();
 });
-
-function createLogMessage(severity: LogLevel, category: string, message: string) {
-  const now = new Date();
-  const timeStr = now.toLocaleTimeString(undefined, {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    fractionalSecondDigits: 3,
-  });
-  return `[${timeStr}] ${severity.toUpperCase().padEnd(7)} | ${category} | ${message}`;
-}

--- a/apps/performance-tests/src/util/BlockHandler.ts
+++ b/apps/performance-tests/src/util/BlockHandler.ts
@@ -4,18 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { setInterval } from "timers/promises";
-import { Logger, LogLevel, SortedArray } from "@itwin/core-bentley";
+import { SortedArray } from "@itwin/core-bentley";
+import { LOGGER } from "./Logging";
 
 const ENABLE_PINGS = false;
 const LOG_CATEGORY = "Presentation.PerformanceTests.BlockHandler";
 
 function log(messageOrCallback: string | (() => string)) {
-  if (!Logger.isEnabled(LOG_CATEGORY, LogLevel.Trace)) {
-    return;
+  if (LOGGER.isEnabled(LOG_CATEGORY, "trace")) {
+    LOGGER.logTrace(LOG_CATEGORY, typeof messageOrCallback === "string" ? messageOrCallback : messageOrCallback());
   }
-
-  const message = typeof messageOrCallback === "string" ? messageOrCallback : messageOrCallback();
-  Logger.logTrace(LOG_CATEGORY, message);
 }
 
 export interface Summary {
@@ -37,15 +35,11 @@ export class BlockHandler {
 
   public getSummary(): Summary {
     const arr = this._samples.extractArray();
-    const count = arr.length;
-    const max = count ? arr[count - 1] : undefined;
-    const p95 = getP95(arr);
-    const median = getMedian(arr);
     return {
-      count,
-      max,
-      p95,
-      median,
+      count: arr.length,
+      max: arr.length ? arr[arr.length - 1] : undefined,
+      p95: getP95(arr),
+      median: getMedian(arr),
     };
   }
 

--- a/apps/performance-tests/src/util/Logging.ts
+++ b/apps/performance-tests/src/util/Logging.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ILogger, LogLevel } from "@itwin/presentation-shared";
+
+export const LOGGER: ILogger = {
+  isEnabled: (_category: string, level: LogLevel) => {
+    return level === "error";
+  },
+  logError: (category: string, message: string) => console.log(createLogMessage("error", category, message)),
+  logWarning: (category: string, message: string) => console.log(createLogMessage("warning", category, message)),
+  logInfo: (category: string, message: string) => console.log(createLogMessage("info", category, message)),
+  logTrace: (category: string, message: string) => console.log(createLogMessage("trace", category, message)),
+};
+
+function createLogMessage(severity: LogLevel, category: string, message: string) {
+  const now = new Date();
+  const timeStr = now.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    fractionalSecondDigits: 3,
+  });
+  return `[${timeStr}] ${severity.toUpperCase().padEnd(7)} | ${category} | ${message}`;
+}

--- a/apps/performance-tests/src/util/StatelessHierarchyProvider.ts
+++ b/apps/performance-tests/src/util/StatelessHierarchyProvider.ts
@@ -37,7 +37,7 @@ export class StatelessHierarchyProvider {
             filter((node) => node.children && (!depth || getNodeDepth(node) < depth)),
             observeOn(asyncScheduler),
           );
-        }, 100),
+        }, 1),
       );
       nodesObservable.subscribe({
         complete: () => resolve(nodeCount),

--- a/apps/performance-tests/src/util/StatelessHierarchyProvider.ts
+++ b/apps/performance-tests/src/util/StatelessHierarchyProvider.ts
@@ -65,6 +65,7 @@ export class StatelessHierarchyProvider {
     return new HierarchyProvider({
       imodelAccess,
       hierarchyDefinition: this._props.getHierarchyFactory(imodelAccess),
+      queryCacheSize: 0,
     });
   }
 }

--- a/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
@@ -70,7 +70,7 @@ import { NodeSelectClauseColumnNames } from "./NodeSelectQueryFactory";
 const LOGGING_NAMESPACE = `${CommonLoggingNamespace}.HierarchyProvider`;
 const PERF_LOGGING_NAMESPACE = `${LOGGING_NAMESPACE}.Performance`;
 const DEFAULT_QUERY_CONCURRENCY = 10;
-const DEFAULT_QUERY_CACHE_SIZE = 50;
+const DEFAULT_QUERY_CACHE_SIZE = 1;
 
 /**
  * Defines the strings used by hierarchy provider.
@@ -112,7 +112,10 @@ export interface HierarchyProviderProps {
 
   /** Maximum number of queries that the provider attempts to execute in parallel. Defaults to `10`. */
   queryConcurrency?: number;
-  /** The amount of queries whose results are stored in-memory for quick retrieval. Defaults to `50`. */
+  /**
+   * The amount of queries whose results are stored in-memory for quick retrieval. Defaults to `1`,
+   * which means only results of the last run query are cached.
+   */
   queryCacheSize?: number;
 
   /**
@@ -165,7 +168,7 @@ export class HierarchyProvider {
   private _valuesFormatter: IPrimitiveValueFormatter;
   private _localizedStrings: HierarchyProviderLocalizedStrings;
   private _queryScheduler: SubscriptionScheduler;
-  private _nodesCache: ChildNodeObservablesCache;
+  private _nodesCache?: ChildNodeObservablesCache;
 
   /**
    * Hierarchy level definitions factory used by this provider.
@@ -199,11 +202,15 @@ export class HierarchyProvider {
     this._valuesFormatter = props?.formatter ?? createDefaultValueFormatter();
     this._localizedStrings = props?.localizedStrings ?? { other: "Other", unspecified: "Not specified" };
     this._queryScheduler = new SubscriptionScheduler(props.queryConcurrency ?? DEFAULT_QUERY_CONCURRENCY);
-    this._nodesCache = new ChildNodeObservablesCache({
-      // we divide the size by 2, because each variation also counts as a query that we cache
-      size: Math.round((props.queryCacheSize ?? DEFAULT_QUERY_CACHE_SIZE) / 2),
-      variationsCount: 1,
-    });
+
+    const queryCacheSize = props.queryCacheSize ?? DEFAULT_QUERY_CACHE_SIZE;
+    if (queryCacheSize !== 0) {
+      this._nodesCache = new ChildNodeObservablesCache({
+        // we divide the size by 2, because each variation also counts as a query that we cache
+        size: Math.ceil(queryCacheSize / 2),
+        variationsCount: 1,
+      });
+    }
   }
 
   /**
@@ -222,7 +229,7 @@ export class HierarchyProvider {
   }
 
   private onGroupingNodeCreated(groupingNode: ProcessedGroupingHierarchyNode, props: GetHierarchyNodesProps) {
-    this._nodesCache.set({ ...props, parentNode: groupingNode }, { observable: from(groupingNode.children), processingStatus: "pre-processed" });
+    this._nodesCache?.set({ ...props, parentNode: groupingNode }, { observable: from(groupingNode.children), processingStatus: "pre-processed" });
   }
 
   private createParsedQueryNodesObservable(
@@ -375,7 +382,7 @@ export class HierarchyProvider {
   private getCachedObservableEntry(props: GetHierarchyNodesProps): CachedNodesObservableEntry {
     const loggingCategory = `${LOGGING_NAMESPACE}.GetCachedObservableEntry`;
     const { parentNode, ...restProps } = props;
-    const cached = props.ignoreCache ? undefined : this._nodesCache.get(props);
+    const cached = props.ignoreCache || !this._nodesCache ? undefined : this._nodesCache.get(props);
     if (cached) {
       // istanbul ignore next
       doLog({
@@ -406,7 +413,7 @@ export class HierarchyProvider {
       ...(filteredInstanceKeys ? { filteredInstanceKeys } : undefined),
     };
     const value = { observable: this.createParsedQueryNodesObservable(nonGroupingNodeChildrenRequestProps), processingStatus: "none" as const };
-    this._nodesCache.set(nonGroupingNodeChildrenRequestProps, value);
+    this._nodesCache?.set(nonGroupingNodeChildrenRequestProps, value);
     doLog({
       category: loggingCategory,
       message: /* istanbul ignore next */ () => `Saved query nodes observable for ${createNodeIdentifierForLogging(parentNode)}`,
@@ -573,7 +580,7 @@ export class HierarchyProvider {
    * Calling the function invalidates internal caches to make sure fresh data is retrieved on new requests.
    */
   public notifyDataSourceChanged() {
-    this._nodesCache.clear();
+    this._nodesCache?.clear();
   }
 }
 


### PR DESCRIPTION
- Performance tests adjustments:
  - Extract tests' logger into a separate module so it can be used not only to pass to hierarchies package, but also by the tests themselves
  - Change performance tests' `expand` parallelism from `100` to `1`. Having a 100 parallel node requests doesn't really simulate a real world users' scenario and just causes a lot of main thread blocking simply because other tasks always have to wait for 100 other tasks to complete. **The change substantially reduces overall time needed to create hierarchies**, but this is a tests' change and what we really care is the library performance.
  - Change the performance tests to not use query cache. This makes debugging easier and our performance measure independent of consumers' configuration.
- The query reader change doesn't affect the performance in a noticeable way, but is just a cleanup.