### PR TITLE
Unified-selection: batch iModel selection changes

### DIFF
--- a/.changeset/modern-parents-visit.md
+++ b/.changeset/modern-parents-visit.md
@@ -1,0 +1,5 @@
+---
+"@itwin/unified-selection": patch
+---
+
+Updated `enableUnifiedSelectionSyncWithIModel` to batch iModel selection changes before synchronizing with `SelectionStorage`.

--- a/packages/unified-selection/src/test/EnableUnifiedSelectionSyncWithIModel.test.ts
+++ b/packages/unified-selection/src/test/EnableUnifiedSelectionSyncWithIModel.test.ts
@@ -196,6 +196,7 @@ describe("IModelSelectionHandler", () => {
     const selectionStorageStub = {
       addToSelection: sinon.spy(),
       removeFromSelection: sinon.spy(),
+      replaceSelection: sinon.spy(),
       clearSelection: sinon.spy(),
       selectionChangeEvent: { addListener: () => () => {} },
     };
@@ -223,6 +224,7 @@ describe("IModelSelectionHandler", () => {
     afterEach(() => {
       selectionStorageStub.addToSelection.resetHistory();
       selectionStorageStub.clearSelection.resetHistory();
+      selectionStorageStub.replaceSelection.resetHistory();
       selectionStorageStub.removeFromSelection.resetHistory();
     });
 
@@ -284,10 +286,7 @@ describe("IModelSelectionHandler", () => {
       triggerSelectionChange({ type: CoreSelectionSetEventType.Remove, removed: removedKeys.map((k) => k.id), set: selectionSet });
 
       await waitFor(() => {
-        expect(selectionStorageStub.removeFromSelection.getCall(0).calledWith({ imodelKey: imodelAccess.key, source: "Tool", selectables: [removedKeys[0]] }))
-          .to.be.true;
-        expect(selectionStorageStub.removeFromSelection.getCall(1).calledWith({ imodelKey: imodelAccess.key, source: "Tool", selectables: [removedKeys[1]] }))
-          .to.be.true;
+        expect(selectionStorageStub.removeFromSelection.calledWith({ imodelKey: imodelAccess.key, source: "Tool", selectables: removedKeys })).to.be.true;
       });
     });
 
@@ -303,11 +302,7 @@ describe("IModelSelectionHandler", () => {
       });
 
       await waitFor(() => {
-        expect(selectionStorageStub.clearSelection).to.be.calledOnceWith({ imodelKey: imodelAccess.key, source: "Tool" });
-        expect(selectionStorageStub.addToSelection.getCall(0).calledWith({ imodelKey: imodelAccess.key, source: "Tool", selectables: [addedKeys[0]] })).to.be
-          .true;
-        expect(selectionStorageStub.addToSelection.getCall(1).calledWith({ imodelKey: imodelAccess.key, source: "Tool", selectables: [addedKeys[1]] })).to.be
-          .true;
+        expect(selectionStorageStub.replaceSelection.calledWith({ imodelKey: imodelAccess.key, source: "Tool", selectables: addedKeys })).to.be.true;
       });
     });
 

--- a/packages/unified-selection/src/unified-selection/EnableUnifiedSelectionSyncWithIModel.ts
+++ b/packages/unified-selection/src/unified-selection/EnableUnifiedSelectionSyncWithIModel.ts
@@ -242,19 +242,22 @@ export class IModelSelectionHandler {
   };
 
   private async handleIModelSelectionChange(type: CoreSelectionSetEventType, iterator: AsyncIterableIterator<SelectableInstanceKey>) {
-    if (type === CoreSelectionSetEventType.Remove) {
-      for await (const selectable of iterator) {
-        this._selectionStorage.removeFromSelection({ imodelKey: this._imodelAccess.key, source: this._selectionSourceName, selectables: [selectable] });
-      }
-      return;
-    }
-
-    if (type === CoreSelectionSetEventType.Replace) {
-      this._selectionStorage.clearSelection({ imodelKey: this._imodelAccess.key, source: this._selectionSourceName });
-    }
-
+    const selectables: SelectableInstanceKey[] = [];
     for await (const selectable of iterator) {
-      this._selectionStorage.addToSelection({ imodelKey: this._imodelAccess.key, source: this._selectionSourceName, selectables: [selectable] });
+      selectables.push(selectable);
+    }
+    const props = {
+      imodelKey: this._imodelAccess.key,
+      source: this._selectionSourceName,
+      selectables,
+    };
+    switch (type) {
+      case CoreSelectionSetEventType.Add:
+        return this._selectionStorage.addToSelection(props);
+      case CoreSelectionSetEventType.Remove:
+        return this._selectionStorage.removeFromSelection(props);
+      case CoreSelectionSetEventType.Replace:
+        return this._selectionStorage.replaceSelection(props);
     }
   }
 


### PR DESCRIPTION
Changed `handleIModelSelectionChange` to update selection storage with all changes at once instead of one by one as this improves performance and prevents storage from being unnecessarily cleaned when the same element is selected.