### PR TITLE
Unified selection: Fix hilite set provider class check caching

### DIFF
--- a/.changeset/funny-candles-double.md
+++ b/.changeset/funny-candles-double.md
@@ -1,0 +1,5 @@
+---
+"@itwin/unified-selection": patch
+---
+
+Fix provider returned by `createHiliteSetProvider` in some cases not caching class hierarchy check results, resulting in duplicate checks for the same classes.

--- a/packages/unified-selection/src/test/Selectable.test.ts
+++ b/packages/unified-selection/src/test/Selectable.test.ts
@@ -78,7 +78,7 @@ describe("Selectables", () => {
     });
 
     it("creates from instance keys", () => {
-      const selectableInstanceKeys = [createSelectableInstanceKey(1, "class1"), createSelectableInstanceKey(2, "class2")];
+      const selectableInstanceKeys = [createSelectableInstanceKey(1, "schema.class1"), createSelectableInstanceKey(2, "schema.class2")];
       const selectables = Selectables.create(selectableInstanceKeys);
       expect(selectables.instanceKeys.size).to.eq(2);
       expect(selectables.custom.size).to.eq(0);
@@ -106,7 +106,7 @@ describe("Selectables", () => {
     });
 
     it("clears instance selectables", () => {
-      const instanceSelectables = [createSelectableInstanceKey(1, "class1"), createSelectableInstanceKey(2, "class2")];
+      const instanceSelectables = [createSelectableInstanceKey(1, "schema.class1"), createSelectableInstanceKey(2, "schema.class2")];
       const selectables = Selectables.create(instanceSelectables);
       expect(selectables.instanceKeys.size).to.eq(2);
       Selectables.clear(selectables);
@@ -134,10 +134,10 @@ describe("Selectables", () => {
     });
 
     it("adds an instance key selectable", () => {
-      const selectables = Selectables.create([createSelectableInstanceKey(1, "class1")]);
+      const selectables = Selectables.create([createSelectableInstanceKey(1, "schema.class1")]);
       expect(selectables.instanceKeys.size).to.eq(1);
 
-      const selectable = createSelectableInstanceKey(2, "class2");
+      const selectable = createSelectableInstanceKey(2, "schema.class2");
       Selectables.add(selectables, [selectable]);
       expect(selectables.instanceKeys.size).to.eq(2);
       expect(Selectables.has(selectables, selectable)).to.be.true;
@@ -181,7 +181,11 @@ describe("Selectables", () => {
     });
 
     it("removes an instance key selectable of the same class", () => {
-      const instanceSelectables = [createSelectableInstanceKey(1, "class"), createSelectableInstanceKey(2, "class"), createSelectableInstanceKey(3, "class")];
+      const instanceSelectables = [
+        createSelectableInstanceKey(1, "schema.class"),
+        createSelectableInstanceKey(2, "schema.class"),
+        createSelectableInstanceKey(3, "schema.class"),
+      ];
       const selectables = Selectables.create(instanceSelectables);
       expect(Selectables.size(selectables)).to.eq(3);
       Selectables.remove(selectables, [instanceSelectables[1]]);
@@ -200,9 +204,9 @@ describe("Selectables", () => {
 
     it("removes an instance key selectable of different classes", () => {
       const instanceSelectables = [
-        createSelectableInstanceKey(1, "class1"),
-        createSelectableInstanceKey(2, "class2"),
-        createSelectableInstanceKey(3, "class3"),
+        createSelectableInstanceKey(1, "schema.class1"),
+        createSelectableInstanceKey(2, "schema.class2"),
+        createSelectableInstanceKey(3, "schema.class3"),
       ];
       const selectables = Selectables.create(instanceSelectables);
       expect(Selectables.size(selectables)).to.eq(3);
@@ -223,9 +227,9 @@ describe("Selectables", () => {
     });
 
     it("does nothing when trying to remove an non-existing instance key selectable", () => {
-      const selectables = Selectables.create([createSelectableInstanceKey(1, "class1")]);
+      const selectables = Selectables.create([createSelectableInstanceKey(1, "schema.class1")]);
       expect(selectables.instanceKeys.size).to.eq(1);
-      Selectables.remove(selectables, [createSelectableInstanceKey(2, "class2")]);
+      Selectables.remove(selectables, [createSelectableInstanceKey(2, "schema.class2")]);
       expect(selectables.instanceKeys.size).to.eq(1);
     });
 

--- a/packages/unified-selection/src/test/SelectionStorage.test.ts
+++ b/packages/unified-selection/src/test/SelectionStorage.test.ts
@@ -10,7 +10,7 @@ import { createStorage, SelectionStorage } from "../unified-selection/SelectionS
 import { createSelectableInstanceKey } from "./_helpers/SelectablesCreator";
 
 const generateSelection = (): SelectableInstanceKey[] => {
-  return [createSelectableInstanceKey(1, "baseClass1"), createSelectableInstanceKey(2, "baseClass2"), createSelectableInstanceKey(3, "baseClass3")];
+  return [createSelectableInstanceKey(1, "base.Class1"), createSelectableInstanceKey(2, "base.Class2"), createSelectableInstanceKey(3, "base.Class3")];
 };
 
 describe("SelectionStorage", () => {
@@ -42,21 +42,21 @@ describe("SelectionStorage", () => {
     });
 
     it("returns available selection levels", () => {
-      selectionStorage.addToSelection({ imodelKey, source: "", selectables: [createSelectableInstanceKey(1, "class1")] });
-      selectionStorage.addToSelection({ imodelKey, source: "", selectables: [createSelectableInstanceKey(2, "class2")], level: 3 });
+      selectionStorage.addToSelection({ imodelKey, source: "", selectables: [createSelectableInstanceKey(1, "schema.class1")] });
+      selectionStorage.addToSelection({ imodelKey, source: "", selectables: [createSelectableInstanceKey(2, "schema.class2")], level: 3 });
       expect(selectionStorage.getSelectionLevels({ imodelKey })).to.deep.eq([0, 3]);
     });
 
     it("doesn't include empty selection levels", () => {
-      selectionStorage.addToSelection({ imodelKey, source: "", selectables: [createSelectableInstanceKey(1, "class1")] });
-      selectionStorage.addToSelection({ imodelKey, source: "", selectables: [createSelectableInstanceKey(2, "class2")], level: 1 });
+      selectionStorage.addToSelection({ imodelKey, source: "", selectables: [createSelectableInstanceKey(1, "schema.class1")] });
+      selectionStorage.addToSelection({ imodelKey, source: "", selectables: [createSelectableInstanceKey(2, "schema.class2")], level: 1 });
       selectionStorage.addToSelection({ imodelKey, source: "", selectables: [], level: 2 });
       expect(selectionStorage.getSelectionLevels({ imodelKey })).to.deep.eq([0, 1]);
     });
 
     it("returns available selection levels with deprecated `iModelKey` prop", () => {
-      selectionStorage.addToSelection({ iModelKey: imodelKey, source: "", selectables: [createSelectableInstanceKey(1, "class1")] });
-      selectionStorage.addToSelection({ iModelKey: imodelKey, source: "", selectables: [createSelectableInstanceKey(2, "class2")], level: 3 });
+      selectionStorage.addToSelection({ iModelKey: imodelKey, source: "", selectables: [createSelectableInstanceKey(1, "schema.class1")] });
+      selectionStorage.addToSelection({ iModelKey: imodelKey, source: "", selectables: [createSelectableInstanceKey(2, "schema.class2")], level: 3 });
       expect(selectionStorage.getSelectionLevels({ iModelKey: imodelKey })).to.deep.eq([0, 3]);
     });
   });
@@ -112,8 +112,8 @@ describe("SelectionStorage", () => {
 
     it("clears higher level selection when adding items to lower level selection", () => {
       selectionStorage.addToSelection({ imodelKey, source, selectables: baseSelection });
-      selectionStorage.addToSelection({ imodelKey, source, selectables: [createSelectableInstanceKey(1, "class1")], level: 1 });
-      selectionStorage.addToSelection({ imodelKey, source, selectables: [createSelectableInstanceKey(2, "class2")], level: 0 });
+      selectionStorage.addToSelection({ imodelKey, source, selectables: [createSelectableInstanceKey(1, "schema.class1")], level: 1 });
+      selectionStorage.addToSelection({ imodelKey, source, selectables: [createSelectableInstanceKey(2, "schema.class2")], level: 0 });
       const selectables = selectionStorage.getSelection({ imodelKey, level: 1 });
       expect(Selectables.isEmpty(selectables)).to.be.true;
     });
@@ -177,8 +177,8 @@ describe("SelectionStorage", () => {
 
     it("clears higher level selection when replacing lower level selection", () => {
       selectionStorage.addToSelection({ imodelKey, source, selectables: baseSelection, level: 0 });
-      selectionStorage.addToSelection({ imodelKey, source, selectables: [createSelectableInstanceKey(1, "class1")], level: 1 });
-      selectionStorage.replaceSelection({ imodelKey, source, selectables: [createSelectableInstanceKey(2, "class2")], level: 0 });
+      selectionStorage.addToSelection({ imodelKey, source, selectables: [createSelectableInstanceKey(1, "schema.class1")], level: 1 });
+      selectionStorage.replaceSelection({ imodelKey, source, selectables: [createSelectableInstanceKey(2, "schema.class2")], level: 0 });
       const selectables = selectionStorage.getSelection({ imodelKey, level: 1 });
       expect(Selectables.isEmpty(selectables)).to.be.true;
     });
@@ -321,8 +321,8 @@ describe("SelectionStorage", () => {
 
     it("doesn't clear higher level selection when removing non-existing items from lower level selection", () => {
       selectionStorage.addToSelection({ imodelKey, source, selectables: baseSelection, level: 0 });
-      selectionStorage.addToSelection({ imodelKey, source, selectables: [createSelectableInstanceKey(1, "class1")], level: 1 });
-      selectionStorage.removeFromSelection({ imodelKey, source, selectables: [createSelectableInstanceKey(2, "class2")] });
+      selectionStorage.addToSelection({ imodelKey, source, selectables: [createSelectableInstanceKey(1, "schema.class1")], level: 1 });
+      selectionStorage.removeFromSelection({ imodelKey, source, selectables: [createSelectableInstanceKey(2, "schema.class2")] });
       const selectables = selectionStorage.getSelection({ imodelKey, level: 1 });
       expect(Selectables.isEmpty(selectables)).to.be.false;
     });

--- a/packages/unified-selection/src/test/_helpers/SelectablesCreator.ts
+++ b/packages/unified-selection/src/test/_helpers/SelectablesCreator.ts
@@ -18,7 +18,7 @@ export const createECInstanceId = (id: number = 1): string => {
  * Generates a random `SelectableInstanceKey`
  * @internal Used for testing only.
  */
-export const createSelectableInstanceKey = (id: number = 1, className: string = "TestSchema:TestClass"): SelectableInstanceKey => {
+export const createSelectableInstanceKey = (id: number = 1, className: string = "TestSchema.TestClass"): SelectableInstanceKey => {
   return {
     className,
     id: createECInstanceId(id),

--- a/packages/unified-selection/src/unified-selection/Selectable.ts
+++ b/packages/unified-selection/src/unified-selection/Selectable.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Id64String } from "@itwin/core-bentley";
+import { normalizeFullClassName } from "@itwin/presentation-shared";
 
 /**
  * ECInstance selectable
@@ -123,7 +124,7 @@ export namespace Selectables {
    */
   export function has(selectables: Selectables, value: SelectableIdentifier): boolean {
     if (Selectable.isInstanceKey(value)) {
-      const normalizedClassName = normalizeClassName(value.className);
+      const normalizedClassName = normalizeFullClassName(value.className);
       const set = selectables.instanceKeys.get(normalizedClassName);
       return !!(set && set.has(value.id));
     }
@@ -173,7 +174,7 @@ export namespace Selectables {
     let hasChanged = false;
     for (const selectable of values) {
       if (Selectable.isInstanceKey(selectable)) {
-        const normalizedClassName = normalizeClassName(selectable.className);
+        const normalizedClassName = normalizeFullClassName(selectable.className);
         let set = selectables.instanceKeys.get(normalizedClassName);
         if (!set) {
           set = new Set<string>();
@@ -201,7 +202,7 @@ export namespace Selectables {
     let hasChanged = false;
     for (const selectable of values) {
       if (Selectable.isInstanceKey(selectable)) {
-        const normalizedClassName = normalizeClassName(selectable.className);
+        const normalizedClassName = normalizeFullClassName(selectable.className);
         const set = selectables.instanceKeys.get(normalizedClassName);
         if (set && set.has(selectable.id)) {
           set.delete(selectable.id);
@@ -266,9 +267,5 @@ export namespace Selectables {
     selectables.custom.forEach((data) => {
       callback(data, index++);
     });
-  }
-
-  function normalizeClassName(className: string): string {
-    return className.replace(".", ":");
   }
 }


### PR DESCRIPTION
The provider wouldn't properly cache class check result for a selectable instance key if its class name was specified in the `Schema.Class` format rather than `Schema:Class`.