### PR TITLE
Hierarchies-react: fix filtering buttons not showing on hover

### DIFF
--- a/.changeset/little-grapes-check.md
+++ b/.changeset/little-grapes-check.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Fixed node filtering buttons not showing when node is hovered.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.css
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.css
@@ -11,7 +11,8 @@
   visibility: hidden;
 }
 
-.stateless-tree-node:focus-within .action-buttons,
-.stateless-tree-node.filtered .action-buttons {
+.stateless-tree-node:hover .action-buttons,
+.stateless-tree-node.filtered .action-buttons,
+.stateless-tree-node:focus-within .action-buttons {
   visibility: visible;
 }


### PR DESCRIPTION
Not sure whether I did not save / did not commit the latest changes with https://github.com/iTwin/presentation/pull/644.