### PR TITLE
`changesets` should ignore app and test packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,6 @@
   "updateInternalDependencies": "patch",
   "ignore": [
     "@itwin/presentation-models-tree",
-    "presentation-test-utilities",
     "presentation-full-stack-tests",
     "presentation-performance-tests",
     "@load-tests/backend",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,10 +8,14 @@
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
   "ignore": [
+    "@itwin/presentation-models-tree",
+    "presentation-test-utilities",
     "presentation-full-stack-tests",
     "presentation-performance-tests",
+    "@load-tests/backend",
     "@load-tests/frontend",
-    "@test-app/frontend",
-    "@itwin/presentation-models-tree"
+    "@test-app/backend",
+    "@test-app/common",
+    "@test-app/frontend"
   ]
 }


### PR DESCRIPTION
Just to avoid this:
![image](https://github.com/user-attachments/assets/3e23e6ee-19b1-4626-9e67-eac2bc805e91)
