### PR TITLE
Hierarchies: Fix like operator not matching substrings

### DIFF
--- a/.changeset/wise-beds-confess.md
+++ b/.changeset/wise-beds-confess.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-hierarchies": patch
 ---
 
-Fixed `like` operator not matching substrings in `NodeSelectQueryFactory`.
+`NodeSelectQueryFactory.createWhereClause`: Fixed `like` operator not matching substrings.

--- a/.changeset/wise-beds-confess.md
+++ b/.changeset/wise-beds-confess.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies": patch
+---
+
+Fixed `like` operator not matching substrings in `NodeSelectQueryFactory`.

--- a/packages/hierarchies/src/hierarchies/NodeSelectQueryFactory.ts
+++ b/packages/hierarchies/src/hierarchies/NodeSelectQueryFactory.ts
@@ -557,7 +557,8 @@ async function createWhereClause(
   const value = rule.value.rawValue;
 
   if (rule.operator === "like" && typeof value === "string") {
-    return `${propertyValueSelector} ${ecsqlOperator} '${value}' ESCAPE '\\'`;
+    const escapedValue = value.replace(/[%_\\]/g, "\\$&");
+    return `${propertyValueSelector} ${ecsqlOperator} '%${escapedValue}%' ESCAPE '\\'`;
   }
   const propertyClass = await classLoader(sourceAlias);
   if (!propertyClass) {

--- a/packages/hierarchies/src/test/NodeSelectQueryFactory.test.ts
+++ b/packages/hierarchies/src/test/NodeSelectQueryFactory.test.ts
@@ -712,7 +712,10 @@ describe("createNodesQueryClauseFactory", () => {
           });
           await testPropertyFilter(createProps("is-equal", "test", `[x].[p] = 'test'`));
           await testPropertyFilter(createProps("is-not-equal", "test", `[x].[p] <> 'test'`));
-          await testPropertyFilter(createProps("like", "test%", `[x].[p] LIKE 'test%' ESCAPE '\\'`));
+          await testPropertyFilter(createProps("like", "test", `[x].[p] LIKE '%test%' ESCAPE '\\'`));
+          await testPropertyFilter(createProps("like", "t%e%st", `[x].[p] LIKE '%t\\%e\\%st%' ESCAPE '\\'`));
+          await testPropertyFilter(createProps("like", "t_e_st", `[x].[p] LIKE '%t\\_e\\_st%' ESCAPE '\\'`));
+          await testPropertyFilter(createProps("like", "t\\e\\st", `[x].[p] LIKE '%t\\\\e\\\\st%' ESCAPE '\\'`));
         });
 
         it(`creates boolean property filters`, async () => {


### PR DESCRIPTION
Fixes needed for https://github.com/iTwin/viewer-components-react/issues/903.