### PR TITLE
Shared: Don't require schema provider when formatting `ConcatenatedValue`

### DIFF
--- a/.changeset/shiny-humans-hug.md
+++ b/.changeset/shiny-humans-hug.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-shared": patch
+---
+
+Fix `ECSql.createConcatenatedValueStringSelector` not casting property value to string. This could cause ECSQL query execution to fail when more than one selector is used.

--- a/.changeset/short-jars-sing.md
+++ b/.changeset/short-jars-sing.md
@@ -1,0 +1,42 @@
+---
+"@itwin/presentation-shared": minor
+---
+
+**BREAKING:** Removed the option to specify value + ECProperty identifier when creating a `ConcatenatedValue`.
+
+The change provides two benefits:
+
+1. Access to schema is not required to format `ConcatenatedValue` parts as they already contain all the necessary metadata required for formatting the value. This is a step towards supporting multiple data sources, where schema information might be not available during formatting.
+2. Previously, the property type information had to be extracted for every row in the result set, which was inefficient. Now, the type information is extracted only once, when creating an ECSql query.
+
+Full list of changes:
+
+- `ConcatenatedValuePart.isProperty` - removed, as the "property" type was removed from the type union.
+
+- `ECSql.createConcatenatedValueJsonSelector` and `ECSql.createConcatenatedValueStringSelector` don't accept an option to specify value + ECProperty identifier as a selector argument anymore. Instead, the option that specifies value selector + type information should be used. The latter kind of selector can be created using the newly added `ECSql.createPrimitivePropertyValueSelectorProps` function (see below).
+
+- Added `ECSql.createPrimitivePropertyValueSelectorProps` function to help create a selector that specifies a value selector + type information. See README for more details.
+
+- The change allows formatting `ConcatenatedValue` parts without the need to access schema information, so `formatConcatenatedValue` function now doesn't require a `schemaProvider` prop.
+
+Mitigation example:
+
+*Before:*
+
+```ts
+const selector: ECSql.createConcatenatedValueJsonSelector([
+  { type: "String", value: "[" },
+  { propertyClassName: "MySchema.MyClass", propertyClassAlias: "this", propertyName: "PropX" },
+  { type: "String", value: "]" },
+]);
+```
+
+*After:*
+
+```ts
+const selector: ECSql.createConcatenatedValueJsonSelector([
+  { type: "String", value: "[" },
+  await ECSql.createPrimitivePropertyValueSelectorProps({ schemaProvider, propertyClassName: "MySchema.MyClass", propertyClassAlias: "this", propertyName: "PropX" }),
+  { type: "String", value: "]" },
+]);
+```

--- a/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/Localization.test.tsx
+++ b/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/Localization.test.tsx
@@ -111,7 +111,7 @@ describe("Hierarchies React", () => {
       it("Tree localization", async function () {
         // __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.Localization.Tree
         function MyTreeComponent({ imodelAccess, imodelKey }: { imodelAccess: IModelAccess; imodelKey: string }) {
-          const { rootNodes, ...state } = useUnifiedSelectionTree({
+          const { rootNodes, expandNode } = useUnifiedSelectionTree({
             sourceName: "MyTreeComponent",
             imodelKey,
             imodelAccess,
@@ -121,12 +121,19 @@ describe("Hierarchies React", () => {
           if (!rootNodes) {
             return localizedStrings.loading;
           }
-          return <TreeRenderer {...state} rootNodes={rootNodes} localizedStrings={localizedStrings} onFilterClick={() => {}} />;
+          return (
+            <TreeRenderer 
+              rootNodes={rootNodes} 
+              expandNode={expandNode} 
+              localizedStrings={localizedStrings} 
+              onFilterClick={() => {}}
+            />
+          );
         }
         // __PUBLISH_EXTRACT_END__
 
-        const { getByRole, getAllByRole } = render(<MyTreeComponent imodelAccess={access} imodelKey={imodel.key} />);
-        await waitFor(() => getByRole("tree"));
+        const { getAllByRole } = render(<MyTreeComponent imodelAccess={access} imodelKey={imodel.key} />);
+        await waitFor(() => getAllByRole("treeitem"));
 
         expect(getAllByRole("button", { name: "Apply hierarchy filter" })).to.not.be.empty;
       });

--- a/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/Localization.test.tsx
+++ b/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/Localization.test.tsx
@@ -121,14 +121,7 @@ describe("Hierarchies React", () => {
           if (!rootNodes) {
             return localizedStrings.loading;
           }
-          return (
-            <TreeRenderer 
-              rootNodes={rootNodes} 
-              expandNode={expandNode} 
-              localizedStrings={localizedStrings} 
-              onFilterClick={() => {}}
-            />
-          );
+          return <TreeRenderer rootNodes={rootNodes} expandNode={expandNode} localizedStrings={localizedStrings} onFilterClick={() => {}} />;
         }
         // __PUBLISH_EXTRACT_END__
 

--- a/apps/full-stack-tests/src/hierarchies/Formatting.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/Formatting.test.ts
@@ -111,8 +111,9 @@ describe("Hierarchies", () => {
           });
           return { schema, model, category, element };
         });
+        const imodelAccess = createIModelAccess(imodel);
 
-        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess: createIModelAccess(imodel) });
+        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess });
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {
@@ -127,7 +128,12 @@ describe("Hierarchies", () => {
                       nodeLabel: {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
-                          { propertyClassName: schema.items.ClassX.fullName, propertyClassAlias: "this", propertyName: "PropX" },
+                          await ECSql.createPrimitivePropertyValueSelectorProps({
+                            schemaProvider: imodelAccess,
+                            propertyClassName: schema.items.ClassX.fullName,
+                            propertyClassAlias: "this",
+                            propertyName: "PropX",
+                          }),
                           { type: "String", value: "]" },
                         ]),
                       },
@@ -232,7 +238,8 @@ describe("Hierarchies", () => {
 
     describe("DateTime", () => {
       it("formats instance node labels", async function () {
-        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess: createIModelAccess(emptyIModel) });
+        const imodelAccess = createIModelAccess(emptyIModel);
+        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess });
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {
@@ -247,7 +254,12 @@ describe("Hierarchies", () => {
                       nodeLabel: {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
-                          { propertyClassName: "BisCore.Subject", propertyClassAlias: "this", propertyName: "LastMod" },
+                          await ECSql.createPrimitivePropertyValueSelectorProps({
+                            schemaProvider: imodelAccess,
+                            propertyClassName: "BisCore.Subject",
+                            propertyClassAlias: "this",
+                            propertyName: "LastMod",
+                          }),
                           { type: "String", value: "]" },
                         ]),
                       },
@@ -361,8 +373,9 @@ describe("Hierarchies", () => {
           const m2 = insertPhysicalSubModel({ builder, modeledElementId: p2.id, isPrivate: true });
           return { modelClassName: m2.className };
         });
+        const imodelAccess = createIModelAccess(imodel);
 
-        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess: createIModelAccess(imodel) });
+        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess });
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {
@@ -377,7 +390,12 @@ describe("Hierarchies", () => {
                       nodeLabel: {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
-                          { propertyClassName: modelClassName, propertyClassAlias: "this", propertyName: "IsPrivate" },
+                          await ECSql.createPrimitivePropertyValueSelectorProps({
+                            schemaProvider: imodelAccess,
+                            propertyClassName: modelClassName,
+                            propertyClassAlias: "this",
+                            propertyName: "IsPrivate",
+                          }),
                           { type: "String", value: "]" },
                         ]),
                       },
@@ -441,8 +459,9 @@ describe("Hierarchies", () => {
         const { imodel, category } = await buildIModel(this, async (builder) => {
           return { category: insertSpatialCategory({ builder, codeValue: "category", rank: Rank.Application }) };
         });
+        const imodelAccess = createIModelAccess(imodel);
 
-        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess: createIModelAccess(imodel) });
+        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess });
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {
@@ -457,7 +476,12 @@ describe("Hierarchies", () => {
                       nodeLabel: {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
-                          { propertyClassName: category.className, propertyClassAlias: "this", propertyName: "Rank" },
+                          await ECSql.createPrimitivePropertyValueSelectorProps({
+                            schemaProvider: imodelAccess,
+                            propertyClassName: category.className,
+                            propertyClassAlias: "this",
+                            propertyName: "Rank",
+                          }),
                           { type: "String", value: "]" },
                         ]),
                       },
@@ -531,7 +555,9 @@ describe("Hierarchies", () => {
           });
           return { model, category, element };
         });
-        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess: createIModelAccess(imodel) });
+        const imodelAccess = createIModelAccess(imodel);
+
+        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess });
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {
@@ -546,7 +572,12 @@ describe("Hierarchies", () => {
                       nodeLabel: {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
-                          { propertyClassName: element.className, propertyClassAlias: "this", propertyName: "Yaw" },
+                          await ECSql.createPrimitivePropertyValueSelectorProps({
+                            schemaProvider: imodelAccess,
+                            propertyClassName: element.className,
+                            propertyClassAlias: "this",
+                            propertyName: "Yaw",
+                          }),
                           { type: "String", value: "]" },
                         ]),
                       },
@@ -619,7 +650,9 @@ describe("Hierarchies", () => {
           });
           return { model, category, element };
         });
-        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess: createIModelAccess(imodel) });
+        const imodelAccess = createIModelAccess(imodel);
+
+        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess });
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {
@@ -634,7 +667,12 @@ describe("Hierarchies", () => {
                       nodeLabel: {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
-                          { propertyClassName: element.className, propertyClassAlias: "this", propertyName: "Origin", specialType: "Point2d" },
+                          await ECSql.createPrimitivePropertyValueSelectorProps({
+                            schemaProvider: imodelAccess,
+                            propertyClassName: element.className,
+                            propertyClassAlias: "this",
+                            propertyName: "Origin",
+                          }),
                           { type: "String", value: "]" },
                         ]),
                       },
@@ -707,7 +745,9 @@ describe("Hierarchies", () => {
           });
           return { model, category, element };
         });
-        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess: createIModelAccess(imodel) });
+        const imodelAccess = createIModelAccess(imodel);
+
+        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess });
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {
@@ -722,7 +762,12 @@ describe("Hierarchies", () => {
                       nodeLabel: {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
-                          { propertyClassName: element.className, propertyClassAlias: "this", propertyName: "Origin", specialType: "Point3d" },
+                          await ECSql.createPrimitivePropertyValueSelectorProps({
+                            schemaProvider: imodelAccess,
+                            propertyClassName: element.className,
+                            propertyClassAlias: "this",
+                            propertyName: "Origin",
+                          }),
                           { type: "String", value: "]" },
                         ]),
                       },
@@ -793,7 +838,9 @@ describe("Hierarchies", () => {
           });
           return { model, category, element };
         });
-        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess: createIModelAccess(imodel) });
+        const imodelAccess = createIModelAccess(imodel);
+
+        const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess });
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {
@@ -808,7 +855,12 @@ describe("Hierarchies", () => {
                       nodeLabel: {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
-                          { propertyClassName: element.className, propertyClassAlias: "this", propertyName: "FederationGuid", specialType: "Guid" },
+                          await ECSql.createPrimitivePropertyValueSelectorProps({
+                            schemaProvider: imodelAccess,
+                            propertyClassName: element.className,
+                            propertyClassAlias: "this",
+                            propertyName: "FederationGuid",
+                          }),
                           { type: "String", value: "]" },
                         ]),
                       },
@@ -840,7 +892,8 @@ describe("Hierarchies", () => {
     });
 
     it("reacts to changed formatter without running queries", async function () {
-      const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess: createIModelAccess(emptyIModel) });
+      const imodelAccess = createIModelAccess(emptyIModel);
+      const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess });
       const hierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ parentNode }) {
           if (!parentNode) {

--- a/apps/full-stack-tests/src/hierarchies/Update.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/Update.test.ts
@@ -564,7 +564,8 @@ describe("Hierarchies", () => {
         }
 
         function createPhysicalModelsProvider() {
-          const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess: createIModelAccess(imodel) });
+          const imodelAccess = createIModelAccess(imodel);
+          const selectQueryFactory = createNodesQueryClauseFactory({ imodelAccess });
           const hierarchy: HierarchyDefinition = {
             async defineHierarchyLevel() {
               return [
@@ -577,9 +578,19 @@ describe("Hierarchies", () => {
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: {
                           selector: ECSql.createConcatenatedValueJsonSelector([
-                            { propertyClassName: Element.classFullName, propertyClassAlias: "modeledElement", propertyName: "CodeValue" },
+                            await ECSql.createPrimitivePropertyValueSelectorProps({
+                              schemaProvider: imodelAccess,
+                              propertyClassName: Element.classFullName,
+                              propertyClassAlias: "modeledElement",
+                              propertyName: "CodeValue",
+                            }),
                             { type: "String", value: ". IsPrivate: " },
-                            { propertyClassName: PhysicalModel.classFullName, propertyClassAlias: "this", propertyName: "IsPrivate" },
+                            await ECSql.createPrimitivePropertyValueSelectorProps({
+                              schemaProvider: imodelAccess,
+                              propertyClassName: PhysicalModel.classFullName,
+                              propertyClassAlias: "this",
+                              propertyName: "IsPrivate",
+                            }),
                           ]),
                         },
                       })}

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/Formatting.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/Formatting.test.ts
@@ -162,7 +162,12 @@ describe("Hierarchies", () => {
                           nodeLabel: {
                             selector: ECSql.createConcatenatedValueJsonSelector([
                               // Create a selector for `CodeValue` property value
-                              { propertyClassName: "BisCore.SpatialCategory", propertyClassAlias: "this", propertyName: "CodeValue" },
+                              await ECSql.createPrimitivePropertyValueSelectorProps({
+                                schemaProvider: imodelAccess,
+                                propertyClassName: "BisCore.SpatialCategory",
+                                propertyClassAlias: "this",
+                                propertyName: "CodeValue",
+                              }),
                               // Include a static string value
                               { type: "String", value: " [" },
                               // Create a selector for `ECInstanceId` property value in hex format

--- a/packages/hierarchies-react/README.md
+++ b/packages/hierarchies-react/README.md
@@ -337,7 +337,7 @@ const localizedStrings = {
 };
 
 function MyTreeComponent({ imodelAccess, imodelKey }: { imodelAccess: IModelAccess; imodelKey: string }) {
-  const { rootNodes, ...state } = useUnifiedSelectionTree({
+  const { rootNodes, expandNode } = useUnifiedSelectionTree({
     sourceName: "MyTreeComponent",
     imodelKey,
     imodelAccess,
@@ -347,7 +347,7 @@ function MyTreeComponent({ imodelAccess, imodelKey }: { imodelAccess: IModelAcce
   if (!rootNodes) {
     return localizedStrings.loading;
   }
-  return <TreeRenderer {...state} rootNodes={rootNodes} localizedStrings={localizedStrings} onFilterClick={() => {}} />;
+  return <TreeRenderer rootNodes={rootNodes} expandNode={expandNode} localizedStrings={localizedStrings} onFilterClick={() => {}} />;
 }
 ```
 

--- a/packages/hierarchies/learning/Formatting.md
+++ b/packages/hierarchies/learning/Formatting.md
@@ -152,7 +152,12 @@ const hierarchyProvider = createHierarchyProvider({
                   nodeLabel: {
                     selector: ECSql.createConcatenatedValueJsonSelector([
                       // Create a selector for `CodeValue` property value
-                      { propertyClassName: "BisCore.SpatialCategory", propertyClassAlias: "this", propertyName: "CodeValue" },
+                      await ECSql.createPrimitivePropertyValueSelectorProps({
+                        schemaProvider: imodelAccess,
+                        propertyClassName: "BisCore.SpatialCategory",
+                        propertyClassAlias: "this",
+                        propertyName: "CodeValue",
+                      }),
                       // Include a static string value
                       { type: "String", value: " [" },
                       // Create a selector for `ECInstanceId` property value in hex format

--- a/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
@@ -338,7 +338,7 @@ class HierarchyProviderImpl implements HierarchyProvider {
       // set parent node keys on the parsed node
       map((node) => Object.assign(node, { parentKeys: createParentNodeKeysList(parentNode) })),
       // format `ConcatenatedValue` labels into string labels
-      mergeMap(async (node) => applyLabelsFormatting(node, this._imodelAccess, this._valuesFormatter)),
+      mergeMap(async (node) => applyLabelsFormatting(node, this._valuesFormatter)),
       // we have `ProcessedHierarchyNode` from here
       preProcessNodes(this.hierarchyDefinition),
       finalize(() =>
@@ -685,14 +685,12 @@ function processNodes<TNode>(processor: (node: TNode) => Promise<TNode | undefin
 
 async function applyLabelsFormatting<TNode extends { label: string | ConcatenatedValue }>(
   node: TNode,
-  schemaProvider: ECSchemaProvider,
   valueFormatter: IPrimitiveValueFormatter,
 ): Promise<TNode & { label: string }> {
   return {
     ...node,
     label: await formatConcatenatedValue({
       value: node.label,
-      schemaProvider,
       valueFormatter,
     }),
   };

--- a/packages/hierarchies/src/test/internal/TreeNodesReader.test.ts
+++ b/packages/hierarchies/src/test/internal/TreeNodesReader.test.ts
@@ -132,11 +132,14 @@ describe("defaultNodesParser", () => {
         type: "Integer",
         value: 123,
       },
-      {
-        className: "x.y",
-        propertyName: "p",
-        value: "test",
-      },
+      "test",
+      [
+        {
+          type: "Boolean",
+          value: true,
+        },
+        "xxx",
+      ],
     ];
     const row: RowDef = {
       [NodeSelectClauseColumnNames.FullClassName]: "schema.class",

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -139,6 +139,28 @@ The ECSql utilities group contains a number of functions to help create complex 
   // result = "'STRING VALUE'"
   ```
 
+- `createPrimitivePropertyValueSelectorProps` - creates `TypedValueSelectClauseProps` for selecting a primitive property value, while also
+  accounting for the property type. The created props may be used when creating `ConcatenatedValue` selectors (see `createConcatenatedValueJsonSelector`
+  and `createConcatenatedValueStringSelector`).
+
+  Example usage:
+
+  ```ts
+  import { ECSql } from "@itwin/presentation-shared";
+
+  const categoryRankSelectorProps = ECSql.createPrimitivePropertyValueSelectorProps({
+    schemaProvider,
+    propertyClassAlias: "x",
+    propertyClassName: "BisCore.Category",
+    propertyName: "Rank",
+  });
+  // categoryRankSelectorProps = { selector: "[x].[Rank]", type: "Integer" }
+
+  // Now we can use the result to create a `ConcatenatedValue` selector:
+  const selector = ECSql.createConcatenatedValueJsonSelector(["Rank: ", categoryRankSelectorProps]);
+  // selector = `json_array('Rank: ', json_object('selector', '[x].[Rank]', 'type', 'Integer'))`
+  ```
+
 - `createInstanceKeySelector` - creates an ECSQL selector for a serialized `InstanceKey` JSON object.
 
   Example usage:
@@ -158,12 +180,7 @@ The ECSql utilities group contains a number of functions to help create complex 
 
   const selector = ECSql.createConcatenatedValueJsonSelector([
     {
-      propertyClassName: "MySchema.MyClass",
-      propertyClassAlias: "my_class",
-      propertyName: "MyProperty",
-    },
-    {
-      selector: "my_class.MyOtherProperty",
+      selector: "my_class.MyProperty",
     },
     {
       value: 123.456,
@@ -171,12 +188,7 @@ The ECSql utilities group contains a number of functions to help create complex 
     },
   ]);
   // selector = `json_array(
-  //     json_object(
-  //         'className', 'MySchema.MyClass',
-  //         'propertyName', 'MyProperty',
-  //         'value', [my_class].[MyProperty]
-  //     ),
-  //     my_class.MyOtherProperty,
+  //     my_class.MyProperty,
   //     json_object(
   //         'value', 123.456,
   //         'type', 'Double'
@@ -205,19 +217,14 @@ The ECSql utilities group contains a number of functions to help create complex 
 
   const selector = ECSql.createConcatenatedValueStringSelector([
     {
-      propertyClassName: "MySchema.MyClass",
-      propertyClassAlias: "my_class",
-      propertyName: "MyProperty",
-    },
-    {
-      selector: "my_class.MyOtherProperty",
+      selector: "my_class.MyProperty",
     },
     {
       value: 123.456,
       type: "Double",
     },
   ]);
-  // selector = `[my_class].[MyProperty] || my_class.MyOtherProperty || 123.456`
+  // selector = `my_class.MyProperty || 123.456`
 
   const queryReader = queryExecutor.createQueryReader(
     {
@@ -274,11 +281,10 @@ The APIs in Values group contain various value types and utilities to work with 
 
   - `create` - given a `PrimitiveValue`, its type and, optionally, extra information, validates the input and creates a `TypedPrimitiveValue`.
 
-- `ConcatenatedValuePart` - a union of different types that may be used to create a single, combined value: primitive ECInstance property value, hardcoded primitive value or just plain string. Also, a namespace, containing the following utilities:
+- `ConcatenatedValuePart` - a union of different types that may be used to create a single, combined value: nested `ConcatenatedValue`, `TypedPrimitiveValue` or just plain string. Also, a namespace, containing the following utilities:
 
   - `isString` - type guard to check if the given `ConcatenatedValuePart` is a `string`.
   - `isPrimitive` - type guard to check if the given `ConcatenatedValuePart` is a `TypedPrimitiveValue`.
-  - `isProperty` - type guard to check if the given `ConcatenatedValuePart` describes a primitive property value.
 
 - `ConcatenatedValue` - an array of `ConcatenatedValuePart`. Also, a namespace containing the following utilities:
 

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -224,7 +224,7 @@ The ECSql utilities group contains a number of functions to help create complex 
       type: "Double",
     },
   ]);
-  // selector = `my_class.MyProperty || 123.456`
+  // selector = `CAST(my_class.MyProperty AS TEXT) || '123.456'`
 
   const queryReader = queryExecutor.createQueryReader(
     {

--- a/packages/shared/api/presentation-shared.api.md
+++ b/packages/shared/api/presentation-shared.api.md
@@ -41,7 +41,7 @@ export namespace ConcatenatedValue {
 }
 
 // @beta
-export type ConcatenatedValuePart = ConcatenatedValue | PrimitivePropertyValue | TypedPrimitiveValue | string;
+export type ConcatenatedValuePart = ConcatenatedValue | TypedPrimitiveValue | string;
 
 // @beta (undocumented)
 export namespace ConcatenatedValuePart {
@@ -49,8 +49,6 @@ export namespace ConcatenatedValuePart {
     export function isConcatenatedValue(part: ConcatenatedValuePart): part is ConcatenatedValue;
     // (undocumented)
     export function isPrimitive(part: ConcatenatedValuePart): part is TypedPrimitiveValue;
-    // (undocumented)
-    export function isProperty(part: ConcatenatedValuePart): part is PrimitivePropertyValue;
     // (undocumented)
     export function isString(part: ConcatenatedValuePart): part is string;
 }
@@ -99,6 +97,14 @@ function createNullableSelector(props: {
     checkSelector: string;
     valueSelector: string;
 }): string;
+
+// @beta
+function createPrimitivePropertyValueSelectorProps({ schemaProvider, propertyClassAlias, propertyClassName, propertyName, }: {
+    schemaProvider: ECSchemaProvider;
+    propertyClassName: string;
+    propertyClassAlias: string;
+    propertyName: string;
+}): Promise<TypedPrimitiveValueSelectorProps>;
 
 // @beta
 function createRawPrimitiveValueSelector(value: PrimitiveValue | undefined): string;
@@ -272,6 +278,7 @@ declare namespace ECSql {
         createConcatenatedValueJsonSelector,
         createConcatenatedValueStringSelector,
         createInstanceKeySelector,
+        createPrimitivePropertyValueSelectorProps,
         createRelationshipPathJoinClause
     }
 }
@@ -355,7 +362,6 @@ export { Event_2 as Event }
 // @beta
 export function formatConcatenatedValue(props: {
     value: ConcatenatedValue | string;
-    schemaProvider: ECSchemaProvider;
     valueFormatter: IPrimitiveValueFormatter;
 }): Promise<string>;
 
@@ -454,13 +460,6 @@ interface Point3d {
 }
 
 // @beta
-interface PrimitivePropertyValue {
-    className: string;
-    propertyName: string;
-    value: PrimitiveValue;
-}
-
-// @beta
 export type PrimitiveValue = Id64String | string | number | boolean | Date | Point2d | Point3d;
 
 // @beta (undocumented)
@@ -470,21 +469,7 @@ export namespace PrimitiveValue {
 }
 
 // @beta
-interface PrimitiveValueSelectorProps {
-    selector: string;
-    type?: PrimitiveValueType;
-}
-
-// @beta
 type PrimitiveValueType = "Id" | Exclude<EC.PrimitiveType, "Binary" | "IGeometry">;
-
-// @beta
-interface PropertyValueSelectClauseProps {
-    propertyClassAlias: string;
-    propertyClassName: string;
-    propertyName: string;
-    specialType?: SpecialPropertyType;
-}
 
 // @beta
 type RelationshipPath<TStep extends RelationshipPathStep = RelationshipPathStep> = TStep[];
@@ -499,9 +484,6 @@ interface RelationshipPathStep {
 
 // @beta
 export function releaseMainThread(): Promise<void>;
-
-// @beta
-type SpecialPropertyType = "Navigation" | "Guid" | "Point2d" | "Point3d";
 
 // @beta
 export function trimWhitespace(str: string): string;
@@ -545,16 +527,28 @@ export namespace TypedPrimitiveValue {
 }
 
 // @beta
-type TypedValueSelectClauseProps = PropertyValueSelectClauseProps | TypedPrimitiveValue | PrimitiveValueSelectorProps;
+type TypedPrimitiveValueSelectorProps = {
+    selector: string;
+} & ({
+    type?: undefined;
+} | {
+    type: Exclude<PrimitiveValueType, "Double">;
+    extendedType?: string;
+} | {
+    type: Extract<PrimitiveValueType, "Double">;
+    extendedType?: string;
+    koqName?: string;
+});
+
+// @beta
+type TypedValueSelectClauseProps = TypedPrimitiveValue | TypedPrimitiveValueSelectorProps;
 
 // @beta (undocumented)
 namespace TypedValueSelectClauseProps {
     // (undocumented)
     function isPrimitiveValue(props: TypedValueSelectClauseProps): props is TypedPrimitiveValue;
     // (undocumented)
-    function isPrimitiveValueSelector(props: TypedValueSelectClauseProps): props is PrimitiveValueSelectorProps;
-    // (undocumented)
-    function isPropertySelector(props: TypedValueSelectClauseProps): props is PropertyValueSelectClauseProps;
+    function isPrimitiveValueSelector(props: TypedValueSelectClauseProps): props is TypedPrimitiveValueSelectorProps;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/shared/src/shared/ConcatenatedValue.ts
+++ b/packages/shared/src/shared/ConcatenatedValue.ts
@@ -3,13 +3,11 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { PrimitivePropertyValue, TypedPrimitiveValue } from "./Values";
+import { TypedPrimitiveValue } from "./Values";
 
 /**
  * A part of a `ConcatenatedValue`, describing one piece of the value. Possible types:
  * - `ConcatenatedValue` describes a nested concatenated value.
- * - `PrimitivePropertyValue` describes an ECProperty value. Generally the value is formatted according to
- *   property metadata before concatenating with other parts.
  * - `TypedPrimitiveValue` describes a value with its type. Generally the value is formatted
  *   according to its type information before concatenating with other parts.
  * - `string` is just concatenated to other parts as-is.
@@ -17,7 +15,7 @@ import { PrimitivePropertyValue, TypedPrimitiveValue } from "./Values";
  * @see `ConcatenatedValue`
  * @beta
  */
-export type ConcatenatedValuePart = ConcatenatedValue | PrimitivePropertyValue | TypedPrimitiveValue | string;
+export type ConcatenatedValuePart = ConcatenatedValue | TypedPrimitiveValue | string;
 
 /** @beta */
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -30,12 +28,6 @@ export namespace ConcatenatedValuePart {
   /** @beta */
   export function isPrimitive(part: ConcatenatedValuePart): part is TypedPrimitiveValue {
     return !!(part as TypedPrimitiveValue).type;
-  }
-
-  /** @beta */
-  export function isProperty(part: ConcatenatedValuePart): part is PrimitivePropertyValue {
-    const candidate = part as PrimitivePropertyValue;
-    return !!candidate.className && !!candidate.propertyName;
   }
 
   /** @beta */

--- a/packages/shared/src/shared/Values.ts
+++ b/packages/shared/src/shared/Values.ts
@@ -227,16 +227,3 @@ export namespace TypedPrimitiveValue {
     throw new Error(`PrimitiveValueType ${type} isn't compatible with value ${JSON.stringify(value)}`);
   }
 }
-
-/**
- * A type for a primitive property value and its metadata - property name and its class full name.
- * @beta
- */
-export interface PrimitivePropertyValue {
-  /** Full name of the class containing the property with `propertyName` name. */
-  className: string;
-  /** Name of the primitive property whose value this data structure holds. */
-  propertyName: string;
-  /** Raw value of the primitive property. */
-  value: PrimitiveValue;
-}

--- a/packages/shared/src/shared/ecsql-snippets/ECSqlValueSelectorSnippets.ts
+++ b/packages/shared/src/shared/ecsql-snippets/ECSqlValueSelectorSnippets.ts
@@ -284,7 +284,7 @@ export function createConcatenatedValueStringSelector(selectors: TypedValueSelec
 }
 function createTypedValueStringSelector(props: TypedValueSelectClauseProps): string {
   if (TypedValueSelectClauseProps.isPrimitiveValueSelector(props)) {
-    return props.selector;
+    return `CAST(${props.selector} AS TEXT)`;
   }
   return createPrimitiveValueStringSelector(props.value);
 }

--- a/packages/shared/src/shared/ecsql-snippets/index.ts
+++ b/packages/shared/src/shared/ecsql-snippets/index.ts
@@ -10,5 +10,6 @@ export {
   createConcatenatedValueJsonSelector,
   createConcatenatedValueStringSelector,
   createInstanceKeySelector,
+  createPrimitivePropertyValueSelectorProps,
 } from "./ECSqlValueSelectorSnippets";
 export { createRelationshipPathJoinClause } from "./ECSqlJoinSnippets";

--- a/packages/shared/src/test/ConcatenatedValue.test.ts
+++ b/packages/shared/src/test/ConcatenatedValue.test.ts
@@ -13,7 +13,6 @@ describe("ConcatenatedValuePart", () => {
     it("returns correct result for different types of parts", () => {
       expect(ConcatenatedValuePart.isString("str")).to.be.true;
       expect(ConcatenatedValuePart.isString({ type: "Integer", value: 123 })).to.be.false;
-      expect(ConcatenatedValuePart.isString({ className: "s.c", propertyName: "p", value: "test" })).to.be.false;
       expect(ConcatenatedValuePart.isString(["str"] satisfies ConcatenatedValue)).to.be.false;
     });
   });
@@ -22,17 +21,7 @@ describe("ConcatenatedValuePart", () => {
     it("returns correct result for different types of parts", () => {
       expect(ConcatenatedValuePart.isPrimitive("str")).to.be.false;
       expect(ConcatenatedValuePart.isPrimitive({ type: "Integer", value: 123 })).to.be.true;
-      expect(ConcatenatedValuePart.isPrimitive({ className: "s.c", propertyName: "p", value: "test" })).to.be.false;
       expect(ConcatenatedValuePart.isPrimitive([{ type: "Integer", value: 123 }] satisfies ConcatenatedValue)).to.be.false;
-    });
-  });
-
-  describe("isProperty", () => {
-    it("returns correct result for different types of parts", () => {
-      expect(ConcatenatedValuePart.isProperty("str")).to.be.false;
-      expect(ConcatenatedValuePart.isProperty({ type: "Integer", value: 123 })).to.be.false;
-      expect(ConcatenatedValuePart.isProperty({ className: "s.c", propertyName: "p", value: "test" })).to.be.true;
-      expect(ConcatenatedValuePart.isProperty([{ className: "s.c", propertyName: "p", value: "test" }] satisfies ConcatenatedValue)).to.be.false;
     });
   });
 
@@ -40,14 +29,7 @@ describe("ConcatenatedValuePart", () => {
     it("returns correct result for different types of parts", () => {
       expect(ConcatenatedValuePart.isConcatenatedValue("str")).to.be.false;
       expect(ConcatenatedValuePart.isConcatenatedValue({ type: "Integer", value: 123 })).to.be.false;
-      expect(ConcatenatedValuePart.isConcatenatedValue({ className: "s.c", propertyName: "p", value: "test" })).to.be.false;
-      expect(
-        ConcatenatedValuePart.isConcatenatedValue([
-          "str",
-          { type: "Integer", value: 123 },
-          { className: "s.c", propertyName: "p", value: "test" },
-        ] satisfies ConcatenatedValue),
-      ).to.be.true;
+      expect(ConcatenatedValuePart.isConcatenatedValue(["str", { type: "Integer", value: 123 }] satisfies ConcatenatedValue)).to.be.true;
     });
   });
 });
@@ -66,19 +48,14 @@ describe("ConcatenatedValue", () => {
     });
 
     it("serializes all parts in order", async () => {
-      const parts: ConcatenatedValuePart[] = [
-        "str1",
-        { type: "Integer", value: 123 },
-        { className: "s.c", propertyName: "p", value: "test" },
-        ["str2", { type: "Integer", value: 123 }, { className: "s.c", propertyName: "p", value: "test" }],
-      ];
+      const parts: ConcatenatedValuePart[] = ["str1", { type: "Integer", value: 123 }, ["str2", { type: "Integer", value: 123 }]];
       expect(
         await ConcatenatedValue.serialize({
           parts,
           partFormatter: async (part) => {
             let partIndex = parts.indexOf(part);
             if (partIndex === -1) {
-              partIndex = (parts[3] as ConcatenatedValue).indexOf(part) + 3;
+              partIndex = (parts[2] as ConcatenatedValue).indexOf(part) + 2;
             }
             if (partIndex % 2 === 1) {
               // sleep for a bit to ensure we get parts in correct order even if they resolve in different order
@@ -87,7 +64,7 @@ describe("ConcatenatedValue", () => {
             return `_${partIndex.toString()}_`;
           },
         }),
-      ).to.eq("_0__1__2__3__4__5_");
+      ).to.eq("_0__1__2__3_");
     });
 
     it("joins parts with given separator", async () => {

--- a/packages/shared/src/test/InstanceLabelSelectClauseFactory.test.ts
+++ b/packages/shared/src/test/InstanceLabelSelectClauseFactory.test.ts
@@ -42,9 +42,9 @@ describe("parseInstanceLabel", () => {
         value: 123,
       },
       {
-        className: "x.y",
-        propertyName: "p",
-        value: "test",
+        type: "String",
+        value: "http://bentley.com",
+        extendedType: "Url",
       },
     ];
     expect(parseInstanceLabel(JSON.stringify(labelParts))).to.deep.eq(labelParts);

--- a/packages/shared/src/test/ecsql-snippets/ECSqlValueSelectorSnippets.test.ts
+++ b/packages/shared/src/test/ecsql-snippets/ECSqlValueSelectorSnippets.test.ts
@@ -333,11 +333,11 @@ const CONCATENATED_VALUE_TEST_CASES = [
   {
     name: "concatenates selectors",
     input: {
-      selectors: [{ selector: "a" }, { selector: "b" }],
+      selectors: [{ selector: "a" }, { value: "b", type: "String" as const }],
     },
     expectations: {
-      json: `json_array(a, b)`,
-      str: `a || b`,
+      json: `json_array(a, json_object('value', 'b', 'type', 'String'))`,
+      str: `CAST(a AS TEXT) || 'b'`,
     },
   },
   {
@@ -351,7 +351,7 @@ const CONCATENATED_VALUE_TEST_CASES = [
     },
     expectations: {
       json: `json_array(xxx)`,
-      str: `xxx`,
+      str: `CAST(xxx AS TEXT)`,
     },
   },
   {
@@ -366,7 +366,7 @@ const CONCATENATED_VALUE_TEST_CASES = [
     },
     expectations: {
       json: `json_array(json_object('value', xxx, 'type', 'Integer'))`,
-      str: `xxx`,
+      str: `CAST(xxx AS TEXT)`,
     },
   },
   {
@@ -382,7 +382,7 @@ const CONCATENATED_VALUE_TEST_CASES = [
     },
     expectations: {
       json: `json_array(json_object('value', xxx, 'type', 'Integer', 'extendedType', 'TestExtendedType'))`,
-      str: `xxx`,
+      str: `CAST(xxx AS TEXT)`,
     },
   },
   {

--- a/packages/shared/src/test/ecsql-snippets/ECSqlValueSelectorSnippets.test.ts
+++ b/packages/shared/src/test/ecsql-snippets/ECSqlValueSelectorSnippets.test.ts
@@ -9,30 +9,24 @@ import {
   createConcatenatedValueStringSelector,
   createInstanceKeySelector,
   createNullableSelector,
+  createPrimitivePropertyValueSelectorProps,
   createRawPrimitiveValueSelector,
   createRawPropertyValueSelector,
   TypedValueSelectClauseProps,
 } from "../../shared/ecsql-snippets/ECSqlValueSelectorSnippets";
+import { EC } from "../../shared/Metadata";
 import { trimWhitespace } from "../../shared/Utils";
+import { createECSchemaProviderStub } from "../MetadataProviderStub";
 
 describe("TypedValueSelectClauseProps", () => {
-  describe("isPropertySelector", () => {
-    it("returns correct result for different types of props", () => {
-      expect(TypedValueSelectClauseProps.isPropertySelector({ propertyClassName: "s.c", propertyClassAlias: "a", propertyName: "p" })).to.be.true;
-      expect(TypedValueSelectClauseProps.isPropertySelector({ selector: "x" })).to.be.false;
-      expect(TypedValueSelectClauseProps.isPropertySelector({ value: 123, type: "Integer" })).to.be.false;
-    });
-  });
   describe("isPrimitiveValueSelector", () => {
     it("returns correct result for different types of props", () => {
-      expect(TypedValueSelectClauseProps.isPrimitiveValueSelector({ propertyClassName: "s.c", propertyClassAlias: "a", propertyName: "p" })).to.be.false;
       expect(TypedValueSelectClauseProps.isPrimitiveValueSelector({ selector: "x" })).to.be.true;
       expect(TypedValueSelectClauseProps.isPrimitiveValueSelector({ value: 123, type: "Integer" })).to.be.false;
     });
   });
   describe("isPrimitiveValue", () => {
     it("returns correct result for different types of props", () => {
-      expect(TypedValueSelectClauseProps.isPrimitiveValue({ propertyClassName: "s.c", propertyClassAlias: "a", propertyName: "p" })).to.be.false;
       expect(TypedValueSelectClauseProps.isPrimitiveValue({ selector: "x" })).to.be.false;
       expect(TypedValueSelectClauseProps.isPrimitiveValue({ value: 123, type: "Integer" })).to.be.true;
     });
@@ -88,6 +82,220 @@ describe("createRawPrimitiveValueSelector", () => {
   });
 });
 
+describe("createPrimitivePropertyValueSelectorProps", () => {
+  it("creates selector props for simple primitive property", async () => {
+    const schemaProvider = createECSchemaProviderStub();
+    schemaProvider.stubEntityClass({
+      schemaName: "x",
+      className: "y",
+      properties: [
+        {
+          name: "p",
+          isPrimitive: () => true,
+          isNavigation: () => false,
+          primitiveType: "String",
+          extendedTypeName: "Json",
+        } as EC.PrimitiveProperty,
+      ],
+    });
+    expect(
+      await createPrimitivePropertyValueSelectorProps({ schemaProvider, propertyClassAlias: "a", propertyClassName: "x.y", propertyName: "p" }),
+    ).to.deep.eq({
+      selector: "[a].[p]",
+      type: "String",
+      extendedType: "Json",
+    } satisfies TypedValueSelectClauseProps);
+  });
+
+  it("creates selector props for Double property", async () => {
+    const schemaProvider = createECSchemaProviderStub();
+    schemaProvider.stubEntityClass({
+      schemaName: "x",
+      className: "y",
+      properties: [
+        {
+          name: "p",
+          isPrimitive: () => true,
+          isNavigation: () => false,
+          primitiveType: "Double",
+          kindOfQuantity: Promise.resolve({ fullName: "TestSchema.TestKindOfQuantity" }),
+          extendedTypeName: "TestExtendedType",
+        } as EC.PrimitiveProperty,
+      ],
+    });
+    expect(
+      await createPrimitivePropertyValueSelectorProps({ schemaProvider, propertyClassAlias: "a", propertyClassName: "x.y", propertyName: "p" }),
+    ).to.deep.eq({
+      selector: "[a].[p]",
+      type: "Double",
+      extendedType: "TestExtendedType",
+      koqName: "TestSchema.TestKindOfQuantity",
+    } satisfies TypedValueSelectClauseProps);
+  });
+
+  it("creates selector props for Navigation property", async () => {
+    const schemaProvider = createECSchemaProviderStub();
+    schemaProvider.stubEntityClass({
+      schemaName: "x",
+      className: "y",
+      properties: [
+        {
+          name: "p",
+          isPrimitive: () => false,
+          isNavigation: () => true,
+        } as EC.NavigationProperty,
+      ],
+    });
+    expect(
+      await createPrimitivePropertyValueSelectorProps({ schemaProvider, propertyClassAlias: "a", propertyClassName: "x.y", propertyName: "p" }),
+    ).to.deep.eq({
+      selector: "[a].[p].[Id]",
+      type: "Id",
+    } satisfies TypedValueSelectClauseProps);
+  });
+
+  it("creates selector props for Guid property", async () => {
+    const schemaProvider = createECSchemaProviderStub();
+    schemaProvider.stubEntityClass({
+      schemaName: "x",
+      className: "y",
+      properties: [
+        {
+          name: "p",
+          isPrimitive: () => true,
+          isNavigation: () => false,
+          primitiveType: "Binary",
+          extendedTypeName: "BeGuid",
+        } as EC.PrimitiveProperty,
+      ],
+    });
+    expect(
+      await createPrimitivePropertyValueSelectorProps({ schemaProvider, propertyClassAlias: "a", propertyClassName: "x.y", propertyName: "p" }),
+    ).to.deep.eq({
+      selector: "GuidToStr([a].[p])",
+      type: "String",
+    } satisfies TypedValueSelectClauseProps);
+  });
+
+  it("creates selector props for Point2d property", async () => {
+    const schemaProvider = createECSchemaProviderStub();
+    schemaProvider.stubEntityClass({
+      schemaName: "x",
+      className: "y",
+      properties: [
+        {
+          name: "p",
+          isPrimitive: () => true,
+          isNavigation: () => false,
+          primitiveType: "Point2d",
+          extendedTypeName: "TestExtendedType",
+        } as EC.PrimitiveProperty,
+      ],
+    });
+    expect(
+      await createPrimitivePropertyValueSelectorProps({ schemaProvider, propertyClassAlias: "a", propertyClassName: "x.y", propertyName: "p" }),
+    ).to.deep.eq({
+      selector: "json_object('x', [a].[p].[x], 'y', [a].[p].[y])",
+      type: "Point2d",
+      extendedType: "TestExtendedType",
+    } satisfies TypedValueSelectClauseProps);
+  });
+
+  it("creates selector props for Point3d property", async () => {
+    const schemaProvider = createECSchemaProviderStub();
+    schemaProvider.stubEntityClass({
+      schemaName: "x",
+      className: "y",
+      properties: [
+        {
+          name: "p",
+          isPrimitive: () => true,
+          isNavigation: () => false,
+          primitiveType: "Point3d",
+          extendedTypeName: "TestExtendedType",
+        } as EC.PrimitiveProperty,
+      ],
+    });
+    expect(
+      await createPrimitivePropertyValueSelectorProps({ schemaProvider, propertyClassAlias: "a", propertyClassName: "x.y", propertyName: "p" }),
+    ).to.deep.eq({
+      selector: "json_object('x', [a].[p].[x], 'y', [a].[p].[y], 'z', [a].[p].[z])",
+      type: "Point3d",
+      extendedType: "TestExtendedType",
+    } satisfies TypedValueSelectClauseProps);
+  });
+
+  it("throws when requested class is not found", async () => {
+    const schemaProvider = createECSchemaProviderStub();
+    await expect(createPrimitivePropertyValueSelectorProps({ schemaProvider, propertyClassAlias: "a", propertyClassName: "x.y", propertyName: "p" })).to
+      .eventually.be.rejected;
+  });
+
+  it("throws when requested property is not found", async () => {
+    const schemaProvider = createECSchemaProviderStub();
+    schemaProvider.stubEntityClass({
+      schemaName: "x",
+      className: "y",
+      properties: [],
+    });
+    await expect(createPrimitivePropertyValueSelectorProps({ schemaProvider, propertyClassAlias: "a", propertyClassName: "x.y", propertyName: "p" })).to
+      .eventually.be.rejected;
+  });
+
+  it("throws when requested property is not primitive", async () => {
+    const schemaProvider = createECSchemaProviderStub();
+    schemaProvider.stubEntityClass({
+      schemaName: "x",
+      className: "y",
+      properties: [
+        {
+          name: "p",
+          isPrimitive: () => false,
+          isNavigation: () => false,
+        } as EC.Property,
+      ],
+    });
+    await expect(createPrimitivePropertyValueSelectorProps({ schemaProvider, propertyClassAlias: "a", propertyClassName: "x.y", propertyName: "p" })).to
+      .eventually.be.rejected;
+  });
+
+  it('throws when requested property is "Binary"', async () => {
+    const schemaProvider = createECSchemaProviderStub();
+    schemaProvider.stubEntityClass({
+      schemaName: "x",
+      className: "y",
+      properties: [
+        {
+          name: "p",
+          isPrimitive: () => true,
+          isNavigation: () => false,
+          primitiveType: "Binary",
+        } as EC.PrimitiveProperty,
+      ],
+    });
+    await expect(createPrimitivePropertyValueSelectorProps({ schemaProvider, propertyClassAlias: "a", propertyClassName: "x.y", propertyName: "p" })).to
+      .eventually.be.rejected;
+  });
+
+  it('throws when requested property is "IGeometry"', async () => {
+    const schemaProvider = createECSchemaProviderStub();
+    schemaProvider.stubEntityClass({
+      schemaName: "x",
+      className: "y",
+      properties: [
+        {
+          name: "p",
+          isPrimitive: () => true,
+          isNavigation: () => false,
+          primitiveType: "IGeometry",
+        } as EC.PrimitiveProperty,
+      ],
+    });
+    await expect(createPrimitivePropertyValueSelectorProps({ schemaProvider, propertyClassAlias: "a", propertyClassName: "x.y", propertyName: "p" })).to
+      .eventually.be.rejected;
+  });
+});
+
 describe("createNullableSelector", () => {
   it("creates valid selector", () => {
     expect(
@@ -133,90 +341,6 @@ const CONCATENATED_VALUE_TEST_CASES = [
     },
   },
   {
-    name: "serializes simple property selector",
-    input: {
-      selectors: [
-        {
-          propertyClassName: "s.c",
-          propertyClassAlias: "alias",
-          propertyName: "prop",
-        },
-      ],
-    },
-    expectations: {
-      json: `json_array(json_object('className', 's.c', 'propertyName', 'prop', 'value', [alias].[prop]))`,
-      str: `[alias].[prop]`,
-    },
-  },
-  {
-    name: "serializes Navigation property selector",
-    input: {
-      selectors: [
-        {
-          propertyClassName: "s.c",
-          propertyClassAlias: "alias",
-          propertyName: "prop",
-          specialType: "Navigation" as const,
-        },
-      ],
-    },
-    expectations: {
-      json: `json_array(json_object('value', [alias].[prop].[Id], 'type', 'Id'))`,
-      str: `CAST([alias].[prop].[Id] AS TEXT)`,
-    },
-  },
-  {
-    name: "serializes Guid property selector",
-    input: {
-      selectors: [
-        {
-          propertyClassName: "s.c",
-          propertyClassAlias: "alias",
-          propertyName: "prop",
-          specialType: "Guid" as const,
-        },
-      ],
-    },
-    expectations: {
-      json: `json_array(json_object('value', GuidToStr([alias].[prop]), 'type', 'String'))`,
-      str: `GuidToStr([alias].[prop])`,
-    },
-  },
-  {
-    name: "serializes Point2d property selector",
-    input: {
-      selectors: [
-        {
-          propertyClassName: "s.c",
-          propertyClassAlias: "alias",
-          propertyName: "prop",
-          specialType: "Point2d" as const,
-        },
-      ],
-    },
-    expectations: {
-      json: `json_array(json_object('value', json_object('x', [alias].[prop].[x], 'y', [alias].[prop].[y]), 'type', 'Point2d'))`,
-      str: `'(' || [alias].[prop].[x] || ', ' || [alias].[prop].[y] || ')'`,
-    },
-  },
-  {
-    name: "serializes Point3d property selector",
-    input: {
-      selectors: [
-        {
-          propertyClassName: "s.c",
-          propertyClassAlias: "alias",
-          propertyName: "prop",
-          specialType: "Point3d" as const,
-        },
-      ],
-    },
-    expectations: {
-      json: `json_array(json_object('value', json_object('x', [alias].[prop].[x], 'y', [alias].[prop].[y], 'z', [alias].[prop].[z]), 'type', 'Point3d'))`,
-      str: `'(' || [alias].[prop].[x] || ', ' || [alias].[prop].[y] || ', ' || [alias].[prop].[z] || ')'`,
-    },
-  },
-  {
     name: "serializes primitive value selector without type",
     input: {
       selectors: [
@@ -242,6 +366,22 @@ const CONCATENATED_VALUE_TEST_CASES = [
     },
     expectations: {
       json: `json_array(json_object('value', xxx, 'type', 'Integer'))`,
+      str: `xxx`,
+    },
+  },
+  {
+    name: "serializes primitive value selector with type and extended type",
+    input: {
+      selectors: [
+        {
+          selector: "xxx",
+          type: "Integer" as const,
+          extendedType: "TestExtendedType",
+        },
+      ],
+    },
+    expectations: {
+      json: `json_array(json_object('value', xxx, 'type', 'Integer', 'extendedType', 'TestExtendedType'))`,
       str: `xxx`,
     },
   },
@@ -298,10 +438,10 @@ const CONCATENATED_VALUE_TEST_CASES = [
   {
     name: "serializes primitive Double value",
     input: {
-      selectors: [{ type: "Double" as const, value: 456.789 }],
+      selectors: [{ type: "Double" as const, koqName: "TestKindOfQuantity", value: 456.789 }],
     },
     expectations: {
-      json: `json_array(json_object('value', 456.789, 'type', 'Double'))`,
+      json: `json_array(json_object('value', 456.789, 'type', 'Double', 'koqName', 'TestKindOfQuantity'))`,
       str: `'456.789'`,
     },
   },


### PR DESCRIPTION
Part of https://github.com/iTwin/presentation/issues/702.

With upcoming changes to support nodes being loaded from different imodels or even other sources, we want to avoid having dependency on an iModel (or its schema provider) after loading the nodes. This PR moves property metadata extraction from when we process the nodes to when we create a query.