### PR TITLE
`components`: Run tests sequentially to avoid coverage flakiness

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,7 +41,7 @@
     "copy:cjs": "cpx \"./src/**/*.{scss,json}\" ./lib/cjs",
     "copy:esm": "cpx \"./src/**/*.{scss,json}\" ./lib/esm",
     "clean": "rimraf lib build",
-    "cover": "c8 npm run -s test",
+    "cover": "c8 npm run -s test:dev",
     "lint": "eslint ./src/**/*.{ts,tsx}",
     "test:dev": "cross-env NODE_OPTIONS=\"--import presentation-test-utilities/node-hooks/ignore-styles\" mocha --enable-source-maps --config ./.mocharc.json",
     "test": "npm run test:dev -- --parallel --jobs=4",


### PR DESCRIPTION
Looks like in `presentation-components` package the coverage numbers are flaky due to the tests being run in parallel. Changing them to run sequentially until I find the culprit.