### PR TITLE
Bump ITwinUI

### DIFF
--- a/.changeset/afraid-rats-attack.md
+++ b/.changeset/afraid-rats-attack.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Fixed warnings related to passing `ref` to the component that is not wrapped in `forwardRef` function.

--- a/.changeset/big-pots-burn.md
+++ b/.changeset/big-pots-burn.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Use `label` prop instead of `title` on `IconButton` to have consistent tooltips and better accessibility support.

--- a/apps/full-stack-tests/package.json
+++ b/apps/full-stack-tests/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@bentley/functional-schema": "^1.0.4",
     "@itwin/appui-abstract": "^4.8.0",
-    "@itwin/itwinui-react": "^3.12.1",
+    "@itwin/itwinui-react": "^3.14.1",
     "@itwin/build-tools": "^4.8.0",
     "@itwin/components-react": "^4.16.0",
     "@itwin/core-backend": "^4.8.0",

--- a/apps/full-stack-tests/src/Utils.ts
+++ b/apps/full-stack-tests/src/Utils.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import sinon from "sinon";
+
+export function stubGetBoundingClientRect() {
+  let stub: sinon.SinonStub<[], DOMRect>;
+
+  beforeEach(() => {
+    stub = sinon.stub(window.Element.prototype, "getBoundingClientRect").returns({
+      height: 20,
+      width: 20,
+      x: 0,
+      y: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+      toJSON: () => {},
+    });
+  });
+
+  afterEach(() => {
+    stub.restore();
+  });
+}

--- a/apps/full-stack-tests/src/components/tree/HierarchyLevelFiltering.test.tsx
+++ b/apps/full-stack-tests/src/components/tree/HierarchyLevelFiltering.test.tsx
@@ -15,6 +15,7 @@ import { buildTestIModel } from "@itwin/presentation-testing";
 import { getByPlaceholderText, getByRole, getByTitle, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { initialize, terminate } from "../../IntegrationTests";
+import { stubGetBoundingClientRect } from "../../Utils";
 import { getNodeByLabel, toggleExpandNode } from "../TreeUtils";
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -22,6 +23,7 @@ import { getNodeByLabel, toggleExpandNode } from "../TreeUtils";
 describe("Learning snippets", () => {
   describe("Tree", () => {
     stubGlobals();
+    stubGetBoundingClientRect();
 
     before(async () => {
       await initialize();

--- a/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/Localization.test.tsx
+++ b/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/Localization.test.tsx
@@ -6,6 +6,7 @@
 /* eslint-disable no-duplicate-imports */
 import { expect } from "chai";
 import { buildIModel } from "../../IModelUtils";
+import { stubGetBoundingClientRect } from "../../Utils";
 import { SchemaContext } from "@itwin/ecschema-metadata";
 import { IModelConnection } from "@itwin/core-frontend";
 import { render, waitFor } from "@testing-library/react";
@@ -35,6 +36,7 @@ import {
 describe("Hierarchies React", () => {
   describe("Learning snippets", () => {
     describe("Localization", () => {
+      stubGetBoundingClientRect();
       // __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.Localization.Strings
       type IModelAccess = Parameters<typeof useUnifiedSelectionTree>[0]["imodelAccess"];
 
@@ -123,10 +125,10 @@ describe("Hierarchies React", () => {
         }
         // __PUBLISH_EXTRACT_END__
 
-        const { getByRole, getAllByTitle } = render(<MyTreeComponent imodelAccess={access} imodelKey={imodel.key} />);
+        const { getByRole, getAllByRole } = render(<MyTreeComponent imodelAccess={access} imodelKey={imodel.key} />);
         await waitFor(() => getByRole("tree"));
 
-        expect(getAllByTitle("Apply hierarchy filter")).to.not.be.empty;
+        expect(getAllByRole("button", { name: "Apply hierarchy filter" })).to.not.be.empty;
       });
 
       it("Tree renderer localization", async function () {
@@ -163,10 +165,10 @@ describe("Hierarchies React", () => {
           return <MyTreeRenderer {...state} rootNodes={rootNodes} localizedStrings={localizedStrings} />;
         }
 
-        const { getByRole, getAllByTitle } = render(<MyTreeComponent imodelAccess={access} imodelKey={imodel.key} />);
+        const { getByRole, getAllByRole } = render(<MyTreeComponent imodelAccess={access} imodelKey={imodel.key} />);
         await waitFor(() => getByRole("tree"));
 
-        expect(getAllByTitle("Apply hierarchy filter")).to.not.be.empty;
+        expect(getAllByRole("button", { name: "Apply hierarchy filter" })).to.not.be.empty;
       });
     });
   });

--- a/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/ReadmeExample.test.tsx
+++ b/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/ReadmeExample.test.tsx
@@ -8,6 +8,7 @@ import { expect } from "chai";
 import { insertPhysicalModelWithPartition } from "presentation-test-utilities";
 import { initialize, terminate } from "../../IntegrationTests";
 import { buildIModel } from "../../IModelUtils";
+import { stubGetBoundingClientRect } from "../../Utils";
 import { render, waitFor } from "@testing-library/react";
 // __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.iModelAccess.Imports
 import { IModelConnection } from "@itwin/core-frontend";
@@ -58,6 +59,7 @@ function createIModelAccess(imodel: IModelConnection) {
 describe("Hierarchies React", () => {
   describe("Learning snippets", () => {
     describe("Readme example", () => {
+      stubGetBoundingClientRect();
       let iModel: IModelConnection;
 
       beforeEach(async function () {

--- a/apps/test-app/frontend/package.json
+++ b/apps/test-app/frontend/package.json
@@ -32,7 +32,7 @@
     "@itwin/eslint-plugin": "^4.1.1",
     "@itwin/imodel-components-react": "^4.16.0",
     "@itwin/itwinui-icons-react": "^2.8.0",
-    "@itwin/itwinui-react": "^3.12.1",
+    "@itwin/itwinui-react": "^3.14.1",
     "@itwin/presentation-common": "^4.8.0",
     "@itwin/presentation-components": "workspace:*",
     "@itwin/presentation-core-interop": "workspace:*",

--- a/packages/components/.mocharc.json
+++ b/packages/components/.mocharc.json
@@ -1,7 +1,7 @@
 {
   "require": ["ignore-styles"],
   "checkLeaks": true,
-  "global": ["IS_REACT_ACT_ENVIRONMENT"],
+  "global": ["IS_REACT_ACT_ENVIRONMENT", "__iui"],
   "timeout": 60000,
   "file": ["./lib/cjs/test/index.js"],
   "exclude": ["./lib/test/coverage/**/*"],

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -88,7 +88,7 @@
     "@itwin/ecschema-metadata": "^4.8.0",
     "@itwin/eslint-plugin": "^4.1.1",
     "@itwin/imodel-components-react": "^4.16.0",
-    "@itwin/itwinui-react": "^3.11.3",
+    "@itwin/itwinui-react": "^3.14.1",
     "@itwin/presentation-common": "^4.8.0",
     "@itwin/presentation-frontend": "^4.8.0",
     "@itwin/webgl-compatibility": "^4.8.0",

--- a/packages/components/src/presentation-components/tree/controlled/PresentationTreeNodeRenderer.tsx
+++ b/packages/components/src/presentation-components/tree/controlled/PresentationTreeNodeRenderer.tsx
@@ -116,7 +116,7 @@ function PresentationTreeNodeActions(props: PresentationTreeNodeActionsProps) {
               e.stopPropagation();
               onClearFilterClick();
             }}
-            title={translate("tree.clear-hierarchy-level-filter")}
+            label={translate("tree.clear-hierarchy-level-filter")}
           >
             <SvgCloseSmall />
           </IconButton>
@@ -130,7 +130,7 @@ function PresentationTreeNodeActions(props: PresentationTreeNodeActionsProps) {
             e.stopPropagation();
             onFilterClick();
           }}
-          title={translate("tree.filter-hierarchy-level")}
+          label={translate("tree.filter-hierarchy-level")}
         >
           {isFiltered ? <SvgFilter /> : <SvgFilterHollow />}
         </IconButton>

--- a/packages/components/src/test/_helpers/Common.ts
+++ b/packages/components/src/test/_helpers/Common.ts
@@ -151,6 +151,28 @@ export function stubDOMMatrix() {
   });
 }
 
+export function stubGetBoundingClientRect() {
+  let stub: sinon.SinonStub<[], DOMRect>;
+
+  beforeEach(() => {
+    stub = sinon.stub(window.Element.prototype, "getBoundingClientRect").returns({
+      height: 20,
+      width: 20,
+      x: 0,
+      y: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+      toJSON: () => {},
+    });
+  });
+
+  afterEach(() => {
+    stub.restore();
+  });
+}
+
 /** Props for `TestErrorBoundary` */
 export interface TestErrorBoundaryProps {
   children: React.ReactNode;

--- a/packages/components/src/test/instance-filter-builder/IntanceFilterBuilder.test.tsx
+++ b/packages/components/src/test/instance-filter-builder/IntanceFilterBuilder.test.tsx
@@ -15,12 +15,13 @@ import { Presentation } from "@itwin/presentation-frontend";
 import { translate } from "../../presentation-components/common/Utils";
 import { ECClassInfo, getIModelMetadataProvider } from "../../presentation-components/instance-filter-builder/ECMetadataProvider";
 import { InstanceFilterBuilder, usePresentationInstanceFilteringProps } from "../../presentation-components/instance-filter-builder/InstanceFilterBuilder";
-import { createTestECClassInfo, stubRaf } from "../_helpers/Common";
+import { createTestECClassInfo, stubGetBoundingClientRect, stubRaf } from "../_helpers/Common";
 import { createTestCategoryDescription, createTestContentDescriptor, createTestPropertiesContentField } from "../_helpers/Content";
 import { act, fireEvent, render, renderHook, waitFor } from "../TestUtils";
 
 describe("InstanceFilterBuilder", () => {
   stubRaf();
+  stubGetBoundingClientRect();
   const classInfos: ClassInfo[] = [
     { id: "0x1", name: "Schema:Class1", label: "Class1" },
     { id: "0x2", name: "Schema:Class2", label: "Class2" },

--- a/packages/components/src/test/instance-filter-builder/PresentationFilterBuilder.test.tsx
+++ b/packages/components/src/test/instance-filter-builder/PresentationFilterBuilder.test.tsx
@@ -14,13 +14,14 @@ import {
   PresentationInstanceFilterBuilder,
   PresentationInstanceFilterInfo,
 } from "../../presentation-components/instance-filter-builder/PresentationFilterBuilder";
-import { createTestECClassInfo, stubDOMMatrix, stubRaf } from "../_helpers/Common";
+import { createTestECClassInfo, stubDOMMatrix, stubGetBoundingClientRect, stubRaf } from "../_helpers/Common";
 import { createTestCategoryDescription, createTestContentDescriptor, createTestPropertiesContentField } from "../_helpers/Content";
 import { render, waitFor, waitForElement } from "../TestUtils";
 
 describe("PresentationInstanceFilter", () => {
   stubRaf();
   stubDOMMatrix();
+  stubGetBoundingClientRect();
 
   const category = createTestCategoryDescription({ name: "root", label: "Root" });
   const classInfo = createTestECClassInfo({ id: "0x123", name: "class1", label: "Class 1" });

--- a/packages/components/src/test/instance-filter-builder/PresentationInstanceFilterDialog.test.tsx
+++ b/packages/components/src/test/instance-filter-builder/PresentationInstanceFilterDialog.test.tsx
@@ -20,13 +20,28 @@ import {
   PresentationInstanceFilterDialog,
   PresentationInstanceFilterPropertiesSource,
 } from "../../presentation-components/instance-filter-builder/PresentationInstanceFilterDialog";
-import { createTestECClassInfo, stubDOMMatrix, stubRaf } from "../_helpers/Common";
+import { createTestECClassInfo, stubDOMMatrix, stubGetBoundingClientRect, stubRaf } from "../_helpers/Common";
 import { createTestCategoryDescription, createTestContentDescriptor, createTestPropertiesContentField } from "../_helpers/Content";
-import { act, render, waitFor, waitForElement, within } from "../TestUtils";
+import {
+  act,
+  getAllByRole,
+  getByPlaceholderText,
+  getByRole,
+  getByTestId,
+  getByText,
+  getByTitle,
+  queryByDisplayValue,
+  queryByText,
+  render,
+  waitFor,
+  waitForElement,
+  within,
+} from "../TestUtils";
 
 describe("PresentationInstanceFilterDialog", () => {
   stubRaf();
   stubDOMMatrix();
+  stubGetBoundingClientRect();
   const category = createTestCategoryDescription({ name: "root", label: "Root" });
   const classInfo = createTestECClassInfo();
   const stringField = createTestPropertiesContentField({
@@ -82,7 +97,7 @@ describe("PresentationInstanceFilterDialog", () => {
   });
 
   it("renders with initial filter", async () => {
-    const { queryByDisplayValue, queryByText } = render(
+    const { baseElement } = render(
       <PresentationInstanceFilterDialog
         imodel={imodel}
         propertiesSource={propertiesSource}
@@ -96,14 +111,14 @@ describe("PresentationInstanceFilterDialog", () => {
     );
 
     // verify class is selected
-    await waitFor(() => expect(queryByText(classInfo.label)).to.not.be.null);
+    await waitFor(() => expect(queryByText(baseElement, classInfo.label)).to.not.be.null);
 
     // verify property is selected
-    await waitFor(() => expect(queryByDisplayValue(stringField.label)).to.not.be.null);
+    await waitFor(() => expect(queryByDisplayValue(baseElement, stringField.label)).to.not.be.null);
   });
 
   it("displays warning message on class selector opening if filtering rules are set ", async () => {
-    const { container, getByTitle, queryByDisplayValue, user, queryByText, getByPlaceholderText } = render(
+    const { baseElement, user } = render(
       <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={() => {}} isOpen={true} />,
       {
         addThemeProvider: true,
@@ -111,25 +126,25 @@ describe("PresentationInstanceFilterDialog", () => {
     );
 
     // open property selector
-    const propertySelector = await getRulePropertySelector(container);
+    const propertySelector = await getRulePropertySelector(baseElement);
     await user.click(propertySelector);
     // select property
-    await user.click(getByTitle(stringField.label));
+    await user.click(getByTitle(baseElement, stringField.label));
 
     // enter value
-    const inputContainer = await waitForElement<HTMLInputElement>(container, ".fb-property-value input");
+    const inputContainer = await waitForElement<HTMLInputElement>(baseElement, ".fb-property-value input");
     await user.type(inputContainer, "test value");
-    await waitFor(() => expect(queryByDisplayValue("test value")).to.not.be.null);
+    await waitFor(() => expect(queryByDisplayValue(baseElement, "test value")).to.not.be.null);
 
     // expand class selector
-    const classListContainer = getByPlaceholderText("instance-filter-builder.selected-classes");
+    const classListContainer = getByPlaceholderText(baseElement, "instance-filter-builder.selected-classes");
     await user.click(classListContainer);
 
-    expect(queryByText(translate("instance-filter-builder.class-selection-warning"))).to.not.be.null;
+    expect(queryByText(baseElement, translate("instance-filter-builder.class-selection-warning"))).to.not.be.null;
   });
 
   it("hides warning message when class selection dropdown is hidden ", async () => {
-    const { container, getByTitle, queryByDisplayValue, user, queryByText, getByPlaceholderText, getByTestId } = render(
+    const { baseElement, user } = render(
       <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={() => {}} isOpen={true} />,
       {
         addThemeProvider: true,
@@ -137,33 +152,33 @@ describe("PresentationInstanceFilterDialog", () => {
     );
 
     // open property selector
-    const propertySelector = await getRulePropertySelector(container);
+    const propertySelector = await getRulePropertySelector(baseElement);
     await user.click(propertySelector);
     // select property
-    await user.click(getByTitle(stringField.label));
+    await user.click(getByTitle(baseElement, stringField.label));
 
     // enter value
-    const inputContainer = await waitFor(() => getByTestId("components-text-editor"));
+    const inputContainer = await waitFor(() => getByTestId(baseElement, "components-text-editor"));
     await user.type(inputContainer, "test value");
-    await waitFor(() => expect(queryByDisplayValue("test value")).to.not.be.null);
+    await waitFor(() => expect(queryByDisplayValue(baseElement, "test value")).to.not.be.null);
 
     // expand class selector
-    const classListContainer = getByPlaceholderText("instance-filter-builder.selected-classes");
+    const classListContainer = getByPlaceholderText(baseElement, "instance-filter-builder.selected-classes");
     await user.click(classListContainer);
 
     // assert that the warning is shown initially
-    expect(queryByText(translate("instance-filter-builder.class-selection-warning"))).to.not.be.null;
+    expect(queryByText(baseElement, translate("instance-filter-builder.class-selection-warning"))).to.not.be.null;
 
     // click somewhere else to hide the dropdown
-    const header = container.querySelector(".presentation-instance-filter-title");
+    const header = baseElement.querySelector(".presentation-instance-filter-title");
     await user.click(header!);
 
     // hiding the dropdown should also hide the warning
-    expect(queryByText(translate("instance-filter-builder.class-selection-warning"))).to.be.null;
+    expect(queryByText(baseElement, translate("instance-filter-builder.class-selection-warning"))).to.be.null;
   });
 
   it("clears all filtering options on class list changing ", async () => {
-    const { container, getByRole, getByTitle, user, queryByDisplayValue, getByPlaceholderText } = render(
+    const { baseElement, user } = render(
       <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={() => {}} isOpen={true} />,
       {
         addThemeProvider: true,
@@ -171,50 +186,47 @@ describe("PresentationInstanceFilterDialog", () => {
     );
 
     // open property selector
-    const propertySelector = await getRulePropertySelector(container);
+    const propertySelector = await getRulePropertySelector(baseElement);
     await user.click(propertySelector);
     // select property
-    await user.click(getByTitle(stringField.label));
+    await user.click(getByTitle(baseElement, stringField.label));
 
     // enter value
-    const inputContainer = await waitForElement<HTMLInputElement>(container, ".fb-property-value input");
+    const inputContainer = await waitForElement<HTMLInputElement>(baseElement, ".fb-property-value input");
     await user.type(inputContainer, "test value");
-    await waitFor(() => expect(queryByDisplayValue("test value")).to.not.be.null);
+    await waitFor(() => expect(queryByDisplayValue(baseElement, "test value")).to.not.be.null);
 
     // expand class selector
-    const classListContainer = getByPlaceholderText("instance-filter-builder.selected-classes");
+    const classListContainer = getByPlaceholderText(baseElement, "instance-filter-builder.selected-classes");
     await user.click(classListContainer);
 
     // deselect class item from dropdown
-    await user.click(within(getByRole("listbox")).getByText("Class Label"));
+    await user.click(within(getByRole(baseElement, "listbox")).getByText("Class Label"));
 
     // assert that filtering rule was cleared
-    await waitFor(() => expect(queryByDisplayValue("test value")).to.be.null);
+    await waitFor(() => expect(queryByDisplayValue(baseElement, "test value")).to.be.null);
   });
 
   it("invokes 'onApply' with string property filter rule", async () => {
     const spy = sinon.spy();
-    const { container, getByTitle, queryByDisplayValue, user } = render(
-      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />,
-      {
-        addThemeProvider: true,
-      },
-    );
+    const { baseElement, user } = render(<PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />, {
+      addThemeProvider: true,
+    });
 
     // open property selector
-    const propertySelector = await getRulePropertySelector(container);
+    const propertySelector = await getRulePropertySelector(baseElement);
     await user.click(propertySelector);
     // select property
-    await user.click(getByTitle(stringField.label));
+    await user.click(getByTitle(baseElement, stringField.label));
 
     // enter value
-    const inputContainer = await waitForElement<HTMLInputElement>(container, ".fb-property-value input");
+    const inputContainer = await waitForElement<HTMLInputElement>(baseElement, ".fb-property-value input");
     await user.type(inputContainer, "test value");
 
-    await waitFor(() => expect(queryByDisplayValue("test value")).to.not.be.null);
+    await waitFor(() => expect(queryByDisplayValue(baseElement, "test value")).to.not.be.null);
     await user.tab();
 
-    const applyButton = await getApplyButton(container);
+    const applyButton = await getApplyButton(baseElement);
     await user.click(applyButton);
 
     await waitFor(() => {
@@ -235,17 +247,14 @@ describe("PresentationInstanceFilterDialog", () => {
 
   it("does not invoke `onApply` when there two empty rules", async () => {
     const spy = sinon.spy();
-    const { container, user, getAllByRole } = render(
-      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />,
-      {
-        addThemeProvider: true,
-      },
-    );
+    const { baseElement, user } = render(<PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />, {
+      addThemeProvider: true,
+    });
 
-    const addButton = getAllByRole("button").find((el) => within(el).queryByText("Add"))!;
+    const addButton = getAllByRole(baseElement, "button").find((el) => within(el).queryByText("Add"))!;
     await user.click(addButton);
 
-    const applyButton = await getApplyButton(container);
+    const applyButton = await getApplyButton(baseElement);
     await user.click(applyButton);
 
     expect(spy).to.not.be.called;
@@ -253,20 +262,17 @@ describe("PresentationInstanceFilterDialog", () => {
 
   it("does not invoke `onApply` when filter is invalid", async () => {
     const spy = sinon.spy();
-    const { container, getByTitle, user } = render(
-      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />,
-      {
-        addThemeProvider: true,
-      },
-    );
+    const { baseElement, user } = render(<PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />, {
+      addThemeProvider: true,
+    });
 
     // open property selector
-    const propertySelector = await getRulePropertySelector(container);
+    const propertySelector = await getRulePropertySelector(baseElement);
     await user.click(propertySelector);
     // select property
-    await user.click(getByTitle(stringField.label));
+    await user.click(getByTitle(baseElement, stringField.label));
 
-    const applyButton = await getApplyButton(container);
+    const applyButton = await getApplyButton(baseElement);
     await user.click(applyButton);
 
     expect(spy).to.not.be.called;
@@ -274,11 +280,11 @@ describe("PresentationInstanceFilterDialog", () => {
 
   it("invokes `onApply` when there are no items selected", async () => {
     const spy = sinon.spy();
-    const { container, user } = render(<PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />, {
+    const { baseElement, user } = render(<PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />, {
       addThemeProvider: true,
     });
 
-    const applyButton = await getApplyButton(container);
+    const applyButton = await getApplyButton(baseElement);
     await user.click(applyButton);
 
     expect(spy).to.be.called;
@@ -286,22 +292,19 @@ describe("PresentationInstanceFilterDialog", () => {
 
   it("invokes `onApply` with only selected classes", async () => {
     const spy = sinon.spy();
-    const { container, getByRole, getByPlaceholderText, user } = render(
-      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />,
-      {
-        addThemeProvider: true,
-      },
-    );
+    const { baseElement, user } = render(<PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />, {
+      addThemeProvider: true,
+    });
 
     // expand class selector
-    const classListContainer = getByPlaceholderText("instance-filter-builder.select-classes-optional");
+    const classListContainer = getByPlaceholderText(baseElement, "instance-filter-builder.select-classes-optional");
     await user.click(classListContainer);
 
     // deselect class item from dropdown
-    const classItem = getByRole("option", { name: "Class Label" });
+    const classItem = getByRole(baseElement, "option", { name: "Class Label" });
     await user.click(classItem);
 
-    const applyButton = await getApplyButton(container);
+    const applyButton = await getApplyButton(baseElement);
     await user.click(applyButton);
 
     expect(spy).to.be.calledWith({ filter: undefined, usedClasses: [classInfo] });
@@ -309,14 +312,14 @@ describe("PresentationInstanceFilterDialog", () => {
 
   it("invokes `onReset` when reset is clicked.", async () => {
     const spy = sinon.spy();
-    const { container, user } = render(
+    const { baseElement, user } = render(
       <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onReset={spy} onApply={() => {}} isOpen={true} />,
       {
         addThemeProvider: true,
       },
     );
 
-    const resetButton = await getResetButton(container);
+    const resetButton = await getResetButton(baseElement);
     await user.click(resetButton);
 
     expect(spy).to.be.called;
@@ -325,30 +328,27 @@ describe("PresentationInstanceFilterDialog", () => {
   it("throws error when filter is missing presentation metadata", async () => {
     const fromComponentsPropertyFilterStub = sinon.stub(PresentationInstanceFilter, "fromComponentsPropertyFilter").throws(new Error("Some Error"));
     const spy = sinon.spy();
-    const { container, getByText, queryByText, user, getByTitle } = render(
-      <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />,
-      {
-        addThemeProvider: true,
-      },
-    );
+    const { baseElement, user } = render(<PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} onApply={spy} isOpen={true} />, {
+      addThemeProvider: true,
+    });
 
     // open property selector
-    const propertySelector = await getRulePropertySelector(container);
+    const propertySelector = await getRulePropertySelector(baseElement);
     await user.click(propertySelector);
     // select property
-    await user.click(getByTitle(stringField.label));
+    await user.click(getByTitle(baseElement, stringField.label));
 
     // open operator selector
-    const operatorSelector = await getRuleOperatorSelector(container);
+    const operatorSelector = await getRuleOperatorSelector(baseElement);
     await user.click(operatorSelector);
     // select operator
-    await user.click(getByText(/filterBuilder.operators.isNotNull/));
+    await user.click(getByText(baseElement, /filterBuilder.operators.isNotNull/));
 
     // wait until operator is selected
-    const applyButton = await getApplyButton(container);
+    const applyButton = await getApplyButton(baseElement);
     await user.click(applyButton);
 
-    await waitFor(() => expect(queryByText("general.error")).to.not.be.null);
+    await waitFor(() => expect(queryByText(baseElement, "general.error")).to.not.be.null);
     fromComponentsPropertyFilterStub.restore();
   });
 
@@ -356,15 +356,15 @@ describe("PresentationInstanceFilterDialog", () => {
     const spy = sinon.spy();
     const title = "custom title";
 
-    const { queryByText } = render(
+    const { baseElement } = render(
       <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSource} title={<div>{title}</div>} onApply={spy} isOpen={true} />,
     );
 
-    await waitFor(() => expect(queryByText(title)).to.not.be.null);
+    await waitFor(() => expect(queryByText(baseElement, title)).to.not.be.null);
   });
 
   it("renders results count", async () => {
-    const { queryByText, queryByDisplayValue } = render(
+    const { baseElement } = render(
       <PresentationInstanceFilterDialog
         imodel={imodel}
         propertiesSource={propertiesSource}
@@ -376,10 +376,10 @@ describe("PresentationInstanceFilterDialog", () => {
     );
 
     // wait for filter builder to render
-    await waitFor(() => expect(queryByDisplayValue(stringField.label)).to.not.be.null);
+    await waitFor(() => expect(queryByDisplayValue(baseElement, stringField.label)).to.not.be.null);
 
     // verify results count renderer is used
-    await waitFor(() => expect(queryByText("Test Results")).to.not.be.null);
+    await waitFor(() => expect(queryByText(baseElement, "Test Results")).to.not.be.null);
   });
 
   it("renders error boundary if error is thrown", async () => {
@@ -387,22 +387,22 @@ describe("PresentationInstanceFilterDialog", () => {
       throw new Error("Cannot load descriptor");
     };
 
-    const { queryByText } = render(
+    const { baseElement } = render(
       <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSourceGetter} onApply={() => {}} isOpen={true} />,
     );
 
-    await waitFor(() => expect(queryByText("general.error")).to.not.be.null);
+    await waitFor(() => expect(queryByText(baseElement, "general.error")).to.not.be.null);
   });
 
   it("renders with lazy-loaded descriptor", async () => {
     const spy = sinon.spy();
     const propertiesSourceGetter = async () => ({ descriptor });
 
-    const { container } = render(<PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSourceGetter} onApply={spy} isOpen={true} />, {
+    const { baseElement } = render(<PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSourceGetter} onApply={spy} isOpen={true} />, {
       addThemeProvider: true,
     });
 
-    await getRulePropertySelector(container);
+    await getRulePropertySelector(baseElement);
   });
 
   it("renders with passed in `toolbarRenderer`", async () => {
@@ -410,7 +410,7 @@ describe("PresentationInstanceFilterDialog", () => {
       return <button>Click Me!</button>;
     };
 
-    const { queryByText } = render(
+    const { baseElement } = render(
       <PresentationInstanceFilterDialog
         imodel={imodel}
         propertiesSource={propertiesSource}
@@ -420,7 +420,7 @@ describe("PresentationInstanceFilterDialog", () => {
       />,
     );
 
-    await waitFor(() => expect(queryByText("Click Me!")).to.not.be.null);
+    await waitFor(() => expect(queryByText(baseElement, "Click Me!")).to.not.be.null);
   });
 
   it("renders spinner while loading descriptor", async () => {
@@ -428,7 +428,7 @@ describe("PresentationInstanceFilterDialog", () => {
     // simulate long loading descriptor
     const propertiesSourceGetter = async () => propertiesSourcePromise;
 
-    const { container } = render(
+    const { baseElement } = render(
       <PresentationInstanceFilterDialog imodel={imodel} propertiesSource={propertiesSourceGetter} onApply={() => {}} isOpen={true} />,
       {
         addThemeProvider: true,
@@ -436,7 +436,7 @@ describe("PresentationInstanceFilterDialog", () => {
     );
 
     await waitFor(() => {
-      expect(container.querySelector(".presentation-instance-filter-dialog-progress")).to.not.be.null;
+      expect(baseElement.querySelector(".presentation-instance-filter-dialog-progress")).to.not.be.null;
     });
 
     await act(async () => {
@@ -444,12 +444,12 @@ describe("PresentationInstanceFilterDialog", () => {
     });
 
     await waitFor(() => {
-      expect(container.querySelector(".presentation-instance-filter-dialog-progress")).to.be.null;
+      expect(baseElement.querySelector(".presentation-instance-filter-dialog-progress")).to.be.null;
     });
   });
 
   async function getRulePropertySelector(container: HTMLElement) {
-    return waitForElement<HTMLInputElement>(container, ".fb-property-name input");
+    return waitForElement<HTMLInputElement>(container, `.fb-property-name [role="combobox"]`);
   }
 
   async function getRuleOperatorSelector(container: HTMLElement) {

--- a/packages/components/src/test/tree/controlled/PresentationTreeRenderer.test.tsx
+++ b/packages/components/src/test/tree/controlled/PresentationTreeRenderer.test.tsx
@@ -28,7 +28,7 @@ import { PresentationTreeRenderer } from "../../../presentation-components/tree/
 import { PresentationTreeDataProvider } from "../../../presentation-components/tree/DataProvider";
 import { IPresentationTreeDataProvider } from "../../../presentation-components/tree/IPresentationTreeDataProvider";
 import { PresentationTreeNodeItem } from "../../../presentation-components/tree/PresentationTreeNodeItem";
-import { createTestPropertyInfo, stubDOMMatrix, stubRaf } from "../../_helpers/Common";
+import { createTestPropertyInfo, stubDOMMatrix, stubGetBoundingClientRect, stubRaf } from "../../_helpers/Common";
 import { createTestContentDescriptor, createTestPropertiesContentField } from "../../_helpers/Content";
 import { act, render, waitFor } from "../../TestUtils";
 import { createTreeModelNodeInput } from "./Helpers";
@@ -36,6 +36,7 @@ import { createTreeModelNodeInput } from "./Helpers";
 describe("PresentationTreeRenderer", () => {
   stubRaf();
   stubDOMMatrix();
+  stubGetBoundingClientRect();
 
   const baseTreeProps = {
     imodel: {} as IModelConnection,
@@ -334,14 +335,14 @@ describe("PresentationTreeRenderer", () => {
       <PresentationTreeRenderer {...baseTreeProps} visibleNodes={visibleNodes} nodeLoader={nodeLoader} onFilterApplied={onFilterAppliedSpy} />,
     );
 
-    const { queryByText, user, getByTitle } = result;
+    const { queryByText, user, getByRole } = result;
     await waitFor(() => expect(queryByText("A")).to.not.be.null);
 
     // ensure that initially the filter is enabled
     let nodeItem = modelSource.getModel().getNode("A")?.item as PresentationTreeNodeItem;
     expect(nodeItem.filtering?.active).to.not.be.undefined;
 
-    const clearFilterButton = await waitFor(() => getByTitle("tree.clear-hierarchy-level-filter"));
+    const clearFilterButton = await waitFor(() => getByRole("button", { name: "tree.clear-hierarchy-level-filter" }));
     await user.click(clearFilterButton);
 
     await waitFor(() => {

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -182,7 +182,7 @@ type SubtreeReloadOptions = {
 type TreeNodeProps = ComponentPropsWithoutRef<typeof TreeNode>;
 
 // @beta
-export function TreeNodeRenderer({ node, expandNode, getIcon, getLabel, getSublabel, onFilterClick, onNodeClick, onNodeKeyDown, isSelected, isDisabled, actionButtonsClassName, getHierarchyLevelDetails, reloadTree, ...treeNodeProps }: TreeNodeRendererProps): JSX_2.Element;
+export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererProps>;
 
 // @beta (undocumented)
 interface TreeNodeRendererOwnProps {
@@ -201,7 +201,7 @@ interface TreeNodeRendererOwnProps {
 }
 
 // @beta (undocumented)
-type TreeNodeRendererProps = Pick<ReturnType<typeof useTree>, "expandNode"> & Partial<Pick<ReturnType<typeof useTree>, "getHierarchyLevelDetails">> & Omit<TreeNodeProps, "label" | "onExpanded" | "onSelected" | "icon"> & TreeNodeRendererOwnProps;
+type TreeNodeRendererProps = Pick<UseTreeResult, "expandNode"> & Partial<Pick<UseTreeResult, "getHierarchyLevelDetails">> & Omit<TreeNodeProps, "label" | "onExpanded" | "onSelected" | "icon"> & TreeNodeRendererOwnProps;
 
 // @beta (undocumented)
 type TreeNodeRendererProps_2 = ComponentPropsWithoutRef<typeof TreeNodeRenderer>;

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
@@ -10,7 +10,7 @@ beta;type;PresentationInfoNode
 beta;interface;PresentationResultSetTooLargeInfoNode
 beta;type;PresentationTreeNode
 beta;type;RenderedTreeNode
-beta;function;TreeNodeRenderer
+beta;const;TreeNodeRenderer
 beta;function;TreeRenderer
 beta;function;UnifiedSelectionProvider
 beta;function;useSelectionHandler

--- a/packages/hierarchies-react/package.json
+++ b/packages/hierarchies-react/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@itwin/build-tools": "^4.8.0",
-    "@itwin/itwinui-react": "^3.12.1",
+    "@itwin/itwinui-react": "^3.14.1",
     "@testing-library/dom": "^10.3.2",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
@@ -150,7 +150,7 @@ type SubtreeReloadOptions = {
 type ReloadTreeOptions = FullTreeReloadOptions | SubtreeReloadOptions;
 
 /** @beta */
-interface UseTreeResult {
+export interface UseTreeResult {
   /**
    * Array containing root tree nodes. It is `undefined` on initial render until any nodes are loaded.
    */

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -186,7 +186,7 @@ const PlaceholderNode = forwardRef<HTMLDivElement, Omit<TreeNodeProps, "onExpand
       label={localizedStrings.loading}
       icon={<ProgressRadial size="x-small" indeterminate title={localizedStrings.loading} />}
       onExpanded={/* istanbul ignore next */ () => {}}
-    ></TreeNode>
+    />
   );
 });
 PlaceholderNode.displayName = "PlaceholderNode";

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -52,7 +52,7 @@ type TreeNodeRendererProps = Pick<UseTreeResult, "expandNode"> &
  * @see https://itwinui.bentley.com/docs/tree
  * @beta
  */
-export const TreeNodeRenderer = forwardRef<HTMLDivElement, TreeNodeRendererProps>(
+export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererProps> = forwardRef(
   (
     {
       node,

--- a/packages/hierarchies-react/src/test/TestUtils.ts
+++ b/packages/hierarchies-react/src/test/TestUtils.ts
@@ -153,3 +153,25 @@ export function createTestGroupingNode({ id, ...props }: Partial<GroupingHierarc
     groupedInstanceKeys: props.groupedInstanceKeys ?? [],
   };
 }
+
+export function stubGetBoundingClientRect() {
+  let stub: sinon.SinonStub<[], DOMRect>;
+
+  beforeEach(() => {
+    stub = sinon.stub(window.Element.prototype, "getBoundingClientRect").returns({
+      height: 20,
+      width: 20,
+      x: 0,
+      y: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+      toJSON: () => {},
+    });
+  });
+
+  afterEach(() => {
+    stub.restore();
+  });
+}

--- a/packages/hierarchies-react/src/test/itwinui/Tree.test.tsx
+++ b/packages/hierarchies-react/src/test/itwinui/Tree.test.tsx
@@ -9,7 +9,7 @@ import { MAX_LIMIT_OVERRIDE } from "../../presentation-hierarchies-react/interna
 import { TreeRenderer } from "../../presentation-hierarchies-react/itwinui/TreeRenderer";
 import { PresentationHierarchyNode, PresentationInfoNode, PresentationTreeNode } from "../../presentation-hierarchies-react/TreeNode";
 import { HierarchyLevelDetails } from "../../presentation-hierarchies-react/UseTree";
-import { act, createStub, createTestHierarchyNode, render, waitFor, within } from "../TestUtils";
+import { act, createStub, createTestHierarchyNode, render, stubGetBoundingClientRect, waitFor, within } from "../TestUtils";
 
 type RequiredTreeProps = Required<ComponentPropsWithoutRef<typeof TreeRenderer>>;
 
@@ -37,6 +37,8 @@ describe("Tree", () => {
     isNodeSelected.reset();
     getHierarchyLevelDetails.reset();
   });
+
+  stubGetBoundingClientRect();
 
   it("renders nodes", () => {
     const rootNodes = createNodes([
@@ -611,13 +613,13 @@ describe("Tree", () => {
       increaseHierarchyLimitWithFiltering: "Custom or, <link>Custom increase the hierarchy level size limit to {{limit}}.</link>",
     };
 
-    const { queryByText, queryByTitle, rerender } = render(<TreeRenderer rootNodes={rootNodes} {...initialProps} />);
+    const { queryByText, queryByRole, queryByTitle, rerender } = render(<TreeRenderer rootNodes={rootNodes} {...initialProps} />);
 
     await waitFor(() => {
       expect(queryByText(/Some Error/)).to.not.be.null;
       expect(queryByText(/Loading.../)).to.not.be.null;
-      expect(queryByTitle(/Apply filter/)).to.not.be.null;
-      expect(queryByTitle(/Clear active filter/)).to.not.be.null;
+      expect(queryByRole("button", { name: "Apply filter" })).to.not.be.null;
+      expect(queryByRole("button", { name: "Clear active filter" })).to.not.be.null;
       expect(queryByText(/No child nodes match current filter/)).to.not.be.null;
       expect(queryByText(/Please provide/)).to.not.be.null;
       expect(queryByText(/additional filtering/)).to.not.be.null;
@@ -634,8 +636,8 @@ describe("Tree", () => {
     await waitFor(() => {
       expect(queryByText(/Some Error/)).to.not.be.null;
       expect(queryByText(/Custom loading.../)).to.not.be.null;
-      expect(queryByTitle(/Custom apply filter/)).to.not.be.null;
-      expect(queryByTitle(/Custom clear active filter/)).to.not.be.null;
+      expect(queryByRole("button", { name: "Custom apply filter" })).to.not.be.null;
+      expect(queryByRole("button", { name: "Custom clear active filter" })).to.not.be.null;
       expect(queryByText(/Custom no child nodes match current filter/)).to.not.be.null;
       expect(queryByText(/Custom please provide/)).to.not.be.null;
       expect(queryByText(/Custom additional filtering/)).to.not.be.null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,10 +128,10 @@ importers:
         version: 4.1.1(eslint@8.57.0)(typescript@5.5.3)
       '@itwin/imodel-components-react':
         specifier: ^4.16.0
-        version: 4.16.0(qdhtb6ypo6expllab27papjmvy)
+        version: 4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/components-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-frontend@4.8.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-geometry@4.8.0)(@itwin/core-orbitgt@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(encoding@0.1.13)(inversify@6.0.2)(reflect-metadata@0.1.14))(@itwin/core-geometry@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-react':
-        specifier: ^3.12.1
-        version: 3.12.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^3.14.1
+        version: 3.14.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/presentation-backend':
         specifier: ^4.8.0
         version: 4.8.0(@itwin/core-backend@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-geometry@4.8.0)(@opentelemetry/api@1.8.0)(encoding@0.1.13))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/ecschema-metadata@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0)))(@itwin/presentation-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/ecschema-metadata@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))))
@@ -660,7 +660,7 @@ importers:
         version: 4.8.0(@itwin/core-bentley@4.8.0)
       '@itwin/appui-react':
         specifier: ^4.16.0
-        version: 4.16.0(ihw5bazvi5sllf62evwds4cyvm)
+        version: 4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/components-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-frontend@4.8.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-geometry@4.8.0)(@itwin/core-orbitgt@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(encoding@0.1.13)(inversify@6.0.2)(reflect-metadata@0.1.14))(@itwin/core-geometry@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/core-telemetry@4.8.0(@itwin/core-geometry@4.8.0))(@itwin/imodel-components-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/components-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-frontend@4.8.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-geometry@4.8.0)(@itwin/core-orbitgt@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(encoding@0.1.13)(inversify@6.0.2)(reflect-metadata@0.1.14))(@itwin/core-geometry@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react-redux@7.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)
       '@itwin/build-tools':
         specifier: ^4.8.0
         version: 4.8.0(@types/node@20.12.12)
@@ -711,13 +711,13 @@ importers:
         version: 4.1.1(eslint@8.57.0)(typescript@5.4.5)
       '@itwin/imodel-components-react':
         specifier: ^4.16.0
-        version: 4.16.0(qdhtb6ypo6expllab27papjmvy)
+        version: 4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/components-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-frontend@4.8.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-geometry@4.8.0)(@itwin/core-orbitgt@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(encoding@0.1.13)(inversify@6.0.2)(reflect-metadata@0.1.14))(@itwin/core-geometry@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-icons-react':
         specifier: ^2.8.0
         version: 2.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-react':
-        specifier: ^3.12.1
-        version: 3.12.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^3.14.1
+        version: 3.14.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/presentation-common':
         specifier: ^4.8.0
         version: 4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/ecschema-metadata@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0)))
@@ -898,10 +898,10 @@ importers:
         version: 4.1.1(eslint@8.57.0)(typescript@5.5.3)
       '@itwin/imodel-components-react':
         specifier: ^4.16.0
-        version: 4.16.0(qdhtb6ypo6expllab27papjmvy)
+        version: 4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/components-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-frontend@4.8.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-geometry@4.8.0)(@itwin/core-orbitgt@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(encoding@0.1.13)(inversify@6.0.2)(reflect-metadata@0.1.14))(@itwin/core-geometry@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-react':
-        specifier: ^3.11.3
-        version: 3.12.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^3.14.1
+        version: 3.14.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/presentation-common':
         specifier: ^4.8.0
         version: 4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/ecschema-metadata@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0)))
@@ -1230,8 +1230,8 @@ importers:
         specifier: ^4.8.0
         version: 4.8.0(@types/node@20.14.6)
       '@itwin/itwinui-react':
-        specifier: ^3.12.1
-        version: 3.12.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^3.14.1
+        version: 3.14.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/dom':
         specifier: ^10.3.2
         version: 10.3.2
@@ -2359,14 +2359,17 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/react@0.26.19':
-    resolution: {integrity: sha512-Jk6zITdjjIvjO/VdQFvpRaD3qPwOHH6AoDHxjhpy+oK4KFgaSP871HYWUAPdnLmx1gQ+w/pB312co3tVml+BXA==}
+  '@floating-ui/react@0.26.23':
+    resolution: {integrity: sha512-9u3i62fV0CFF3nIegiWiRDwOs7OW/KhSUJDNx2MkQM3LbE5zQOY01sL3nelcVBXvX7Ovvo3A49I8ql+20Wg/Hw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
   '@floating-ui/utils@0.2.4':
     resolution: {integrity: sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA==}
+
+  '@floating-ui/utils@0.2.7':
+    resolution: {integrity: sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==}
 
   '@grpc/grpc-js@1.10.9':
     resolution: {integrity: sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==}
@@ -2603,8 +2606,8 @@ packages:
       react: '>=16.8.6 < 19.0.0'
       react-dom: '>=16.8.6 < 19.0.0'
 
-  '@itwin/itwinui-react@3.12.1':
-    resolution: {integrity: sha512-aTwMVNtKEgzwdVhPg4o4Hvyb7eWfwf1+lQL/fLn9c1p0esrcXhiCzcAxRrotG/2H+UP5e4W6wnGMbSQOKFNkmA==}
+  '@itwin/itwinui-react@3.14.1':
+    resolution: {integrity: sha512-uTNzkYzYTFrM6BEuRXDeinvJIM7RUeJ2ywGXFhd0KqX2vR4YPAxoKoWem37yCQWKfDDaVYyAsbZENhMCM39SBA==}
     peerDependencies:
       react: '>= 17.0.0 < 19.0.0'
       react-dom: '>=17.0.0 < 19.0.0'
@@ -3419,9 +3422,18 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
+  '@tanstack/react-virtual@3.10.7':
+    resolution: {integrity: sha512-yeP+M0G8D+15ZFPivpuQ5hoM4Fa/PzERBx8P8EGcfEsXX3JOb9G9UUrqc47ZXAxvK+YqzM9T5qlJUYUFOwCZJw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+
   '@tanstack/table-core@8.16.0':
     resolution: {integrity: sha512-dCG8vQGk4js5v88/k83tTedWOwjGnIyONrKpHpfmSJB8jwFHl8GSu1sBBxbtACVAPtAQgwNxl0rw1d3RqRM1Tg==}
     engines: {node: '>=12'}
+
+  '@tanstack/virtual-core@3.10.7':
+    resolution: {integrity: sha512-ND5dfsU0n9F4gROzwNNDJmg6y8n9pI8YWxtgbfJ5UcNn7Hx+MxEXtXcQ189tS7sh8pmCObgz2qSiyRKTZxT4dg==}
 
   '@tapjs/after-each@2.0.8':
     resolution: {integrity: sha512-btkpQ/BhmRyG50rezduxEZb3pMJblECvTQa41+U2ln2te1prDTlllHlpq4lOjceUksl8KFF1avDqcBqIqPzneQ==}
@@ -8703,8 +8715,8 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/core': 3.598.0
       '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/middleware-host-header': 3.598.0
@@ -8751,8 +8763,8 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/core': 3.598.0
       '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/middleware-host-header': 3.598.0
@@ -8793,11 +8805,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.600.0':
+  '@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/core': 3.598.0
       '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/middleware-host-header': 3.598.0
@@ -8836,6 +8848,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.3
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso@3.598.0':
@@ -8881,11 +8894,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)':
+  '@aws-sdk/client-sts@3.600.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0
+      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/core': 3.598.0
       '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/middleware-host-header': 3.598.0
@@ -8924,7 +8937,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.3
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/core@3.598.0':
@@ -8968,7 +8980,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.598.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/credential-provider-env': 3.598.0
       '@aws-sdk/credential-provider-http': 3.598.0
       '@aws-sdk/credential-provider-process': 3.598.0
@@ -9026,7 +9038,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.598.0(@aws-sdk/client-sts@3.600.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/types': 3.598.0
       '@smithy/property-provider': 3.1.2
       '@smithy/types': 3.2.0
@@ -9036,7 +9048,7 @@ snapshots:
     dependencies:
       '@aws-sdk/client-cognito-identity': 3.600.0
       '@aws-sdk/client-sso': 3.598.0
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/credential-provider-cognito-identity': 3.600.0
       '@aws-sdk/credential-provider-env': 3.598.0
       '@aws-sdk/credential-provider-http': 3.598.0
@@ -9093,7 +9105,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.598.0(@aws-sdk/client-sso-oidc@3.600.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.600.0
+      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/types': 3.598.0
       '@smithy/property-provider': 3.1.2
       '@smithy/shared-ini-file-loader': 3.1.2
@@ -9724,15 +9736,17 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@floating-ui/react@0.26.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@floating-ui/react@0.26.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@floating-ui/utils': 0.2.4
+      '@floating-ui/utils': 0.2.7
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tabbable: 6.2.0
 
   '@floating-ui/utils@0.2.4': {}
+
+  '@floating-ui/utils@0.2.7': {}
 
   '@grpc/grpc-js@1.10.9':
     dependencies:
@@ -9819,8 +9833,8 @@ snapshots:
     dependencies:
       '@itwin/core-bentley': 4.8.0
 
-  '@itwin/appui-react@4.16.0(ihw5bazvi5sllf62evwds4cyvm)':
-    dependencies:
+  ? '@itwin/appui-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/components-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-frontend@4.8.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-geometry@4.8.0)(@itwin/core-orbitgt@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(encoding@0.1.13)(inversify@6.0.2)(reflect-metadata@0.1.14))(@itwin/core-geometry@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/core-telemetry@4.8.0(@itwin/core-geometry@4.8.0))(@itwin/imodel-components-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/components-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-frontend@4.8.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-geometry@4.8.0)(@itwin/core-orbitgt@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(encoding@0.1.13)(inversify@6.0.2)(reflect-metadata@0.1.14))(@itwin/core-geometry@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react-redux@7.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)'
+  : dependencies:
       '@bentley/icons-generic': 1.0.34
       '@itwin/appui-abstract': 4.8.0(@itwin/core-bentley@4.8.0)
       '@itwin/components-react': 4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9831,10 +9845,10 @@ snapshots:
       '@itwin/core-quantity': 4.8.0(@itwin/core-bentley@4.8.0)
       '@itwin/core-react': 4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/core-telemetry': 4.8.0(@itwin/core-geometry@4.8.0)
-      '@itwin/imodel-components-react': 4.16.0(qdhtb6ypo6expllab27papjmvy)
+      '@itwin/imodel-components-react': 4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/components-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-frontend@4.8.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-geometry@4.8.0)(@itwin/core-orbitgt@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(encoding@0.1.13)(inversify@6.0.2)(reflect-metadata@0.1.14))(@itwin/core-geometry@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@itwin/itwinui-react': 3.12.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@itwin/itwinui-react': 3.14.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-react-v2': '@itwin/itwinui-react@2.12.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
       '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
@@ -9907,7 +9921,7 @@ snapshots:
       '@itwin/core-bentley': 4.8.0
       '@itwin/core-react': 4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@itwin/itwinui-react': 3.12.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@itwin/itwinui-react': 3.14.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
       immer: 9.0.6
@@ -10049,7 +10063,7 @@ snapshots:
       '@itwin/appui-abstract': 4.8.0(@itwin/core-bentley@4.8.0)
       '@itwin/core-bentley': 4.8.0
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@itwin/itwinui-react': 3.12.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@itwin/itwinui-react': 3.14.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
       dompurify: 2.5.5
@@ -10142,8 +10156,8 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@itwin/imodel-components-react@4.16.0(qdhtb6ypo6expllab27papjmvy)':
-    dependencies:
+  ? '@itwin/imodel-components-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/components-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-frontend@4.8.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-common@4.8.0(@itwin/core-bentley@4.8.0)(@itwin/core-geometry@4.8.0))(@itwin/core-geometry@4.8.0)(@itwin/core-orbitgt@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(encoding@0.1.13)(inversify@6.0.2)(reflect-metadata@0.1.14))(@itwin/core-geometry@4.8.0)(@itwin/core-quantity@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
+  : dependencies:
       '@bentley/icons-generic': 1.0.34
       '@itwin/appui-abstract': 4.8.0(@itwin/core-bentley@4.8.0)
       '@itwin/components-react': 4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@itwin/core-react@4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10154,7 +10168,7 @@ snapshots:
       '@itwin/core-quantity': 4.8.0(@itwin/core-bentley@4.8.0)
       '@itwin/core-react': 4.16.0(@itwin/appui-abstract@4.8.0(@itwin/core-bentley@4.8.0))(@itwin/core-bentley@4.8.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@itwin/itwinui-react': 3.12.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@itwin/itwinui-react': 3.14.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
       react: 18.3.1
@@ -10185,11 +10199,12 @@ snapshots:
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tippy.js: 6.3.7
 
-  '@itwin/itwinui-react@3.12.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@itwin/itwinui-react@3.14.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@floating-ui/react': 0.26.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react': 0.26.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.11
+      '@tanstack/react-virtual': 3.10.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       classnames: 2.5.1
       jotai: 2.8.3(@types/react@18.3.3)(react@18.3.1)
       react: 18.3.1
@@ -11357,7 +11372,15 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@tanstack/react-virtual@3.10.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.10.7
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@tanstack/table-core@8.16.0': {}
+
+  '@tanstack/virtual-core@3.10.7': {}
 
   '@tapjs/after-each@2.0.8(@tapjs/core@2.1.6(@types/node@20.12.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:


### PR DESCRIPTION
Bumped iTwinUI version.
Fixed warnings about passing ref to the component that does not use `forwardRef`
Updated `IconButton` usage to use `label` instead of `title`.
Updated tests to work with latest iTwinUI changes.