### PR TITLE
[hierarchies-react]: Avoid double tree load

### DIFF
--- a/.changeset/odd-steaks-occur.md
+++ b/.changeset/odd-steaks-occur.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Avoid double tree load when `getFilteredPaths` are provided during first render.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
@@ -186,7 +186,6 @@ function useTreeInternal({
     provider.setFormatter(currentFormatter.current);
     const removeHierarchyChangedListener = provider.hierarchyChanged.addListener(() => actions.reloadTree());
     actions.setHierarchyProvider(provider);
-    actions.reloadTree({ state: "keep" });
     setHierarchyProvider(provider);
     return () => {
       removeHierarchyChangedListener();
@@ -194,7 +193,6 @@ function useTreeInternal({
       if (isIDisposable(provider)) {
         provider.dispose();
       }
-      setHierarchyProvider(undefined);
     };
   }, [actions, getHierarchyProvider]);
 
@@ -218,12 +216,13 @@ function useTreeInternal({
         if (!disposed) {
           hierarchyProvider.setHierarchyFilter(paths ? { paths } : undefined);
           actions.reloadTree({ state: paths ? "discard" : "keep" });
+          setIsFiltering(false);
         }
-        setIsFiltering(false);
       }
     })();
     return () => {
       disposed = true;
+      actions.dispose();
     };
   }, [actions, hierarchyProvider, getFilteredPaths]);
 

--- a/packages/hierarchies-react/src/test/UseTree.test.tsx
+++ b/packages/hierarchies-react/src/test/UseTree.test.tsx
@@ -694,6 +694,7 @@ describe("useTree", () => {
         return createAsyncIterator(childNodes.slice(0, 1));
       }),
       setFormatter: sinon.stub(),
+      setHierarchyFilter: sinon.stub(),
     };
     rerender({ ...initialProps, getHierarchyProvider: () => newProvider as unknown as hierarchiesModule.HierarchyProvider });
 
@@ -788,6 +789,7 @@ describe("useUnifiedSelectionTree", () => {
     hierarchyChanged: new BeEvent(),
     getNodes: createStub<hierarchiesModule.HierarchyProvider["getNodes"]>(),
     setFormatter: sinon.stub(),
+    setHierarchyFilter: sinon.stub(),
   };
 
   type UseUnifiedSelectionTree = Parameters<typeof useUnifiedSelectionTree>[0];


### PR DESCRIPTION
Fixed double tree load happening if `getFilteredPaths` are provided during first render. One load is started when hierarchies provider is created and second is started after filtered paths are loaded.

After this change tree load will start only after filtered paths are loaded to avoid unnecessary loading unfiltered tree that will be immediately discarded.