### PR TITLE
Deliver cjs package.json

### DIFF
--- a/.changeset/lazy-buttons-grab.md
+++ b/.changeset/lazy-buttons-grab.md
@@ -1,0 +1,8 @@
+---
+"@itwin/presentation-core-interop": patch
+"@itwin/presentation-hierarchies": patch
+"@itwin/presentation-opentelemetry": patch
+"@itwin/presentation-testing": patch
+---
+
+Added missing `package.json` file under `cjs` folder.

--- a/.changeset/lazy-buttons-grab.md
+++ b/.changeset/lazy-buttons-grab.md
@@ -5,4 +5,4 @@
 "@itwin/presentation-testing": patch
 ---
 
-Added missing `package.json` file under `cjs` folder.
+Added missing `package.json` file under `cjs` folder. It is needed for package to work as commonjs module.

--- a/packages/core-interop/.npmignore
+++ b/packages/core-interop/.npmignore
@@ -7,6 +7,7 @@
 !lib/**/*.d.ts.map
 !lib/**/*.js
 !lib/**/*.js.map
+!lib/**/*.json
 
 # then ignore some stuff again
 lib/**/test/**

--- a/packages/hierarchies/.npmignore
+++ b/packages/hierarchies/.npmignore
@@ -8,6 +8,7 @@
 !lib/**/*.d.ts.map
 !lib/**/*.js
 !lib/**/*.js.map
+!lib/**/*.json
 
 # then ignore some stuff again
 lib/**/test/**

--- a/packages/opentelemetry/.npmignore
+++ b/packages/opentelemetry/.npmignore
@@ -6,5 +6,7 @@
 !lib/**/*.js
 !lib/**/*.js.map
 !*.md
+!lib/**/*.json
+
 # then ignore some stuff again
 lib/**/test/**

--- a/packages/testing/.npmignore
+++ b/packages/testing/.npmignore
@@ -6,5 +6,7 @@
 !lib/**/*.js
 !lib/**/*.js.map
 !*.md
+!lib/**/*.json
+
 # then ignore some stuff again
 lib/**/test/**


### PR DESCRIPTION
Updated npmignore to include dummy package.json that is needed for package to work as commonjs module.