### PR TITLE
Add missing tooltips

### DIFF
--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/LocalizationContext.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/LocalizationContext.tsx
@@ -55,6 +55,11 @@ export interface LocalizedStrings {
    * Default value: `Retry`.
    */
   retry: string;
+  /**
+   * Tooltip for expander button in tree.
+   * Default value: `Expand node`.
+   */
+  expanderTooltip: string;
 }
 
 /** @internal */
@@ -72,6 +77,7 @@ const defaultLocalizedStrings: LocalizedStrings = {
   increaseHierarchyLimit: "<link>Increase the hierarchy level size limit to {{limit}}.</link>",
   increaseHierarchyLimitWithFiltering: "Or, <link>increase the hierarchy level size limit to {{limit}}.</link>",
   retry: "Retry",
+  expanderTooltip: "Expand node",
 };
 
 const localizationContext = createContext<LocalizationContext>({ localizedStrings: defaultLocalizedStrings });

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -100,6 +100,7 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
           }}
           icon={getIcon ? getIcon(node) : undefined}
           label={getLabel ? getLabel(node) : node.label}
+          expanderProps={{ label: localizedStrings.expanderTooltip, labelProps: { placement: "left" } }}
           sublabel={getSublabel ? getSublabel(node) : undefined}
         >
           <ButtonGroup className={cx("action-buttons", actionButtonsClassName)}>


### PR DESCRIPTION
Added a tooltip for expander:
![image](https://github.com/user-attachments/assets/bcdbdcf2-2cc7-4544-a08a-23975cf887e3)
