### PR TITLE
Partial hierarchies localization

### DIFF
--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/LocalizationContext.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/LocalizationContext.tsx
@@ -68,15 +68,15 @@ const defaultLocalizedStrings: LocalizedStrings = {
 const localizationContext = createContext<LocalizationContext>({ localizedStrings: defaultLocalizedStrings });
 
 interface LocalizationContextProviderProps {
-  localizedStrings?: LocalizedStrings;
+  localizedStrings?: Partial<LocalizedStrings>;
 }
 
 /** @beta */
 export function LocalizationContextProvider({ localizedStrings, children }: PropsWithChildren<LocalizationContextProviderProps>) {
-  const [state, setState] = useState({ localizedStrings: localizedStrings ?? defaultLocalizedStrings });
+  const [state, setState] = useState({ localizedStrings: { ...defaultLocalizedStrings, ...localizedStrings } });
 
   useEffect(() => {
-    setState({ localizedStrings: localizedStrings ?? defaultLocalizedStrings });
+    setState({ localizedStrings: { ...defaultLocalizedStrings, ...localizedStrings } });
   }, [localizedStrings]);
 
   return <localizationContext.Provider value={state}>{children}</localizationContext.Provider>;

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
@@ -17,7 +17,7 @@ type TreeNodeRendererProps = ComponentPropsWithoutRef<typeof TreeNodeRenderer>;
 interface TreeRendererOwnProps {
   rootNodes: PresentationTreeNode[];
   selectionMode?: SelectionMode;
-  localizedStrings?: LocalizedStrings;
+  localizedStrings?: Partial<LocalizedStrings>;
 }
 
 type TreeRendererProps = Pick<ReturnType<typeof useTree>, "rootNodes" | "expandNode"> &

--- a/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
@@ -169,7 +169,7 @@ interface HierarchyProviderProps {
   formatter?: IPrimitiveValueFormatter;
 
   /** A set of localized strings to use. Defaults to English strings. */
-  localizedStrings?: HierarchyProviderLocalizedStrings;
+  localizedStrings?: Partial<HierarchyProviderLocalizedStrings>;
 
   /** Props for filtering the hierarchy. */
   filtering?: {
@@ -224,7 +224,7 @@ class HierarchyProviderImpl implements HierarchyProvider {
       this.hierarchyDefinition = filteringDefinition;
     }
     this._valuesFormatter = props?.formatter ?? createDefaultValueFormatter();
-    this._localizedStrings = props?.localizedStrings ?? { other: "Other", unspecified: "Not specified" };
+    this._localizedStrings = { other: "Other", unspecified: "Not specified", ...props?.localizedStrings };
     this._queryScheduler = new SubscriptionScheduler(props.queryConcurrency ?? DEFAULT_QUERY_CONCURRENCY);
 
     const queryCacheSize = props.queryCacheSize ?? DEFAULT_QUERY_CACHE_SIZE;


### PR DESCRIPTION
Switched to `Partial<LocalizedStrings>` instead of just `LocalizedStrings`.