### PR TITLE
Fix docs pipeline failing on non pull request builds

### DIFF
--- a/.azure-pipelines/generate-docs.yaml
+++ b/.azure-pipelines/generate-docs.yaml
@@ -21,6 +21,7 @@ resources:
 
 stages:
   - stage: Check_Changes
+    condition: eq(variables['Build.Reason'], 'PullRequest')
     jobs:
     - job: detect_docs_change
       displayName: Check docs changes
@@ -78,10 +79,10 @@ stages:
   - stage: Generate_Docs
     dependsOn: Check_Changes
     condition: |
-      and(
-        succeeded(),
-        or(
-          ne(variables['Build.Reason'], 'PullRequest'),
+      or(
+        ne(variables['Build.Reason'], 'PullRequest'),
+        and(
+          succeeded(),
           eq(dependencies.Check_Changes.outputs['detect_docs_change.changed_files.docsModified'], 'true')
         )
       )

--- a/.azure-pipelines/generate-docs.yaml
+++ b/.azure-pipelines/generate-docs.yaml
@@ -130,7 +130,7 @@ stages:
 
   - stage: Validate_Docs
     dependsOn: Generate_Docs
-    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'PullRequest', 'Manual'))
+    condition: and(succeeded('Generate_Docs'), in(variables['Build.Reason'], 'IndividualCI', 'PullRequest', 'Manual'))
     jobs:
       - template: common/config/azure-pipelines/jobs/docs-build.yaml@itwinjs-core
         parameters:
@@ -140,7 +140,7 @@ stages:
 
   - stage: Tag_Docs
     dependsOn: Validate_Docs
-    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Manual'))
+    condition: and(succeeded('Validate_Docs'), in(variables['Build.Reason'], 'IndividualCI', 'Manual'))
     jobs:
       - job:
         displayName: Tag Docs


### PR DESCRIPTION
After https://github.com/iTwin/presentation/pull/594 docs pipeline was failing on non pull request builds as it was trying to detect changes. Changed `Check_Changes` to only run on pull requests.