### PR TITLE
Parallelize tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -81,7 +81,7 @@
         "--config",
         "./.mocharc.json",
         "--no-timeouts",
-        "lib/cjs/test/**/*.test.js"
+        "--parallel=false"
       ],
       "outFiles": [
         "${workspaceFolder}/packages/components/lib/**/*.js"
@@ -101,7 +101,7 @@
         "--config",
         "./.mocharc.json",
         "--no-timeouts",
-        "lib/cjs/test/**/*.test.js"
+        "--parallel=false"
       ],
       "outFiles": [
         "${workspaceFolder}/packages/opentelemetry/lib/**/*.js"
@@ -121,7 +121,7 @@
         "--config",
         "./.mocharc.json",
         "--no-timeouts",
-        "lib/cjs/test/**/*.test.js"
+        "--parallel=false"
       ],
       "outFiles": [
         "${workspaceFolder}/packages/testing/lib/**/*.js"
@@ -141,7 +141,7 @@
         "--config",
         "./.mocharc.json",
         "--no-timeouts",
-        "./lib/**/*.test.js"
+        "--parallel=false"
       ],
       "env": {
         "NODE_ENV": "development",
@@ -158,7 +158,7 @@
         "--config",
         "./.mocharc.json",
         "--no-timeouts",
-        "lib/cjs/test/**/*.test.js"
+        "--parallel=false"
       ],
       "outFiles": [
         "${workspaceFolder}/packages/shared/lib/**/*.js"
@@ -178,7 +178,7 @@
         "--config",
         "./.mocharc.json",
         "--no-timeouts",
-        "lib/cjs/test/**/*.test.js"
+        "--parallel=false"
       ],
       "outFiles": [
         "${workspaceFolder}/packages/hierarchies/lib/**/*.js"
@@ -198,7 +198,7 @@
         "--config",
         "./.mocharc.json",
         "--no-timeouts",
-        "lib/cjs/test/**/*.test.js"
+        "--parallel=false"
       ],
       "outFiles": [
         "${workspaceFolder}/packages/core-interop/lib/**/*.js"
@@ -217,7 +217,8 @@
       "args": [
         "--config",
         "./.mocharc.json",
-        "--no-timeouts"
+        "--no-timeouts",
+        "--parallel=false"
       ],
       "outFiles": [
         "${workspaceFolder}/packages/components/lib/**/*.js",
@@ -244,7 +245,7 @@
         "--config",
         "./.mocharc.json",
         "--no-timeouts",
-        "lib/cjs/test/**/*.test.js"
+        "--parallel=false"
       ],
       "outFiles": [
         "${workspaceFolder}/packages/unified-selection/lib/**/*.js"
@@ -264,7 +265,7 @@
         "--config",
         "./.mocharc.json",
         "--no-timeouts",
-        "lib/cjs/test/**/*.test.js"
+        "--parallel=false"
       ],
       "outFiles": [
         "${workspaceFolder}/packages/hierarchies-react/lib/**/*.js"

--- a/apps/full-stack-tests/.mocharc.json
+++ b/apps/full-stack-tests/.mocharc.json
@@ -1,11 +1,9 @@
 {
-  "require": ["ignore-styles"],
+  "require": ["ignore-styles", "./lib/setup.js"],
   "checkLeaks": true,
   "globals": ["requestAnimationFrame", "IS_REACT_ACT_ENVIRONMENT"],
   "timeout": 60000,
   "slow": 500,
-  "file": ["./lib/setup.js"],
-  "reporter": ["node_modules/@itwin/build-tools/mocha-reporter"],
-  "reporterOptions": ["mochaFile=lib/test/junit_results.xml"],
+  "parallel": true,
   "spec": ["./lib/**/*.test.js"]
 }

--- a/apps/full-stack-tests/package.json
+++ b/apps/full-stack-tests/package.json
@@ -4,8 +4,8 @@
   "description": "Presentation integration tests",
   "private": true,
   "scripts": {
-    "build": "tsc",
-    "build:watch": "tsc -w",
+    "build": "node ./scripts/setup-tests.js && tsc",
+    "build:watch": "npm run build -- -w",
     "clean": "rimraf lib build",
     "cover": "npm run -s test",
     "lint": "eslint ./src/**/*.{ts,tsx}",

--- a/apps/full-stack-tests/scripts/setup-tests.js
+++ b/apps/full-stack-tests/scripts/setup-tests.js
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+const { execFileSync } = require("child_process");
+const cpx = require("cpx2");
+const fs = require("fs");
+const path = require("path");
+
+cpx.copySync(`assets/**/*`, "lib/assets");
+copyITwinFrontendAssets("lib/public");
+pseudoLocalize("lib/public/locales");
+
+function copyITwinFrontendAssets(outputDir) {
+  const iTwinPackagesPath = "node_modules/@itwin";
+  fs.readdirSync(iTwinPackagesPath)
+    .map((packageName) => {
+      const packagePath = path.resolve(iTwinPackagesPath, packageName);
+      return path.join(packagePath, "lib", "public");
+    })
+    .filter((assetsPath) => fs.existsSync(assetsPath))
+    .forEach((src) => {
+      cpx.copySync(`${src}/**/*`, outputDir);
+    });
+}
+
+function pseudoLocalize(localesDir) {
+  const betoolsPath = path.resolve("node_modules", "@itwin", "build-tools", "bin", "betools.js");
+  const args = [betoolsPath, "pseudolocalize", "--englishDir", `${localesDir}/en`, "--out", `${localesDir}/en-PSEUDO`];
+  try {
+    execFileSync("node", args);
+  } catch {
+    throw new Error("Failed to pseudoLocalize localization files");
+  }
+}

--- a/apps/full-stack-tests/src/IntegrationTests.ts
+++ b/apps/full-stack-tests/src/IntegrationTests.ts
@@ -66,7 +66,7 @@ export async function initialize(props?: { backendTimeout?: number }) {
   const presentationTestingInitProps: PresentationTestingInitProps = {
     rpcs: [SnapshotIModelRpcInterface, IModelReadRpcInterface, PresentationRpcInterface, ECSchemaRpcInterface],
     backendProps: backendInitProps,
-    backendHostProps: { cacheDir: path.join(__dirname, ".cache") },
+    backendHostProps: { cacheDir: path.join(__dirname, ".cache", `${process.pid}`) },
     frontendProps: frontendInitProps,
     frontendApp: IntegrationTestsApp,
     frontendAppOptions,

--- a/apps/full-stack-tests/src/components/tree/Update.test.tsx
+++ b/apps/full-stack-tests/src/components/tree/Update.test.tsx
@@ -15,8 +15,9 @@ import {
   TreeModelNode,
   TreeModelRootNode,
   TreeModelSource,
+  UiComponents,
 } from "@itwin/components-react";
-import { IModelConnection, SnapshotConnection } from "@itwin/core-frontend";
+import { IModelApp, IModelConnection, SnapshotConnection } from "@itwin/core-frontend";
 import { ChildNodeSpecificationTypes, Ruleset, RuleTypes } from "@itwin/presentation-common";
 import { IPresentationTreeDataProvider, usePresentationTreeState, UsePresentationTreeStateProps } from "@itwin/presentation-components";
 import { Presentation } from "@itwin/presentation-frontend";
@@ -45,6 +46,14 @@ describe("Tree update", () => {
 
   describe("detection", () => {
     let defaultProps: Omit<UsePresentationTreeStateProps, "ruleset">;
+
+    before(async () => {
+      await UiComponents.initialize(IModelApp.localization);
+    });
+
+    after(() => {
+      UiComponents.terminate();
+    });
 
     beforeEach(() => {
       defaultProps = {

--- a/apps/full-stack-tests/src/unified-selection/HiliteSet.test.ts
+++ b/apps/full-stack-tests/src/unified-selection/HiliteSet.test.ts
@@ -33,7 +33,11 @@ describe("HiliteSet", () => {
   let iModel: IModelConnection;
 
   before(async () => {
-    await initialize();
+    await initialize({
+      backendHostProps: {
+        cacheDir: path.join(__dirname, ".cache", `${process.pid}`),
+      },
+    });
     // eslint-disable-next-line @itwin/no-internal
     RpcManager.registerImpl(ECSchemaRpcInterface, ECSchemaRpcImpl);
     RpcConfiguration.developmentMode = true;

--- a/apps/full-stack-tests/src/unified-selection/SelectionScope.test.ts
+++ b/apps/full-stack-tests/src/unified-selection/SelectionScope.test.ts
@@ -29,7 +29,11 @@ describe("SelectionScope", () => {
   let iModel: IModelConnection;
 
   before(async () => {
-    await initialize();
+    await initialize({
+      backendHostProps: {
+        cacheDir: path.join(__dirname, ".cache", `${process.pid}`),
+      },
+    });
     // eslint-disable-next-line @itwin/no-internal
     RpcManager.registerImpl(ECSchemaRpcInterface, ECSchemaRpcImpl);
     RpcConfiguration.developmentMode = true;

--- a/packages/components/.mocharc.json
+++ b/packages/components/.mocharc.json
@@ -1,10 +1,9 @@
 {
-  "require": ["ignore-styles"],
+  "require": ["ignore-styles", "./lib/cjs/test/setup"],
   "checkLeaks": true,
   "global": ["IS_REACT_ACT_ENVIRONMENT", "__iui"],
   "timeout": 60000,
-  "file": ["./lib/cjs/test/index.js"],
-  "exclude": ["./lib/test/coverage/**/*"],
-  "reporter": ["node_modules/@itwin/build-tools/mocha-reporter"],
-  "reporterOptions": ["mochaFile=lib/test/junit_results.xml"]
+  "parallel": true,
+  "spec": ["./lib/cjs/test/**/*.test.js"],
+  "exclude": ["./lib/test/coverage/**/*"]
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -36,7 +36,7 @@
     "clean": "rimraf lib build",
     "cover": "nyc npm -s test",
     "lint": "eslint ./src/**/*.{ts,tsx}",
-    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json",
     "test:watch": "npm -s test -- --reporter min --watch-extensions ts,tsx --watch",
     "docs": "npm run -s docs:extract && npm run -s docs:reference && npm run -s docs:changelog",
     "docs:changelog": "cpx ./CHANGELOG.md ./build/docs/reference/presentation-components",

--- a/packages/components/src/test/setup.ts
+++ b/packages/components/src/test/setup.ts
@@ -2,49 +2,53 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+// WARNING: The order of imports in this file is important!
 
+// setup chai
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import chaiJestSnapshot from "chai-jest-snapshot";
 import chaiSubset from "chai-subset";
-import globalJsdom from "global-jsdom";
-import * as jsdom from "jsdom";
-import path from "path";
-import ResizeObserver from "resize-observer-polyfill";
 import sinonChai from "sinon-chai";
-
-// setup chai
 chai.use(chaiAsPromised);
 chai.use(chaiJestSnapshot);
 chai.use(sinonChai);
 chai.use(chaiSubset);
 
 // get rid of various xhr errors in the console
+import globalJsdom from "global-jsdom";
+import * as jsdom from "jsdom";
 globalJsdom(undefined, {
   virtualConsole: new jsdom.VirtualConsole().sendTo(console, { omitJSDOMErrors: true }),
 });
+
+// polyfill ResizeObserver
+import ResizeObserver from "resize-observer-polyfill";
 global.ResizeObserver = ResizeObserver;
 
-before(function () {
-  chaiJestSnapshot.resetSnapshotRegistry();
-  getGlobalThis().IS_REACT_ACT_ENVIRONMENT = true;
-});
-
-after(function () {
-  delete require.cache[__filename];
-  delete getGlobalThis().IS_REACT_ACT_ENVIRONMENT;
-});
-
-beforeEach(function () {
-  const currentTest = (this as unknown as Mocha.Context).currentTest!;
-
-  // set up snapshot name
-  const sourceFilePath = currentTest.file!.replace(`lib${path.sep}cjs${path.sep}test`, `src${path.sep}test`).replace(/\.(jsx?|tsx?)$/, "");
-  const snapPath = `${sourceFilePath}.snap`;
-  chaiJestSnapshot.setFilename(snapPath);
-  chaiJestSnapshot.setTestName(currentTest.fullTitle());
-});
-
+// supply mocha hooks
+import path from "path";
+import { cleanup } from "@testing-library/react";
+export const mochaHooks = {
+  beforeAll() {
+    chaiJestSnapshot.resetSnapshotRegistry();
+    getGlobalThis().IS_REACT_ACT_ENVIRONMENT = true;
+  },
+  beforeEach() {
+    // set up snapshot name
+    const currentTest = (this as unknown as Mocha.Context).currentTest!;
+    const sourceFilePath = currentTest.file!.replace(`lib${path.sep}cjs${path.sep}test`, `src${path.sep}test`).replace(/\.(jsx?|tsx?)$/, "");
+    const snapPath = `${sourceFilePath}.snap`;
+    chaiJestSnapshot.setFilename(snapPath);
+    chaiJestSnapshot.setTestName(currentTest.fullTitle());
+  },
+  afterEach() {
+    cleanup();
+  },
+  afterAll() {
+    delete getGlobalThis().IS_REACT_ACT_ENVIRONMENT;
+  },
+};
 function getGlobalThis(): typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean } {
   /* istanbul ignore else */
   if (typeof globalThis !== "undefined") {

--- a/packages/core-interop/.mocharc.json
+++ b/packages/core-interop/.mocharc.json
@@ -1,8 +1,8 @@
 {
+  "require": ["./lib/cjs/test/setup"],
   "checkLeaks": true,
   "timeout": 60000,
-  "file": ["./lib/cjs/test/index.js"],
-  "exclude": ["./lib/test/coverage/**/*"],
-  "reporter": ["node_modules/@itwin/build-tools/mocha-reporter"],
-  "reporterOptions": ["mochaFile=lib/test/junit_results.xml"]
+  "parallel": false,
+  "spec": ["./lib/cjs/test/**/*.test.js"],
+  "exclude": ["./lib/test/coverage/**/*"]
 }

--- a/packages/core-interop/package.json
+++ b/packages/core-interop/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf lib",
     "cover": "nyc npm -s test",
     "lint": "eslint ./src/**/*.ts",
-    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json",
     "extract-api": "extract-api --entry=presentation-core-interop --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/presentation-core-interop.api.md",
     "validate-markdowns": "node ../../scripts/validateMarkdowns.js README.md"

--- a/packages/core-interop/src/test/setup.ts
+++ b/packages/core-interop/src/test/setup.ts
@@ -3,15 +3,19 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+// setup chai
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import sinon from "sinon";
 import sinonChai from "sinon-chai";
-
-// setup chai
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
 
-beforeEach(function () {
-  sinon.restore();
-});
+import sinon from "sinon";
+export const mochaHooks = {
+  beforeAll() {},
+  beforeEach() {},
+  afterEach() {
+    sinon.restore();
+  },
+  afterAll() {},
+};

--- a/packages/hierarchies-react/.mocharc.json
+++ b/packages/hierarchies-react/.mocharc.json
@@ -1,10 +1,9 @@
 {
-  "require": ["ignore-styles"],
+  "require": ["ignore-styles", "./lib/cjs/test/setup"],
   "checkLeaks": true,
   "global": ["IS_REACT_ACT_ENVIRONMENT"],
   "timeout": 60000,
-  "file": ["./lib/cjs/test/index.js"],
-  "exclude": ["./lib/test/coverage/**/*"],
-  "reporter": ["node_modules/@itwin/build-tools/mocha-reporter"],
-  "reporterOptions": ["mochaFile=lib/test/junit_results.xml"]
+  "parallel": true,
+  "spec": ["./lib/cjs/test/**/*.test.js"],
+  "exclude": ["./lib/test/coverage/**/*"]
 }

--- a/packages/hierarchies-react/package.json
+++ b/packages/hierarchies-react/package.json
@@ -40,7 +40,7 @@
     "clean": "rimraf lib build",
     "cover": "nyc npm -s test",
     "lint": "eslint ./src/**/*.{ts,tsx}",
-    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json",
     "test:watch": "npm -s test -- --reporter min --watch-extensions ts,tsx --watch",
     "extract-api": "extract-api --entry=presentation-hierarchies-react --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/presentation-hierarchies-react.api.md",

--- a/packages/hierarchies/.mocharc.json
+++ b/packages/hierarchies/.mocharc.json
@@ -1,8 +1,8 @@
 {
+  "require": ["./lib/cjs/test/setup"],
   "checkLeaks": true,
   "timeout": 60000,
-  "file": ["./lib/cjs/test/index.js"],
-  "exclude": ["./lib/test/coverage/**/*"],
-  "reporter": ["node_modules/@itwin/build-tools/mocha-reporter"],
-  "reporterOptions": ["mochaFile=lib/test/junit_results.xml"]
+  "parallel": false,
+  "spec": ["./lib/cjs/test/**/*.test.js"],
+  "exclude": ["./lib/test/coverage/**/*"]
 }

--- a/packages/hierarchies/package.json
+++ b/packages/hierarchies/package.json
@@ -32,7 +32,7 @@
     "clean": "rimraf lib",
     "cover": "nyc npm -s test",
     "lint": "eslint ./src/**/*.ts",
-    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json",
     "extract-api": "extract-api --entry=presentation-hierarchies --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/presentation-hierarchies.api.md",
     "update-extractions": "node ../../scripts/updateExtractions.js --targets=./README.md,./learning",

--- a/packages/hierarchies/src/test/setup.ts
+++ b/packages/hierarchies/src/test/setup.ts
@@ -5,8 +5,17 @@
 
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
+import chaiSubset from "chai-subset";
 import sinonChai from "sinon-chai";
 
 // setup chai
 chai.use(chaiAsPromised);
+chai.use(chaiSubset);
 chai.use(sinonChai);
+
+export const mochaHooks = {
+  beforeAll() {},
+  beforeEach() {},
+  afterEach() {},
+  afterAll() {},
+};

--- a/packages/opentelemetry/.mocharc.json
+++ b/packages/opentelemetry/.mocharc.json
@@ -1,8 +1,8 @@
 {
+  "require": ["./lib/cjs/test/setup"],
   "checkLeaks": true,
   "timeout": 60000,
-  "file": ["./lib/cjs/test/index.js"],
-  "exclude": ["./lib/test/coverage/**/*"],
-  "reporter": ["node_modules/@itwin/build-tools/mocha-reporter"],
-  "reporterOptions": ["mochaFile=lib/test/junit_results.xml"]
+  "parallel": false,
+  "spec": ["./lib/cjs/test/**/*.test.js"],
+  "exclude": ["./lib/test/coverage/**/*"]
 }

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -33,7 +33,7 @@
     "docs:reference": "cross-env NODE_PROJECT_ROOT_DIRECTORY=../../ betools docs --includes=./build/docs/extract --json=./build/docs/reference/presentation-opentelemetry/file.json --tsIndexFile=presentation-opentelemetry.ts --onlyJson",
     "docs:extract": "betools extract --fileExt=ts --extractFrom=./src/test --recursive --out=./build/docs/extract",
     "lint": "eslint \"./src/**/*.ts\"",
-    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json",
     "extract-api": "extract-api --entry=presentation-opentelemetry --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/presentation-opentelemetry.api.md"
   },

--- a/packages/opentelemetry/src/test/setup.ts
+++ b/packages/opentelemetry/src/test/setup.ts
@@ -2,13 +2,15 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
 import * as chai from "chai";
-import chaiAsPromised from "chai-as-promised";
-import chaiSubset from "chai-subset";
 import sinonChai from "sinon-chai";
 
-// setup chai
-chai.use(chaiAsPromised);
-chai.use(chaiSubset);
+// configure chai
 chai.use(sinonChai);
+
+export const mochaHooks = {
+  beforeAll() {},
+  beforeEach() {},
+  afterEach() {},
+  afterAll() {},
+};

--- a/packages/shared/.mocharc.json
+++ b/packages/shared/.mocharc.json
@@ -1,8 +1,8 @@
 {
+  "require": ["./lib/cjs/test/setup"],
   "checkLeaks": true,
   "timeout": 60000,
-  "file": ["./lib/cjs/test/index.js"],
-  "exclude": ["./lib/test/coverage/**/*"],
-  "reporter": ["node_modules/@itwin/build-tools/mocha-reporter"],
-  "reporterOptions": ["mochaFile=lib/test/junit_results.xml"]
+  "parallel": false,
+  "spec": ["./lib/cjs/test/**/*.test.js"],
+  "exclude": ["./lib/test/coverage/**/*"]
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -31,7 +31,7 @@
     "clean": "rimraf lib temp",
     "cover": "nyc npm -s test",
     "lint": "eslint \"./src/**/*.ts\"",
-    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json",
     "extract-api": "extract-api --entry=presentation-shared --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/presentation-shared.api.md",
     "validate-markdowns": "node ../../scripts/validateMarkdowns.js README.md"

--- a/packages/shared/src/test/setup.ts
+++ b/packages/shared/src/test/setup.ts
@@ -2,8 +2,20 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+
 import * as chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import chaiSubset from "chai-subset";
 import sinonChai from "sinon-chai";
 
-// configure chai
+// setup chai
+chai.use(chaiAsPromised);
+chai.use(chaiSubset);
 chai.use(sinonChai);
+
+export const mochaHooks = {
+  beforeAll() {},
+  beforeEach() {},
+  afterEach() {},
+  afterAll() {},
+};

--- a/packages/testing/.mocharc.json
+++ b/packages/testing/.mocharc.json
@@ -1,9 +1,8 @@
 {
-  "require": ["global-jsdom/register", "ignore-styles"],
+  "require": ["global-jsdom/register", "ignore-styles", "./lib/cjs/test/setup"],
   "checkLeaks": true,
   "timeout": 60000,
-  "file": ["./lib/cjs/test/index.js"],
-  "exclude": ["./lib/test/coverage/**/*"],
-  "reporter": ["node_modules/@itwin/build-tools/mocha-reporter"],
-  "reporterOptions": ["mochaFile=lib/test/junit_results.xml"]
+  "parallel": false,
+  "spec": ["./lib/cjs/test/**/*.test.js"],
+  "exclude": ["./lib/test/coverage/**/*"]
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -32,7 +32,7 @@
     "docs:changelog": "cpx ./CHANGELOG.md ./build/docs/reference/presentation-testing",
     "docs:reference": "cross-env NODE_PROJECT_ROOT_DIRECTORY=../../ betools docs --includes=./build/docs/extract --json=./build/docs/reference/presentation-testing/file.json --tsIndexFile=presentation-testing.ts --onlyJson --testExcludeGlob=./src/test/**",
     "lint": "eslint ./src/**/*.ts",
-    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json",
     "extract-api": "extract-api --entry=presentation-testing --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/presentation-testing.api.md"
   },

--- a/packages/testing/src/test/setup.ts
+++ b/packages/testing/src/test/setup.ts
@@ -15,20 +15,20 @@ chai.use(chaiAsPromised);
 chai.use(chaiJestSnapshot);
 chai.use(sinonChai);
 
-before(function () {
-  chaiJestSnapshot.resetSnapshotRegistry();
-});
-after(function () {
-  delete require.cache[__filename];
-});
-beforeEach(function () {
-  const currentTest = this.currentTest!;
-
-  // set up snapshot name
-  const sourceFilePath = currentTest.file!.replace(`lib${path.sep}cjs${path.sep}test`, `src${path.sep}test`).replace(/\.(jsx?|tsx?)$/, "");
-  const snapPath = `${sourceFilePath}.snap`;
-  chaiJestSnapshot.setFilename(snapPath);
-  chaiJestSnapshot.setTestName(currentTest.fullTitle());
-
-  sinon.restore();
-});
+export const mochaHooks = {
+  beforeAll() {
+    chaiJestSnapshot.resetSnapshotRegistry();
+  },
+  beforeEach() {
+    // set up snapshot name
+    const currentTest = (this as unknown as Mocha.Context).currentTest!;
+    const sourceFilePath = currentTest.file!.replace(`lib${path.sep}cjs${path.sep}test`, `src${path.sep}test`).replace(/\.(jsx?|tsx?)$/, "");
+    const snapPath = `${sourceFilePath}.snap`;
+    chaiJestSnapshot.setFilename(snapPath);
+    chaiJestSnapshot.setTestName(currentTest.fullTitle());
+  },
+  afterEach() {
+    sinon.restore();
+  },
+  afterAll() {},
+};

--- a/packages/unified-selection/.mocharc.json
+++ b/packages/unified-selection/.mocharc.json
@@ -1,9 +1,8 @@
 {
-  "require": ["ignore-styles"],
+  "require": ["ignore-styles", "./lib/cjs/test/setup"],
   "checkLeaks": true,
   "timeout": 60000,
-  "file": ["./lib/cjs/test/index.js"],
-  "exclude": ["./lib/test/coverage/**/*"],
-  "reporter": ["node_modules/@itwin/build-tools/mocha-reporter"],
-  "reporterOptions": ["mochaFile=lib/test/junit_results.xml"]
+  "parallel": false,
+  "spec": ["./lib/cjs/test/**/*.test.js"],
+  "exclude": ["./lib/test/coverage/**/*"]
 }

--- a/packages/unified-selection/package.json
+++ b/packages/unified-selection/package.json
@@ -35,7 +35,7 @@
     "clean": "rimraf lib build",
     "cover": "nyc npm -s test",
     "lint": "eslint ./src/**/*.ts",
-    "test": "mocha --enable-source-maps --config ./.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
+    "test": "mocha --enable-source-maps --config ./.mocharc.json",
     "test:watch": "npm -s test -- --reporter min --watch-extensions ts --watch",
     "extract-api": "extract-api --entry=unified-selection --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/unified-selection.api.md",

--- a/packages/unified-selection/src/test/setup.ts
+++ b/packages/unified-selection/src/test/setup.ts
@@ -5,10 +5,15 @@
 
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import chaiSubset from "chai-subset";
 import sinonChai from "sinon-chai";
 
 // setup chai
 chai.use(chaiAsPromised);
-chai.use(chaiSubset);
 chai.use(sinonChai);
+
+export const mochaHooks = {
+  beforeAll() {},
+  beforeEach() {},
+  afterEach() {},
+  afterAll() {},
+};


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/712.

Made it possible to run all tests in the repo in parallel mode. However, it looks like it's not worth doing that when the test suite is very quick - for example, the `unified-selection` package in serial mode runs in ~0.5 s., and in parallel mode it takes ~2 s. From what I see, switching to parallel becomes worth it when the whole test suite takes 8-10 seconds. So only the following suites are switched to parallel:
- `presentation-components`: took ~38 s. in serial mode, now takes ~21 s. in parallel mode.
- `presentation-hierarchies-react`: took ~13 s. in serial mode, now takes ~9 s. in parallel mode.
- `presentation-full-stack-tests`: took ~2 m. in serial mode, now takes ~30 s. in parallel mode.

Also attempted to see if `vitest` gives any performance boost for one of the smaller packages (`unified-selection`). Results:
- mocha 1 process: ~0.5 second.
- mocha parallel: ~2 seconds.
- vitest 1 process: ~4.5 second.
- vitest parallel: ~2 seconds.

As a result, decided to keep using mocha. BTW, I made a complete switch from mocha+sinon+chai to vitest, including all the assertions and so on. That was quite a substantial effort for such a small test suite. Would need to dedicate a lot of time for larger suites.