### PR TITLE
`hierarchies`: Remove `@internal` tags from public APIs that aren't exported through the barrel

### DIFF
--- a/.changeset/six-students-play.md
+++ b/.changeset/six-students-play.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies": patch
+---
+
+Remove `@internal` tags from public APIs that aren't exported through the barrel. They were added to explicitly say that not adding to barrel was intentional, but that makes the `@itwin/no-internal` linter rule angry.

--- a/packages/hierarchies/src/hierarchies/HierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyDefinition.ts
@@ -17,19 +17,13 @@ import {
 } from "./HierarchyNode";
 import { InstancesNodeKey } from "./HierarchyNodeKey";
 
-/**
- * A nodes definition that returns a single custom defined node.
- * @internal
- */
+/** A nodes definition that returns a single custom defined node. */
 export interface CustomHierarchyNodeDefinition {
   /** The node to be created in the hierarchy level */
   node: ParsedCustomHierarchyNode;
 }
 
-/**
- * A nodes definition that returns an ECSQL query for selecting nodes from an iModel.
- * @internal
- */
+/** A nodes definition that returns an ECSQL query for selecting nodes from an iModel. */
 export interface InstanceNodesQueryDefinition {
   /**
    * Full name of the class whose instances are going to be returned. It's okay if the attribute

--- a/packages/hierarchies/src/hierarchies/HierarchyNode.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyNode.ts
@@ -149,8 +149,6 @@ export namespace HierarchyNode {
 /**
  * A type of `HierarchyNode` that doesn't know about its children and is an input when requesting
  * them using `HierarchyProvider.getNodes`.
- *
- * @internal
  */
 export type ParentHierarchyNode<TBase = HierarchyNode> = OmitOverUnion<TBase, "children">;
 
@@ -198,16 +196,10 @@ interface HierarchyNodeLabelGroupingGroupParams extends HierarchyNodeLabelGroupi
   action?: "group";
 }
 
-/**
- * A data structure for defining possible label grouping types.
- * @internal
- */
+/** A data structure for defining possible label grouping types. */
 export type HierarchyNodeLabelGroupingParams = boolean | HierarchyNodeLabelGroupingMergeParams | HierarchyNodeLabelGroupingGroupParams;
 
-/**
- * Grouping parameters that are shared across all types of groupings.
- * @internal
- */
+/** Grouping parameters that are shared across all types of groupings. */
 export interface HierarchyNodeGroupingParamsBase {
   /** Hiding option that determines whether to hide group nodes which have no siblings at the same hierarchy level. */
   hideIfNoSiblings?: boolean;
@@ -221,8 +213,6 @@ export interface HierarchyNodeGroupingParamsBase {
  * Defines possible values for `BaseGroupingParams.autoExpand` attribute:
  * - `single-child` - set the grouping node to auto-expand if it groups a single node.
  * - `always` - always set the grouping node to auto-expand.
- *
- * @internal
  */
 export type HierarchyNodeAutoExpandProp = "single-child" | "always";
 
@@ -239,10 +229,7 @@ interface HierarchyNodeBaseClassGroupingParams extends HierarchyNodeGroupingPara
   fullClassNames: string[];
 }
 
-/**
- * A data structure that represents properties grouping.
- * @internal
- */
+/** A data structure that represents properties grouping. */
 export interface HierarchyNodePropertiesGroupingParams extends HierarchyNodeGroupingParamsBase {
   /**
    * Full name of a class whose properties are used to group the node. Only has effect if the node
@@ -289,10 +276,7 @@ export interface HierarchyNodePropertiesGroupingParams extends HierarchyNodeGrou
   propertyGroups: HierarchyNodePropertyGroup[];
 }
 
-/**
- * A data structure that represents specific properties' grouping params.
- * @internal
- */
+/** A data structure that represents specific properties' grouping params. */
 export interface HierarchyNodePropertyGroup {
   /** A string indicating the name of the property to group by. */
   propertyName: string;
@@ -302,10 +286,7 @@ export interface HierarchyNodePropertyGroup {
   ranges?: HierarchyNodePropertyValueRange[];
 }
 
-/**
- * A data structure that represents boundaries for a value.
- * @internal
- */
+/** A data structure that represents boundaries for a value. */
 export interface HierarchyNodePropertyValueRange {
   /** Defines the lower bound of the range. */
   fromValue: number;
@@ -315,36 +296,24 @@ export interface HierarchyNodePropertyValueRange {
   rangeLabel?: string;
 }
 
-/**
- * Processing parameters that apply to instance nodes.
- * @internal
- */
+/** Processing parameters that apply to instance nodes. */
 export interface InstanceHierarchyNodeProcessingParams extends HierarchyNodeProcessingParamsBase {
   grouping?: HierarchyNodeGroupingParams;
 }
 
-/**
- * A custom (not based on data in an iModel) node that has processing parameters.
- * @internal
- */
+/** A custom (not based on data in an iModel) node that has processing parameters. */
 export type ProcessedCustomHierarchyNode = Omit<NonGroupingHierarchyNode, "key" | "children"> & {
   key: string;
   children?: boolean;
   processingParams?: HierarchyNodeProcessingParamsBase;
 };
-/**
- * An instances' (based on data in an iModel) node that has processing parameters.
- * @internal
- */
+/** An instances' (based on data in an iModel) node that has processing parameters. */
 export type ProcessedInstanceHierarchyNode = Omit<NonGroupingHierarchyNode, "key" | "children"> & {
   key: InstancesNodeKey;
   children?: boolean;
   processingParams?: InstanceHierarchyNodeProcessingParams;
 };
-/**
- * A grouping node that groups either instance nodes or other grouping nodes.
- * @internal
- */
+/** A grouping node that groups either instance nodes or other grouping nodes. */
 export type ProcessedGroupingHierarchyNode = Omit<GroupingHierarchyNode, "children"> & {
   children: Array<ProcessedGroupingHierarchyNode | ProcessedInstanceHierarchyNode>;
 };
@@ -367,13 +336,7 @@ export type ProcessedHierarchyNode = ProcessedCustomHierarchyNode | ProcessedIns
 export type ParsedHierarchyNode<TBase = ParsedCustomHierarchyNode | ParsedInstanceHierarchyNode> = OmitOverUnion<TBase, "label" | "parentKeys"> & {
   label: string | ConcatenatedValue;
 };
-/**
- * A kind of `ProcessedCustomHierarchyNode` that has unformatted label and doesn't know about its ancestors.
- * @internal
- */
+/** A kind of `ProcessedCustomHierarchyNode` that has unformatted label and doesn't know about its ancestors. */
 export type ParsedCustomHierarchyNode = ParsedHierarchyNode<ProcessedCustomHierarchyNode>;
-/**
- * A kind of `ProcessedInstanceHierarchyNode` that has unformatted label and doesn't know about its ancestors.
- * @internal
- */
+/** A kind of `ProcessedInstanceHierarchyNode` that has unformatted label and doesn't know about its ancestors. */
 export type ParsedInstanceHierarchyNode = ParsedHierarchyNode<ProcessedInstanceHierarchyNode>;

--- a/packages/hierarchies/src/hierarchies/HierarchyNodeKey.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyNodeKey.ts
@@ -21,10 +21,7 @@ export interface InstancesNodeKey {
   instanceKeys: InstanceKey[];
 }
 
-/**
- * A key for a class-grouping node.
- * @internal
- */
+/** A key for a class-grouping node. */
 export interface ClassGroupingNodeKey {
   /** Type of the node */
   type: "class-grouping";
@@ -33,10 +30,7 @@ export interface ClassGroupingNodeKey {
   className: string;
 }
 
-/**
- * A key for a label-grouping node.
- * @internal
- */
+/** A key for a label-grouping node. */
 export interface LabelGroupingNodeKey {
   /** Type of the node */
   type: "label-grouping";
@@ -54,8 +48,6 @@ export interface LabelGroupingNodeKey {
 /**
  * A key property grouping node that groups nodes whose values don't fall into any other
  * property group in the hierarchy level.
- *
- * @internal
  */
 export interface PropertyOtherValuesGroupingNodeKey {
   /** Type of the node */
@@ -67,10 +59,7 @@ export interface PropertyOtherValuesGroupingNodeKey {
   }>;
 }
 
-/**
- * A key for a property grouping node that groups nodes by formatted property value.
- * @internal
- */
+/** A key for a property grouping node that groups nodes by formatted property value. */
 export interface PropertyValueGroupingNodeKey {
   /** Type of the node */
   type: "property-grouping:value";
@@ -85,10 +74,7 @@ export interface PropertyValueGroupingNodeKey {
   formattedPropertyValue: string;
 }
 
-/**
- * A key for a property grouping node that groups nodes by a range of property values.
- * @internal
- */
+/** A key for a property grouping node that groups nodes by a range of property values. */
 export interface PropertyValueRangeGroupingNodeKey {
   /** Type of the node */
   type: "property-grouping:range";
@@ -106,10 +92,7 @@ export interface PropertyValueRangeGroupingNodeKey {
   toValue: number;
 }
 
-/**
- * A key for a property grouping node.
- * @internal
- */
+/** A key for a property grouping node. */
 export type PropertyGroupingNodeKey = PropertyValueRangeGroupingNodeKey | PropertyValueGroupingNodeKey | PropertyOtherValuesGroupingNodeKey;
 
 /**
@@ -118,10 +101,7 @@ export type PropertyGroupingNodeKey = PropertyValueRangeGroupingNodeKey | Proper
  */
 export type GroupingNodeKey = ClassGroupingNodeKey | LabelGroupingNodeKey | PropertyGroupingNodeKey;
 
-/**
- * A key for either an instance node or one of the instance grouping nodes.
- * @internal
- */
+/** A key for either an instance node or one of the instance grouping nodes. */
 export type StandardHierarchyNodeKey = InstancesNodeKey | GroupingNodeKey;
 
 /**


### PR DESCRIPTION
Using a type guard to get `@internal` type from a `@public` one makes linter angry, e.g.:
```ts
const node: HierarchyNode = getNode();
if (HierarchyNode.isLabelGroupingNode(node)) {
  console.log(node.key.label);
}
```
gives:
![image](https://github.com/iTwin/presentation/assets/35135765/f9336a3b-1cd5-4b0d-8ab3-15f6f3501fa5)
