### PR TITLE
Components: Do not propagate key down events in property editors

### DIFF
--- a/.changeset/sour-pumas-sell.md
+++ b/.changeset/sour-pumas-sell.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Disabled property editors from propagating key down events.

--- a/packages/components/src/presentation-components/properties/editors/NavigationPropertyEditor.tsx
+++ b/packages/components/src/presentation-components/properties/editors/NavigationPropertyEditor.tsx
@@ -21,10 +21,6 @@ export class NavigationPropertyEditor extends PropertyEditorBase {
     return false;
   }
   // istanbul ignore next
-  public override get containerStopsKeydownPropagation(): boolean {
-    return false;
-  }
-  // istanbul ignore next
   public get reactNode(): React.ReactNode {
     return <NavigationPropertyTargetEditor />;
   }

--- a/packages/components/src/presentation-components/properties/editors/NumericPropertyEditor.tsx
+++ b/packages/components/src/presentation-components/properties/editors/NumericPropertyEditor.tsx
@@ -27,11 +27,6 @@ export class NumericPropertyEditorBase extends PropertyEditorBase {
   }
 
   // istanbul ignore next
-  public override get containerStopsKeydownPropagation(): boolean {
-    return false;
-  }
-
-  // istanbul ignore next
   public override get containerHandlesTab(): boolean {
     return false;
   }

--- a/packages/components/src/presentation-components/properties/editors/QuantityPropertyEditor.tsx
+++ b/packages/components/src/presentation-components/properties/editors/QuantityPropertyEditor.tsx
@@ -20,11 +20,6 @@ export const QuantityEditorName = "presentation-quantity-editor";
  */
 export class QuantityPropertyEditorBase extends PropertyEditorBase {
   // istanbul ignore next
-  public override get containerStopsKeydownPropagation(): boolean {
-    return false;
-  }
-
-  // istanbul ignore next
   public get reactNode(): React.ReactNode {
     return <QuantityPropertyEditor />;
   }

--- a/packages/components/src/presentation-components/properties/inputs/NavigationPropertyTargetSelector.tsx
+++ b/packages/components/src/presentation-components/properties/inputs/NavigationPropertyTargetSelector.tsx
@@ -85,7 +85,7 @@ export const NavigationPropertyTargetSelector = forwardRef<PropertyEditorAttribu
         styles={{
           control: () => ({}),
           container: () => ({}),
-          menuPortal: (base) => ({ ...base, zIndex: 9999, width }),
+          menuPortal: (base) => ({ ...base, zIndex: 9999, width, pointerEvents: "auto" }),
           menu: (base) => ({ ...base, margin: 0 }),
           dropdownIndicator: () => ({}),
         }}


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/677. Additionally fixed not being able to select targets in target dropdown menu in `NavigationPropertyTargetSelector`.