### PR TITLE
Hierarchies-react: pass node to `onNodeClick` instead of node ID

### DIFF
--- a/.changeset/orange-clocks-sin.md
+++ b/.changeset/orange-clocks-sin.md
@@ -1,5 +1,24 @@
 ---
-"@itwin/presentation-hierarchies-react": patch
+"@itwin/presentation-hierarchies-react": minor
 ---
 
-Modified `onNodeClick` and `onNodeKeyDown` callbacks to pass entire node instead of id in `TreeNodeRenderer`.
+Modified `onNodeClick` and `onNodeKeyDown` callbacks to pass entire node instead of id in `TreeNodeRenderer`. This change breaks the existing API, so the consuming code needs to be adjusted to use `node.id` instead of `nodeId`:
+
+```typescript
+import { TreeNodeRenderer } from "@itwin/presentation-hierarchies-react";
+
+export function MyTreeNodeRenderer(props) {
+  return (
+    <TreeNodeRenderer
+      {...props}
+      // Previous implementation
+      onNodeClick={(nodeId, isSelected, event) => someFunc(nodeId)}
+      onNodeKeyDown={(nodeId, isSelected, event) => someFunc(nodeId)}
+
+      // After the change
+      onNodeClick={(node, isSelected, event) => someFunc(node.id)}
+      onNodeKeyDown={(node, isSelected, event) => someFunc(node.id)}
+    />
+  );
+}
+```

--- a/.changeset/orange-clocks-sin.md
+++ b/.changeset/orange-clocks-sin.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Modified `onNodeClick` and `onNodeKeyDown` callbacks to pass entire node instead of id in `TreeNodeRenderer`.

--- a/.changeset/orange-clocks-sin.md
+++ b/.changeset/orange-clocks-sin.md
@@ -2,7 +2,7 @@
 "@itwin/presentation-hierarchies-react": minor
 ---
 
-Modified `onNodeClick` and `onNodeKeyDown` callbacks to pass entire node instead of id in `TreeNodeRenderer`. This change breaks the existing API, so the consuming code needs to be adjusted to use `node.id` instead of `nodeId`:
+Modified `onNodeClick` and `onNodeKeyDown` callbacks to pass node instead of id and changed `onFilterClick` to pass `HierarchyLevelDetails` instead of node id in `TreeNodeRenderer`. This change allows to access additional information about a node (such as `extendedData`) without having to perform a lookup. This change breaks the existing API, so the consuming code needs to be adjusted:
 
 ```typescript
 import { TreeNodeRenderer } from "@itwin/presentation-hierarchies-react";
@@ -14,10 +14,15 @@ export function MyTreeNodeRenderer(props) {
       // Previous implementation
       onNodeClick={(nodeId, isSelected, event) => someFunc(nodeId)}
       onNodeKeyDown={(nodeId, isSelected, event) => someFunc(nodeId)}
+      onFilterClick={(nodeId) => {
+        const hierarchyLevelDetails = getHierarchyLevelDetails(nodeId);
+        someFunc(hierarchyLevelDetails);
+      }}
 
       // After the change
       onNodeClick={(node, isSelected, event) => someFunc(node.id)}
       onNodeKeyDown={(node, isSelected, event) => someFunc(node.id)}
+      onFilterClick={(hierarchyLevelDetails) => someFunc(hierarchyLevelDetails)}
     />
   );
 }

--- a/apps/test-app/frontend/package.json
+++ b/apps/test-app/frontend/package.json
@@ -32,7 +32,7 @@
     "@itwin/eslint-plugin": "^4.0.0",
     "@itwin/imodel-components-react": "^4.13.4",
     "@itwin/itwinui-icons-react": "^2.8.0",
-    "@itwin/itwinui-react": "^3.9.1",
+    "@itwin/itwinui-react": "^3.11.1",
     "@itwin/presentation-common": "^4.6.0",
     "@itwin/presentation-components": "workspace:*",
     "@itwin/presentation-core-interop": "workspace:*",

--- a/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { ComponentPropsWithoutRef, ReactElement, useCallback, useEffect, useMemo, useState } from "react";
+import { ComponentPropsWithoutRef, ReactElement, useEffect, useMemo, useState } from "react";
 import { debounceTime, Subject } from "rxjs";
 import { IModelConnection } from "@itwin/core-frontend";
 import { SvgFolder, SvgImodelHollow, SvgItem, SvgLayers, SvgModel } from "@itwin/itwinui-icons-react";
@@ -90,9 +90,6 @@ function Tree({ imodel, imodelAccess, height, width }: { imodel: IModelConnectio
   };
 
   const [filteringOptions, setFilteringOptions] = useState<HierarchyLevelDetails>();
-  const onFilterClick = useCallback((hierarchyLevelDetails: HierarchyLevelDetails) => {
-    setFilteringOptions(hierarchyLevelDetails);
-  }, []);
   const propertiesSource = useMemo<(() => Promise<PresentationInstanceFilterPropertiesSource>) | undefined>(() => {
     if (!filteringOptions) {
       return undefined;
@@ -154,7 +151,7 @@ function Tree({ imodel, imodelAccess, height, width }: { imodel: IModelConnectio
 
     return (
       <Flex.Item alignSelf="flex-start" style={{ width: "100%", overflow: "auto" }}>
-        <TreeRenderer rootNodes={rootNodes ?? []} {...treeProps} onFilterClick={onFilterClick} getIcon={getIcon} selectionMode={"extended"} />
+        <TreeRenderer rootNodes={rootNodes ?? []} {...treeProps} onFilterClick={setFilteringOptions} getIcon={getIcon} selectionMode={"extended"} />
       </Flex.Item>
     );
   };

--- a/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
@@ -89,22 +89,17 @@ function Tree({ imodel, imodelAccess, height, width }: { imodel: IModelConnectio
     setFormatter(newValue ? customFormatter : undefined);
   };
 
-  const { getHierarchyLevelDetails } = treeProps;
-  const [filteringOptions, setFilteringOptions] = useState<{ nodeId: string | undefined; hierarchyLevelDetails: HierarchyLevelDetails }>();
-  const onFilterClick = useCallback(
-    (nodeId: string | undefined) => {
-      const hierarchyLevelDetails = getHierarchyLevelDetails(nodeId);
-      setFilteringOptions(hierarchyLevelDetails ? { nodeId, hierarchyLevelDetails } : undefined);
-    },
-    [getHierarchyLevelDetails],
-  );
+  const [filteringOptions, setFilteringOptions] = useState<HierarchyLevelDetails>();
+  const onFilterClick = useCallback((hierarchyLevelDetails: HierarchyLevelDetails) => {
+    setFilteringOptions(hierarchyLevelDetails);
+  }, []);
   const propertiesSource = useMemo<(() => Promise<PresentationInstanceFilterPropertiesSource>) | undefined>(() => {
     if (!filteringOptions) {
       return undefined;
     }
 
     return async () => {
-      const inputKeysIterator = filteringOptions.hierarchyLevelDetails.getInstanceKeysIterator();
+      const inputKeysIterator = filteringOptions.getInstanceKeysIterator();
       const inputKeys = [];
       for await (const inputKey of inputKeysIterator) {
         inputKeys.push(inputKey);
@@ -140,7 +135,7 @@ function Tree({ imodel, imodelAccess, height, width }: { imodel: IModelConnectio
   }, [filteringOptions, imodel]);
 
   const getInitialFilter = useMemo(() => {
-    const currentFilter = filteringOptions?.hierarchyLevelDetails.instanceFilter;
+    const currentFilter = filteringOptions?.instanceFilter;
     if (!currentFilter) {
       return undefined;
     }
@@ -212,7 +207,7 @@ function Tree({ imodel, imodelAccess, height, width }: { imodel: IModelConnectio
           if (!filteringOptions) {
             return;
           }
-          treeProps.getHierarchyLevelDetails(filteringOptions.nodeId)?.setInstanceFilter(toGenericFilter(info));
+          filteringOptions?.setInstanceFilter(toGenericFilter(info));
           setFilteringOptions(undefined);
         }}
         onClose={() => {

--- a/apps/test-app/frontend/vite.config.mts
+++ b/apps/test-app/frontend/vite.config.mts
@@ -21,7 +21,7 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: 3000,
+    port: 3005,
     strictPort: true,
   },
   resolve: {

--- a/apps/test-app/frontend/vite.config.mts
+++ b/apps/test-app/frontend/vite.config.mts
@@ -21,7 +21,7 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: 3005,
+    port: 3000,
     strictPort: true,
   },
   resolve: {

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -116,7 +116,7 @@ export type RenderedTreeNode = PresentationTreeNode | {
 export { SelectionStorage }
 
 // @beta
-export function TreeNodeRenderer({ node, expandNode, getIcon, getSublabel, onFilterClick, onNodeClick, onNodeKeyDown, isSelected, isDisabled, actionButtonsClassName, getHierarchyLevelDetails, ...nodeProps }: TreeNodeRendererProps): JSX_2.Element;
+export function TreeNodeRenderer({ node, expandNode, getIcon, getSublabel, onFilterClick, onNodeClick, onNodeKeyDown, isSelected, isDisabled, actionButtonsClassName, getHierarchyLevelDetails, nodeProps, ...treeNodeProps }: TreeNodeRendererProps): JSX_2.Element;
 
 // @beta
 export function TreeRenderer({ rootNodes, expandNode, selectNodes, isNodeSelected, onFilterClick, getIcon, getSublabel, getHierarchyLevelDetails, selectionMode, localizedStrings, ...treeProps }: TreeRendererProps): JSX_2.Element;

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
@@ -10,7 +10,7 @@ beta;PresentationInfoNode = PresentationGenericInfoNode | PresentationResultSetT
 beta;PresentationResultSetTooLargeInfoNode
 beta;PresentationTreeNode = PresentationHierarchyNode | PresentationInfoNode
 beta;RenderedTreeNode = PresentationTreeNode |
-beta;TreeNodeRenderer({ node, expandNode, getIcon, getSublabel, onFilterClick, onNodeClick, onNodeKeyDown, isSelected, isDisabled, actionButtonsClassName, getHierarchyLevelDetails, ...nodeProps }: TreeNodeRendererProps): JSX_2.Element
+beta;TreeNodeRenderer({ node, expandNode, getIcon, getSublabel, onFilterClick, onNodeClick, onNodeKeyDown, isSelected, isDisabled, actionButtonsClassName, getHierarchyLevelDetails, nodeProps, ...treeNodeProps }: TreeNodeRendererProps): JSX_2.Element
 beta;TreeRenderer({ rootNodes, expandNode, selectNodes, isNodeSelected, onFilterClick, getIcon, getSublabel, getHierarchyLevelDetails, selectionMode, localizedStrings, ...treeProps }: TreeRendererProps): JSX_2.Element
 beta;UnifiedSelectionProvider({ storage, children }: PropsWithChildren
 beta;useSelectionHandler(props: UseSelectionHandlerProps): UseSelectionHandlerResult

--- a/packages/hierarchies-react/package.json
+++ b/packages/hierarchies-react/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@itwin/build-tools": "^4.6.0",
-    "@itwin/itwinui-react": "^3.0.0",
+    "@itwin/itwinui-react": "^3.11.1",
     "@testing-library/dom": "^9.3.4",
     "@testing-library/react": "^14.3.1",
     "@testing-library/user-event": "^14.5.2",

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -5,7 +5,7 @@
 
 import "./TreeNodeRenderer.css";
 import cx from "classnames";
-import { ComponentPropsWithoutRef, ReactElement } from "react";
+import { ComponentPropsWithoutRef, ReactElement, useRef } from "react";
 import { SvgFilter, SvgFilterHollow, SvgRemove } from "@itwin/itwinui-icons-react";
 import { Anchor, ButtonGroup, Flex, IconButton, ProgressRadial, Text, TreeNode } from "@itwin/itwinui-react";
 import { MAX_LIMIT_OVERRIDE } from "../internal/Utils";
@@ -50,77 +50,81 @@ export function TreeNodeRenderer({
   isDisabled,
   actionButtonsClassName,
   getHierarchyLevelDetails,
-  ...nodeProps
+  nodeProps,
+  ...treeNodeProps
 }: TreeNodeRendererProps) {
   const { localizedStrings } = useLocalizationContext();
+  const nodeRef = useRef<HTMLDivElement>(null);
+
   if ("type" in node && node.type === "ChildrenPlaceholder") {
-    return <PlaceholderNode {...nodeProps} />;
+    return <PlaceholderNode {...treeNodeProps} />;
   }
 
   if (isPresentationHierarchyNode(node)) {
     return (
-      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-      <div
-        onClick={(event) => !isDisabled && onNodeClick?.(node, !isSelected, event)}
-        onKeyDown={(event) => {
-          // Ignore if it is called on the element inside, e.g. checkbox or expander
-          if (!isDisabled && event.target instanceof HTMLElement && event.target.classList.contains("stateless-tree-node")) {
-            onNodeKeyDown?.(node, !isSelected, event);
-          }
+      <TreeNode
+        {...treeNodeProps}
+        nodeProps={{
+          ...nodeProps,
+          ref: nodeRef,
+          tabIndex: nodeProps?.tabIndex ?? 0,
+          onClick: (event) => !isDisabled && onNodeClick?.(node, !isSelected, event),
+          onKeyDown: (event) => {
+            // Ignore if it is called on the element inside, e.g. checkbox or expander
+            if (!isDisabled && event.target === nodeRef.current) {
+              onNodeKeyDown?.(node, !isSelected, event);
+            }
+          },
         }}
+        isSelected={isSelected}
+        isDisabled={isDisabled}
+        className={cx(treeNodeProps.className, "stateless-tree-node", { filtered: node.isFiltered })}
+        label={node.label}
+        onExpanded={(_, isExpanded) => {
+          expandNode(node.id, isExpanded);
+        }}
+        icon={getIcon ? getIcon(node) : undefined}
+        sublabel={getSublabel ? getSublabel(node) : undefined}
       >
-        <TreeNode
-          {...nodeProps}
-          isSelected={isSelected}
-          isDisabled={isDisabled}
-          className={cx(nodeProps.className, "stateless-tree-node", { filtered: node.isFiltered })}
-          label={node.label}
-          onExpanded={(_, isExpanded) => {
-            expandNode(node.id, isExpanded);
-          }}
-          icon={getIcon ? getIcon(node) : undefined}
-          sublabel={getSublabel ? getSublabel(node) : undefined}
-        >
-          <ButtonGroup className={cx("action-buttons", actionButtonsClassName)}>
-            {getHierarchyLevelDetails && node.isFiltered ? (
-              <IconButton
-                className="filtering-action-button"
-                styleType="borderless"
-                size="small"
-                title={localizedStrings.clearHierarchyLevelFilter}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  getHierarchyLevelDetails(node.id)?.setInstanceFilter(undefined);
-                }}
-              >
-                <SvgRemove />
-              </IconButton>
-            ) : null}
-            {onFilterClick && node.isFilterable ? (
-              <IconButton
-                className="filtering-action-button"
-                styleType="borderless"
-                size="small"
-                title={localizedStrings.filterHierarchyLevel}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  const hierarchyLevelDetails = getHierarchyLevelDetails?.(node.id);
-                  hierarchyLevelDetails && onFilterClick(hierarchyLevelDetails);
-                }}
-              >
-                {node.isFiltered ? <SvgFilter /> : <SvgFilterHollow />}
-              </IconButton>
-            ) : null}
-          </ButtonGroup>
-        </TreeNode>
-      </div>
+        <ButtonGroup className={cx("action-buttons", actionButtonsClassName)}>
+          {getHierarchyLevelDetails && node.isFiltered ? (
+            <IconButton
+              className="filtering-action-button"
+              styleType="borderless"
+              size="small"
+              title={localizedStrings.clearHierarchyLevelFilter}
+              onClick={(e) => {
+                e.stopPropagation();
+                getHierarchyLevelDetails(node.id)?.setInstanceFilter(undefined);
+              }}
+            >
+              <SvgRemove />
+            </IconButton>
+          ) : null}
+          {onFilterClick && node.isFilterable ? (
+            <IconButton
+              className="filtering-action-button"
+              styleType="borderless"
+              size="small"
+              title={localizedStrings.filterHierarchyLevel}
+              onClick={(e) => {
+                e.stopPropagation();
+                const hierarchyLevelDetails = getHierarchyLevelDetails?.(node.id);
+                hierarchyLevelDetails && onFilterClick(hierarchyLevelDetails);
+              }}
+            >
+              {node.isFiltered ? <SvgFilter /> : <SvgFilterHollow />}
+            </IconButton>
+          ) : null}
+        </ButtonGroup>
+      </TreeNode>
     );
   }
 
   if (node.type === "ResultSetTooLarge") {
     return (
       <ResultSetTooLargeNode
-        {...nodeProps}
+        {...treeNodeProps}
         limit={node.resultSetSizeLimit}
         onOverrideLimit={getHierarchyLevelDetails ? (limit) => getHierarchyLevelDetails(node.parentNodeId)?.setSizeLimit(limit) : undefined}
         onFilterClick={
@@ -136,10 +140,10 @@ export function TreeNodeRenderer({
   }
 
   if (node.type === "NoFilterMatches") {
-    return <TreeNode {...nodeProps} label={localizedStrings.noFilteredChildren} isDisabled={true} onExpanded={/* istanbul ignore next */ () => {}} />;
+    return <TreeNode {...treeNodeProps} label={localizedStrings.noFilteredChildren} isDisabled={true} onExpanded={/* istanbul ignore next */ () => {}} />;
   }
 
-  return <TreeNode {...nodeProps} label={node.message} isDisabled={true} onExpanded={/* istanbul ignore next */ () => {}} />;
+  return <TreeNode {...treeNodeProps} label={node.message} isDisabled={true} onExpanded={/* istanbul ignore next */ () => {}} />;
 }
 
 function PlaceholderNode(props: Omit<TreeNodeProps, "onExpanded" | "label">) {

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -21,8 +21,8 @@ interface TreeNodeRendererOwnProps {
   onFilterClick?: (nodeId: string | undefined) => void;
   getIcon?: (node: PresentationHierarchyNode) => ReactElement | undefined;
   getSublabel?: (node: PresentationHierarchyNode) => ReactElement | undefined;
-  onNodeClick?: (nodeId: string, isSelected: boolean, event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
-  onNodeKeyDown?: (nodeId: string, isSelected: boolean, event: React.KeyboardEvent<HTMLElement>) => void;
+  onNodeClick?: (node: PresentationHierarchyNode, isSelected: boolean, event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  onNodeKeyDown?: (node: PresentationHierarchyNode, isSelected: boolean, event: React.KeyboardEvent<HTMLElement>) => void;
   actionButtonsClassName?: string;
 }
 
@@ -61,11 +61,11 @@ export function TreeNodeRenderer({
     return (
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
       <div
-        onClick={(event) => !isDisabled && onNodeClick?.(node.id, !isSelected, event)}
+        onClick={(event) => !isDisabled && onNodeClick?.(node, !isSelected, event)}
         onKeyDown={(event) => {
           // Ignore if it is called on the element inside, e.g. checkbox or expander
           if (!isDisabled && event.target instanceof HTMLElement && event.target.classList.contains("stateless-tree-node")) {
-            onNodeKeyDown?.(node.id, !isSelected, event);
+            onNodeKeyDown?.(node, !isSelected, event);
           }
         }}
       >

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -10,7 +10,7 @@ import { SvgFilter, SvgFilterHollow, SvgRemove } from "@itwin/itwinui-icons-reac
 import { Anchor, ButtonGroup, Flex, IconButton, ProgressRadial, Text, TreeNode } from "@itwin/itwinui-react";
 import { MAX_LIMIT_OVERRIDE } from "../internal/Utils";
 import { isPresentationHierarchyNode, PresentationHierarchyNode } from "../TreeNode";
-import { useTree } from "../UseTree";
+import { HierarchyLevelDetails, useTree } from "../UseTree";
 import { useLocalizationContext } from "./LocalizationContext";
 import { RenderedTreeNode } from "./TreeRenderer";
 
@@ -18,7 +18,7 @@ type TreeNodeProps = ComponentPropsWithoutRef<typeof TreeNode>;
 
 interface TreeNodeRendererOwnProps {
   node: RenderedTreeNode;
-  onFilterClick?: (nodeId: string | undefined) => void;
+  onFilterClick?: (hierarchyLevelDetails: HierarchyLevelDetails) => void;
   getIcon?: (node: PresentationHierarchyNode) => ReactElement | undefined;
   getSublabel?: (node: PresentationHierarchyNode) => ReactElement | undefined;
   onNodeClick?: (node: PresentationHierarchyNode, isSelected: boolean, event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
@@ -104,7 +104,8 @@ export function TreeNodeRenderer({
                 title={localizedStrings.filterHierarchyLevel}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onFilterClick(node.id);
+                  const hierarchyLevelDetails = getHierarchyLevelDetails?.(node.id);
+                  hierarchyLevelDetails && onFilterClick(hierarchyLevelDetails);
                 }}
               >
                 {node.isFiltered ? <SvgFilter /> : <SvgFilterHollow />}
@@ -125,7 +126,8 @@ export function TreeNodeRenderer({
         onFilterClick={
           onFilterClick
             ? () => {
-                onFilterClick(node.parentNodeId);
+                const hierarchyLevelDetails = getHierarchyLevelDetails?.(node.parentNodeId);
+                hierarchyLevelDetails && onFilterClick(hierarchyLevelDetails);
               }
             : undefined
         }

--- a/packages/hierarchies-react/src/test/UseSelectionHandler.test.tsx
+++ b/packages/hierarchies-react/src/test/UseSelectionHandler.test.tsx
@@ -6,7 +6,7 @@
 import { expect } from "chai";
 import sinon from "sinon";
 import { UserEvent } from "@testing-library/user-event";
-import { PresentationHierarchyNode, PresentationInfoNode, PresentationTreeNode } from "../presentation-hierarchies-react/TreeNode";
+import { isPresentationHierarchyNode, PresentationHierarchyNode, PresentationInfoNode, PresentationTreeNode } from "../presentation-hierarchies-react/TreeNode";
 import { SelectionChangeType, SelectionMode, useSelectionHandler } from "../presentation-hierarchies-react/UseSelectionHandler";
 import { render } from "./TestUtils";
 
@@ -19,18 +19,19 @@ interface TestComponentProps {
 
 function TestComponent({ rootNodes, selectNodes, selectionMode, isSelected }: TestComponentProps) {
   const { onNodeKeyDown, onNodeClick } = useSelectionHandler({ rootNodes, selectNodes, selectionMode });
-  const invalidNode = { id: "invalid" } as PresentationHierarchyNode;
+  const invalidNode = { id: "invalid", children: [] } as unknown as PresentationHierarchyNode;
   const nodes = rootNodes ? [...rootNodes, invalidNode] : [invalidNode];
   return (
     <>
       {nodes?.map((node) => {
+        const isHierarchyNode = isPresentationHierarchyNode(node);
         return (
           <div
             role="button"
             key={node.id}
             tabIndex={0}
-            onClick={(e) => onNodeClick(node.id, isSelected, e)}
-            onKeyDown={(e) => onNodeKeyDown(node.id, isSelected, e)}
+            onClick={(e) => isHierarchyNode && onNodeClick(node, isSelected, e)}
+            onKeyDown={(e) => isHierarchyNode && onNodeKeyDown(node, isSelected, e)}
           >
             {node.id}
           </div>

--- a/packages/hierarchies-react/src/test/itwinui/Tree.test.tsx
+++ b/packages/hierarchies-react/src/test/itwinui/Tree.test.tsx
@@ -12,7 +12,7 @@ import { HierarchyLevelDetails } from "../../presentation-hierarchies-react/UseT
 import { act, createStub, createTestHierarchyNode, render, waitFor, within } from "../TestUtils";
 
 describe("Tree", () => {
-  const onFilterClick = createStub<(nodeId: string | undefined) => void>();
+  const onFilterClick = createStub<(hierarchyLevelDetails: HierarchyLevelDetails) => void>();
   const expandNode = createStub<(nodeId: string, isExpanded: boolean) => void>();
   const selectNodes = createStub<(nodeIds: Array<string>, changeType: SelectionChangeType) => void>();
   const isNodeSelected = createStub<(nodeId: string) => boolean>();
@@ -249,11 +249,14 @@ describe("Tree", () => {
       },
     ]);
 
+    const hierarchyLevelDetails = {} as unknown as HierarchyLevelDetails;
+    getHierarchyLevelDetails.returns(hierarchyLevelDetails);
+
     const { user, queryByText, getByRole } = render(<TreeRenderer rootNodes={rootNodes} {...initialProps} />);
 
     expect(queryByText("root-1")).to.not.be.null;
     await user.click(getByRole("button", { name: "Apply filter" }));
-    expect(onFilterClick).to.be.calledOnceWith("root-1");
+    expect(onFilterClick).to.be.calledOnceWith(hierarchyLevelDetails);
   });
 
   describe("`ResultSetTooLarge` node", () => {
@@ -331,11 +334,13 @@ describe("Tree", () => {
         },
       ]);
 
+      const hierarchyLevelDetails = {} as unknown as HierarchyLevelDetails;
+      getHierarchyLevelDetails.returns(hierarchyLevelDetails);
       const { user, getByText, queryByText } = render(<TreeRenderer rootNodes={rootNodes} {...initialProps} />);
 
       expect(queryByText(/there are more items than allowed limit of 100/i)).to.not.be.null;
       await user.click(getByText("additional filtering"));
-      expect(onFilterClick).to.be.calledOnceWith("parent-id");
+      expect(onFilterClick).to.be.calledOnceWith(hierarchyLevelDetails);
     });
 
     it("overrides hierarchy level size limit", async () => {

--- a/packages/hierarchies-react/src/test/itwinui/Tree.test.tsx
+++ b/packages/hierarchies-react/src/test/itwinui/Tree.test.tsx
@@ -99,12 +99,13 @@ describe("Tree", () => {
 
     const { user, getByRole } = render(<TreeRenderer rootNodes={rootNodes} expandNode={initialProps.expandNode} selectionMode={"single"} />);
 
-    const node = getByRole("treeitem");
-    expect(within(node).queryByText("test node")).to.not.be.null;
-    expect(node.ariaSelected).to.eq("false");
+    const nodeWrapper = getByRole("treeitem");
+    const node = within(nodeWrapper).getByText("test node");
+    expect(node).to.not.be.null;
+    expect(nodeWrapper.ariaSelected).to.eq("false");
 
     await user.click(node);
-    expect(node.ariaSelected).to.eq("false");
+    expect(nodeWrapper.ariaSelected).to.eq("false");
   });
 
   it("selects/unselects nodes", async () => {

--- a/packages/hierarchies-react/src/test/itwinui/Tree.test.tsx
+++ b/packages/hierarchies-react/src/test/itwinui/Tree.test.tsx
@@ -153,6 +153,7 @@ describe("Tree", () => {
     act(() => {
       node1.focus();
     });
+    await user.tab();
     await user.keyboard("{Enter}");
     expect(selectNodes).to.be.calledOnceWith(["root-1"], "remove");
     selectNodes.reset();
@@ -161,6 +162,7 @@ describe("Tree", () => {
     act(() => {
       node2.focus();
     });
+    await user.tab();
     await user.keyboard("{Enter}");
     expect(selectNodes).to.be.calledOnceWith(["root-2"], "replace");
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,8 +684,8 @@ importers:
         specifier: ^2.8.0
         version: 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-react':
-        specifier: ^3.9.1
-        version: 3.11.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^3.11.1
+        version: 3.11.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/presentation-common':
         specifier: ^4.6.0
         version: 4.6.0(@itwin/core-bentley@4.6.0)(@itwin/core-common@4.6.0(@itwin/core-bentley@4.6.0)(@itwin/core-geometry@4.6.0))(@itwin/core-quantity@4.6.0(@itwin/core-bentley@4.6.0))(@itwin/ecschema-metadata@4.6.0(@itwin/core-bentley@4.6.0)(@itwin/core-quantity@4.6.0(@itwin/core-bentley@4.6.0)))
@@ -1186,8 +1186,8 @@ importers:
         specifier: ^4.6.0
         version: 4.6.0(@types/node@20.12.12)
       '@itwin/itwinui-react':
-        specifier: ^3.0.0
-        version: 3.11.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^3.11.1
+        version: 3.11.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@testing-library/dom':
         specifier: ^9.3.4
         version: 9.3.4
@@ -2515,6 +2515,12 @@ packages:
     peerDependencies:
       react: '>= 17.0.0 < 19.0.0'
       react-dom: '>=17.0.0 < 19.0.0'
+
+  '@itwin/itwinui-react@3.11.1':
+    resolution: {integrity: sha512-RMWpuCsqtEqdaA6ox4NnWaebVJbkG9H65CN4s3G+owUX4jR/h+/FH2JOPmhwldUMraKExPMCFUU9JJ4dTPHjtA==}
+    peerDependencies:
+      react: 18.2.0
+      react-dom: 18.2.0
 
   '@itwin/itwinui-variables@3.2.0':
     resolution: {integrity: sha512-YuJ3IyqRRynQRKPiTz6odF8hVxmAVABxitrqj2VZ1ZtKRVO6EyrWMgZP90cYF1l0EjqzOxG71focaHcZH5C6Ow==}
@@ -8046,8 +8052,8 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.583.0(@aws-sdk/client-sts@3.583.0)
-      '@aws-sdk/client-sts': 3.583.0
+      '@aws-sdk/client-sso-oidc': 3.583.0
+      '@aws-sdk/client-sts': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
       '@aws-sdk/core': 3.582.0
       '@aws-sdk/credential-provider-node': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)(@aws-sdk/client-sts@3.583.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -8094,8 +8100,8 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.583.0(@aws-sdk/client-sts@3.583.0)
-      '@aws-sdk/client-sts': 3.583.0
+      '@aws-sdk/client-sso-oidc': 3.583.0
+      '@aws-sdk/client-sts': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
       '@aws-sdk/core': 3.582.0
       '@aws-sdk/credential-provider-node': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)(@aws-sdk/client-sts@3.583.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -8136,11 +8142,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.583.0(@aws-sdk/client-sts@3.583.0)':
+  '@aws-sdk/client-sso-oidc@3.583.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.583.0
+      '@aws-sdk/client-sts': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
       '@aws-sdk/core': 3.582.0
       '@aws-sdk/credential-provider-node': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)(@aws-sdk/client-sts@3.583.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -8179,7 +8185,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.2
     transitivePeerDependencies:
-      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso@3.583.0':
@@ -8225,11 +8230,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.583.0':
+  '@aws-sdk/client-sts@3.583.0(@aws-sdk/client-sso-oidc@3.583.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.583.0(@aws-sdk/client-sts@3.583.0)
+      '@aws-sdk/client-sso-oidc': 3.583.0
       '@aws-sdk/core': 3.582.0
       '@aws-sdk/credential-provider-node': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)(@aws-sdk/client-sts@3.583.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -8268,6 +8273,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.2
     transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/core@3.582.0':
@@ -8311,7 +8317,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.583.0(@aws-sdk/client-sso-oidc@3.583.0)(@aws-sdk/client-sts@3.583.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.583.0
+      '@aws-sdk/client-sts': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
       '@aws-sdk/credential-provider-env': 3.577.0
       '@aws-sdk/credential-provider-process': 3.577.0
       '@aws-sdk/credential-provider-sso': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
@@ -8368,7 +8374,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.577.0(@aws-sdk/client-sts@3.583.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.583.0
+      '@aws-sdk/client-sts': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.0.0
       '@smithy/types': 3.0.0
@@ -8378,7 +8384,7 @@ snapshots:
     dependencies:
       '@aws-sdk/client-cognito-identity': 3.583.0
       '@aws-sdk/client-sso': 3.583.0
-      '@aws-sdk/client-sts': 3.583.0
+      '@aws-sdk/client-sts': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
       '@aws-sdk/credential-provider-cognito-identity': 3.583.0
       '@aws-sdk/credential-provider-env': 3.577.0
       '@aws-sdk/credential-provider-http': 3.582.0
@@ -8435,7 +8441,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.577.0(@aws-sdk/client-sso-oidc@3.583.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.583.0(@aws-sdk/client-sts@3.583.0)
+      '@aws-sdk/client-sso-oidc': 3.583.0
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.0.0
       '@smithy/shared-ini-file-loader': 3.0.0
@@ -9125,7 +9131,7 @@ snapshots:
       '@itwin/imodel-components-react': 4.13.4(@itwin/appui-abstract@4.6.0(@itwin/core-bentley@4.6.0))(@itwin/components-react@4.13.4(@itwin/appui-abstract@4.6.0(@itwin/core-bentley@4.6.0))(@itwin/core-bentley@4.6.0)(@itwin/core-react@4.13.4(@itwin/appui-abstract@4.6.0(@itwin/core-bentley@4.6.0))(@itwin/core-bentley@4.6.0)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@itwin/core-bentley@4.6.0)(@itwin/core-common@4.6.0(@itwin/core-bentley@4.6.0)(@itwin/core-geometry@4.6.0))(@itwin/core-frontend@4.6.0(@itwin/appui-abstract@4.6.0(@itwin/core-bentley@4.6.0))(@itwin/core-bentley@4.6.0)(@itwin/core-common@4.6.0(@itwin/core-bentley@4.6.0)(@itwin/core-geometry@4.6.0))(@itwin/core-geometry@4.6.0)(@itwin/core-orbitgt@4.6.0)(@itwin/core-quantity@4.6.0(@itwin/core-bentley@4.6.0))(inversify@6.0.2)(reflect-metadata@0.1.14))(@itwin/core-geometry@4.6.0)(@itwin/core-quantity@4.6.0(@itwin/core-bentley@4.6.0))(@itwin/core-react@4.13.4(@itwin/appui-abstract@4.6.0(@itwin/core-bentley@4.6.0))(@itwin/core-bentley@4.6.0)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@itwin/itwinui-react': 3.11.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@itwin/itwinui-react': 3.11.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-react-v2': '@itwin/itwinui-react@2.12.26(react-dom@18.2.0(react@18.2.0))(react@18.2.0)'
       '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
@@ -9410,6 +9416,20 @@ snapshots:
       tippy.js: 6.3.7
 
   '@itwin/itwinui-react@3.11.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@floating-ui/react': 0.26.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      classnames: 2.5.1
+      jotai: 2.8.1(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-table: 7.8.0(react@18.2.0)
+      react-transition-group: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@itwin/itwinui-react@3.11.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/react': 0.26.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)


### PR DESCRIPTION
Changes needed for https://github.com/iTwin/viewer-components-react/issues/867. Also memoized the `onNodeClick` and `onNodeKeyDown` as `TreeRenderer` contains a hook that depends on them.