### PR TITLE
Hierarchies: Allow disabling expansion to filter targets

### DIFF
--- a/.changeset/chilly-eagles-know.md
+++ b/.changeset/chilly-eagles-know.md
@@ -2,4 +2,26 @@
 "@itwin/presentation-hierarchies": minor
 ---
 
-`createHierarchyProvider`: Added ability to specify whether hierarchy should be expanded to filtering path target, when specifying the `filtering.paths` prop. With this change, hierarchy is no longer expanded to `filtering.paths` targets by default.
+`createHierarchyProvider`: Added ability to specify whether hierarchy should be expanded to filtering path target, when specifying the `filtering.paths` prop.
+
+With this change, hierarchy is no longer expanded to filter targets by default. To achieve the same behavior, paths with `autoExpand` option should be provided:
+
+_Before:_
+
+```tsx
+const hierarchyProvider = createHierarchyProvider({
+  imodelAccess,
+  hierarchyDefinition: createHierarchyDefinition(imodelAccess),
+  filtering: { paths: filterPaths },
+});
+```
+
+_Now:_
+
+```tsx
+const hierarchyProvider = createHierarchyProvider({
+  imodelAccess,
+  hierarchyDefinition: createHierarchyDefinition(imodelAccess),
+  filtering: { paths: filterPaths.map((path) => ({ path, options: { autoExpand: true } })) },
+});
+```

--- a/.changeset/chilly-eagles-know.md
+++ b/.changeset/chilly-eagles-know.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-hierarchies": minor
 ---
 
-Added ability to specify whether hierarchy should be expanded to filtering path target when passed to `HierarchyProvider`.
+`createHierarchyProvider`: Added ability to specify whether hierarchy should be expanded to filtering path target, when specifying the `filtering.paths` prop.

--- a/.changeset/chilly-eagles-know.md
+++ b/.changeset/chilly-eagles-know.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies": minor
+---
+
+Added ability to specify whether hierarchy should be expanded to filtering path target when passed to `HierarchyProvider`.

--- a/.changeset/chilly-eagles-know.md
+++ b/.changeset/chilly-eagles-know.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-hierarchies": minor
 ---
 
-`createHierarchyProvider`: Added ability to specify whether hierarchy should be expanded to filtering path target, when specifying the `filtering.paths` prop.
+`createHierarchyProvider`: Added ability to specify whether hierarchy should be expanded to filtering path target, when specifying the `filtering.paths` prop. With this change, hierarchy is no longer expanded to `filtering.paths` targets by default.

--- a/.changeset/dirty-dogs-run.md
+++ b/.changeset/dirty-dogs-run.md
@@ -3,3 +3,21 @@
 ---
 
 `useTree` and `useUnifiedSelectionTree`: Extended return type of `getFilteredPaths` prop to allow specifying whether hierarchy should be expanded to filtering path target.
+
+With this change, hierarchy is no longer expanded to filter targets by default. To achieve the same behavior, paths with `autoExpand` option should be returned:
+
+_Before:_
+
+```tsx
+async function getFilteredPaths(): Promise<HierarchyNodeIdentifiersPath[]> {
+  return paths;
+}
+```
+
+_Now:_
+
+```tsx
+async function getFilteredPaths(): Promise<Array<{ path: HierarchyNodeIdentifiersPath; options?: { autoExpand?: boolean }>> {
+  return paths.map((path) => ({ path, options: { autoExpand: true } }));
+}
+```

--- a/.changeset/dirty-dogs-run.md
+++ b/.changeset/dirty-dogs-run.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": minor
+---
+
+Updated `getFilteredPaths` in `useTree` to allow specifying whether hierarchy should be expanded to filtering path target.

--- a/.changeset/dirty-dogs-run.md
+++ b/.changeset/dirty-dogs-run.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-hierarchies-react": minor
 ---
 
-Updated `getFilteredPaths` in `useTree` to allow specifying whether hierarchy should be expanded to filtering path target.
+`useTree` and `useUnifiedSelectionTree`: Extended return type of `getFilteredPaths` prop to allow specifying whether hierarchy should be expanded to filtering path target.

--- a/apps/full-stack-tests/src/hierarchies/HierarchyFiltering.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchyFiltering.test.ts
@@ -94,7 +94,11 @@ describe("Hierarchies", () => {
         };
 
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy, filteredNodePaths: [[keys.rootSubject, { key: "custom" }, keys.childSubject2]] }),
+          provider: createProvider({
+            imodel,
+            hierarchy,
+            filteredNodePaths: [{ path: [keys.rootSubject, { key: "custom" }, keys.childSubject2], options: { autoExpand: true } }],
+          }),
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -167,7 +171,7 @@ describe("Hierarchies", () => {
         };
 
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy, filteredNodePaths: [[keys.rootSubject, { key: "custom2" }]] }),
+          provider: createProvider({ imodel, hierarchy, filteredNodePaths: [{ path: [keys.rootSubject, { key: "custom2" }], options: { autoExpand: true } }] }),
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -254,7 +258,11 @@ describe("Hierarchies", () => {
         };
 
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy, filteredNodePaths: [[keys.rootSubject, { key: "custom" }, keys.childSubject2]] }),
+          provider: createProvider({
+            imodel,
+            hierarchy,
+            filteredNodePaths: [{ path: [keys.rootSubject, { key: "custom" }, keys.childSubject2], options: { autoExpand: true } }],
+          }),
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -509,7 +517,14 @@ describe("Hierarchies", () => {
             };
 
             await validateHierarchy({
-              provider: createProvider({ imodel, hierarchy, filteredNodePaths: [[x], [x, y]] }),
+              provider: createProvider({
+                imodel,
+                hierarchy,
+                filteredNodePaths: [
+                  { path: [x], options: { autoExpand: true } },
+                  { path: [x, y], options: { autoExpand: true } },
+                ],
+              }),
               expect: [
                 NodeValidators.createForInstanceNode({
                   instanceKeys: [x],
@@ -591,7 +606,14 @@ describe("Hierarchies", () => {
             };
 
             await validateHierarchy({
-              provider: createProvider({ imodel, hierarchy, filteredNodePaths: [[x], [x, y1]] }),
+              provider: createProvider({
+                imodel,
+                hierarchy,
+                filteredNodePaths: [
+                  { path: [x], options: { autoExpand: true } },
+                  { path: [x, y1], options: { autoExpand: true } },
+                ],
+              }),
               expect: [
                 NodeValidators.createForInstanceNode({
                   instanceKeys: [x],

--- a/apps/full-stack-tests/src/hierarchies/Utils.ts
+++ b/apps/full-stack-tests/src/hierarchies/Utils.ts
@@ -8,8 +8,11 @@ import { IModelConnection } from "@itwin/core-frontend";
 import { Schema, SchemaContext, SchemaInfo, SchemaKey, SchemaMatchType } from "@itwin/ecschema-metadata";
 import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
 import { createECSchemaProvider as createECSchemaProviderInterop, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
-import { createHierarchyProvider, createLimitingECSqlQueryExecutor, HierarchyDefinition, HierarchyNodeIdentifiersPath } from "@itwin/presentation-hierarchies";
+import { createHierarchyProvider, createLimitingECSqlQueryExecutor, HierarchyDefinition, HierarchyNode } from "@itwin/presentation-hierarchies";
 import { createCachingECClassHierarchyInspector, IPrimitiveValueFormatter, parseFullClassName } from "@itwin/presentation-shared";
+
+type HierarchyNodeFiltering = Required<HierarchyNode>["filtering"];
+type HierarchyFilteringPaths = Required<HierarchyNodeFiltering>["filteredChildrenIdentifierPaths"];
 
 export function createSchemaContext(imodel: IModelConnection | IModelDb | ECDb) {
   const schemas = new SchemaContext();
@@ -55,7 +58,7 @@ export function createProvider(props: {
   hierarchy: HierarchyDefinition;
   formatterFactory?: (schemas: SchemaContext) => IPrimitiveValueFormatter;
   localizedStrings?: Parameters<typeof createHierarchyProvider>[0]["localizedStrings"];
-  filteredNodePaths?: HierarchyNodeIdentifiersPath[];
+  filteredNodePaths?: HierarchyFilteringPaths;
   queryCacheSize?: number;
 }) {
   const { imodel, hierarchy, formatterFactory, localizedStrings, filteredNodePaths, queryCacheSize } = props;

--- a/apps/full-stack-tests/src/hierarchies/Utils.ts
+++ b/apps/full-stack-tests/src/hierarchies/Utils.ts
@@ -8,11 +8,11 @@ import { IModelConnection } from "@itwin/core-frontend";
 import { Schema, SchemaContext, SchemaInfo, SchemaKey, SchemaMatchType } from "@itwin/ecschema-metadata";
 import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
 import { createECSchemaProvider as createECSchemaProviderInterop, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
-import { createHierarchyProvider, createLimitingECSqlQueryExecutor, HierarchyDefinition, HierarchyNode } from "@itwin/presentation-hierarchies";
+import { createHierarchyProvider, createLimitingECSqlQueryExecutor, HierarchyDefinition } from "@itwin/presentation-hierarchies";
 import { createCachingECClassHierarchyInspector, IPrimitiveValueFormatter, parseFullClassName } from "@itwin/presentation-shared";
 
-type HierarchyNodeFiltering = Required<HierarchyNode>["filtering"];
-type HierarchyFilteringPaths = Required<HierarchyNodeFiltering>["filteredChildrenIdentifierPaths"];
+type HierarchyProviderProps = Parameters<typeof createHierarchyProvider>[0];
+type HierarchyFilteringPaths = NonNullable<NonNullable<HierarchyProviderProps["filtering"]>["paths"]>;
 
 export function createSchemaContext(imodel: IModelConnection | IModelDb | ECDb) {
   const schemas = new SchemaContext();

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -13,7 +13,6 @@ import { ECSchemaProvider } from '@itwin/presentation-shared';
 import { GenericInstanceFilter } from '@itwin/presentation-hierarchies';
 import { HierarchyDefinition } from '@itwin/presentation-hierarchies';
 import { HierarchyNode } from '@itwin/presentation-hierarchies';
-import { HierarchyNodeIdentifiersPath } from '@itwin/presentation-hierarchies';
 import { HierarchyProvider } from '@itwin/presentation-hierarchies';
 import { InstanceKey } from '@itwin/presentation-shared';
 import { IPrimitiveValueFormatter } from '@itwin/presentation-shared';
@@ -28,6 +27,9 @@ import { TreeNode } from '@itwin/itwinui-react';
 
 // @beta
 export function createRenderedTreeNodeData(node: RenderedTreeNode, isNodeSelected: (nodeId: string) => boolean): NodeData<RenderedTreeNode>;
+
+// @beta (undocumented)
+type FilteredPaths = Required<HierarchyNodeFiltering>["filteredChildrenIdentifierPaths"];
 
 // @beta
 type FullTreeReloadOptions = {
@@ -55,6 +57,9 @@ export interface HierarchyLevelDetails {
 }
 
 export { HierarchyNode }
+
+// @beta (undocumented)
+type HierarchyNodeFiltering = Required<HierarchyNode>["filtering"];
 
 export { HierarchyProvider }
 
@@ -242,7 +247,7 @@ export function useTree(props: UseTreeProps): UseTreeResult;
 
 // @beta (undocumented)
 interface UseTreeProps extends Pick<Parameters<typeof createHierarchyProvider>[0], "localizedStrings"> {
-    getFilteredPaths?: (props: GetFilteredPathsProps) => Promise<HierarchyNodeIdentifiersPath[] | undefined>;
+    getFilteredPaths?: (props: GetFilteredPathsProps) => Promise<FilteredPaths | undefined>;
     getHierarchyDefinition: (props: {
         imodelAccess: IModelAccess;
     }) => HierarchyDefinition;

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -28,9 +28,6 @@ import { TreeNode } from '@itwin/itwinui-react';
 // @beta
 export function createRenderedTreeNodeData(node: RenderedTreeNode, isNodeSelected: (nodeId: string) => boolean): NodeData<RenderedTreeNode>;
 
-// @beta (undocumented)
-type FilteredPaths = Required<HierarchyNodeFiltering>["filteredChildrenIdentifierPaths"];
-
 // @beta
 type FullTreeReloadOptions = {
     dataSourceChanged?: true;
@@ -42,6 +39,9 @@ export { GenericInstanceFilter }
 interface GetFilteredPathsProps {
     imodelAccess: IModelAccess;
 }
+
+// @beta (undocumented)
+type HierarchyFilteringPaths = NonNullable<NonNullable<HierarchyProviderProps["filtering"]>["paths"]>;
 
 // @beta
 export interface HierarchyLevelDetails {
@@ -58,10 +58,10 @@ export interface HierarchyLevelDetails {
 
 export { HierarchyNode }
 
-// @beta (undocumented)
-type HierarchyNodeFiltering = Required<HierarchyNode>["filtering"];
-
 export { HierarchyProvider }
+
+// @beta (undocumented)
+type HierarchyProviderProps = Parameters<typeof createHierarchyProvider>[0];
 
 // @beta (undocumented)
 type IModelAccess = ECSchemaProvider & LimitingECSqlQueryExecutor & ECClassHierarchyInspector;
@@ -246,8 +246,8 @@ interface UseSelectionHandlerResult {
 export function useTree(props: UseTreeProps): UseTreeResult;
 
 // @beta (undocumented)
-interface UseTreeProps extends Pick<Parameters<typeof createHierarchyProvider>[0], "localizedStrings"> {
-    getFilteredPaths?: (props: GetFilteredPathsProps) => Promise<FilteredPaths | undefined>;
+interface UseTreeProps extends Pick<HierarchyProviderProps, "localizedStrings"> {
+    getFilteredPaths?: (props: GetFilteredPathsProps) => Promise<HierarchyFilteringPaths | undefined>;
     getHierarchyDefinition: (props: {
         imodelAccess: IModelAccess;
     }) => HierarchyDefinition;

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
@@ -9,7 +9,6 @@ import {
   GenericInstanceFilter,
   HierarchyDefinition,
   HierarchyNode,
-  HierarchyNodeIdentifiersPath,
   HierarchyProvider,
   LimitingECSqlQueryExecutor,
 } from "@itwin/presentation-hierarchies";
@@ -88,6 +87,9 @@ interface GetFilteredPathsProps {
   imodelAccess: IModelAccess;
 }
 
+type HierarchyNodeFiltering = Required<HierarchyNode>["filtering"];
+type FilteredPaths = Required<HierarchyNodeFiltering>["filteredChildrenIdentifierPaths"];
+
 /** @beta */
 interface UseTreeProps extends Pick<Parameters<typeof createHierarchyProvider>[0], "localizedStrings"> {
   /** Object that provides access to the iModel schema and can run queries against the iModel. */
@@ -95,7 +97,7 @@ interface UseTreeProps extends Pick<Parameters<typeof createHierarchyProvider>[0
   /** Provides the hierarchy definition for the tree. */
   getHierarchyDefinition: (props: { imodelAccess: IModelAccess }) => HierarchyDefinition;
   /** Provides paths to filtered nodes. */
-  getFilteredPaths?: (props: GetFilteredPathsProps) => Promise<HierarchyNodeIdentifiersPath[] | undefined>;
+  getFilteredPaths?: (props: GetFilteredPathsProps) => Promise<FilteredPaths | undefined>;
   /**
    * Callback that is called just after a certain action is finished.
    * Can be used for performance tracking.
@@ -224,7 +226,7 @@ function useTreeInternal({
       setHierarchySource({ hierarchyProvider: provider, isFiltering: false });
     };
 
-    const createProvider = (paths: HierarchyNodeIdentifiersPath[] | undefined) => {
+    const createProvider = (paths: FilteredPaths | undefined) => {
       return createHierarchyProvider({
         imodelAccess,
         hierarchyDefinition: getHierarchyDefinition({ imodelAccess }),

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
@@ -88,16 +88,19 @@ interface GetFilteredPathsProps {
 }
 
 /** @beta */
+type HierarchyProviderProps = Parameters<typeof createHierarchyProvider>[0];
+
+/** @beta */
 type HierarchyFilteringPaths = NonNullable<NonNullable<HierarchyProviderProps["filtering"]>["paths"]>;
 
 /** @beta */
-interface UseTreeProps extends Pick<Parameters<typeof createHierarchyProvider>[0], "localizedStrings"> {
+interface UseTreeProps extends Pick<HierarchyProviderProps, "localizedStrings"> {
   /** Object that provides access to the iModel schema and can run queries against the iModel. */
   imodelAccess: ECSchemaProvider & LimitingECSqlQueryExecutor & ECClassHierarchyInspector;
   /** Provides the hierarchy definition for the tree. */
   getHierarchyDefinition: (props: { imodelAccess: IModelAccess }) => HierarchyDefinition;
   /** Provides paths to filtered nodes. */
-  getFilteredPaths?: (props: GetFilteredPathsProps) => Promise<FilteredPaths | undefined>;
+  getFilteredPaths?: (props: GetFilteredPathsProps) => Promise<HierarchyFilteringPaths | undefined>;
   /**
    * Callback that is called just after a certain action is finished.
    * Can be used for performance tracking.
@@ -226,7 +229,7 @@ function useTreeInternal({
       setHierarchySource({ hierarchyProvider: provider, isFiltering: false });
     };
 
-    const createProvider = (paths: FilteredPaths | undefined) => {
+    const createProvider = (paths: HierarchyFilteringPaths | undefined) => {
       return createHierarchyProvider({
         imodelAccess,
         hierarchyDefinition: getHierarchyDefinition({ imodelAccess }),

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
@@ -88,10 +88,7 @@ interface GetFilteredPathsProps {
 }
 
 /** @beta */
-type HierarchyNodeFiltering = Required<HierarchyNode>["filtering"];
-
-/** @beta */
-type FilteredPaths = Required<HierarchyNodeFiltering>["filteredChildrenIdentifierPaths"];
+type HierarchyFilteringPaths = NonNullable<NonNullable<HierarchyProviderProps["filtering"]>["paths"]>;
 
 /** @beta */
 interface UseTreeProps extends Pick<Parameters<typeof createHierarchyProvider>[0], "localizedStrings"> {

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
@@ -87,7 +87,10 @@ interface GetFilteredPathsProps {
   imodelAccess: IModelAccess;
 }
 
+/** @beta */
 type HierarchyNodeFiltering = Required<HierarchyNode>["filtering"];
+
+/** @beta */
 type FilteredPaths = Required<HierarchyNodeFiltering>["filteredChildrenIdentifierPaths"];
 
 /** @beta */

--- a/packages/hierarchies-react/src/test/UseTree.test.tsx
+++ b/packages/hierarchies-react/src/test/UseTree.test.tsx
@@ -9,6 +9,7 @@ import { PropsWithChildren } from "react";
 import { act } from "react-dom/test-utils";
 import sinon from "sinon";
 import * as hierarchiesModule from "@itwin/presentation-hierarchies";
+import { FilteringPath } from "@itwin/presentation-hierarchies/lib/cjs/hierarchies/HierarchyProvider";
 import { IPrimitiveValueFormatter } from "@itwin/presentation-shared";
 import { createStorage, Selectables, StorageSelectionChangeEventArgs, StorageSelectionChangesListener } from "@itwin/unified-selection";
 import { createNodeId } from "../presentation-hierarchies-react/internal/Utils";
@@ -105,7 +106,7 @@ describe("useTree", () => {
       return createAsyncIterator(props.parentNode === undefined ? [createTestHierarchyNode({ id: "root-1" })] : []);
     });
 
-    const promise = new ResolvablePromise<hierarchiesModule.HierarchyNodeIdentifiersPath[] | undefined>();
+    const promise = new ResolvablePromise<FilteringPath[] | undefined>();
     const getFilteredPaths = async () => promise;
 
     const { result } = renderHook(useTree, { initialProps: { ...initialProps, getFilteredPaths } });

--- a/packages/hierarchies-react/src/test/UseTree.test.tsx
+++ b/packages/hierarchies-react/src/test/UseTree.test.tsx
@@ -9,7 +9,6 @@ import { PropsWithChildren } from "react";
 import { act } from "react-dom/test-utils";
 import sinon from "sinon";
 import * as hierarchiesModule from "@itwin/presentation-hierarchies";
-import { FilteringPath } from "@itwin/presentation-hierarchies/lib/cjs/hierarchies/HierarchyProvider";
 import { IPrimitiveValueFormatter } from "@itwin/presentation-shared";
 import { createStorage, Selectables, StorageSelectionChangeEventArgs, StorageSelectionChangesListener } from "@itwin/unified-selection";
 import { createNodeId } from "../presentation-hierarchies-react/internal/Utils";
@@ -38,6 +37,7 @@ describe("useTree", () => {
   const onHierarchyLoadErrorStub = sinon.stub();
 
   type UseTreeProps = Parameters<typeof useTree>[0];
+  type FilteredPaths = ReturnType<Required<UseTreeProps>["getFilteredPaths"]>;
   const initialProps: UseTreeProps = {
     imodelAccess: {} as UseTreeProps["imodelAccess"],
     getHierarchyDefinition: () => ({}) as hierarchiesModule.HierarchyDefinition,
@@ -106,7 +106,7 @@ describe("useTree", () => {
       return createAsyncIterator(props.parentNode === undefined ? [createTestHierarchyNode({ id: "root-1" })] : []);
     });
 
-    const promise = new ResolvablePromise<FilteringPath[] | undefined>();
+    const promise = new ResolvablePromise<FilteredPaths | undefined>();
     const getFilteredPaths = async () => promise;
 
     const { result } = renderHook(useTree, { initialProps: { ...initialProps, getFilteredPaths } });

--- a/packages/hierarchies/api/presentation-hierarchies.api.md
+++ b/packages/hierarchies/api/presentation-hierarchies.api.md
@@ -28,7 +28,7 @@ interface BaseHierarchyNode {
     filtering?: {
         isFilterTarget?: boolean;
         hasFilterTargetAncestor?: boolean;
-        filteredChildrenIdentifierPaths?: FilteringPath[];
+        filteredChildrenIdentifierPaths?: HierarchyFilteringPath[];
     };
     label: string;
     parentKeys: HierarchyNodeKey[];
@@ -179,14 +179,6 @@ interface ECSqlValueSelector {
     selector: string;
 }
 
-// @beta
-type FilteringPath = HierarchyNodeIdentifiersPath | {
-    path: HierarchyNodeIdentifiersPath;
-    options?: {
-        autoExpand?: boolean;
-    };
-};
-
 export { GenericInstanceFilter }
 
 // @beta
@@ -220,6 +212,14 @@ export interface HierarchyDefinition {
 
 // @beta
 type HierarchyDefinitionParentNode = Omit<NonGroupingHierarchyNode, "children">;
+
+// @beta
+type HierarchyFilteringPath = HierarchyNodeIdentifiersPath | {
+    path: HierarchyNodeIdentifiersPath;
+    options?: {
+        autoExpand?: boolean;
+    };
+};
 
 // @beta
 export type HierarchyLevelDefinition = HierarchyNodesDefinition[];
@@ -425,7 +425,7 @@ interface HierarchyProviderLocalizedStrings {
 // @beta
 interface HierarchyProviderProps {
     filtering?: {
-        paths: FilteringPath[];
+        paths: HierarchyFilteringPath[];
     };
     formatter?: IPrimitiveValueFormatter;
     hierarchyDefinition: HierarchyDefinition;

--- a/packages/hierarchies/api/presentation-hierarchies.api.md
+++ b/packages/hierarchies/api/presentation-hierarchies.api.md
@@ -28,7 +28,7 @@ interface BaseHierarchyNode {
     filtering?: {
         isFilterTarget?: boolean;
         hasFilterTargetAncestor?: boolean;
-        filteredChildrenIdentifierPaths?: HierarchyNodeIdentifiersPath[];
+        filteredChildrenIdentifierPaths?: FilteringPath[];
     };
     label: string;
     parentKeys: HierarchyNodeKey[];
@@ -178,6 +178,14 @@ interface ECSqlValueSelector {
     // (undocumented)
     selector: string;
 }
+
+// @beta
+type FilteringPath = HierarchyNodeIdentifiersPath | {
+    path: HierarchyNodeIdentifiersPath;
+    options?: {
+        autoExpand?: boolean;
+    };
+};
 
 export { GenericInstanceFilter }
 
@@ -417,7 +425,7 @@ interface HierarchyProviderLocalizedStrings {
 // @beta
 interface HierarchyProviderProps {
     filtering?: {
-        paths: HierarchyNodeIdentifiersPath[];
+        paths: FilteringPath[];
     };
     formatter?: IPrimitiveValueFormatter;
     hierarchyDefinition: HierarchyDefinition;

--- a/packages/hierarchies/src/hierarchies/HierarchyNode.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyNode.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ConcatenatedValue, InstanceKey, OmitOverUnion, PrimitiveValue } from "@itwin/presentation-shared";
-import { HierarchyNodeIdentifiersPath } from "./HierarchyNodeIdentifier";
 import {
   ClassGroupingNodeKey,
   GroupingNodeKey,
@@ -17,9 +16,10 @@ import {
   PropertyValueRangeGroupingNodeKey,
   StandardHierarchyNodeKey,
 } from "./HierarchyNodeKey";
+import { FilteringPath } from "./HierarchyProvider";
 
 /**
- * A data structure that represents a single non-grouping hierarchy node.
+ * A data structure that defines attributes that are common to all types of hierarchy nodes.
  * @beta
  */
 interface BaseHierarchyNode {
@@ -37,7 +37,7 @@ interface BaseHierarchyNode {
   filtering?: {
     isFilterTarget?: boolean;
     hasFilterTargetAncestor?: boolean;
-    filteredChildrenIdentifierPaths?: HierarchyNodeIdentifiersPath[];
+    filteredChildrenIdentifierPaths?: FilteringPath[];
   };
 }
 

--- a/packages/hierarchies/src/hierarchies/HierarchyNode.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyNode.ts
@@ -16,7 +16,7 @@ import {
   PropertyValueRangeGroupingNodeKey,
   StandardHierarchyNodeKey,
 } from "./HierarchyNodeKey";
-import { FilteringPath } from "./HierarchyProvider";
+import { HierarchyFilteringPath } from "./HierarchyProvider";
 
 /**
  * A data structure that defines attributes that are common to all types of hierarchy nodes.
@@ -37,7 +37,7 @@ interface BaseHierarchyNode {
   filtering?: {
     isFilterTarget?: boolean;
     hasFilterTargetAncestor?: boolean;
-    filteredChildrenIdentifierPaths?: FilteringPath[];
+    filteredChildrenIdentifierPaths?: HierarchyFilteringPath[];
   };
 }
 

--- a/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
@@ -137,6 +137,12 @@ interface HierarchyProviderLocalizedStrings {
 }
 
 /**
+ * A path of hierarchy node identifiers for filtering the hierarchy with additional options.
+ * @beta
+ */
+export type FilteringPath = HierarchyNodeIdentifiersPath | { path: HierarchyNodeIdentifiersPath; options?: { autoExpand?: boolean } };
+
+/**
  * Props for `createHierarchyProvider`.
  * @beta
  */
@@ -176,7 +182,7 @@ interface HierarchyProviderProps {
   /** Props for filtering the hierarchy. */
   filtering?: {
     /** A list of node identifiers from root to target node. */
-    paths: HierarchyNodeIdentifiersPath[];
+    paths: FilteringPath[];
   };
 }
 

--- a/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
@@ -140,7 +140,7 @@ interface HierarchyProviderLocalizedStrings {
  * A path of hierarchy node identifiers for filtering the hierarchy with additional options.
  * @beta
  */
-export type FilteringPath = HierarchyNodeIdentifiersPath | { path: HierarchyNodeIdentifiersPath; options?: { autoExpand?: boolean } };
+export type HierarchyFilteringPath = HierarchyNodeIdentifiersPath | { path: HierarchyNodeIdentifiersPath; options?: { autoExpand?: boolean } };
 
 /**
  * Props for `createHierarchyProvider`.
@@ -182,7 +182,7 @@ interface HierarchyProviderProps {
   /** Props for filtering the hierarchy. */
   filtering?: {
     /** A list of node identifiers from root to target node. */
-    paths: FilteringPath[];
+    paths: HierarchyFilteringPath[];
   };
 }
 

--- a/packages/hierarchies/src/hierarchies/internal/FilteringHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/internal/FilteringHierarchyDefinition.ts
@@ -150,10 +150,7 @@ async function matchFilters<
   TDefinition = TIdentifier extends InstanceKey ? InstanceNodesQueryDefinition : CustomHierarchyNodeDefinition,
 >(
   definition: TDefinition,
-  filteringProps: {
-    filteredNodePaths: FilteringPath[];
-    isDirectParentFilterTarget?: boolean;
-  },
+  filteringProps: { filteredNodePaths: FilteringPath[]; isDirectParentFilterTarget?: boolean },
   predicate: (id: HierarchyNodeIdentifier) => Promise<boolean>,
   classHierarchy: ECClassHierarchyInspector,
   matchedDefinitionProcessor: (

--- a/packages/hierarchies/src/hierarchies/internal/FilteringHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/internal/FilteringHierarchyDefinition.ts
@@ -59,7 +59,7 @@ export class FilteringHierarchyDefinition implements HierarchyDefinition {
         node.children.some(
           (child: ProcessedHierarchyNode) =>
             child.filtering &&
-            (child.filtering.isFilterTarget || child.filtering.filteredChildrenIdentifierPaths?.some((path) => !("path" in path) || path.options?.autoExpand)),
+            (child.filtering.isFilterTarget || child.filtering.filteredChildrenIdentifierPaths?.some((path) => "path" in path && path.options?.autoExpand)),
         )
       ) {
         return Object.assign(processedNode, { autoExpand: true });
@@ -229,7 +229,7 @@ function applyFilterAttributes<TNode extends ParsedHierarchyNode>(
   hasFilterTargetAncestor: boolean,
 ): TNode {
   const shouldAutoExpand = !!filteredChildrenIdentifierPaths?.some((childPath) => {
-    return "path" in childPath ? childPath.path.length && childPath.options?.autoExpand !== false : !!childPath.length;
+    return "path" in childPath && childPath.path.length && childPath.options?.autoExpand;
   });
   const result = { ...node };
   if (shouldAutoExpand) {

--- a/packages/hierarchies/src/test/HierarchyProvider.test.ts
+++ b/packages/hierarchies/src/test/HierarchyProvider.test.ts
@@ -620,7 +620,6 @@ describe("createHierarchyProvider", () => {
           filtering: {
             filteredChildrenIdentifierPaths: [[{ className: "c.d", id: "0x456" }]],
           },
-          autoExpand: true,
         },
       ]);
     });

--- a/packages/hierarchies/src/test/internal/FilteringHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/internal/FilteringHierarchyDefinition.test.ts
@@ -482,7 +482,6 @@ describe("FilteringHierarchyDefinition", () => {
             key: "custom",
             label: "custom",
             children: false,
-            autoExpand: true,
           },
         };
         const sourceFactory = {
@@ -498,6 +497,7 @@ describe("FilteringHierarchyDefinition", () => {
           {
             node: {
               ...sourceDefinition.node,
+              autoExpand: true,
               filtering: {
                 filteredChildrenIdentifierPaths: [{ path: [{ key: "123" }], options: { autoExpand: true } }, [{ key: "456" }]],
               },

--- a/packages/hierarchies/src/test/internal/FilteringHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/internal/FilteringHierarchyDefinition.test.ts
@@ -108,7 +108,7 @@ describe("FilteringHierarchyDefinition", () => {
       expect(node.autoExpand).to.be.undefined;
     });
 
-    it("does not set auto-expand when filtered children paths list is not empty", () => {
+    it("does not set auto-expand when filtered children paths list is provided without `autoExpand` option", () => {
       const filteringFactory = createFilteringHierarchyLevelsFactory();
       const paths: HierarchyNodeIdentifiersPath[] = [[createTestInstanceKey({ id: "0x1" })]];
       const row = {
@@ -244,7 +244,7 @@ describe("FilteringHierarchyDefinition", () => {
       expect(result.autoExpand).to.be.undefined;
     });
 
-    it("does not set auto-expand on class grouping nodes if any child has filtered children paths", async () => {
+    it("does not set auto-expand on class grouping nodes if children have filtered children paths list set without `autoExpand` option", async () => {
       const inputNode = {
         ...createClassGroupingNode(),
         children: [

--- a/packages/hierarchies/src/test/internal/FilteringHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/internal/FilteringHierarchyDefinition.test.ts
@@ -118,7 +118,7 @@ describe("FilteringHierarchyDefinition", () => {
       expect(node.autoExpand).to.be.true;
     });
 
-    it("doesn't set auto-expand when all filtered children paths contain `expandToTarget` = false", () => {
+    it("doesn't set auto-expand when all filtered children paths contain `autoExpand = false`", () => {
       const filteringFactory = createFilteringHierarchyLevelsFactory();
       const paths = [{ path: [createTestInstanceKey({ id: "0x1" })], options: { autoExpand: false } }];
       const row = {
@@ -129,7 +129,7 @@ describe("FilteringHierarchyDefinition", () => {
       expect(node.autoExpand).to.be.undefined;
     });
 
-    it("sets auto-expand when one of filtered children paths contains `expandToTarget` = true", () => {
+    it("sets auto-expand when one of filtered children paths contains `autoExpand = true`", () => {
       const filteringFactory = createFilteringHierarchyLevelsFactory();
       const paths = [
         { path: [createTestInstanceKey({ id: "0x1" })], options: { autoExpand: false } },
@@ -143,7 +143,7 @@ describe("FilteringHierarchyDefinition", () => {
       expect(node.autoExpand).to.be.true;
     });
 
-    it("sets auto-expand when one of filtered children paths does not contain `expandToTarget`", () => {
+    it("sets auto-expand when one of filtered children paths does not contain `autoExpand` option", () => {
       const filteringFactory = createFilteringHierarchyLevelsFactory();
       const paths = [{ path: createTestInstanceKey({ id: "0x1" }), options: { autoExpand: false } }, [createTestInstanceKey({ id: "0x2" })]];
       const row = {
@@ -269,7 +269,7 @@ describe("FilteringHierarchyDefinition", () => {
       expect(result.autoExpand).to.be.true;
     });
 
-    it("doesn't set auto-expand on class grouping nodes when all filtered children paths contain `expandToTarget` = false", async () => {
+    it("doesn't set auto-expand on class grouping nodes when all filtered children paths contain `autoExpand = false`", async () => {
       const inputNode = {
         ...createClassGroupingNode(),
         children: [
@@ -284,7 +284,7 @@ describe("FilteringHierarchyDefinition", () => {
       expect(result.autoExpand).to.be.undefined;
     });
 
-    it("sets auto-expand when one of filtered children paths contains `expandToTarget` = true", async () => {
+    it("sets auto-expand when one of filtered children paths contains `autoExpand = true`", async () => {
       const inputNode = {
         ...createClassGroupingNode(),
         children: [

--- a/packages/hierarchies/src/test/internal/FilteringHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/internal/FilteringHierarchyDefinition.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../hierarchies/HierarchyDefinition";
 import { HierarchyNode, ParsedCustomHierarchyNode, ProcessedCustomHierarchyNode } from "../../hierarchies/HierarchyNode";
 import { HierarchyNodeIdentifiersPath } from "../../hierarchies/HierarchyNodeIdentifier";
+import { HierarchyFilteringPath } from "../../hierarchies/HierarchyProvider";
 import {
   applyECInstanceIdsFilter,
   ECSQL_COLUMN_NAME_FilteredChildrenPaths,
@@ -959,7 +960,7 @@ describe("FilteringHierarchyDefinition", () => {
 function createFilteringHierarchyLevelsFactory(props?: {
   classHierarchy?: ECClassHierarchyInspector;
   sourceFactory?: HierarchyDefinition;
-  nodeIdentifierPaths?: HierarchyNodeIdentifiersPath[];
+  nodeIdentifierPaths?: HierarchyFilteringPath[];
 }) {
   const { classHierarchy, sourceFactory, nodeIdentifierPaths } = props ?? {};
   return new FilteringHierarchyDefinition({


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/673.