### PR TITLE
`components`: Fix non-loaded nodes not being shift selected

### DIFF
--- a/.changeset/rare-pugs-sniff.md
+++ b/.changeset/rare-pugs-sniff.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Fixed shift select not selecting nodes that are not yet loaded in `UnifiedSelectionTreeEventHandler`.

--- a/packages/components/src/presentation-components/tree/controlled/UseUnifiedSelection.ts
+++ b/packages/components/src/presentation-components/tree/controlled/UseUnifiedSelection.ts
@@ -105,6 +105,7 @@ export class UnifiedSelectionTreeEventHandler extends TreeEventHandler implement
   }
 
   public override onSelectionReplaced({ replacements }: TreeSelectionReplacementEventArgs) {
+    this.#cancelled.next();
     let firstEmission = true;
     const withUnifiedSelection = toRxjsObservable(replacements).pipe(
       takeUntil(this.#cancelled),
@@ -216,7 +217,7 @@ export class UnifiedSelectionTreeEventHandler extends TreeEventHandler implement
       return;
     }
 
-    if (evt.changeType === SelectionChangeType.Clear || evt.changeType === SelectionChangeType.Replace) {
+    if (evt.source !== this.#selectionSourceName && (evt.changeType === SelectionChangeType.Clear || evt.changeType === SelectionChangeType.Replace)) {
       this.#cancelled.next();
     }
 


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/608.