### PR TITLE
Hierarchies-react: `onHierarchyLimitExceeded` callback

### DIFF
--- a/.changeset/friendly-bananas-smoke.md
+++ b/.changeset/friendly-bananas-smoke.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": minor
+---
+
+Added `onHierarchyLimitExceeded` callback for tracking when hierarchy level exceeds the limit.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/internal/TreeActions.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/internal/TreeActions.ts
@@ -22,6 +22,7 @@ export class TreeActions {
   constructor(
     private _onModelChanged: (model: TreeModel) => void,
     private _onLoad: (actionType: "initial-load" | "hierarchy-level-load" | "reload", duration: number) => void,
+    private _onHierarchyLimitExceeded: () => void,
     seed?: TreeModel,
   ) {
     this._loader = new NoopTreeLoader();
@@ -133,7 +134,7 @@ export class TreeActions {
   }
 
   public setHierarchyProvider(provider?: HierarchyProvider) {
-    this._loader = provider ? new TreeLoader(provider) : /* istanbul ignore next */ new NoopTreeLoader();
+    this._loader = provider ? new TreeLoader(provider, this._onHierarchyLimitExceeded) : /* istanbul ignore next */ new NoopTreeLoader();
   }
 
   public getNode(nodeId: string | undefined): TreeModelNode | TreeModelRootNode | undefined {

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/internal/TreeLoader.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/internal/TreeLoader.ts
@@ -36,7 +36,10 @@ export interface ITreeLoader {
 
 /** @internal */
 export class TreeLoader implements ITreeLoader {
-  constructor(private _hierarchyProvider: HierarchyProvider) {}
+  constructor(
+    private _hierarchyProvider: HierarchyProvider,
+    private _onHierarchyLimitExceeded: () => void,
+  ) {}
 
   private loadChildren({ parent, getHierarchyLevelOptions, buildNode, ignoreCache }: Omit<LoadNodesOptions, "shouldLoadChildren">) {
     const { instanceFilter, hierarchyLevelSizeLimit } = getHierarchyLevelOptions(parent);
@@ -57,6 +60,7 @@ export class TreeLoader implements ITreeLoader {
           parentId: parent.id,
         };
         if (err instanceof RowsLimitExceededError) {
+          this._onHierarchyLimitExceeded();
           return of([{ ...nodeProps, type: "ResultSetTooLarge" as const, resultSetSizeLimit: err.limit }]);
         }
         return of([{ ...nodeProps, type: "Unknown" as const, message: "Failed to create hierarchy level" }]);

--- a/packages/hierarchies-react/src/test/internal/TreeActions.test.ts
+++ b/packages/hierarchies-react/src/test/internal/TreeActions.test.ts
@@ -19,7 +19,7 @@ describe("TreeActions", () => {
   const onLoadStub = createStub<(type: "initial-load" | "hierarchy-level-load" | "reload", duration: number) => void>();
 
   function createActions(seed: TreeModel) {
-    const actions = new TreeActions(onModelChangedStub, onLoadStub, seed);
+    const actions = new TreeActions(onModelChangedStub, onLoadStub, () => {}, seed);
     actions.setHierarchyProvider(provider as unknown as HierarchyProvider);
     return actions;
   }


### PR DESCRIPTION
Added callback needed to track when hierarchy limit was exceeded to add feature reporting.