### PR TITLE
Ignore error while loading filtered paths

### DIFF
--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
@@ -163,8 +163,12 @@ function useTreeInternal({
       }
 
       setHierarchySource((prev) => ({ ...prev, isFiltering: true }));
-      const filteredPaths = await getFilteredPaths({ imodelAccess });
-      return createProvider(filteredPaths);
+      try {
+        const filteredPaths = await getFilteredPaths({ imodelAccess });
+        return createProvider(filteredPaths);
+      } catch {
+        return createProvider(undefined);
+      }
     };
 
     let disposed = false;

--- a/packages/hierarchies-react/src/test/UseTree.test.tsx
+++ b/packages/hierarchies-react/src/test/UseTree.test.tsx
@@ -184,6 +184,23 @@ describe("useTree", () => {
     });
   });
 
+  it("ignores error during filtered paths loading", async () => {
+    hierarchyProvider.getNodes.callsFake(() => {
+      return createAsyncIterator([createTestHierarchyNode({ id: "root-1" })]);
+    });
+    const getFilteredPaths = async () => {
+      throw new Error("test error");
+    };
+    const { result } = renderHook(useTree, { initialProps: { ...initialProps, getFilteredPaths } });
+
+    await waitFor(() => {
+      expect(result.current.rootNodes).to.have.lengthOf(1);
+      expect(createHierarchyProviderStub).to.be.calledWith(
+        sinon.match((props: Parameters<typeof hierarchiesModule.createHierarchyProvider>[0]) => props.filtering === undefined),
+      );
+    });
+  });
+
   it("expands node", async () => {
     const rootNodes = [createTestHierarchyNode({ id: "root-1", children: true })];
     const childNodes = [createTestHierarchyNode({ id: "child-1" })];


### PR DESCRIPTION
Ignore errors thrown while loading filtered paths and show whole hierarchy.