### PR TITLE
Run tests for coverage in parallel mode

### DIFF
--- a/apps/full-stack-tests/src/setup.ts
+++ b/apps/full-stack-tests/src/setup.ts
@@ -28,6 +28,7 @@ global.ResizeObserver = class ResizeObserver {
 };
 
 // supply mocha hooks
+import v8 from "node:v8";
 const { cleanup, configure } = await import("@testing-library/react");
 export const mochaHooks = {
   beforeAll() {
@@ -50,6 +51,7 @@ export const mochaHooks = {
   },
   afterAll() {
     delete getGlobalThis().IS_REACT_ACT_ENVIRONMENT;
+    v8.takeCoverage();
   },
 };
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,7 +41,7 @@
     "copy:cjs": "cpx \"./src/**/*.{scss,json}\" ./lib/cjs",
     "copy:esm": "cpx \"./src/**/*.{scss,json}\" ./lib/esm",
     "clean": "rimraf lib build",
-    "cover": "c8 npm run -s test:dev",
+    "cover": "c8 npm run -s test",
     "lint": "eslint ./src/**/*.{ts,tsx}",
     "test:dev": "cross-env NODE_OPTIONS=\"--import presentation-test-utilities/node-hooks/ignore-styles\" mocha --enable-source-maps --config ./.mocharc.json",
     "test": "npm run test:dev -- --parallel --jobs=4",

--- a/packages/components/src/test/setup.ts
+++ b/packages/components/src/test/setup.ts
@@ -31,6 +31,7 @@ global.ResizeObserver = class ResizeObserver {
 
 // supply mocha hooks
 import path from "path";
+import v8 from "node:v8";
 const { cleanup, configure } = await import("@testing-library/react");
 export const mochaHooks = {
   beforeAll() {
@@ -53,6 +54,7 @@ export const mochaHooks = {
   },
   afterAll() {
     delete getGlobalThis().IS_REACT_ACT_ENVIRONMENT;
+    v8.takeCoverage();
   },
 };
 function getGlobalThis(): typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean } {

--- a/packages/hierarchies-react/src/test/setup.ts
+++ b/packages/hierarchies-react/src/test/setup.ts
@@ -21,6 +21,7 @@ globalJsdom(undefined, {
 });
 
 // supply mocha hooks
+import v8 from "node:v8";
 const { cleanup } = await import("@testing-library/react");
 export const mochaHooks = {
   beforeAll() {
@@ -32,6 +33,7 @@ export const mochaHooks = {
   },
   afterAll() {
     delete getGlobalThis().IS_REACT_ACT_ENVIRONMENT;
+    v8.takeCoverage();
   },
 };
 function getGlobalThis(): typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean } {


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/762.

I did not get to the bottom of this... What I determined is that `c8` has nothing to do with this. Running `mocha` tests in parallel mode with `NODE_V8_COVERAGE` set to some directory randomly skips some APIs from coverage results. The higher the parallelism - the higher the miss chance. This must be related to when `v8` takes coverage and how `mocha` terminates the worker processes - probably the process gets terminated before `v8` finishes taking coverage results for that process. Adding a `v8.takeCoverage()` call after a test suite run seems to take care of that. Added it to all packages that run tests in parallel. Calling the function seems to have no effect if `NODE_V8_COVERAGE` is not set.