### PR TITLE
Update pipeline permissions

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -17,6 +17,8 @@ jobs:
     name: Release
     permissions:
       id-token: write
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The `changeset-release` pipeline requires some additional permissions when using `secrets.GITHUB_TOKEN`.