### PR TITLE
Hierarchies: fix `preProcessNode` and `postProcessNode` losing `this` context

### DIFF
--- a/.changeset/rude-boxes-argue.md
+++ b/.changeset/rude-boxes-argue.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies": patch
+---
+
+Fixed `preProcessNode` and `postProcessNode` losing `this` context in `HierarchyProvider`.

--- a/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
@@ -606,12 +606,14 @@ class HierarchyProviderImpl implements HierarchyProvider {
 
 function preProcessNodes(hierarchyFactory: HierarchyDefinition) {
   return hierarchyFactory.preProcessNode
-    ? processNodes(hierarchyFactory.preProcessNode)
+    ? processNodes(hierarchyFactory.preProcessNode.bind(hierarchyFactory))
     : (o: Observable<ProcessedCustomHierarchyNode | ProcessedInstanceHierarchyNode>) => o;
 }
 
 function postProcessNodes(hierarchyFactory: HierarchyDefinition) {
-  return hierarchyFactory.postProcessNode ? processNodes(hierarchyFactory.postProcessNode) : (o: Observable<ProcessedHierarchyNode>) => o;
+  return hierarchyFactory.postProcessNode
+    ? processNodes(hierarchyFactory.postProcessNode.bind(hierarchyFactory))
+    : (o: Observable<ProcessedHierarchyNode>) => o;
 }
 
 function processNodes<TNode>(processor: (node: TNode) => Promise<TNode | undefined>) {

--- a/packages/hierarchies/src/test/HierarchyProvider.test.ts
+++ b/packages/hierarchies/src/test/HierarchyProvider.test.ts
@@ -172,7 +172,7 @@ describe("createHierarchyProvider", () => {
     });
   });
 
-  describe.only("Custom processing", () => {
+  describe("Custom processing", () => {
     class TestHierarchyDefinition implements HierarchyDefinition {
       public node = { key: "custom", label: "custom", children: false };
       public preProcessStub = sinon.stub().resolves({ ...this.node, isPreprocessed: true });


### PR DESCRIPTION
Fixed `preProcessNode` and `postProcessNode` not retaining `this` context.