### PR TITLE
Hierarchies-react: use `TreeNode` `onClick` and `onKeyDown` callbacks

### DIFF
--- a/.changeset/stale-horses-grin.md
+++ b/.changeset/stale-horses-grin.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Switch to `onClick` and `onNodeKeyDown` callbacks provided by `TreeNode` in `TreeNodeRenderer`.

--- a/apps/test-app/frontend/package.json
+++ b/apps/test-app/frontend/package.json
@@ -32,7 +32,7 @@
     "@itwin/eslint-plugin": "^4.0.0",
     "@itwin/imodel-components-react": "^4.14.1",
     "@itwin/itwinui-icons-react": "^2.8.0",
-    "@itwin/itwinui-react": "^3.11.3",
+    "@itwin/itwinui-react": "^3.12.0",
     "@itwin/presentation-common": "^4.7.1",
     "@itwin/presentation-components": "workspace:*",
     "@itwin/presentation-core-interop": "workspace:*",

--- a/apps/test-app/frontend/package.json
+++ b/apps/test-app/frontend/package.json
@@ -32,7 +32,7 @@
     "@itwin/eslint-plugin": "^4.0.0",
     "@itwin/imodel-components-react": "^4.14.1",
     "@itwin/itwinui-icons-react": "^2.8.0",
-    "@itwin/itwinui-react": "^3.12.0",
+    "@itwin/itwinui-react": "^3.12.1",
     "@itwin/presentation-common": "^4.7.1",
     "@itwin/presentation-components": "workspace:*",
     "@itwin/presentation-core-interop": "workspace:*",

--- a/packages/hierarchies-react/package.json
+++ b/packages/hierarchies-react/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@itwin/build-tools": "^4.7.1",
-    "@itwin/itwinui-react": "^3.11.3",
+    "@itwin/itwinui-react": "^3.12.0",
     "@testing-library/dom": "^9.3.4",
     "@testing-library/react": "^14.3.1",
     "@testing-library/user-event": "^14.5.2",

--- a/packages/hierarchies-react/package.json
+++ b/packages/hierarchies-react/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@itwin/build-tools": "^4.7.1",
-    "@itwin/itwinui-react": "^3.12.0",
+    "@itwin/itwinui-react": "^3.12.1",
     "@testing-library/dom": "^9.3.4",
     "@testing-library/react": "^14.3.1",
     "@testing-library/user-event": "^14.5.2",

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -70,6 +70,7 @@ export function TreeNodeRenderer({
 }: TreeNodeRendererProps) {
   const { localizedStrings } = useLocalizationContext();
   const applyFilterButtonRef = useRef<HTMLButtonElement>(null);
+  const nodeRef = useRef<HTMLLIElement>(null);
 
   if ("type" in node && node.type === "ChildrenPlaceholder") {
     return <PlaceholderNode {...treeNodeProps} />;
@@ -77,63 +78,60 @@ export function TreeNodeRenderer({
 
   if (isPresentationHierarchyNode(node)) {
     return (
-      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-      <div
+      <TreeNode
+        {...treeNodeProps}
+        ref={nodeRef}
+        isSelected={isSelected}
+        isDisabled={isDisabled}
+        className={cx(treeNodeProps.className, "stateless-tree-node", { filtered: node.isFiltered })}
         onClick={(event) => !isDisabled && onNodeClick?.(node, !isSelected, event)}
         onKeyDown={(event) => {
           // Ignore if it is called on the element inside, e.g. checkbox or expander
-          if (!isDisabled && event.target instanceof HTMLElement && event.target.classList.contains("stateless-tree-node")) {
+          if (!isDisabled && event.target === nodeRef.current) {
             onNodeKeyDown?.(node, !isSelected, event);
           }
         }}
+        onExpanded={(_, isExpanded) => {
+          expandNode(node.id, isExpanded);
+        }}
+        icon={getIcon ? getIcon(node) : undefined}
+        label={getLabel ? getLabel(node) : node.label}
+        sublabel={getSublabel ? getSublabel(node) : undefined}
       >
-        <TreeNode
-          {...treeNodeProps}
-          isSelected={isSelected}
-          isDisabled={isDisabled}
-          className={cx(treeNodeProps.className, "stateless-tree-node", { filtered: node.isFiltered })}
-          onExpanded={(_, isExpanded) => {
-            expandNode(node.id, isExpanded);
-          }}
-          icon={getIcon ? getIcon(node) : undefined}
-          label={getLabel ? getLabel(node) : node.label}
-          sublabel={getSublabel ? getSublabel(node) : undefined}
-        >
-          <ButtonGroup className={cx("action-buttons", actionButtonsClassName)}>
-            {getHierarchyLevelDetails && node.isFiltered ? (
-              <IconButton
-                className="filtering-action-button"
-                styleType="borderless"
-                size="small"
-                title={localizedStrings.clearHierarchyLevelFilter}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  getHierarchyLevelDetails(node.id)?.setInstanceFilter(undefined);
-                  applyFilterButtonRef.current?.focus();
-                }}
-              >
-                <SvgRemove />
-              </IconButton>
-            ) : null}
-            {onFilterClick && node.isFilterable ? (
-              <IconButton
-                ref={applyFilterButtonRef}
-                className="filtering-action-button"
-                styleType="borderless"
-                size="small"
-                title={localizedStrings.filterHierarchyLevel}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  const hierarchyLevelDetails = getHierarchyLevelDetails?.(node.id);
-                  hierarchyLevelDetails && onFilterClick(hierarchyLevelDetails);
-                }}
-              >
-                {node.isFiltered ? <SvgFilter /> : <SvgFilterHollow />}
-              </IconButton>
-            ) : null}
-          </ButtonGroup>
-        </TreeNode>
-      </div>
+        <ButtonGroup className={cx("action-buttons", actionButtonsClassName)}>
+          {getHierarchyLevelDetails && node.isFiltered ? (
+            <IconButton
+              className="filtering-action-button"
+              styleType="borderless"
+              size="small"
+              title={localizedStrings.clearHierarchyLevelFilter}
+              onClick={(e) => {
+                e.stopPropagation();
+                getHierarchyLevelDetails(node.id)?.setInstanceFilter(undefined);
+                applyFilterButtonRef.current?.focus();
+              }}
+            >
+              <SvgRemove />
+            </IconButton>
+          ) : null}
+          {onFilterClick && node.isFilterable ? (
+            <IconButton
+              ref={applyFilterButtonRef}
+              className="filtering-action-button"
+              styleType="borderless"
+              size="small"
+              title={localizedStrings.filterHierarchyLevel}
+              onClick={(e) => {
+                e.stopPropagation();
+                const hierarchyLevelDetails = getHierarchyLevelDetails?.(node.id);
+                hierarchyLevelDetails && onFilterClick(hierarchyLevelDetails);
+              }}
+            >
+              {node.isFiltered ? <SvgFilter /> : <SvgFilterHollow />}
+            </IconButton>
+          ) : null}
+        </ButtonGroup>
+      </TreeNode>
     );
   }
 

--- a/packages/hierarchies-react/src/test/index.ts
+++ b/packages/hierarchies-react/src/test/index.ts
@@ -26,11 +26,6 @@ function getPaths(json: string) {
 // The following makes stubbing workspace package exports possible
 const originalCompile = (m as any).prototype._compile;
 (m as any).prototype._compile = function (content: any, filename: any) {
-  // skip itwinui-react meta.js file as it causes module to be re-declared
-  if (filename.includes("itwinui-react\\cjs\\utils\\meta.js")) {
-    return;
-  }
-
   // Obtain exports from the loaded script
   originalCompile.call(this, content, filename);
 

--- a/packages/hierarchies-react/src/test/index.ts
+++ b/packages/hierarchies-react/src/test/index.ts
@@ -26,6 +26,11 @@ function getPaths(json: string) {
 // The following makes stubbing workspace package exports possible
 const originalCompile = (m as any).prototype._compile;
 (m as any).prototype._compile = function (content: any, filename: any) {
+  // skip itwinui-react meta.js file as it causes module to be re-declared
+  if (filename.includes("itwinui-react\\cjs\\utils\\meta.js")) {
+    return;
+  }
+
   // Obtain exports from the loaded script
   originalCompile.call(this, content, filename);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -704,8 +704,8 @@ importers:
         specifier: ^2.8.0
         version: 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-react':
-        specifier: ^3.11.3
-        version: 3.11.3(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^3.12.0
+        version: 3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/presentation-common':
         specifier: ^4.7.1
         version: 4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-common@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1))(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/ecschema-metadata@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1)))
@@ -889,7 +889,7 @@ importers:
         version: 4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/components-react@4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@itwin/core-react@4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@itwin/core-bentley@4.7.1)(@itwin/core-common@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1))(@itwin/core-frontend@4.7.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@itwin/core-common@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1))(@itwin/core-geometry@4.7.1)(@itwin/core-orbitgt@4.7.1)(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1))(encoding@0.1.13)(inversify@6.0.2)(reflect-metadata@0.1.14))(@itwin/core-geometry@4.7.1)(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-react@4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-react':
         specifier: ^3.11.3
-        version: 3.11.3(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/presentation-common':
         specifier: ^4.7.1
         version: 4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-common@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1))(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/ecschema-metadata@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1)))
@@ -1215,8 +1215,8 @@ importers:
         specifier: ^4.7.1
         version: 4.7.1(@types/node@20.14.6)
       '@itwin/itwinui-react':
-        specifier: ^3.11.3
-        version: 3.11.3(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^3.12.0
+        version: 3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@testing-library/dom':
         specifier: ^9.3.4
         version: 9.3.4
@@ -2331,20 +2331,20 @@ packages:
   '@floating-ui/dom@1.6.5':
     resolution: {integrity: sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==}
 
-  '@floating-ui/react-dom@2.1.0':
-    resolution: {integrity: sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==}
+  '@floating-ui/react-dom@2.1.1':
+    resolution: {integrity: sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/react@0.26.17':
-    resolution: {integrity: sha512-ESD+jYWwqwVzaIgIhExrArdsCL1rOAzryG/Sjlu8yaD3Mtqi3uVyhbE2V7jD58Mo52qbzKz2eUY/Xgh5I86FCQ==}
+  '@floating-ui/react@0.26.19':
+    resolution: {integrity: sha512-Jk6zITdjjIvjO/VdQFvpRaD3qPwOHH6AoDHxjhpy+oK4KFgaSP871HYWUAPdnLmx1gQ+w/pB312co3tVml+BXA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/utils@0.2.2':
-    resolution: {integrity: sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw==}
+  '@floating-ui/utils@0.2.4':
+    resolution: {integrity: sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA==}
 
   '@grpc/grpc-js@1.10.9':
     resolution: {integrity: sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==}
@@ -2581,8 +2581,8 @@ packages:
       react: '>=16.8.6 < 19.0.0'
       react-dom: '>=16.8.6 < 19.0.0'
 
-  '@itwin/itwinui-react@3.11.3':
-    resolution: {integrity: sha512-DMdcKd95RtYG0OpBYzsEIcKQCzvcNTf6CsMlJL/j2S1bkCYhac9RHBjNzqIn1bSHlWTvHYEZAwpqdf1ssjfQQg==}
+  '@itwin/itwinui-react@3.12.0':
+    resolution: {integrity: sha512-zr13Q8GZPKCDCry0jf87Zmw2TYAaCWR1SMXzvSkFk7gj8mw3TM58eEmRrYmnRWU4wRhTPT4XfW4Y/6QUfBDy3w==}
     peerDependencies:
       react: '>= 17.0.0 < 19.0.0'
       react-dom: '>=17.0.0 < 19.0.0'
@@ -3414,6 +3414,9 @@ packages:
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
+  '@swc/helpers@0.5.11':
+    resolution: {integrity: sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==}
 
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -9827,28 +9830,28 @@ snapshots:
 
   '@floating-ui/core@1.6.2':
     dependencies:
-      '@floating-ui/utils': 0.2.2
+      '@floating-ui/utils': 0.2.4
 
   '@floating-ui/dom@1.6.5':
     dependencies:
       '@floating-ui/core': 1.6.2
-      '@floating-ui/utils': 0.2.2
+      '@floating-ui/utils': 0.2.4
 
-  '@floating-ui/react-dom@2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@floating-ui/react-dom@2.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/dom': 1.6.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@floating-ui/react@0.26.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@floating-ui/react@0.26.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@floating-ui/utils': 0.2.2
+      '@floating-ui/react-dom': 2.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/utils': 0.2.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tabbable: 6.2.0
 
-  '@floating-ui/utils@0.2.2': {}
+  '@floating-ui/utils@0.2.4': {}
 
   '@grpc/grpc-js@1.10.9':
     dependencies:
@@ -9934,7 +9937,7 @@ snapshots:
       '@itwin/imodel-components-react': 4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/components-react@4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@itwin/core-react@4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@itwin/core-bentley@4.7.1)(@itwin/core-common@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1))(@itwin/core-frontend@4.7.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@itwin/core-common@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1))(@itwin/core-geometry@4.7.1)(@itwin/core-orbitgt@4.7.1)(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1))(encoding@0.1.13)(inversify@6.0.2)(reflect-metadata@0.1.14))(@itwin/core-geometry@4.7.1)(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-react@4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@itwin/itwinui-react': 3.11.3(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@itwin/itwinui-react': 3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-react-v2': '@itwin/itwinui-react@2.12.26(react-dom@18.2.0(react@18.2.0))(react@18.2.0)'
       '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
@@ -10007,7 +10010,7 @@ snapshots:
       '@itwin/core-bentley': 4.7.1
       '@itwin/core-react': 4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@itwin/itwinui-react': 3.11.3(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@itwin/itwinui-react': 3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
       immer: 9.0.6
@@ -10148,7 +10151,7 @@ snapshots:
       '@itwin/appui-abstract': 4.7.1(@itwin/core-bentley@4.7.1)
       '@itwin/core-bentley': 4.7.1
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@itwin/itwinui-react': 3.11.3(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@itwin/itwinui-react': 3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
       dompurify: 2.5.5
@@ -10233,7 +10236,7 @@ snapshots:
       '@itwin/core-quantity': 4.7.1(@itwin/core-bentley@4.7.1)
       '@itwin/core-react': 4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@itwin/itwinui-react': 3.11.3(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@itwin/itwinui-react': 3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
       react: 18.2.0
@@ -10264,17 +10267,17 @@ snapshots:
       react-transition-group: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       tippy.js: 6.3.7
 
-  '@itwin/itwinui-react@3.11.3(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@itwin/itwinui-react@3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@floating-ui/react': 0.26.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/react': 0.26.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@swc/helpers': 0.5.11
       classnames: 2.5.1
       jotai: 2.8.3(@types/react@18.2.79)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-table: 7.8.0(react@18.2.0)
       react-transition-group: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      tslib: 2.6.3
     transitivePeerDependencies:
       - '@types/react'
 
@@ -11479,6 +11482,10 @@ snapshots:
       tslib: 2.6.3
 
   '@socket.io/component-emitter@3.1.2': {}
+
+  '@swc/helpers@0.5.11':
+    dependencies:
+      tslib: 2.6.3
 
   '@szmarczak/http-timer@4.0.6':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -704,8 +704,8 @@ importers:
         specifier: ^2.8.0
         version: 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-react':
-        specifier: ^3.12.0
-        version: 3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^3.12.1
+        version: 3.12.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/presentation-common':
         specifier: ^4.7.1
         version: 4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-common@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1))(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/ecschema-metadata@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1)))
@@ -889,7 +889,7 @@ importers:
         version: 4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/components-react@4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@itwin/core-react@4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@itwin/core-bentley@4.7.1)(@itwin/core-common@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1))(@itwin/core-frontend@4.7.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@itwin/core-common@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1))(@itwin/core-geometry@4.7.1)(@itwin/core-orbitgt@4.7.1)(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1))(encoding@0.1.13)(inversify@6.0.2)(reflect-metadata@0.1.14))(@itwin/core-geometry@4.7.1)(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-react@4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-react':
         specifier: ^3.11.3
-        version: 3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 3.12.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/presentation-common':
         specifier: ^4.7.1
         version: 4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-common@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1))(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/ecschema-metadata@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1)))
@@ -1215,8 +1215,8 @@ importers:
         specifier: ^4.7.1
         version: 4.7.1(@types/node@20.14.6)
       '@itwin/itwinui-react':
-        specifier: ^3.12.0
-        version: 3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^3.12.1
+        version: 3.12.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@testing-library/dom':
         specifier: ^9.3.4
         version: 9.3.4
@@ -2581,8 +2581,8 @@ packages:
       react: '>=16.8.6 < 19.0.0'
       react-dom: '>=16.8.6 < 19.0.0'
 
-  '@itwin/itwinui-react@3.12.0':
-    resolution: {integrity: sha512-zr13Q8GZPKCDCry0jf87Zmw2TYAaCWR1SMXzvSkFk7gj8mw3TM58eEmRrYmnRWU4wRhTPT4XfW4Y/6QUfBDy3w==}
+  '@itwin/itwinui-react@3.12.1':
+    resolution: {integrity: sha512-aTwMVNtKEgzwdVhPg4o4Hvyb7eWfwf1+lQL/fLn9c1p0esrcXhiCzcAxRrotG/2H+UP5e4W6wnGMbSQOKFNkmA==}
     peerDependencies:
       react: '>= 17.0.0 < 19.0.0'
       react-dom: '>=17.0.0 < 19.0.0'
@@ -9937,7 +9937,7 @@ snapshots:
       '@itwin/imodel-components-react': 4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/components-react@4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@itwin/core-react@4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@itwin/core-bentley@4.7.1)(@itwin/core-common@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1))(@itwin/core-frontend@4.7.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@itwin/core-common@4.7.1(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1))(@itwin/core-geometry@4.7.1)(@itwin/core-orbitgt@4.7.1)(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1))(encoding@0.1.13)(inversify@6.0.2)(reflect-metadata@0.1.14))(@itwin/core-geometry@4.7.1)(@itwin/core-quantity@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-react@4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@itwin/itwinui-react': 3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@itwin/itwinui-react': 3.12.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-react-v2': '@itwin/itwinui-react@2.12.26(react-dom@18.2.0(react@18.2.0))(react@18.2.0)'
       '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
@@ -10010,7 +10010,7 @@ snapshots:
       '@itwin/core-bentley': 4.7.1
       '@itwin/core-react': 4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@itwin/itwinui-react': 3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@itwin/itwinui-react': 3.12.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
       immer: 9.0.6
@@ -10151,7 +10151,7 @@ snapshots:
       '@itwin/appui-abstract': 4.7.1(@itwin/core-bentley@4.7.1)
       '@itwin/core-bentley': 4.7.1
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@itwin/itwinui-react': 3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@itwin/itwinui-react': 3.12.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
       dompurify: 2.5.5
@@ -10236,7 +10236,7 @@ snapshots:
       '@itwin/core-quantity': 4.7.1(@itwin/core-bentley@4.7.1)
       '@itwin/core-react': 4.14.1(@itwin/appui-abstract@4.7.1(@itwin/core-bentley@4.7.1))(@itwin/core-bentley@4.7.1)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@itwin/itwinui-react': 3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@itwin/itwinui-react': 3.12.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
       react: 18.2.0
@@ -10267,7 +10267,7 @@ snapshots:
       react-transition-group: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       tippy.js: 6.3.7
 
-  '@itwin/itwinui-react@3.12.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@itwin/itwinui-react@3.12.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/react': 0.26.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)


### PR DESCRIPTION
`TreeNode` now provides proper `onClick` and `onKeyDown` so wrapping the node is no longer necessary.