### PR TITLE
Add `ref` to TreeNodeRendererProps

### DIFF
--- a/.changeset/stupid-books-pump.md
+++ b/.changeset/stupid-books-pump.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Added missing `ref` property to `TreeNodeRendererProps` type.

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -18,6 +18,7 @@ import { JSX as JSX_3 } from 'react/jsx-runtime.js';
 import { NodeData } from '@itwin/itwinui-react';
 import { PropsWithChildren } from 'react';
 import { ReactElement } from 'react';
+import { RefAttributes } from 'react';
 import { SelectionStorage } from '@itwin/unified-selection';
 import { Tree } from '@itwin/itwinui-react';
 import { TreeNode } from '@itwin/itwinui-react';
@@ -161,7 +162,7 @@ export { SelectionStorage }
 type TreeNodeProps = ComponentPropsWithoutRef<typeof TreeNode>;
 
 // @beta
-export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererProps>;
+export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererProps & RefAttributes<HTMLDivElement>>;
 
 // @beta (undocumented)
 interface TreeNodeRendererOwnProps {

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -5,7 +5,7 @@
 
 import "./TreeNodeRenderer.css";
 import cx from "classnames";
-import { ComponentPropsWithoutRef, forwardRef, LegacyRef, MutableRefObject, ReactElement, Ref, useCallback, useRef } from "react";
+import { ComponentPropsWithoutRef, forwardRef, LegacyRef, MutableRefObject, ReactElement, Ref, RefAttributes, useCallback, useRef } from "react";
 import { SvgFilter, SvgFilterHollow, SvgRemove } from "@itwin/itwinui-icons-react";
 import { Anchor, ButtonGroup, Flex, IconButton, ProgressRadial, Text, TreeNode } from "@itwin/itwinui-react";
 import { MAX_LIMIT_OVERRIDE } from "../internal/Utils.js";
@@ -52,7 +52,7 @@ type TreeNodeRendererProps = Pick<UseTreeResult, "expandNode"> &
  * @see https://itwinui.bentley.com/docs/tree
  * @beta
  */
-export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererProps> = forwardRef(
+export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererProps & RefAttributes<HTMLDivElement>> = forwardRef(
   (
     {
       node,


### PR DESCRIPTION
Added missing `ref` to TreeNodeRendererProps.