### PR TITLE
Hierarchies-react: Disable node deselection with extended selection mode

### DIFF
--- a/.changeset/lucky-radios-trade.md
+++ b/.changeset/lucky-radios-trade.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Changed `extended` selection mode to not deselect nodes when `ctrl` is not used.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseSelectionHandler.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseSelectionHandler.ts
@@ -133,11 +133,10 @@ function getExtendedSelectionAction(isSelected: boolean, shiftDown: boolean, ctr
   if (shiftDown) {
     return { select: "range", type: "replace" };
   }
-  if (!isSelected) {
-    return { select: "node", type: "remove" };
+  if (ctrlDown) {
+    return { select: "node", type: isSelected ? "add" : "remove" };
   }
-
-  return { select: "node", type: ctrlDown ? "add" : "replace" };
+  return { select: "node", type: isSelected ? "replace" : "disabled" };
 }
 
 function computeFlatNodeList(rootNodes: Array<PresentationTreeNode>): FlatTreeState {

--- a/packages/hierarchies-react/src/test/UseSelectionHandler.test.tsx
+++ b/packages/hierarchies-react/src/test/UseSelectionHandler.test.tsx
@@ -188,6 +188,18 @@ describe("useSelectionHandler", () => {
         expect(selectNodesStub).to.be.calledOnceWith(["node"], "replace");
       });
 
+      it("does not deselect node when clicked", async () => {
+        const rootNode = createHierarchyNode("node");
+        const { user, getByText } = render(<TestComponent {...createProps([rootNode], selectionMode, false)} />);
+
+        const node = getByText("node");
+        node.focus();
+
+        await clickNode(user, node);
+
+        expect(selectNodesStub).to.not.be.called;
+      });
+
       it("adds to selection when node is clicked and `ctrl` used", async () => {
         const rootNode = createHierarchyNode("node");
         const { user, getByText } = render(<TestComponent {...createProps([rootNode], selectionMode, true)} />);


### PR DESCRIPTION
Changed `extended` selection mode to not deselect nodes when `ctrl` is not used.