### PR TITLE
Components: Use raw value instead of display value in `NumericPropertyEditor`

### DIFF
--- a/.changeset/twelve-otters-design.md
+++ b/.changeset/twelve-otters-design.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Updated `NumericPropertyEditor` to use the raw value instead of the display value.

--- a/.changeset/twelve-otters-design.md
+++ b/.changeset/twelve-otters-design.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-components": patch
 ---
 
-Updated `NumericPropertyEditor` to use the raw value instead of the display value.
+Updated `NumericPropertyEditor` to use raw values instead of display values.

--- a/packages/components/src/presentation-components/properties/editors/NumericPropertyEditor.tsx
+++ b/packages/components/src/presentation-components/properties/editors/NumericPropertyEditor.tsx
@@ -22,11 +22,6 @@ export const NumericEditorName = "presentation-numeric-editor";
  */
 export class NumericPropertyEditorBase extends PropertyEditorBase {
   // istanbul ignore next
-  public override get containerHandlesEnter(): boolean {
-    return false;
-  }
-
-  // istanbul ignore next
   public override get containerHandlesTab(): boolean {
     return false;
   }

--- a/packages/components/src/presentation-components/properties/inputs/NumericPropertyInput.tsx
+++ b/packages/components/src/presentation-components/properties/inputs/NumericPropertyInput.tsx
@@ -26,7 +26,7 @@ export const NumericPropertyInput = forwardRef<PropertyEditorAttributes, Numeric
     () => ({
       getValue: () => ({
         valueFormat: PropertyValueFormat.Primitive,
-        value: isNaN(Number(inputValue)) ? undefined : Number(inputValue),
+        value: !inputValue || isNaN(Number(inputValue)) ? undefined : Number(inputValue),
         displayValue: inputValue,
       }),
       htmlElement: divRef.current,
@@ -42,7 +42,11 @@ export const NumericPropertyInput = forwardRef<PropertyEditorAttributes, Numeric
     onCommit &&
       onCommit({
         propertyRecord,
-        newValue: { valueFormat: PropertyValueFormat.Primitive, value: isNaN(Number(inputValue)) ? undefined : Number(inputValue), displayValue: inputValue },
+        newValue: {
+          valueFormat: PropertyValueFormat.Primitive,
+          value: !inputValue || isNaN(Number(inputValue)) ? undefined : Number(inputValue),
+          displayValue: inputValue,
+        },
       });
   };
   return (
@@ -58,9 +62,6 @@ function getInputTargetFromPropertyRecord(propertyRecord: PropertyRecord) {
   // istanbul ignore if
   if (value.valueFormat !== PropertyValueFormat.Primitive) {
     return undefined;
-  }
-  if (value.displayValue !== undefined) {
-    return value.displayValue;
   }
   return value.value?.toString();
 }

--- a/packages/components/src/test/properties/inputs/NumericPropertyInput.test.tsx
+++ b/packages/components/src/test/properties/inputs/NumericPropertyInput.test.tsx
@@ -69,6 +69,18 @@ describe("<NumericPropertyInput />", () => {
     expect((ref.current?.getValue() as PrimitiveValue).value).to.be.eq(-101);
   });
 
+  it("returns undefined value when input is empty", async () => {
+    const record = createRecord(-10);
+    const ref = createRef<PropertyEditorAttributes>();
+    const { getByRole, queryByDisplayValue, user } = render(<NumericPropertyInput propertyRecord={record} ref={ref} />);
+
+    const inputContainer = await waitFor(() => getByRole("textbox"));
+
+    await user.clear(inputContainer);
+    expect(queryByDisplayValue("")).to.not.be.null;
+    expect((ref.current?.getValue() as PrimitiveValue).value).to.be.undefined;
+  });
+
   it("allows typing `-1`", async () => {
     const record = createRecord();
     const ref = createRef<PropertyEditorAttributes>();


### PR DESCRIPTION
Changes for https://github.com/iTwin/appui/issues/915.