### PR TITLE
Hierarchies-react: Reload tree on data change

### DIFF
--- a/.changeset/pink-moose-drop.md
+++ b/.changeset/pink-moose-drop.md
@@ -1,0 +1,20 @@
+---
+"@itwin/presentation-hierarchies-react": minor
+---
+
+Added `dataMightHaveChanged` option to `reloadTree` function retuned by `useTree` and `useUnifiedSelectionTree`. It allows to specify that data used to build tree might have changed and need to be repulled and tree reloaded.
+
+```ts
+import { registerTxnListeners } from "@itwin/presentation-core-interop";
+
+function MyTree({ imodel, ...props}: Props) {
+  const { reloadTree, treeProps } = useTree(props);
+  useEffect(() => {
+    // listen for changes in iModel and reload tree
+    return registerTxnListeners(imodel.txns, () => {
+      reloadTree({ dataMightHaveChanged: true });
+    });
+  }, [imodel, reloadTree]);
+  return <TreeRenderer {...treeProps} />;
+}
+```

--- a/.changeset/pink-moose-drop.md
+++ b/.changeset/pink-moose-drop.md
@@ -2,7 +2,7 @@
 "@itwin/presentation-hierarchies-react": minor
 ---
 
-Added `dataMightHaveChanged` option to `reloadTree` function retuned by `useTree` and `useUnifiedSelectionTree`. It allows to specify that data used to build the tree might have changed and need to be repulled when reloading the hierarchy.
+Added `dataSourceChanged` option to `reloadTree` function retuned by `useTree` and `useUnifiedSelectionTree`. It allows to specify that data used to build the tree might have changed and need to be repulled when reloading the hierarchy.
 
 ```ts
 import { registerTxnListeners } from "@itwin/presentation-core-interop";
@@ -12,7 +12,7 @@ function MyTree({ imodel, ...props}: Props) {
   useEffect(() => {
     // listen for changes in iModel and reload tree
     return registerTxnListeners(imodel.txns, () => {
-      reloadTree({ dataMightHaveChanged: true });
+      reloadTree({ dataSourceChanged: true });
     });
   }, [imodel, reloadTree]);
   return <TreeRenderer {...treeProps} />;

--- a/.changeset/pink-moose-drop.md
+++ b/.changeset/pink-moose-drop.md
@@ -2,7 +2,7 @@
 "@itwin/presentation-hierarchies-react": minor
 ---
 
-Added `dataMightHaveChanged` option to `reloadTree` function retuned by `useTree` and `useUnifiedSelectionTree`. It allows to specify that data used to build tree might have changed and need to be repulled and tree reloaded.
+Added `dataMightHaveChanged` option to `reloadTree` function retuned by `useTree` and `useUnifiedSelectionTree`. It allows to specify that data used to build the tree might have changed and need to be repulled when reloading the hierarchy.
 
 ```ts
 import { registerTxnListeners } from "@itwin/presentation-core-interop";

--- a/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
@@ -78,7 +78,7 @@ function Tree({ imodel, imodelAccess, height, width }: { imodel: IModelConnectio
     }
 
     return registerTxnListeners(imodel.txns, () => {
-      reloadTree({ dataMightHaveChanged: true });
+      reloadTree({ dataSourceChanged: true });
     });
   }, [imodel, reloadTree]);
 
@@ -312,7 +312,7 @@ function getIcon(node: PresentationHierarchyNode): ReactElement | undefined {
 }
 
 async function removeSelectedElements(imodel: IModelConnection) {
-  const keys = getElementIds(imodel);
+  const keys = getSelectedElementIds(imodel);
   if (keys.length === 0) {
     return;
   }
@@ -320,7 +320,7 @@ async function removeSelectedElements(imodel: IModelConnection) {
   await MyAppFrontend.deleteElements(imodel, keys);
 }
 
-function getElementIds(imodel: IModelConnection) {
+function getSelectedElementIds(imodel: IModelConnection) {
   const selection = Presentation.selection.getSelection(imodel);
   const keys: InstanceKey[] = [];
   selection.forEach((elementKey) => {

--- a/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
@@ -7,15 +7,15 @@ import { ComponentPropsWithoutRef, ReactElement, useCallback, useEffect, useMemo
 import { debounceTime, Subject } from "rxjs";
 import { IModelConnection } from "@itwin/core-frontend";
 import { SvgFolder, SvgImodelHollow, SvgItem, SvgLayers, SvgModel } from "@itwin/itwinui-icons-react";
-import { Flex, ProgressRadial, SearchBox, Text, ToggleSwitch } from "@itwin/itwinui-react";
-import { ClassInfo, DefaultContentDisplayTypes, Descriptor, KeySet } from "@itwin/presentation-common";
+import { Button, Flex, ProgressRadial, SearchBox, Text, ToggleSwitch } from "@itwin/itwinui-react";
+import { ClassInfo, DefaultContentDisplayTypes, Descriptor, InstanceKey, KeySet } from "@itwin/presentation-common";
 import {
   PresentationInstanceFilter,
   PresentationInstanceFilterDialog,
   PresentationInstanceFilterInfo,
   PresentationInstanceFilterPropertiesSource,
 } from "@itwin/presentation-components";
-import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+import { createECSchemaProvider, createECSqlQueryExecutor, registerTxnListeners } from "@itwin/presentation-core-interop";
 import { Presentation } from "@itwin/presentation-frontend";
 import { createLimitingECSqlQueryExecutor, GenericInstanceFilter, LimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
 import { HierarchyLevelDetails, PresentationHierarchyNode, TreeRenderer, useUnifiedSelectionTree } from "@itwin/presentation-hierarchies-react";
@@ -60,13 +60,7 @@ function Tree({ imodel, imodelAccess, height, width }: { imodel: IModelConnectio
     };
   }, [filter]);
 
-  const {
-    rootNodes,
-    isLoading,
-    reloadTree: _,
-    setFormatter,
-    ...treeProps
-  } = useUnifiedSelectionTree({
+  const { rootNodes, isLoading, reloadTree, setFormatter, ...treeProps } = useUnifiedSelectionTree({
     imodelKey: imodel.key,
     sourceName: "StatelessTreeV2",
     imodelAccess,
@@ -77,6 +71,16 @@ function Tree({ imodel, imodelAccess, height, width }: { imodel: IModelConnectio
       console.log(`Stateless-tree-${action}, Duration: ${duration}ms`);
     },
   });
+
+  useEffect(() => {
+    if (!imodel.isBriefcaseConnection()) {
+      return;
+    }
+
+    return registerTxnListeners(imodel.txns, () => {
+      reloadTree({ dataMightHaveChanged: true });
+    });
+  }, [imodel, reloadTree]);
 
   const [shouldUseCustomFormatter, setShouldUseCustomFormatter] = useState<boolean>(false);
   const toggleFormatter = () => {
@@ -197,6 +201,7 @@ function Tree({ imodel, imodelAccess, height, width }: { imodel: IModelConnectio
       <Flex style={{ width: "100%", padding: "0.5rem" }}>
         <DebouncedSearchBox onChange={setFilter} />
         <ToggleSwitch onChange={toggleFormatter} checked={shouldUseCustomFormatter} />
+        {imodel.isBriefcaseConnection() ? <Button onClick={() => void removeSelectedElements(imodel)}>Delete</Button> : null}
       </Flex>
       {renderContent()}
       {renderLoadingOverlay()}
@@ -304,4 +309,24 @@ function getIcon(node: PresentationHierarchyNode): ReactElement | undefined {
   }
 
   return undefined;
+}
+
+async function removeSelectedElements(imodel: IModelConnection) {
+  const keys = getElementIds(imodel);
+  if (keys.length === 0) {
+    return;
+  }
+
+  await MyAppFrontend.deleteElements(imodel, keys);
+}
+
+function getElementIds(imodel: IModelConnection) {
+  const selection = Presentation.selection.getSelection(imodel);
+  const keys: InstanceKey[] = [];
+  selection.forEach((elementKey) => {
+    if ("id" in elementKey) {
+      keys.push(elementKey);
+    }
+  });
+  return keys.map((key) => key.id);
 }

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
@@ -104,7 +104,7 @@ interface UseTreeResult {
    * or tree is reloading.
    */
   isLoading: boolean;
-  reloadTree: (options?: { discardState?: boolean }) => void;
+  reloadTree: (options?: { discardState?: boolean; dataMightHaveChanged?: boolean }) => void;
   expandNode: (nodeId: string, isExpanded: boolean) => void;
   selectNodes: (nodeIds: Array<string>, changeType: SelectionChangeType) => void;
   isNodeSelected: (nodeId: string) => boolean;
@@ -200,21 +200,36 @@ function useTreeInternal({
     };
   }, [actions, imodelAccess, localizedStrings, getHierarchyDefinition, getFilteredPaths]);
 
-  const getNode = useRef((nodeId: string) => {
-    return actions.getNode(nodeId);
-  }).current;
+  const getNode = useCallback(
+    (nodeId: string) => {
+      return actions.getNode(nodeId);
+    },
+    [actions],
+  );
 
-  const expandNode = useRef((nodeId: string, isExpanded: boolean) => {
-    actions.expandNode(nodeId, isExpanded);
-  }).current;
+  const expandNode = useCallback(
+    (nodeId: string, isExpanded: boolean) => {
+      actions.expandNode(nodeId, isExpanded);
+    },
+    [actions],
+  );
 
-  const reloadTree = useRef((options?: { discardState?: boolean }) => {
-    actions.reloadTree(options);
-  }).current;
+  const reloadTree = useCallback(
+    (options?: { discardState?: boolean; dataMightHaveChanged?: boolean }) => {
+      if (options?.dataMightHaveChanged) {
+        hierarchySource.hierarchyProvider?.notifyDataSourceChanged();
+      }
+      actions.reloadTree(options);
+    },
+    [actions, hierarchySource],
+  );
 
-  const selectNodes = useRef((nodeIds: Array<string>, changeType: SelectionChangeType) => {
-    actions.selectNodes(nodeIds, changeType);
-  }).current;
+  const selectNodes = useCallback(
+    (nodeIds: Array<string>, changeType: SelectionChangeType) => {
+      actions.selectNodes(nodeIds, changeType);
+    },
+    [actions],
+  );
 
   const isNodeSelected = useCallback((nodeId: string) => TreeModel.isNodeSelected(state.model, nodeId), [state]);
 

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
@@ -104,7 +104,7 @@ interface UseTreeResult {
    * or tree is reloading.
    */
   isLoading: boolean;
-  reloadTree: (options?: { discardState?: boolean; dataMightHaveChanged?: boolean }) => void;
+  reloadTree: (options?: { discardState?: boolean; dataSourceChanged?: boolean }) => void;
   expandNode: (nodeId: string, isExpanded: boolean) => void;
   selectNodes: (nodeIds: Array<string>, changeType: SelectionChangeType) => void;
   isNodeSelected: (nodeId: string) => boolean;
@@ -200,23 +200,23 @@ function useTreeInternal({
     };
   }, [actions, imodelAccess, localizedStrings, getHierarchyDefinition, getFilteredPaths]);
 
-  const getNode = useCallback(
+  const getNode = useCallback<(nodeId: string) => TreeModelRootNode | TreeModelNode | undefined>(
     (nodeId: string) => {
       return actions.getNode(nodeId);
     },
     [actions],
   );
 
-  const expandNode = useCallback(
+  const expandNode = useCallback<UseTreeResult["expandNode"]>(
     (nodeId: string, isExpanded: boolean) => {
       actions.expandNode(nodeId, isExpanded);
     },
     [actions],
   );
 
-  const reloadTree = useCallback(
-    (options?: { discardState?: boolean; dataMightHaveChanged?: boolean }) => {
-      if (options?.dataMightHaveChanged) {
+  const reloadTree = useCallback<UseTreeResult["reloadTree"]>(
+    (options?: { discardState?: boolean; dataSourceChanged?: boolean }) => {
+      if (options?.dataSourceChanged) {
         hierarchySource.hierarchyProvider?.notifyDataSourceChanged();
       }
       actions.reloadTree(options);
@@ -224,16 +224,16 @@ function useTreeInternal({
     [actions, hierarchySource],
   );
 
-  const selectNodes = useCallback(
+  const selectNodes = useCallback<UseTreeResult["selectNodes"]>(
     (nodeIds: Array<string>, changeType: SelectionChangeType) => {
       actions.selectNodes(nodeIds, changeType);
     },
     [actions],
   );
 
-  const isNodeSelected = useCallback((nodeId: string) => TreeModel.isNodeSelected(state.model, nodeId), [state]);
+  const isNodeSelected = useCallback<UseTreeResult["isNodeSelected"]>((nodeId: string) => TreeModel.isNodeSelected(state.model, nodeId), [state]);
 
-  const setFormatter = useCallback(
+  const setFormatter = useCallback<UseTreeResult["setFormatter"]>(
     (formatter: IPrimitiveValueFormatter | undefined) => {
       currentFormatter.current = formatter;
       // istanbul ignore if

--- a/packages/hierarchies-react/src/test/UseTree.test.tsx
+++ b/packages/hierarchies-react/src/test/UseTree.test.tsx
@@ -543,7 +543,7 @@ describe("useTree", () => {
     });
   });
 
-  it("notifies hierarchy provider about changed date when `reloadTree` is called with `dataMightHaveChanged`", async () => {
+  it("notifies hierarchy provider about changed data source when `reloadTree` is called with `dataSourceChanged`", async () => {
     const rootNodes = [createTestHierarchyNode({ id: "root-1", children: false })];
 
     hierarchyProvider.getNodes.callsFake((props) => {
@@ -567,7 +567,7 @@ describe("useTree", () => {
     });
 
     act(() => {
-      result.current.reloadTree({ dataMightHaveChanged: true });
+      result.current.reloadTree({ dataSourceChanged: true });
     });
 
     await waitFor(() => {

--- a/packages/hierarchies-react/src/test/UseTree.test.tsx
+++ b/packages/hierarchies-react/src/test/UseTree.test.tsx
@@ -27,6 +27,7 @@ describe("useTree", () => {
     getNodes: createStub<hierarchiesModule.HierarchyProvider["getNodes"]>(),
     getNodeInstanceKeys: createStub<hierarchiesModule.HierarchyProvider["getNodeInstanceKeys"]>(),
     setFormatter: createStub<hierarchiesModule.HierarchyProvider["setFormatter"]>(),
+    notifyDataSourceChanged: createStub<hierarchiesModule.HierarchyProvider["notifyDataSourceChanged"]>(),
   };
   let createHierarchyProviderStub: sinon.SinonStub<
     Parameters<typeof hierarchiesModule.createHierarchyProvider>,
@@ -49,6 +50,9 @@ describe("useTree", () => {
 
   beforeEach(() => {
     hierarchyProvider.getNodes.reset();
+    hierarchyProvider.getNodeInstanceKeys.reset();
+    hierarchyProvider.setFormatter.reset();
+    hierarchyProvider.notifyDataSourceChanged.reset();
     createHierarchyProviderStub.reset();
     createHierarchyProviderStub.returns(hierarchyProvider as unknown as hierarchiesModule.HierarchyProvider);
   });
@@ -536,6 +540,39 @@ describe("useTree", () => {
     await waitFor(() => {
       expect(result.current.rootNodes).to.have.lengthOf(1);
       expect((result.current.rootNodes![0] as PresentationHierarchyNode).children).to.have.lengthOf(2);
+    });
+  });
+
+  it("notifies hierarchy provider about changed date when `reloadTree` is called with `dataMightHaveChanged`", async () => {
+    const rootNodes = [createTestHierarchyNode({ id: "root-1", children: false })];
+
+    hierarchyProvider.getNodes.callsFake((props) => {
+      if (props.parentNode === undefined) {
+        return createAsyncIterator(rootNodes);
+      }
+      return createAsyncIterator([]);
+    });
+    const { result } = renderHook(useTree, { initialProps });
+
+    await waitFor(() => {
+      expect(result.current.rootNodes).to.have.lengthOf(1);
+    });
+
+    hierarchyProvider.getNodes.reset();
+    hierarchyProvider.getNodes.callsFake((props) => {
+      if (props.parentNode === undefined) {
+        return createAsyncIterator([...rootNodes, createTestHierarchyNode({ id: "root-2", children: false })]);
+      }
+      return createAsyncIterator([]);
+    });
+
+    act(() => {
+      result.current.reloadTree({ dataMightHaveChanged: true });
+    });
+
+    await waitFor(() => {
+      expect(result.current.rootNodes).to.have.lengthOf(2);
+      expect(hierarchyProvider.notifyDataSourceChanged).to.be.calledOnce;
     });
   });
 


### PR DESCRIPTION
Updated `reloadTree` options to allow to notify `HierarchyProvider` about data changes. This makes sure that `HierarchyProvider` has cleared caches and pulls new data when tree is reloading.