### PR TITLE
Revert token for non PR benchmark pipelines

### DIFF
--- a/.github/workflows/benchmark-hierarchies.yml
+++ b/.github/workflows/benchmark-hierarchies.yml
@@ -70,6 +70,6 @@ jobs:
           tool: 'customSmallerIsBetter'
           output-file-path: ./apps/performance-tests/hierarchies-benchmark.json
           # Access token to deploy GitHub Pages branch
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.IMJS_ADMIN_GH_TOKEN }}
           # Push and deploy GitHub pages branch automatically
           auto-push: true

--- a/.github/workflows/benchmark-unified-selection.yml
+++ b/.github/workflows/benchmark-unified-selection.yml
@@ -68,6 +68,6 @@ jobs:
           tool: 'customSmallerIsBetter'
           output-file-path: ./apps/performance-tests/unified-selection-benchmark.json
           # Access token to deploy GitHub Pages branch
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.IMJS_ADMIN_GH_TOKEN }}
           # Push and deploy GitHub pages branch automatically
           auto-push: true


### PR DESCRIPTION
Reverting https://github.com/iTwin/presentation/pull/658 for `benchmark-unified-selection.yml` and `benchmark-hierarchies.yml` due to failures when trying to push benchmark results.