### PR TITLE
Unified selection: fix transient elements support

### DIFF
--- a/.changeset/poor-badgers-sparkle.md
+++ b/.changeset/poor-badgers-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@itwin/unified-selection": patch
+---
+
+Fixed transient element keys handling in unified selection storage.

--- a/packages/unified-selection/api/unified-selection.api.md
+++ b/packages/unified-selection/api/unified-selection.api.md
@@ -229,6 +229,9 @@ export type StorageSelectionChangeType =
 | "clear";
 
 // @public
+export const TRANSIENT_ELEMENT_CLASSNAME = "/TRANSIENT";
+
+// @public
 interface Uint32Set {
     addIds(ids: Id64Arg): void;
     deleteIds(ids: Id64Arg): void;

--- a/packages/unified-selection/api/unified-selection.exports.csv
+++ b/packages/unified-selection/api/unified-selection.exports.csv
@@ -19,3 +19,4 @@ public;interface;SelectionStorage
 public;interface;StorageSelectionChangeEventArgs
 public;type;StorageSelectionChangesListener
 public;type;StorageSelectionChangeType
+public;const;TRANSIENT_ELEMENT_CLASSNAME

--- a/packages/unified-selection/src/test/Selectable.test.ts
+++ b/packages/unified-selection/src/test/Selectable.test.ts
@@ -5,7 +5,7 @@
 
 import { expect } from "chai";
 import sinon from "sinon";
-import { CustomSelectable, Selectable, SelectableInstanceKey, Selectables } from "../unified-selection/Selectable.js";
+import { CustomSelectable, Selectable, SelectableInstanceKey, Selectables, TRANSIENT_ELEMENT_CLASSNAME } from "../unified-selection/Selectable.js";
 import { createCustomSelectable, createECInstanceId, createSelectableInstanceKey } from "./_helpers/SelectablesCreator.js";
 
 describe("Selectable", () => {
@@ -157,6 +157,12 @@ describe("Selectables", () => {
       const selectables = Selectables.create([selectable]);
       expect(Selectables.size(selectables)).to.eq(1);
       Selectables.add(selectables, [selectableFormat]);
+      expect(Selectables.size(selectables)).to.eq(1);
+    });
+
+    it("adds transient element instance key", () => {
+      const selectable = createSelectableInstanceKey(1, TRANSIENT_ELEMENT_CLASSNAME);
+      const selectables = Selectables.create([selectable]);
       expect(Selectables.size(selectables)).to.eq(1);
     });
 

--- a/packages/unified-selection/src/unified-selection.ts
+++ b/packages/unified-selection/src/unified-selection.ts
@@ -3,7 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-export { CustomSelectable, Selectable, SelectableIdentifier, SelectableInstanceKey, Selectables } from "./unified-selection/Selectable.js";
+export {
+  TRANSIENT_ELEMENT_CLASSNAME,
+  CustomSelectable,
+  Selectable,
+  SelectableIdentifier,
+  SelectableInstanceKey,
+  Selectables,
+} from "./unified-selection/Selectable.js";
 export { SelectionStorage, createStorage } from "./unified-selection/SelectionStorage.js";
 export { createHiliteSetProvider, HiliteSet, HiliteSetProvider } from "./unified-selection/HiliteSetProvider.js";
 export { createCachingHiliteSetProvider, CachingHiliteSetProvider } from "./unified-selection/CachingHiliteSetProvider.js";

--- a/packages/unified-selection/src/unified-selection.ts
+++ b/packages/unified-selection/src/unified-selection.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-export * from "./unified-selection/Selectable.js";
+export { CustomSelectable, Selectable, SelectableIdentifier, SelectableInstanceKey, Selectables } from "./unified-selection/Selectable.js";
 export { SelectionStorage, createStorage } from "./unified-selection/SelectionStorage.js";
 export { createHiliteSetProvider, HiliteSet, HiliteSetProvider } from "./unified-selection/HiliteSetProvider.js";
 export { createCachingHiliteSetProvider, CachingHiliteSetProvider } from "./unified-selection/CachingHiliteSetProvider.js";

--- a/packages/unified-selection/src/unified-selection/Selectable.ts
+++ b/packages/unified-selection/src/unified-selection/Selectable.ts
@@ -79,7 +79,10 @@ export interface Selectables {
   custom: Map<string, CustomSelectable>;
 }
 
-/** @internal */
+/**
+ * Class name used to create `SelectableInstanceKey` for transient elements.
+ * @public
+ */
 export const TRANSIENT_ELEMENT_CLASSNAME = "/TRANSIENT";
 
 /** @public */

--- a/packages/unified-selection/src/unified-selection/Selectable.ts
+++ b/packages/unified-selection/src/unified-selection/Selectable.ts
@@ -79,6 +79,9 @@ export interface Selectables {
   custom: Map<string, CustomSelectable>;
 }
 
+/** @internal */
+export const TRANSIENT_ELEMENT_CLASSNAME = "/TRANSIENT";
+
 /** @public */
 export namespace Selectables {
   /**
@@ -123,7 +126,7 @@ export namespace Selectables {
    */
   export function has(selectables: Selectables, value: SelectableIdentifier): boolean {
     if (Selectable.isInstanceKey(value)) {
-      const normalizedClassName = normalizeFullClassName(value.className);
+      const normalizedClassName = normalizeClassName(value.className);
       const set = selectables.instanceKeys.get(normalizedClassName);
       return !!(set && set.has(value.id));
     }
@@ -173,7 +176,7 @@ export namespace Selectables {
     let hasChanged = false;
     for (const selectable of values) {
       if (Selectable.isInstanceKey(selectable)) {
-        const normalizedClassName = normalizeFullClassName(selectable.className);
+        const normalizedClassName = normalizeClassName(selectable.className);
         let set = selectables.instanceKeys.get(normalizedClassName);
         if (!set) {
           set = new Set<string>();
@@ -201,7 +204,7 @@ export namespace Selectables {
     let hasChanged = false;
     for (const selectable of values) {
       if (Selectable.isInstanceKey(selectable)) {
-        const normalizedClassName = normalizeFullClassName(selectable.className);
+        const normalizedClassName = normalizeClassName(selectable.className);
         const set = selectables.instanceKeys.get(normalizedClassName);
         if (set && set.has(selectable.id)) {
           set.delete(selectable.id);
@@ -267,4 +270,8 @@ export namespace Selectables {
       callback(data, index++);
     });
   }
+}
+
+function normalizeClassName(fullClassName: string) {
+  return fullClassName === TRANSIENT_ELEMENT_CLASSNAME ? fullClassName : normalizeFullClassName(fullClassName);
 }


### PR DESCRIPTION
Class name used in transient element instance key does not follow ECSchema class name formats: Schema:Class or Schema.Class.
Added exception for transient element instance key when normalizing class names.