### PR TITLE
`models-tree`: Pre-determine subjects' children flag

### DIFF
--- a/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
+++ b/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
@@ -565,29 +565,27 @@ class SubjectModelIdsCache {
   }
 
   public async getParentSubjectIds(): Promise<Id64String[]> {
-    await this.initCache();
-    if (!this._parentSubjectIds) {
-      this._parentSubjectIds = (async () => {
-        const hasChildModels = (subjectId: Id64String) => {
-          if ((this._subjectModels!.get(subjectId)?.size ?? 0) > 0) {
-            return true;
-          }
-          const childSubjectIds = this._subjectsHierarchy!.get(subjectId);
-          return childSubjectIds && [...childSubjectIds].some(hasChildModels);
-        };
-        const parentSubjectIds = new Set<Id64String>();
-        const addIfHasChildren = (subjectId: Id64String) => {
-          if (hasChildModels(subjectId)) {
-            parentSubjectIds.add(subjectId);
-          }
-        };
-        this._subjectsHierarchy!.forEach((childSubjectIds, parentSubjectId) => {
-          addIfHasChildren(parentSubjectId);
-          childSubjectIds.forEach(addIfHasChildren);
-        });
-        return [...parentSubjectIds];
-      })();
-    }
+    this._parentSubjectIds ??= (async () => {
+      await this.initCache();
+      const hasChildModels = (subjectId: Id64String) => {
+        if ((this._subjectModels!.get(subjectId)?.size ?? 0) > 0) {
+          return true;
+        }
+        const childSubjectIds = this._subjectsHierarchy!.get(subjectId);
+        return childSubjectIds && [...childSubjectIds].some(hasChildModels);
+      };
+      const parentSubjectIds = new Set<Id64String>();
+      const addIfHasChildren = (subjectId: Id64String) => {
+        if (hasChildModels(subjectId)) {
+          parentSubjectIds.add(subjectId);
+        }
+      };
+      this._subjectsHierarchy!.forEach((childSubjectIds, parentSubjectId) => {
+        addIfHasChildren(parentSubjectId);
+        childSubjectIds.forEach(addIfHasChildren);
+      });
+      return [...parentSubjectIds];
+    })();
     return this._parentSubjectIds;
   }
 

--- a/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
+++ b/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
@@ -179,6 +179,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                   }),
                 },
                 hideIfNoChildren: true,
+                hasChildren: { selector: `InVirtualSet(?, this.ECInstanceId)` },
                 grouping: { byLabel: { action: "merge", groupId: "subject" } },
                 extendedData: {
                   imageId: "icon-folder",
@@ -191,7 +192,10 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
               this.ECInstanceId IN (${childSubjectIds.map(() => "?").join(",")})
               ${subjectFilterClauses.where ? `AND ${subjectFilterClauses.where}` : ""}
           `,
-          bindings: [...childSubjectIds.map((id): ECSqlBinding => ({ type: "id", value: id }))],
+          bindings: [
+            { type: "idset", value: await this._subjectModelIdsCache.getParentSubjectIds() },
+            ...childSubjectIds.map((id): ECSqlBinding => ({ type: "id", value: id })),
+          ],
         },
       });
     childModelIds.length &&
@@ -475,6 +479,7 @@ class SubjectModelIdsCache {
   private _subjectsHierarchy: Map<Id64String, Set<Id64String>> | undefined;
   private _subjectModels: Map<Id64String, Set<Id64String>> | undefined;
   private _subjectInfos: Map<Id64String, { hideInHierarchy: boolean }> | undefined;
+  private _parentSubjectIds: Promise<Id64String[]> | undefined; // the list should contain a subject id if its node should be shown as having children
   private _init: Promise<void> | undefined;
 
   constructor(private _queryExecutor: ECSqlQueryExecutor) {}
@@ -557,6 +562,33 @@ class SubjectModelIdsCache {
         }
         this.forEachChildSubject(childSubjectId, cb);
       });
+  }
+
+  public async getParentSubjectIds(): Promise<Id64String[]> {
+    await this.initCache();
+    if (!this._parentSubjectIds) {
+      this._parentSubjectIds = (async () => {
+        const hasChildModels = (subjectId: Id64String) => {
+          if ((this._subjectModels!.get(subjectId)?.size ?? 0) > 0) {
+            return true;
+          }
+          const childSubjectIds = this._subjectsHierarchy!.get(subjectId);
+          return childSubjectIds && [...childSubjectIds].some(hasChildModels);
+        };
+        const parentSubjectIds = new Set<Id64String>();
+        const addIfHasChildren = (subjectId: Id64String) => {
+          if (hasChildModels(subjectId)) {
+            parentSubjectIds.add(subjectId);
+          }
+        };
+        this._subjectsHierarchy!.forEach((childSubjectIds, parentSubjectId) => {
+          addIfHasChildren(parentSubjectId);
+          childSubjectIds.forEach(addIfHasChildren);
+        });
+        return [...parentSubjectIds];
+      })();
+    }
+    return this._parentSubjectIds;
   }
 
   public async getChildSubjectIds(parentSubjectIds: Id64String[]): Promise<Id64String[]> {


### PR DESCRIPTION
Part of https://github.com/iTwin/presentation/issues/597.

Often, to determine whether a Subject node needs to be displayed or not, we have to run a bunch of queries to see if its branch contains at least one Model with elements. However, with https://github.com/iTwin/presentation/pull/598, we already have that information, so here we just make use of it.

![image](https://github.com/iTwin/presentation/assets/35135765/c0a8e76e-61fa-4f5b-aea9-1ce1491125d0)

![image](https://github.com/iTwin/presentation/assets/35135765/1db32530-eb08-4337-a1dd-625c7380ce41)

There're still a few cases that need to be look at.