### PR TITLE
Hierarchies: Custom hierarchy providers learning

### DIFF
--- a/.changeset/rude-ligers-vanish.md
+++ b/.changeset/rude-ligers-vanish.md
@@ -1,0 +1,7 @@
+---
+"@itwin/presentation-hierarchies": minor
+---
+
+Extended `createPredicateBasedHierarchyDefinition` props to accept `HierarchyDefinition` functions: `parseNode`, `preProcessNode` and `postProcessNode`.
+
+The change allows creating a fully capable `HierarchyDefinition` with all the custom behaviors provided by those functions.

--- a/.changeset/strong-cherries-sort.md
+++ b/.changeset/strong-cherries-sort.md
@@ -1,0 +1,19 @@
+---
+"@itwin/presentation-hierarchies": minor
+---
+
+Added hierarchy filtering helper to make hierarchy filtering easier to implement.
+
+The helper can be created using the `createHierarchyFilteringHelper` function and supplying it the root level filtering paths and parent node. From there, filtering information for specific hierarchy level is determined and an object with the following attributes is returned:
+
+- `hasFilter` tells if the hierarchy level has a filter applied.
+- `hasFilterTargetAncestor` tells if there's a filter target ancestor node up in the hierarchy.
+- `getChildNodeFilteringIdentifiers()` returns an array of hierarchy node identifiers that apply specifically for this hierarchy level.
+- `createChildNodeProps()` and `createChildNodePropsAsync()` return attributes that should be applied to nodes in filtered hierarchy levels, after applying the filter.
+
+See the [Implementing hierarchy filtering support](./learning/CustomHierarchyProviders.md#implementing-hierarchy-filtering-support) learning page for a usage example.
+
+In addition, deprecated a few APIs that are replaced by filtering helper:
+
+- `extractFilteringProps` function,
+- `HierarchyNodeFilteringProps.create` function.

--- a/apps/full-stack-tests/src/hierarchies/HierarchyFiltering.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchyFiltering.test.ts
@@ -223,6 +223,112 @@ describe("Hierarchies", () => {
           ],
         });
       });
+
+      it("filters generic nodes when targeting child and ancestor", async function () {
+        const { imodel } = await buildIModel(this, async () => {});
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ parentNode }) {
+            if (!parentNode) {
+              return [
+                {
+                  node: {
+                    key: "custom1",
+                    label: "custom1",
+                  },
+                },
+                {
+                  node: {
+                    key: "custom2",
+                    label: "custom2",
+                  },
+                },
+              ];
+            }
+            if (HierarchyNode.isGeneric(parentNode) && parentNode.label === "custom2") {
+              return [
+                {
+                  node: {
+                    key: "custom21",
+                    label: "custom21",
+                  },
+                },
+                {
+                  node: {
+                    key: "custom22",
+                    label: "custom22",
+                  },
+                },
+              ];
+            }
+            if (HierarchyNode.isGeneric(parentNode) && parentNode.label === "custom22") {
+              return [
+                {
+                  node: {
+                    key: "custom221",
+                    label: "custom221",
+                  },
+                },
+                {
+                  node: {
+                    key: "custom222",
+                    label: "custom222",
+                  },
+                },
+              ];
+            }
+            return [];
+          },
+        };
+        await validateHierarchy({
+          provider: createProvider({
+            imodel,
+            hierarchy,
+            filteredNodePaths: [
+              { path: [{ type: "generic", id: "custom2" }], options: { autoExpand: true } },
+              {
+                path: [
+                  { type: "generic", id: "custom2" },
+                  { type: "generic", id: "custom22" },
+                  { type: "generic", id: "custom222" },
+                ],
+                options: { autoExpand: true },
+              },
+            ],
+          }),
+          expect: [
+            NodeValidators.createForGenericNode({
+              key: "custom2",
+              autoExpand: true,
+              isFilterTarget: true,
+              children: [
+                NodeValidators.createForGenericNode({
+                  key: "custom21",
+                  autoExpand: false,
+                  isFilterTarget: false,
+                  children: false,
+                }),
+                NodeValidators.createForGenericNode({
+                  key: "custom22",
+                  autoExpand: true,
+                  isFilterTarget: false,
+                  children: [
+                    NodeValidators.createForGenericNode({
+                      key: "custom221",
+                      autoExpand: false,
+                      isFilterTarget: false,
+                    }),
+                    NodeValidators.createForGenericNode({
+                      key: "custom222",
+                      autoExpand: false,
+                      isFilterTarget: true,
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ],
+        });
+      });
     });
 
     describe("instance nodes", () => {
@@ -309,6 +415,101 @@ describe("Hierarchies", () => {
                   children: [
                     NodeValidators.createForInstanceNode({
                       instanceKeys: [keys.childSubject2],
+                      isFilterTarget: true,
+                      children: false,
+                      autoExpand: false,
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ],
+        });
+      });
+
+      it("filters instance nodes when targeting child and ancestor", async function () {
+        const { imodel, ...keys } = await buildIModel(this, async (builder) => {
+          const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
+          const childSubject1 = insertSubject({ builder, codeValue: "test subject 1", parentId: rootSubject.id });
+          const childSubject2 = insertSubject({ builder, codeValue: "test subject 2", parentId: rootSubject.id });
+          const childSubject21 = insertSubject({ builder, codeValue: "test subject 21", parentId: rootSubject.id });
+          const childSubject22 = insertSubject({ builder, codeValue: "test subject 22", parentId: rootSubject.id });
+          const childSubject221 = insertSubject({ builder, codeValue: "test subject 221", parentId: rootSubject.id });
+          const childSubject222 = insertSubject({ builder, codeValue: "test subject 222", parentId: rootSubject.id });
+          return { rootSubject, childSubject1, childSubject2, childSubject21, childSubject22, childSubject221, childSubject222 };
+        });
+        const imodelAccess = createIModelAccess(imodel);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess }),
+        });
+        const createHierarchyLevelDefinition = async (whereClause: (alias: string) => string) => [
+          {
+            fullClassName: subjectClassName,
+            query: {
+              ecsql: `
+                SELECT ${await selectQueryFactory.createSelectClause({
+                  ecClassId: { selector: `this.ECClassId` },
+                  ecInstanceId: { selector: `this.ECInstanceId` },
+                  nodeLabel: { selector: `this.CodeValue` },
+                })}
+                FROM ${subjectClassName} AS this
+                ${whereClause("this")}
+              `,
+            },
+          },
+        ];
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ parentNode }) {
+            if (!parentNode) {
+              return createHierarchyLevelDefinition((alias: string) => `WHERE ${alias}.ECInstanceId IN (${keys.childSubject1.id}, ${keys.childSubject2.id})`);
+            }
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 2") {
+              return createHierarchyLevelDefinition((alias: string) => `WHERE ${alias}.ECInstanceId IN (${keys.childSubject21.id}, ${keys.childSubject22.id})`);
+            }
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 22") {
+              return createHierarchyLevelDefinition(
+                (alias: string) => `WHERE ${alias}.ECInstanceId IN (${keys.childSubject221.id}, ${keys.childSubject222.id})`,
+              );
+            }
+            return [];
+          },
+        };
+
+        await validateHierarchy({
+          provider: createProvider({
+            imodel,
+            hierarchy,
+            filteredNodePaths: [
+              { path: [keys.childSubject2], options: { autoExpand: true } },
+              { path: [keys.childSubject2, keys.childSubject22, keys.childSubject222], options: { autoExpand: true } },
+            ],
+          }),
+          expect: [
+            NodeValidators.createForInstanceNode({
+              instanceKeys: [keys.childSubject2],
+              isFilterTarget: true,
+              autoExpand: true,
+              children: [
+                NodeValidators.createForInstanceNode({
+                  instanceKeys: [keys.childSubject21],
+                  isFilterTarget: false,
+                  children: false,
+                  autoExpand: false,
+                }),
+                NodeValidators.createForInstanceNode({
+                  instanceKeys: [keys.childSubject22],
+                  autoExpand: true,
+                  isFilterTarget: false,
+                  children: [
+                    NodeValidators.createForInstanceNode({
+                      instanceKeys: [keys.childSubject221],
+                      isFilterTarget: false,
+                      children: false,
+                      autoExpand: false,
+                    }),
+                    NodeValidators.createForInstanceNode({
+                      instanceKeys: [keys.childSubject222],
                       isFilterTarget: true,
                       children: false,
                       autoExpand: false,

--- a/apps/full-stack-tests/src/hierarchies/HierarchyFiltering.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchyFiltering.test.ts
@@ -139,6 +139,7 @@ describe("Hierarchies", () => {
                       instanceKeys: [keys.childSubject2],
                       isFilterTarget: true,
                       children: false,
+                      autoExpand: false,
                     }),
                   ],
                 }),
@@ -223,6 +224,7 @@ describe("Hierarchies", () => {
         });
       });
     });
+
     describe("instance nodes", () => {
       it("filters through instance nodes that are in multiple paths", async function () {
         const { imodel, ...keys } = await buildIModel(this, async (builder) => {
@@ -287,24 +289,29 @@ describe("Hierarchies", () => {
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.childSubject1],
+              autoExpand: true,
               children: [
                 NodeValidators.createForInstanceNode({
                   instanceKeys: [keys.childSubject3],
                   isFilterTarget: true,
                   children: false,
+                  autoExpand: false,
                 }),
               ],
             }),
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.childSubject4],
+              autoExpand: true,
               children: [
                 NodeValidators.createForInstanceNode({
                   instanceKeys: [keys.childSubject1],
+                  autoExpand: true,
                   children: [
                     NodeValidators.createForInstanceNode({
                       instanceKeys: [keys.childSubject2],
                       isFilterTarget: true,
                       children: false,
+                      autoExpand: false,
                     }),
                   ],
                 }),
@@ -404,6 +411,7 @@ describe("Hierarchies", () => {
                   instanceKeys: [keys.childSubject2],
                   isFilterTarget: true,
                   children: false,
+                  autoExpand: false,
                 }),
               ],
             }),

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/CustomHierarchyProvider.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/CustomHierarchyProvider.test.ts
@@ -22,12 +22,7 @@ import { registerTxnListeners } from "@itwin/presentation-core-interop";
 import { ConcatenatedValue, ConcatenatedValuePart, createDefaultValueFormatter, IPrimitiveValueFormatter, julianToDateTime } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.FilteringProviderImports
-import {
-  createHierarchyFilteringHelper,
-  GenericNodeKey,
-  HierarchyFilteringPath,
-  HierarchyNodeIdentifier,
-} from "@itwin/presentation-hierarchies";
+import { createHierarchyFilteringHelper, GenericNodeKey, HierarchyFilteringPath, HierarchyNodeIdentifier } from "@itwin/presentation-hierarchies";
 // __PUBLISH_EXTRACT_END__
 import { buildIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/CustomHierarchyProvider.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/CustomHierarchyProvider.test.ts
@@ -1,0 +1,592 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/* eslint-disable no-console */
+/* eslint-disable no-duplicate-imports */
+/* eslint-disable @typescript-eslint/no-base-to-string */
+
+import { expect } from "chai";
+import { collect } from "presentation-test-utilities";
+import * as sinon from "sinon";
+// __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.Imports
+import { BeEvent } from "@itwin/core-bentley";
+import { HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";
+// __PUBLISH_EXTRACT_END__
+// __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.IModelProviderImports
+import { using } from "@itwin/core-bentley";
+import { BriefcaseConnection, IModelConnection } from "@itwin/core-frontend";
+import { registerTxnListeners } from "@itwin/presentation-core-interop";
+// __PUBLISH_EXTRACT_END__
+// __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.FormattingProviderImports
+import { ConcatenatedValue, ConcatenatedValuePart, createDefaultValueFormatter, IPrimitiveValueFormatter, julianToDateTime } from "@itwin/presentation-shared";
+// __PUBLISH_EXTRACT_END__
+// __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.FilteringProviderImports
+import {
+  createHierarchyFilteringHelper,
+  GenericNodeKey,
+  HierarchyFilteringPath,
+  HierarchyNodeIdentifier,
+} from "@itwin/presentation-hierarchies";
+// __PUBLISH_EXTRACT_END__
+import { buildIModel } from "../../IModelUtils.js";
+import { initialize, terminate } from "../../IntegrationTests.js";
+
+describe("Hierarchies", () => {
+  describe("Learning snippets", () => {
+    describe("Custom hierarchy providers", () => {
+      before(async () => {
+        await initialize();
+      });
+
+      after(async () => {
+        await terminate();
+      });
+
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it("creates basic provider", async function () {
+        // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.BasicProviderExample
+        // Create a hierarchy provider that returns an infinite hierarchy, where each node has one child node.
+        const provider: HierarchyProvider = {
+          async *getNodes({ parentNode }) {
+            yield !parentNode
+              ? {
+                  key: { type: "generic", id: `root` },
+                  label: `Root node`,
+                  children: true,
+                  parentKeys: [],
+                }
+              : {
+                  key: { type: "generic", id: `child-${parentNode.parentKeys.length + 1}` },
+                  label: `Child ${parentNode.parentKeys.length + 1}`,
+                  children: true,
+                  parentKeys: [...parentNode.parentKeys, parentNode.key],
+                };
+          },
+          async *getNodeInstanceKeys() {},
+          setFormatter() {},
+          setHierarchyFilter() {},
+          hierarchyChanged: new BeEvent(),
+        };
+        // __PUBLISH_EXTRACT_END__
+
+        const rootNodes = await collect(provider.getNodes({ parentNode: undefined }));
+        expect(rootNodes)
+          .to.have.lengthOf(1)
+          .and.to.containSubset([
+            {
+              label: "Root node",
+              children: true,
+            },
+          ]);
+        const childNodes1 = await collect(provider.getNodes({ parentNode: rootNodes[0] }));
+        expect(childNodes1)
+          .to.have.lengthOf(1)
+          .and.to.containSubset([
+            {
+              label: "Child 1",
+              children: true,
+            },
+          ]);
+        const childNodes2 = await collect(provider.getNodes({ parentNode: childNodes1[0] }));
+        expect(childNodes2)
+          .to.have.lengthOf(1)
+          .and.to.containSubset([
+            {
+              label: "Child 2",
+              children: true,
+            },
+          ]);
+      });
+
+      it("creates iModel provider", async function () {
+        const { imodel } = await buildIModel(this, async () => {});
+        const consoleLogSpy = sinon.stub(console, "log");
+
+        // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.CustomIModelProviderExample
+        // Create a hierarchy provider that returns the root bis.Subject and a hierarchy of its children.
+        class IModelHierarchyProvider implements HierarchyProvider {
+          public hierarchyChanged = new BeEvent();
+          private _disposeTxnListeners: (() => void) | undefined;
+
+          public constructor(private _imodel: IModelConnection) {
+            if (this._imodel instanceof BriefcaseConnection) {
+              // Briefcase connections support data modifications - the provider should listen to txn changes
+              // and raise `hierarchyChanged` event when the hierarchy should be refreshed. `BriefcaseTxns` has a number
+              // of events that we should listen to - here we're using `registerTxnListeners` helper to simplify subscription.
+              this._disposeTxnListeners = registerTxnListeners(this._imodel.txns, () => this.hierarchyChanged.raiseEvent());
+            }
+          }
+
+          // Make this provider disposable. Owners of the provider should make sure `dispose` is called when the
+          // provider is no longer needed.
+          // The tree state hooks from `@itwin/presentation-hierarchies-react` package take care of this for you.
+          public dispose() {
+            this._disposeTxnListeners?.();
+          }
+
+          public async *getNodes({ parentNode }: Parameters<HierarchyProvider["getNodes"]>[0]): AsyncIterableIterator<HierarchyNode> {
+            if (!parentNode) {
+              // Query and return root bis.Subject node
+              for await (const row of this._imodel.createQueryReader(
+                `
+                  SELECT
+                    COALESCE(s.UserLabel, s.CodeValue, ec_classname(s.ECClassId, 'c')) label,
+                    (SELECT 1 FROM bis.Element c WHERE c.Parent.Id = s.ECInstanceId LIMIT 1) hasChildren
+                  FROM bis.Subject s
+                  WHERE s.Parent.Id IS NULL
+                `,
+              )) {
+                yield {
+                  key: { type: "instances", instanceKeys: [{ className: "BisCore.Subject", id: "0x1", imodelKey: this._imodel.key }] },
+                  label: row.label,
+                  children: !!row.hasChildren,
+                  parentKeys: [],
+                };
+              }
+              return;
+            }
+            // Query and return children for the given parent node, assuming it's based on data from the same iModel
+            if (
+              HierarchyNode.isInstancesNode(parentNode) &&
+              parentNode.key.instanceKeys.length > 0 &&
+              parentNode.key.instanceKeys.every((k) => k.imodelKey === this._imodel.key)
+            ) {
+              for await (const row of this._imodel.createQueryReader(
+                `
+                  SELECT
+                    ec_classname(e.ECClassId, 's.c') className,
+                    e.ECInstanceId id,
+                    COALESCE(e.UserLabel, e.CodeValue, ec_classname(e.ECClassId, 'c')) label,
+                    (SELECT 1 FROM bis.Element c WHERE c.Parent.Id = e.ECInstanceId LIMIT 1) hasChildren
+                  FROM bis.Element e
+                  WHERE e.Parent.Id IN (${parentNode.key.instanceKeys.map((key) => key.id).join(",")})
+                `,
+              )) {
+                yield {
+                  key: { type: "instances", instanceKeys: [{ className: row.className, id: row.id, imodelKey: this._imodel.key }] },
+                  label: row.label,
+                  children: !!row.hasChildren,
+                  parentKeys: [...parentNode.parentKeys, parentNode.key],
+                };
+              }
+            }
+          }
+
+          // Since we're returning nodes based on instances in an iModel, we should also implement the `getNodeInstanceKeys` method
+          // allow efficient retrieval of instance keys
+          public async *getNodeInstanceKeys({ parentNode }: Parameters<HierarchyProvider["getNodeInstanceKeys"]>[0]) {
+            if (!parentNode) {
+              // Don't need to run a query here - we know all iModels have one root Subject with `0x1` id
+              yield { className: "BisCore.Subject", id: "0x1", imodelKey: this._imodel.key };
+              return;
+            }
+            // Query and return children instance keys for the given parent node
+            if (
+              HierarchyNode.isInstancesNode(parentNode) &&
+              parentNode.key.instanceKeys.length > 0 &&
+              parentNode.key.instanceKeys.every((k) => k.imodelKey === this._imodel.key)
+            ) {
+              for await (const row of this._imodel.createQueryReader(
+                `
+                  SELECT ec_classname(e.ECClassId, 's.c') className, e.ECInstanceId id
+                  FROM bis.Element e
+                  WHERE e.Parent.Id IN (${parentNode.key.instanceKeys.map((key) => key.id).join(",")})
+                `,
+              )) {
+                yield { className: row.className, id: row.id, imodelKey: this._imodel.key };
+              }
+            }
+          }
+
+          public setFormatter() {}
+          public setHierarchyFilter() {}
+        }
+
+        // The `using` function makes sure the provider is disposed when it's no longer needed
+        await using(new IModelHierarchyProvider(imodel), async (provider) => {
+          // Traverse the hierarchy to ensure expected nodes are returned. The result depends on
+          // the iModel given to the provider.
+          await traverseHierarchy(provider);
+        });
+        // __PUBLISH_EXTRACT_END__
+
+        expect(consoleLogSpy.callCount).to.eq(3);
+        expect(consoleLogSpy.getCall(0).args[0]).to.eq(imodel.rootSubject.name);
+        expect(consoleLogSpy.getCall(1).args[0]).to.eq("  BisCore.RealityDataSources");
+        expect(consoleLogSpy.getCall(2).args[0]).to.eq("  BisCore.DictionaryModel");
+      });
+
+      it("creates 3rd party service provider", async function () {
+        const consoleLogSpy = sinon.stub(console, "log");
+
+        // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.3rdPartyServiceProviderExample
+        // Create a fake books service that simulates fetching authors and books data.
+        const booksService = createBooksService();
+
+        // Create a hierarchy provider that returns a two-level hierarchy, where root nodes are authors and their
+        // children are books.
+        const provider: HierarchyProvider = {
+          async *getNodes({ parentNode }) {
+            if (!parentNode) {
+              // For root nodes, query authors and return nodes based on them
+              for (const author of await booksService.getAuthors()) {
+                yield {
+                  key: { type: "generic", id: `author:${author.key}` },
+                  label: author.name,
+                  children: author.hasBooks,
+                  parentKeys: [],
+                };
+              }
+            } else if (HierarchyNode.isGeneric(parentNode) && parentNode.key.id.startsWith("author:")) {
+              // For author parent node, query books and return nodes based on them
+              for (const book of await booksService.getBooks({ authorKey: parentNode.key.id.slice(7) })) {
+                yield {
+                  key: { type: "generic", id: `book:${book.key}` },
+                  label: book.title,
+                  children: false,
+                  parentKeys: [...parentNode.parentKeys, parentNode.key],
+                };
+              }
+            }
+          },
+          async *getNodeInstanceKeys() {},
+          setHierarchyFilter() {},
+          setFormatter() {},
+          hierarchyChanged: new BeEvent(),
+        };
+
+        // Traverse the hierarchy:
+        await traverseHierarchy(provider);
+        // Output:
+        // J.R.R. Tolkien
+        //   The Hobbit
+        //   The Fellowship of Ring
+        //   The two towers
+        // Mark Twain
+        //   Adventures of Huckleberry Finn
+        //   The Adventures of Tom Sawyer
+        // Tom Clancy
+        //   The hunt for Red October
+        //   Red storm rising
+        //   Executive orders
+        // __PUBLISH_EXTRACT_END__
+
+        expect(consoleLogSpy.getCalls().map((call) => call.args[0])).to.deep.eq([
+          "J.R.R. Tolkien",
+          "  The Hobbit",
+          "  The Fellowship of Ring",
+          "  The two towers",
+          "Mark Twain",
+          "  Adventures of Huckleberry Finn",
+          "  The Adventures of Tom Sawyer",
+          "Tom Clancy",
+          "  The hunt for Red October",
+          "  Red storm rising",
+          "  Executive orders",
+        ]);
+      });
+
+      it("creates formatting provider", async function () {
+        const consoleLogSpy = sinon.stub(console, "log");
+
+        // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.FormattingProviderExample
+        // Create a hierarchy provider that returns a single root node with formatted label. The formatter used by the
+        // provider can be changed by calling the `setFormatter` method.
+        class FormattingHierarchyProvider implements HierarchyProvider {
+          private _formatter: IPrimitiveValueFormatter = createDefaultValueFormatter();
+          public hierarchyChanged = new BeEvent();
+          public async *getNodes(): ReturnType<HierarchyProvider["getNodes"]> {
+            yield {
+              key: { type: "generic", id: `formatted-node` },
+              // We're using `ConcatenatedValue` to simplify formatting complex values consisting of different parts
+              // that may need to be formatted differently
+              label: await ConcatenatedValue.serialize({
+                parts: [
+                  "Boolean: ",
+                  { type: "Boolean", value: true },
+                  " | Integer: ",
+                  { type: "Integer", value: 123 },
+                  " | Double: ",
+                  { type: "Double", value: 4.56 },
+                  " | Date/Time: ",
+                  { type: "DateTime", extendedType: "ShortDate", value: new Date(Date.UTC(2024, 11, 31)) },
+                  " | Point2d: ",
+                  { type: "Point2d", value: { x: 1.234, y: 5.678 } },
+                ],
+                partFormatter: async (x) => (ConcatenatedValuePart.isString(x) ? x : this._formatter(x)),
+              }),
+              children: false,
+              parentKeys: [],
+            };
+          }
+          public async *getNodeInstanceKeys() {}
+          public setFormatter(formatter: IPrimitiveValueFormatter | undefined) {
+            this._formatter = formatter ?? createDefaultValueFormatter();
+          }
+          public setHierarchyFilter() {}
+        }
+
+        const provider = new FormattingHierarchyProvider();
+
+        // Default formatter will format the node label to the following value (Date/Time formatted according to the locale and time zone):
+        // `Boolean: true | Integer: 123 | Double: 4.56 | Date/Time: 2024-12-31 | Point2d: (1.23, 5.68)`
+        console.log((await provider.getNodes().next()).value.label);
+
+        provider.setFormatter(async (typedValue) => {
+          switch (typedValue.type) {
+            case "Boolean":
+              return typedValue.value ? "Yes" : "No";
+            case "Integer":
+              return `i${typedValue.value.toLocaleString()}`;
+            case "Double":
+              return typedValue.value.toExponential(1);
+            case "DateTime":
+              return (
+                typeof typedValue.value === "string"
+                  ? new Date(typedValue.value)
+                  : typeof typedValue.value === "number"
+                    ? julianToDateTime(typedValue.value)
+                    : typedValue.value
+              ).toISOString();
+            case "Point2d":
+              return `{ x: ${typedValue.value.x.toExponential(1)}, y: ${typedValue.value.y.toExponential(1)} }`;
+          }
+          return typedValue.value.toString();
+        });
+
+        // With the above formatter, the node label is formatted to the following value:
+        // `Boolean: Yes | Integer: i123 | Double: 4.6e+0 | Date/Time: 2024-12-31T00:00:00.000Z | Point2d: { x: 1.2e+0, y: 5.7e+0 }`
+        console.log((await provider.getNodes().next()).value.label);
+        // __PUBLISH_EXTRACT_END__
+
+        expect(consoleLogSpy.callCount).to.eq(2);
+        expect(consoleLogSpy.getCall(0).args[0]).to.eq(
+          `Boolean: true | Integer: 123 | Double: 4.56 | Date/Time: ${new Date(Date.UTC(2024, 11, 31)).toLocaleDateString()} | Point2d: (1.23, 5.68)`,
+        );
+        expect(consoleLogSpy.getCall(1).args[0]).to.eq(
+          "Boolean: Yes | Integer: i123 | Double: 4.6e+0 | Date/Time: 2024-12-31T00:00:00.000Z | Point2d: { x: 1.2e+0, y: 5.7e+0 }",
+        );
+      });
+
+      it("creates filtering provider", async function () {
+        const consoleLogSpy = sinon.stub(console, "log");
+        const booksService = createBooksService();
+
+        // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.FilteringProviderExample.PathsLookup
+        // A function that matches given string against authors and books, and returns hierarchy paths
+        // from root to the matched node. This function must be aware of the hierarchy structure to know what paths
+        // to create.
+        async function createFilterPaths(filter: string): Promise<HierarchyFilteringPath[]> {
+          const results: HierarchyFilteringPath[] = [];
+          const [matchingAuthors, matchingBooks] = await Promise.all([booksService.getAuthors({ name: filter }), booksService.getBooks({ title: filter })]);
+          for (const author of matchingAuthors) {
+            results.push([{ type: "generic", id: `author:${author.key}` }]);
+          }
+          for (const book of matchingBooks) {
+            results.push([
+              { type: "generic", id: `author:${book.authorKey}` },
+              { type: "generic", id: `book:${book.key}` },
+            ]);
+          }
+          return results;
+        }
+        // __PUBLISH_EXTRACT_END__
+
+        // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.FilteringProviderExample.Provider
+        let rootFilter: Parameters<HierarchyProvider["setHierarchyFilter"]>[0];
+        const provider: HierarchyProvider = {
+          async *getNodes({ parentNode }) {
+            const filteringHelper = createHierarchyFilteringHelper(rootFilter?.paths, parentNode);
+            const targetNodeKeys = filteringHelper.getChildNodeFilteringIdentifiers();
+            if (!parentNode) {
+              // For root nodes, query authors and return nodes based on them
+              const authors = await booksService.getAuthors(
+                targetNodeKeys
+                  ? {
+                      rules: targetNodeKeys
+                        .filter((key) => HierarchyNodeIdentifier.isGenericNodeIdentifier(key) && key.id.startsWith("author:"))
+                        .map(({ id }) => ({ key: id.slice(7) })),
+                      operator: "or",
+                    }
+                  : undefined,
+              );
+              for (const author of authors) {
+                const nodeKey: GenericNodeKey = { type: "generic", id: `author:${author.key}` };
+                yield {
+                  key: nodeKey,
+                  label: author.name,
+                  children: author.hasBooks,
+                  parentKeys: [],
+                  ...filteringHelper.createChildNodeProps({ nodeKey }),
+                };
+              }
+            } else if (HierarchyNode.isGeneric(parentNode) && parentNode.key.id.startsWith("author:")) {
+              // For author parent node, query books and return nodes based on them
+              const books = await booksService.getBooks({
+                rules: [
+                  { authorKey: parentNode.key.id.slice(7) },
+                  ...(targetNodeKeys
+                    ? [
+                        {
+                          rules: targetNodeKeys
+                            .filter((key) => HierarchyNodeIdentifier.isGenericNodeIdentifier(key) && key.id.startsWith("book:"))
+                            .map(({ id }) => ({ key: id.slice(5) })),
+                          operator: "or" as const,
+                        },
+                      ]
+                    : []),
+                ],
+                operator: "and",
+              });
+              for (const book of books) {
+                const nodeKey: GenericNodeKey = { type: "generic", id: `book:${book.key}` };
+                yield {
+                  key: nodeKey,
+                  label: book.title,
+                  children: false,
+                  parentKeys: [...parentNode.parentKeys, parentNode.key],
+                  ...filteringHelper.createChildNodeProps({ nodeKey }),
+                };
+              }
+            }
+          },
+          setHierarchyFilter(props) {
+            // Here we receive all paths that we want to filter the hierarchy by. The paths start from root, so
+            // we just store them in a variable to use later when querying root nodes.
+            rootFilter = props;
+          },
+          async *getNodeInstanceKeys() {},
+          setFormatter() {},
+          hierarchyChanged: new BeEvent(),
+        };
+        // __PUBLISH_EXTRACT_END__
+
+        // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.FilteringProviderExample.TraverseFiltered1
+        // Apply the filter "of" and traverse the filtered hierarchy. Notice that author node
+        // of "The Fellowship of Ring" is included, even though it doesn't match the filter.
+        provider.setHierarchyFilter({ paths: await createFilterPaths("of") });
+        await traverseHierarchy(provider);
+        // Output:
+        // J.R.R. Tolkien
+        //   The Fellowship of Ring
+        // Mark Twain
+        //   Adventures of Huckleberry Finn
+        //   The Adventures of Tom Sawyer
+        // __PUBLISH_EXTRACT_END__
+
+        expect(consoleLogSpy.getCalls().map((call) => call.args[0])).to.deep.eq([
+          "J.R.R. Tolkien",
+          "  The Fellowship of Ring",
+          "Mark Twain",
+          "  Adventures of Huckleberry Finn",
+          "  The Adventures of Tom Sawyer",
+        ]);
+        consoleLogSpy.resetHistory();
+
+        // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.FilteringProviderExample.TraverseFiltered2
+        // Apply the filter "tom" and traverse the filtered hierarchy. Notice that all books
+        // of "Tom Clancy" are included, even though they don't match the filter.
+        provider.setHierarchyFilter({ paths: await createFilterPaths("tom") });
+        await traverseHierarchy(provider);
+        // Output:
+        // Mark Twain
+        //   The Adventures of Tom Sawyer
+        // Tom Clancy
+        //   The hunt for Red October
+        //   Red storm rising
+        //   Executive orders
+        // __PUBLISH_EXTRACT_END__
+
+        expect(consoleLogSpy.getCalls().map((call) => call.args[0])).to.deep.eq([
+          "Mark Twain",
+          "  The Adventures of Tom Sawyer",
+          "Tom Clancy",
+          "  The hunt for Red October",
+          "  Red storm rising",
+          "  Executive orders",
+        ]);
+      });
+    });
+  });
+});
+
+// __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.BooksService
+// Creates a books service that provides authors and books data. The service has two methods:
+// - `getAuthors` - returns authors based on the provided query.
+// - `getBooks` - returns books based on the provided query.
+function createBooksService() {
+  const authors = [
+    { key: "OL26320A", name: "J.R.R. Tolkien", hasBooks: true },
+    { key: "OL18319A", name: "Mark Twain", hasBooks: true },
+    { key: "OL25277A", name: "Tom Clancy", hasBooks: true },
+  ];
+  const books = [
+    { key: "OL27482W", title: "The Hobbit", authorKey: "OL26320A" },
+    { key: "OL27513W", title: "The Fellowship of Ring", authorKey: "OL26320A" },
+    { key: "OL27479W", title: "The two towers", authorKey: "OL26320A" },
+
+    { key: "OL53908W", title: "Adventures of Huckleberry Finn", authorKey: "OL18319A" },
+    { key: "OL53919W", title: "The Adventures of Tom Sawyer", authorKey: "OL18319A" },
+
+    { key: "OL159452W", title: "The hunt for Red October", authorKey: "OL25277A" },
+    { key: "OL159642W", title: "Red storm rising", authorKey: "OL25277A" },
+    { key: "OL449001W", title: "Executive orders", authorKey: "OL25277A" },
+  ];
+  type Query<TEntry> = { rules: (Partial<TEntry> | Query<TEntry>)[]; operator: "and" | "or" } | Partial<TEntry>;
+  function filterEntries<TEntry>(entries: TEntry[], query: Query<TEntry> | undefined, entryMatcher: (entry: TEntry, query: Partial<TEntry>) => boolean) {
+    function matchEntry(entry: TEntry, partialQuery?: Query<TEntry>): boolean {
+      return (
+        !partialQuery ||
+        ("rules" in partialQuery
+          ? partialQuery.rules[partialQuery.operator === "and" ? "every" : "some"]((rule) => matchEntry(entry, rule))
+          : entryMatcher(entry, partialQuery))
+      );
+    }
+    return entries.filter((entry) => matchEntry(entry, query));
+  }
+  async function getAuthors(query?: Query<(typeof authors)[0]>) {
+    return filterEntries(authors, query, (entry, { key, name, hasBooks }) => {
+      if (key && entry.key !== key) {
+        return false;
+      }
+      if (name && !entry.name.toLocaleLowerCase().includes(name.toLocaleLowerCase())) {
+        return false;
+      }
+      if (hasBooks !== undefined && entry.hasBooks !== hasBooks) {
+        return false;
+      }
+      return true;
+    });
+  }
+  async function getBooks(query?: Query<(typeof books)[0]>) {
+    return filterEntries(books, query, (entry, { key, authorKey, title }) => {
+      if (key && entry.key !== key) {
+        return false;
+      }
+      if (title && !entry.title.toLocaleLowerCase().includes(title.toLocaleLowerCase())) {
+        return false;
+      }
+      if (authorKey && entry.authorKey !== authorKey) {
+        return false;
+      }
+      return true;
+    });
+  }
+  return { getAuthors, getBooks };
+}
+// __PUBLISH_EXTRACT_END__
+
+async function traverseHierarchy(provider: HierarchyProvider): Promise<void>;
+async function traverseHierarchy(provider: HierarchyProvider, parentNode: HierarchyNode, level: number): Promise<void>;
+async function traverseHierarchy(provider: HierarchyProvider, parentNode: HierarchyNode | undefined = undefined, level: number = 0): Promise<void> {
+  for await (const node of provider.getNodes({ parentNode })) {
+    console.log(`${" ".repeat(level * 2)}${node.label}`);
+    if (node.children) {
+      await traverseHierarchy(provider, node, level + 1);
+    }
+  }
+}

--- a/apps/performance-tests/src/hierarchies/Filtering.test.ts
+++ b/apps/performance-tests/src/hierarchies/Filtering.test.ts
@@ -3,11 +3,11 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { expect } from "chai";
 import { IModelDb, PhysicalElement, SnapshotDb } from "@itwin/core-backend";
 import { Id64 } from "@itwin/core-bentley";
 import { createNodesQueryClauseFactory, DefineHierarchyLevelProps, HierarchyFilteringPath, HierarchyNode } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory, ECClassHierarchyInspector, ECSchemaProvider } from "@itwin/presentation-shared";
-import { expect } from "chai";
 import { Datasets } from "../util/Datasets";
 import { run } from "../util/TestUtilities";
 import { StatelessHierarchyProvider } from "./StatelessHierarchyProvider";

--- a/apps/test-app/backend/src/SampleRpcImpl.ts
+++ b/apps/test-app/backend/src/SampleRpcImpl.ts
@@ -35,11 +35,16 @@ export default class SampleRpcImpl extends SampleRpcInterface {
 
   public override async getConnectionProps(imodelPath: string): Promise<IModelConnectionProps> {
     const db = SnapshotDb.openFile(imodelPath);
+    // eslint-disable-next-line @itwin/no-internal
     return db.getConnectionProps();
   }
 
   public override async closeConnection(imodelPath: string): Promise<void> {
     SnapshotDb.findByFilename(imodelPath)?.close();
+  }
+
+  public override async getRssFeed({ url }: { url: string }): Promise<string> {
+    return fetch(url).then(async (response) => response.text());
   }
 }
 

--- a/apps/test-app/common/src/SampleRpcInterface.ts
+++ b/apps/test-app/common/src/SampleRpcInterface.ts
@@ -38,4 +38,9 @@ export abstract class SampleRpcInterface extends RpcInterface {
   public async closeConnection(_imodelName: string): Promise<void> {
     return this.forward(arguments);
   }
+
+  @RpcOperation.setRoutingProps(localDeploymentOnly)
+  public async getRssFeed(_: { url: string }): Promise<string> {
+    return this.forward(arguments);
+  }
 }

--- a/apps/test-app/frontend/package.json
+++ b/apps/test-app/frontend/package.json
@@ -64,10 +64,12 @@
     "react-resize-detector": "^10.0.1",
     "redux": "^4.2.1",
     "reflect-metadata": "catalog:itwinjs-core",
+    "rss-parser": "^3.13.0",
     "rxjs": "catalog:rxjs",
     "sass": "^1.75.0",
     "typescript": "catalog:build-tools",
     "vite": "^5.2.14",
+    "vite-plugin-node-polyfills": "^0.22.0",
     "vite-plugin-static-copy": "^1.0.3"
   }
 }

--- a/apps/test-app/frontend/src/components/app/App.tsx
+++ b/apps/test-app/frontend/src/components/app/App.tsx
@@ -35,6 +35,7 @@ import { IModelSelector } from "../imodel-selector/IModelSelector";
 import { PropertiesWidget } from "../properties-widget/PropertiesWidget";
 import { RulesetSelector } from "../ruleset-selector/RulesetSelector";
 import { TableWidget } from "../table-widget/TableWidget";
+import { MultiDataSourceTree } from "../tree-widget/MultiDataSourceTree";
 import { RulesDrivenTreeWidget } from "../tree-widget/RulesDrivenTree";
 import { StatelessTreeV2 } from "../tree-widget/StatelessTree";
 import { UnitSystemSelector } from "../unit-system-selector/UnitSystemSelector";
@@ -233,9 +234,16 @@ function IModelComponents(props: IModelComponentsProps) {
               canPopout: true,
             },
             {
-              id: "stateless-tree",
-              label: "Stateless tree",
-              content: <StatelessTreePanel imodel={imodel} />,
+              id: "stateless-models-tree",
+              label: "Stateless Models tree",
+              content: <StatelessModelsTreePanel imodel={imodel} />,
+              defaultState: WidgetState.Open,
+              canPopout: true,
+            },
+            {
+              id: "multi-datasource-tree",
+              label: "Multi data source tree",
+              content: <MultiDataSourceTreePanel imodel={imodel} />,
               defaultState: WidgetState.Open,
               canPopout: true,
             },
@@ -313,11 +321,20 @@ function RulesDrivenTreePanel(props: { imodel: IModelConnection; rulesetId?: str
   );
 }
 
-function StatelessTreePanel(props: { imodel: IModelConnection }) {
+function StatelessModelsTreePanel(props: { imodel: IModelConnection }) {
   const { width, height, ref } = useResizeDetector<HTMLDivElement>();
   return (
     <div className="tree-widget-tabs-content" ref={ref} style={{ width: "100%", height: "100%", overflow: "hidden" }}>
       <StatelessTreeV2 imodel={props.imodel} width={width ?? 0} height={height ?? 0} />
+    </div>
+  );
+}
+
+function MultiDataSourceTreePanel(props: { imodel: IModelConnection }) {
+  const { width, height, ref } = useResizeDetector<HTMLDivElement>();
+  return (
+    <div className="tree-widget-tabs-content" ref={ref} style={{ width: "100%", height: "100%", overflow: "hidden" }}>
+      <MultiDataSourceTree imodel={props.imodel} width={width ?? 0} height={height ?? 0} />
     </div>
   );
 }

--- a/apps/test-app/frontend/src/components/tree-widget/MultiDataSourceTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/MultiDataSourceTree.tsx
@@ -1,0 +1,487 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ComponentPropsWithoutRef, ReactElement, useCallback, useEffect, useMemo, useState } from "react";
+import RssParser from "rss-parser";
+import { debounceTime, Subject } from "rxjs";
+import { BeEvent, Id64String } from "@itwin/core-bentley";
+import { IModelConnection } from "@itwin/core-frontend";
+import { SvgFolder, SvgGlobe, SvgImodelHollow, SvgItem, SvgModel } from "@itwin/itwinui-icons-react";
+import { Flex, ProgressRadial, SearchBox, Text } from "@itwin/itwinui-react";
+import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+import {
+  createHierarchyFilteringHelper,
+  createIModelHierarchyProvider,
+  createLimitingECSqlQueryExecutor,
+  createNodesQueryClauseFactory,
+  createPredicateBasedHierarchyDefinition,
+  DefineInstanceNodeChildHierarchyLevelProps,
+  GenericNodeKey,
+  GetHierarchyNodesProps,
+  HierarchyFilteringPath,
+  HierarchyNode,
+  HierarchyNodeIdentifier,
+  HierarchyNodeIdentifiersPath,
+  HierarchyProvider,
+  mergeProviders,
+} from "@itwin/presentation-hierarchies";
+import { PresentationHierarchyNode, TreeRenderer, useUnifiedSelectionTree } from "@itwin/presentation-hierarchies-react";
+import {
+  createBisInstanceLabelSelectClauseFactory,
+  createCachingECClassHierarchyInspector,
+  ECSql,
+  IInstanceLabelSelectClauseFactory,
+  InstanceKey,
+  IPrimitiveValueFormatter,
+} from "@itwin/presentation-shared";
+import { SampleRpcInterface } from "@test-app/common";
+import { MyAppFrontend } from "../../api/MyAppFrontend";
+
+type UseTreeProps = Parameters<typeof useUnifiedSelectionTree>[0];
+type IModelAccess = Parameters<typeof createIModelHierarchyProvider>[0]["imodelAccess"];
+
+export function MultiDataSourceTree({ imodel, ...props }: { imodel: IModelConnection; height: number; width: number }) {
+  const [imodelAccess, setIModelAccess] = useState<IModelAccess>();
+  useEffect(() => setIModelAccess(createIModelAccess(imodel)), [imodel]);
+
+  if (!imodelAccess) {
+    return null;
+  }
+
+  return <Tree {...props} imodelAccess={imodelAccess} />;
+}
+
+function createIModelAccess(imodel: IModelConnection) {
+  const schemas = MyAppFrontend.getSchemaContext(imodel);
+  const schemaProvider = createECSchemaProvider(schemas);
+  return {
+    imodelKey: imodel.key,
+    ...schemaProvider,
+    ...createCachingECClassHierarchyInspector({ schemaProvider }),
+    ...createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 1000),
+  };
+}
+
+const RSS_PROVIDER = createRssHierarchyProvider();
+
+function Tree({ imodelAccess, height, width }: { imodelAccess: IModelAccess; height: number; width: number }) {
+  const [filter, setFilter] = useState("");
+  const getFilteredPaths = useMemo<UseTreeProps["getFilteredPaths"]>(() => {
+    return async () => {
+      if (!filter) {
+        return undefined;
+      }
+      return Promise.all([getModelsHierarchyFilteringPaths({ imodelAccess, filter }), RSS_PROVIDER.getFilteredPaths(filter)]).then(
+        ([imodelPaths, rssPaths]) => [...imodelPaths, ...rssPaths],
+      );
+    };
+  }, [filter, imodelAccess]);
+
+  const {
+    rootNodes,
+    isLoading,
+    reloadTree,
+    setFormatter: _,
+    ...treeProps
+  } = useUnifiedSelectionTree({
+    sourceName: "MultiIModelTree",
+    getHierarchyProvider: useCallback(
+      () =>
+        mergeProviders({
+          providers: [
+            createIModelHierarchyProvider({
+              imodelAccess,
+              hierarchyDefinition: createModelsHierarchyDefinition({ imodelAccess }),
+            }),
+            RSS_PROVIDER,
+          ],
+        }),
+      [imodelAccess],
+    ),
+    getFilteredPaths,
+  });
+
+  const renderContent = () => {
+    if (rootNodes && rootNodes.length === 0 && filter) {
+      return (
+        <Flex alignItems="center" justifyContent="center" flexDirection="column" style={{ height: "100%" }}>
+          <Text isMuted>There are no nodes matching filter text {filter}</Text>
+        </Flex>
+      );
+    }
+
+    return (
+      <Flex.Item alignSelf="flex-start" style={{ width: "100%", overflow: "auto" }}>
+        <TreeRenderer rootNodes={rootNodes ?? []} {...treeProps} reloadTree={reloadTree} getIcon={getIcon} selectionMode={"extended"} />
+      </Flex.Item>
+    );
+  };
+
+  const renderLoadingOverlay = () => {
+    if (rootNodes !== undefined && !isLoading) {
+      return <></>;
+    }
+    return (
+      <div
+        style={{
+          position: "absolute",
+          zIndex: 1000,
+          height: "inherit",
+          width: "100%",
+          overflow: "hidden",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            opacity: 0.5,
+            pointerEvents: "none",
+            width: "100%",
+            height: "100%",
+            backgroundColor: "var(--iui-color-background-backdrop)",
+          }}
+        />
+        <ProgressRadial size="large" indeterminate />
+      </div>
+    );
+  };
+
+  return (
+    <Flex flexDirection="column" style={{ width, height }}>
+      <Flex style={{ width: "100%", padding: "0.5rem" }}>
+        <DebouncedSearchBox onChange={setFilter} />
+      </Flex>
+      {renderContent()}
+      {renderLoadingOverlay()}
+    </Flex>
+  );
+}
+
+type SearchBoxProps = ComponentPropsWithoutRef<typeof SearchBox>;
+
+function DebouncedSearchBox({ onChange, ...props }: Omit<SearchBoxProps, "onChange"> & { onChange: (text: string) => void }) {
+  const handleChange = useMemo(() => {
+    return debounced(onChange, 500);
+  }, [onChange]);
+
+  return <SearchBox {...props} inputProps={{ ...props.inputProps, value: undefined, onChange: (e) => handleChange(e.currentTarget.value) }} />;
+}
+
+function debounced<TArgs>(callback: (args: TArgs) => void, delay: number) {
+  const subject = new Subject<() => void>();
+  subject.pipe(debounceTime(delay)).subscribe({
+    next: (invoke) => invoke(),
+  });
+
+  return (args: TArgs) => {
+    subject.next(() => {
+      callback(args);
+    });
+  };
+}
+
+function createModelsHierarchyDefinition({ imodelAccess }: { imodelAccess: IModelAccess }) {
+  const labels = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
+  const clauses = createNodesQueryClauseFactory({ imodelAccess, instanceLabelSelectClauseFactory: labels });
+  return createPredicateBasedHierarchyDefinition({
+    classHierarchyInspector: imodelAccess,
+    hierarchy: {
+      rootNodes: async () => [
+        {
+          fullClassName: "BisCore.Subject",
+          query: {
+            ecsql: `
+              SELECT ${await clauses.createSelectClause({
+                ecClassId: { selector: "this.ECClassId" },
+                ecInstanceId: { selector: "this.ECInstanceId" },
+                nodeLabel: { selector: await labels.createSelectClause({ classAlias: "this", className: "BisCore.Subject" }) },
+                hasChildren: true,
+                extendedData: {
+                  nodeType: "root-subject",
+                },
+              })}
+              FROM BisCore.Subject this
+              WHERE this.ECInstanceId = 0x1
+            `,
+          },
+        },
+      ],
+      childNodes: [
+        {
+          parentInstancesNodePredicate: "BisCore.Subject",
+          definitions: async () => [
+            {
+              fullClassName: "BisCore.Model",
+              query: {
+                ecsql: `
+                  SELECT ${await clauses.createSelectClause({
+                    ecClassId: { selector: "this.ECClassId" },
+                    ecInstanceId: { selector: "this.ECInstanceId" },
+                    nodeLabel: { selector: await labels.createSelectClause({ classAlias: "this", className: "BisCore.Model" }) },
+                    grouping: {
+                      byClass: true,
+                    },
+                    extendedData: {
+                      nodeType: "model",
+                    },
+                  })}
+                  FROM BisCore.Model this
+                `,
+              },
+            },
+          ],
+        },
+        {
+          parentInstancesNodePredicate: "BisCore.Model",
+          definitions: async ({ parentNode }: DefineInstanceNodeChildHierarchyLevelProps) => [
+            {
+              fullClassName: "BisCore.Model",
+              query: {
+                ecsql: `
+                  SELECT ${await clauses.createSelectClause({
+                    ecClassId: { selector: "this.ECClassId" },
+                    ecInstanceId: { selector: "this.ECInstanceId" },
+                    nodeLabel: { selector: await labels.createSelectClause({ classAlias: "this", className: "BisCore.Model" }) },
+                    grouping: {
+                      byClass: true,
+                    },
+                    extendedData: {
+                      nodeType: "model",
+                    },
+                  })}
+                  FROM BisCore.Model this
+                  WHERE this.ParentModel.Id IN (${parentNode.key.instanceKeys.map((key) => key.id).join(",")})
+                `,
+              },
+            },
+          ],
+        },
+      ],
+    },
+    postProcessNode: async (node) => {
+      if (HierarchyNode.isClassGroupingNode(node)) {
+        return { ...node, extendedData: { nodeType: "model-class" } };
+      }
+      return node;
+    },
+  });
+}
+async function getModelsHierarchyFilteringPaths({ imodelAccess, filter }: { imodelAccess: IModelAccess; filter: string }): Promise<HierarchyFilteringPath[]> {
+  const labelsFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
+  const [rootSubjectPath, modelPaths] = await Promise.all([
+    getRootSubjectFilteredPath({ imodelAccess, filter, labelsFactory }),
+    Array.fromAsync(getModelsFilteringPaths({ imodelAccess, filter, labelsFactory })),
+  ]);
+  return [...(rootSubjectPath ? [rootSubjectPath] : []), ...modelPaths];
+}
+async function* getModelsFilteringPaths({
+  imodelAccess,
+  filter,
+  labelsFactory,
+}: {
+  imodelAccess: IModelAccess;
+  filter: string;
+  labelsFactory: IInstanceLabelSelectClauseFactory;
+}): AsyncIterableIterator<HierarchyFilteringPath> {
+  const whereClause = `${await labelsFactory.createSelectClause({
+    classAlias: "m",
+    className: "BisCore.Model",
+    selectorsConcatenator: ECSql.createConcatenatedValueStringSelector,
+  })} LIKE '%' || ? || '%' ESCAPE '\\'`;
+  const modelsReader = imodelAccess.createQueryReader({
+    ctes: [
+      `ModelsHierarchy(ECInstanceId, ParentId, Path) AS (
+        SELECT
+          m.ECInstanceId,
+          m.ParentModel.Id,
+          json_array(${ECSql.createInstanceKeySelector({ alias: "m" })})
+        FROM BisCore.Model m
+        WHERE ${whereClause}
+
+        UNION ALL
+
+        SELECT
+          pm.ECInstanceId,
+          pm.ParentModel.Id,
+          json_insert(
+            cm.Path,
+            '$[#]', ${ECSql.createInstanceKeySelector({ alias: "pm" })}
+          )
+        FROM ModelsHierarchy cm
+        JOIN BisCore.Model pm ON pm.ECInstanceId = cm.ParentId
+      )`,
+    ],
+    ecsql: `
+      SELECT mh.Path AS path
+      FROM ModelsHierarchy mh
+      WHERE mh.ParentId IS NULL
+    `,
+    bindings: [{ type: "string", value: filter.replace(/[%_\\]/g, "\\$&") }],
+  });
+  for await (const row of modelsReader) {
+    const path = JSON.parse(row.path) as HierarchyNodeIdentifiersPath;
+    yield {
+      path: [
+        { className: "BisCore.Subject", id: "0x1", imodelKey: imodelAccess.imodelKey },
+        ...path.reverse().map((k) => ({ ...k, imodelKey: imodelAccess.imodelKey })),
+      ],
+      options: {
+        autoExpand: true,
+      },
+    };
+  }
+}
+async function getRootSubjectFilteredPath({
+  imodelAccess,
+  filter,
+  labelsFactory,
+}: {
+  imodelAccess: IModelAccess;
+  filter: string;
+  labelsFactory: IInstanceLabelSelectClauseFactory;
+}): Promise<HierarchyNodeIdentifiersPath | undefined> {
+  const reader = imodelAccess.createQueryReader({
+    ecsql: `
+      SELECT this.ECInstanceId AS id
+      FROM BisCore.Subject this
+      WHERE
+        ${await labelsFactory.createSelectClause({ classAlias: "this", className: "BisCore.Subject", selectorsConcatenator: ECSql.createConcatenatedValueStringSelector })} LIKE '%' || ? || '%' ESCAPE '\\'
+        AND this.ECInstanceId = 0x1
+    `,
+    bindings: [{ type: "string", value: filter.replace(/[%_\\]/g, "\\$&") }],
+  });
+  const row = (await reader.next()).value as { id: Id64String } | undefined;
+  return row ? [{ className: "BisCore.Subject", id: row.id, imodelKey: imodelAccess.imodelKey }] : undefined;
+}
+
+function getIcon(node: PresentationHierarchyNode): ReactElement | undefined {
+  switch (node.extendedData?.nodeType) {
+    case "root-subject":
+      return <SvgImodelHollow />;
+    case "model-class":
+      return <SvgFolder />;
+    case "model":
+      return <SvgModel />;
+    case "rss-root":
+      return <SvgGlobe />;
+    case "rss-item":
+      return <SvgItem />;
+  }
+  return undefined;
+}
+
+function createRssHierarchyProvider(): HierarchyProvider & { getFilteredPaths: (filter: string) => Promise<HierarchyFilteringPath[]> } {
+  let feedPromise: ReturnType<RssParser["parseURL"]> | undefined;
+  async function getFeed() {
+    if (!feedPromise) {
+      // ideally we'd fetch straight from medium, but use our backend as means to avoid CORS
+      feedPromise = SampleRpcInterface.getClient()
+        .getRssFeed({ url: "https://medium.com/feed/itwinjs" })
+        .then(async (xml) => new RssParser().parseString(xml));
+    }
+    const feed = await feedPromise;
+    return feed;
+  }
+
+  let filter: HierarchyFilteringPath[] | undefined;
+  return {
+    hierarchyChanged: new BeEvent(),
+
+    async getFilteredPaths(filterString: string): Promise<HierarchyFilteringPath[]> {
+      const feed = await getFeed();
+      if (!feed) {
+        return [];
+      }
+      const paths = new Array<HierarchyNodeIdentifiersPath>();
+
+      if ((feed.title ?? "<no title>").toLocaleLowerCase().includes(filterString.toLocaleLowerCase())) {
+        paths.push([{ type: "generic", id: "rss-root", source: "rss" }]);
+      }
+
+      feed.items.forEach((item) => {
+        if ((item.title ?? "<no title>").toLocaleLowerCase().includes(filterString.toLocaleLowerCase())) {
+          paths.push([
+            { type: "generic", id: "rss-root", source: "rss" },
+            { type: "generic", id: `rss-${item.guid!}`, source: "rss" },
+          ]);
+        }
+      });
+
+      return paths.map((path) => ({ path, options: { autoExpand: true } }));
+    },
+
+    async *getNodes({ parentNode }: GetHierarchyNodesProps): AsyncIterableIterator<HierarchyNode> {
+      const feed = await getFeed();
+      if (!feed) {
+        return;
+      }
+
+      async function* generateNodes(): AsyncIterableIterator<HierarchyNode & { key: GenericNodeKey }> {
+        if (!parentNode) {
+          yield {
+            key: { type: "generic", id: `rss-root`, source: "rss" },
+            label: feed.title ?? "<no title>",
+            parentKeys: [],
+            children: feed.items.length > 0,
+            extendedData: {
+              nodeType: "rss-root",
+            },
+          } satisfies HierarchyNode;
+          return;
+        }
+        if (HierarchyNode.isGeneric(parentNode) && parentNode.key.id === "rss-root") {
+          let count = 0;
+          for (const item of feed.items) {
+            yield {
+              key: { type: "generic", id: `rss-${item.guid!}`, source: "rss" },
+              label: item.title ?? "<no title>",
+              parentKeys: [parentNode.key],
+              children: false,
+              extendedData: {
+                nodeType: "rss-item",
+              },
+            } satisfies HierarchyNode;
+            if (++count > 10) {
+              return;
+            }
+          }
+        }
+      }
+
+      const filteringHelper = createHierarchyFilteringHelper(filter, parentNode);
+      if (!filteringHelper.hasFilter) {
+        yield* generateNodes();
+        return;
+      }
+
+      const targetNodeKeys = filteringHelper.getChildNodeFilteringIdentifiers()!;
+      for await (const node of generateNodes()) {
+        if (targetNodeKeys.some((target) => HierarchyNodeIdentifier.equal(target, node.key))) {
+          yield {
+            ...node,
+            ...filteringHelper.createChildNodeProps({ nodeKey: node.key }),
+          };
+        }
+      }
+    },
+
+    async *getNodeInstanceKeys(_props: Omit<GetHierarchyNodesProps, "ignoreCache">): AsyncIterableIterator<InstanceKey> {},
+
+    setFormatter(_formatter: IPrimitiveValueFormatter | undefined): void {},
+
+    setHierarchyFilter(
+      props:
+        | {
+            paths: HierarchyFilteringPath[];
+          }
+        | undefined,
+    ): void {
+      filter = props?.paths;
+    },
+  };
+}

--- a/apps/test-app/frontend/vite.config.mts
+++ b/apps/test-app/frontend/vite.config.mts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { defineConfig } from "vite";
+import { nodePolyfills } from "vite-plugin-node-polyfills";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import react from "@vitejs/plugin-react";
 
@@ -10,6 +11,9 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [
     react(),
+    nodePolyfills({
+      include: ["stream", "events", "timers", "buffer", "util"],
+    }),
     viteStaticCopy({
       targets: [
         {

--- a/packages/hierarchies/README.md
+++ b/packages/hierarchies/README.md
@@ -35,7 +35,7 @@ A `HierarchyNode` data structure in the package represents a single node in a hi
 
 ### Hierarchy providers
 
-`HierarchyProvider` is the core concept of the library, which consumers use directly to build hierarchies. While that is an interface that consumers are free to implement, the package delivers a couple of built-in implementations:
+`HierarchyProvider` is the core concept of the library, which consumers use directly to build hierarchies. While that is an interface [that consumers are free to implement](./learning/CustomHierarchyProviders.md), the package delivers a couple of built-in implementations:
 
 - A provider that builds hierarchies based on data in an [iTwin.js iModel](https://www.itwinjs.org/learning/imodels/#imodel-overview). The `createIModelHierarchyProvider` function is used to create such a provider. See [iModel-based hierarchies](./learning/imodel/HierarchyProvider.md) learning page for more information.
 
@@ -52,6 +52,7 @@ Below is a list of learning material related to building hierarchies:
   - [Logging](./learning/Logging.md)
   - [Hierarchy filtering](./learning/HierarchyFiltering.md)
   - [Merged hierarchies](./learning/MergedHierarchies.md)
+  - [Custom hierarchy providers](./learning/CustomHierarchyProviders.md)
 - iModel-based hierarchies:
   - [Hierarchy provider](./learning/imodel/HierarchyProvider.md)
   - [Hierarchy definition](./learning/imodel/HierarchyDefinition.md)

--- a/packages/hierarchies/api/presentation-hierarchies.api.md
+++ b/packages/hierarchies/api/presentation-hierarchies.api.md
@@ -49,7 +49,7 @@ export function createHierarchyFilteringHelper(rootLevelFilteringProps: Hierarch
         pathMatcher: (identifier: HierarchyNodeIdentifier) => boolean;
     }) => Pick<HierarchyNode, "filtering" | "autoExpand"> | undefined;
     createChildNodePropsAsync: (props: {
-        pathMatcher: (identifier: HierarchyNodeIdentifier) => Promise<boolean>;
+        pathMatcher: (identifier: HierarchyNodeIdentifier) => boolean | Promise<boolean>;
     }) => Promise<Pick<HierarchyNode, "filtering" | "autoExpand"> | undefined>;
 };
 
@@ -174,7 +174,7 @@ interface ECSqlValueSelector {
 
 // @public @deprecated
 export function extractFilteringProps(rootLevelFilteringProps: HierarchyFilteringPath[], parentNode: Pick<NonGroupingHierarchyNode, "filtering"> | undefined): {
-    filteredNodePaths: Exclude<HierarchyFilteringPath, HierarchyNodeIdentifiersPath>[];
+    filteredNodePaths: HierarchyFilteringPath[];
     hasFilterTargetAncestor: boolean;
 } | undefined;
 

--- a/packages/hierarchies/api/presentation-hierarchies.api.md
+++ b/packages/hierarchies/api/presentation-hierarchies.api.md
@@ -629,7 +629,7 @@ export interface NonGroupingHierarchyNode extends BaseHierarchyNode {
 type ParentHierarchyNode<TBase = HierarchyNode> = OmitOverUnion<TBase, "children">;
 
 // @public
-interface PredicateBasedHierarchyDefinitionProps {
+interface PredicateBasedHierarchyDefinitionProps extends Pick<HierarchyDefinition, "parseNode" | "preProcessNode" | "postProcessNode"> {
     classHierarchyInspector: ECClassHierarchyInspector;
     hierarchy: {
         rootNodes: (props: DefineRootHierarchyLevelProps) => Promise<HierarchyLevelDefinition>;

--- a/packages/hierarchies/api/presentation-hierarchies.api.md
+++ b/packages/hierarchies/api/presentation-hierarchies.api.md
@@ -39,6 +39,21 @@ export interface ClassGroupingNodeKey {
 }
 
 // @public
+export function createHierarchyFilteringHelper(rootLevelFilteringProps: HierarchyFilteringPath[] | undefined, parentNode: Pick<NonGroupingHierarchyNode, "filtering"> | undefined): {
+    hasFilter: boolean;
+    hasFilterTargetAncestor: boolean;
+    getChildNodeFilteringIdentifiers: () => HierarchyNodeIdentifier[] | undefined;
+    createChildNodeProps: (props: {
+        nodeKey: InstancesNodeKey | GenericNodeKey;
+    } | {
+        pathMatcher: (identifier: HierarchyNodeIdentifier) => boolean;
+    }) => Pick<HierarchyNode, "filtering" | "autoExpand"> | undefined;
+    createChildNodePropsAsync: (props: {
+        pathMatcher: (identifier: HierarchyNodeIdentifier) => Promise<boolean>;
+    }) => Promise<Pick<HierarchyNode, "filtering" | "autoExpand"> | undefined>;
+};
+
+// @public
 export function createIModelHierarchyProvider(props: IModelHierarchyProviderProps): HierarchyProvider & {
     dispose: () => void;
 };
@@ -157,9 +172,9 @@ interface ECSqlValueSelector {
     selector: string;
 }
 
-// @public
+// @public @deprecated
 export function extractFilteringProps(rootLevelFilteringProps: HierarchyFilteringPath[], parentNode: Pick<NonGroupingHierarchyNode, "filtering"> | undefined): {
-    filteredNodePaths: HierarchyFilteringPath[];
+    filteredNodePaths: Exclude<HierarchyFilteringPath, HierarchyNodeIdentifiersPath>[];
     hasFilterTargetAncestor: boolean;
 } | undefined;
 
@@ -234,7 +249,7 @@ export namespace HierarchyFilteringPath {
 }
 
 // @public (undocumented)
-interface HierarchyFilteringPathOptions {
+export interface HierarchyFilteringPathOptions {
     autoExpand?: boolean | FilterTargetGroupingNodeInfo;
 }
 
@@ -323,7 +338,7 @@ type HierarchyNodeFilteringProps = {
 
 // @public (undocumented)
 namespace HierarchyNodeFilteringProps {
-    // (undocumented)
+    // @deprecated (undocumented)
     function create(props: {
         hasFilterTargetAncestor?: boolean;
         filteredChildrenIdentifierPaths?: HierarchyFilteringPath[];

--- a/packages/hierarchies/api/presentation-hierarchies.exports.csv
+++ b/packages/hierarchies/api/presentation-hierarchies.exports.csv
@@ -1,6 +1,7 @@
 sep=;
 Release Tag;API Item Type;API Item Name
 public;interface;ClassGroupingNodeKey
+public;function;createHierarchyFilteringHelper
 public;function;createIModelHierarchyProvider
 public;function;createLimitingECSqlQueryExecutor
 public;function;createNodesQueryClauseFactory
@@ -10,6 +11,7 @@ public;interface;DefineHierarchyLevelProps
 public;type;DefineInstanceNodeChildHierarchyLevelProps
 public;type;DefineRootHierarchyLevelProps
 public;function;extractFilteringProps
+deprecated;function;extractFilteringProps
 public;interface;GenericNodeKey
 public;interface;GetHierarchyNodesProps
 public;function;getLogger
@@ -18,6 +20,7 @@ public;type;GroupingNodeKey
 public;interface;HierarchyDefinition
 public;type;HierarchyFilteringPath
 public;namespace;HierarchyFilteringPath
+public;interface;HierarchyFilteringPathOptions
 public;type;HierarchyLevelDefinition
 public;type;HierarchyNode
 public;namespace;HierarchyNode

--- a/packages/hierarchies/learning/CustomHierarchyProviders.md
+++ b/packages/hierarchies/learning/CustomHierarchyProviders.md
@@ -1,0 +1,558 @@
+# Custom hierarchy providers
+
+In this package, a hierarchy provider is defined through the `HierarchyProvider` interface and available implementations delivered by this package are listed in the [Hierarchy providers](../README.md) README section. This learning page shows how to implement a custom hierarchy provider.
+
+## Basic example
+
+In the most basic form, a hierarchy provider only needs to implement the `getNodes` method, as it's responsible for returning nodes. The following example provider simply returns dynamically created nodes:
+
+<!-- [[include: [Presentation.Hierarchies.CustomHierarchyProviders.Imports, Presentation.Hierarchies.CustomHierarchyProviders.BasicProviderExample], ts]] -->
+<!-- BEGIN EXTRACTION -->
+
+```ts
+import { BeEvent } from "@itwin/core-bentley";
+import { HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";
+
+// Create a hierarchy provider that returns an infinite hierarchy, where each node has one child node.
+const provider: HierarchyProvider = {
+  async *getNodes({ parentNode }) {
+    yield !parentNode
+      ? {
+          key: { type: "generic", id: `root` },
+          label: `Root node`,
+          children: true,
+          parentKeys: [],
+        }
+      : {
+          key: { type: "generic", id: `child-${parentNode.parentKeys.length + 1}` },
+          label: `Child ${parentNode.parentKeys.length + 1}`,
+          children: true,
+          parentKeys: [...parentNode.parentKeys, parentNode.key],
+        };
+  },
+  async *getNodeInstanceKeys() {},
+  setFormatter() {},
+  setHierarchyFilter() {},
+  hierarchyChanged: new BeEvent(),
+};
+```
+
+<!-- END EXTRACTION -->
+
+## iModel-based hierarchy provider example
+
+`@itwin/presentation-hierarchies` package provides the `createIModelHierarchyProvider` function to create a hierarchy provider that fetches nodes from an iModel. The provider has many advanced features like running multiple queries in parallel, grouping, caching an more.
+
+However, it's possible to write one from scratch. The following example demonstrates how to create a simple iModel-based hierarchy provider:
+
+<!-- [[include: [Presentation.Hierarchies.CustomHierarchyProviders.Imports, Presentation.Hierarchies.CustomHierarchyProviders.IModelProviderImports, Presentation.Hierarchies.CustomHierarchyProviders.CustomIModelProviderExample], ts]] -->
+<!-- BEGIN EXTRACTION -->
+
+```ts
+import { BeEvent } from "@itwin/core-bentley";
+import { HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";
+
+import { using } from "@itwin/core-bentley";
+import { BriefcaseConnection, IModelConnection } from "@itwin/core-frontend";
+import { registerTxnListeners } from "@itwin/presentation-core-interop";
+
+// Create a hierarchy provider that returns the root bis.Subject and a hierarchy of its children.
+class IModelHierarchyProvider implements HierarchyProvider {
+  public hierarchyChanged = new BeEvent();
+  private _disposeTxnListeners: (() => void) | undefined;
+
+  public constructor(private _imodel: IModelConnection) {
+    if (this._imodel instanceof BriefcaseConnection) {
+      // Briefcase connections support data modifications - the provider should listen to txn changes
+      // and raise `hierarchyChanged` event when the hierarchy should be refreshed. `BriefcaseTxns` has a number
+      // of events that we should listen to - here we're using `registerTxnListeners` helper to simplify subscription.
+      this._disposeTxnListeners = registerTxnListeners(this._imodel.txns, () => this.hierarchyChanged.raiseEvent());
+    }
+  }
+
+  // Make this provider disposable. Owners of the provider should make sure `dispose` is called when the
+  // provider is no longer needed.
+  // The tree state hooks from `@itwin/presentation-hierarchies-react` package take care of this for you.
+  public dispose() {
+    this._disposeTxnListeners?.();
+  }
+
+  public async *getNodes({ parentNode }: Parameters<HierarchyProvider["getNodes"]>[0]): AsyncIterableIterator<HierarchyNode> {
+    if (!parentNode) {
+      // Query and return root bis.Subject node
+      for await (const row of this._imodel.createQueryReader(
+        `
+          SELECT
+            COALESCE(s.UserLabel, s.CodeValue, ec_classname(s.ECClassId, 'c')) label,
+            (SELECT 1 FROM bis.Element c WHERE c.Parent.Id = s.ECInstanceId LIMIT 1) hasChildren
+          FROM bis.Subject s
+          WHERE s.Parent.Id IS NULL
+        `,
+      )) {
+        yield {
+          key: { type: "instances", instanceKeys: [{ className: "BisCore.Subject", id: "0x1", imodelKey: this._imodel.key }] },
+          label: row.label,
+          children: !!row.hasChildren,
+          parentKeys: [],
+        };
+      }
+      return;
+    }
+    // Query and return children for the given parent node, assuming it's based on data from the same iModel
+    if (
+      HierarchyNode.isInstancesNode(parentNode) &&
+      parentNode.key.instanceKeys.length > 0 &&
+      parentNode.key.instanceKeys.every((k) => k.imodelKey === this._imodel.key)
+    ) {
+      for await (const row of this._imodel.createQueryReader(
+        `
+          SELECT
+            ec_classname(e.ECClassId, 's.c') className,
+            e.ECInstanceId id,
+            COALESCE(e.UserLabel, e.CodeValue, ec_classname(e.ECClassId, 'c')) label,
+            (SELECT 1 FROM bis.Element c WHERE c.Parent.Id = e.ECInstanceId LIMIT 1) hasChildren
+          FROM bis.Element e
+          WHERE e.Parent.Id IN (${parentNode.key.instanceKeys.map((key) => key.id).join(",")})
+        `,
+      )) {
+        yield {
+          key: { type: "instances", instanceKeys: [{ className: row.className, id: row.id, imodelKey: this._imodel.key }] },
+          label: row.label,
+          children: !!row.hasChildren,
+          parentKeys: [...parentNode.parentKeys, parentNode.key],
+        };
+      }
+    }
+  }
+
+  // Since we're returning nodes based on instances in an iModel, we should also implement the `getNodeInstanceKeys` method
+  // allow efficient retrieval of instance keys
+  public async *getNodeInstanceKeys({ parentNode }: Parameters<HierarchyProvider["getNodeInstanceKeys"]>[0]) {
+    if (!parentNode) {
+      // Don't need to run a query here - we know all iModels have one root Subject with `0x1` id
+      yield { className: "BisCore.Subject", id: "0x1", imodelKey: this._imodel.key };
+      return;
+    }
+    // Query and return children instance keys for the given parent node
+    if (
+      HierarchyNode.isInstancesNode(parentNode) &&
+      parentNode.key.instanceKeys.length > 0 &&
+      parentNode.key.instanceKeys.every((k) => k.imodelKey === this._imodel.key)
+    ) {
+      for await (const row of this._imodel.createQueryReader(
+        `
+          SELECT ec_classname(e.ECClassId, 's.c') className, e.ECInstanceId id
+          FROM bis.Element e
+          WHERE e.Parent.Id IN (${parentNode.key.instanceKeys.map((key) => key.id).join(",")})
+        `,
+      )) {
+        yield { className: row.className, id: row.id, imodelKey: this._imodel.key };
+      }
+    }
+  }
+
+  public setFormatter() {}
+  public setHierarchyFilter() {}
+}
+
+// The `using` function makes sure the provider is disposed when it's no longer needed
+await using(new IModelHierarchyProvider(imodel), async (provider) => {
+  // Traverse the hierarchy to ensure expected nodes are returned. The result depends on
+  // the iModel given to the provider.
+  await traverseHierarchy(provider);
+});
+```
+
+<!-- END EXTRACTION -->
+
+## 3rd party service-based hierarchy provider example
+
+Similar to querying nodes from an iModel, it's possible to query data for creating nodes from a 3rd party service. The following example demonstrates how to create a simple service-based hierarchy provider.
+
+First, let's define a sample books service:
+
+<!-- [[include: [Presentation.Hierarchies.CustomHierarchyProviders.BooksService], ts]] -->
+<!-- BEGIN EXTRACTION -->
+
+```ts
+// Creates a books service that provides authors and books data. The service has two methods:
+// - `getAuthors` - returns authors based on the provided query.
+// - `getBooks` - returns books based on the provided query.
+function createBooksService() {
+  const authors = [
+    { key: "OL26320A", name: "J.R.R. Tolkien", hasBooks: true },
+    { key: "OL18319A", name: "Mark Twain", hasBooks: true },
+    { key: "OL25277A", name: "Tom Clancy", hasBooks: true },
+  ];
+  const books = [
+    { key: "OL27482W", title: "The Hobbit", authorKey: "OL26320A" },
+    { key: "OL27513W", title: "The Fellowship of Ring", authorKey: "OL26320A" },
+    { key: "OL27479W", title: "The two towers", authorKey: "OL26320A" },
+
+    { key: "OL53908W", title: "Adventures of Huckleberry Finn", authorKey: "OL18319A" },
+    { key: "OL53919W", title: "The Adventures of Tom Sawyer", authorKey: "OL18319A" },
+
+    { key: "OL159452W", title: "The hunt for Red October", authorKey: "OL25277A" },
+    { key: "OL159642W", title: "Red storm rising", authorKey: "OL25277A" },
+    { key: "OL449001W", title: "Executive orders", authorKey: "OL25277A" },
+  ];
+  type Query<TEntry> = { rules: (Partial<TEntry> | Query<TEntry>)[]; operator: "and" | "or" } | Partial<TEntry>;
+  function filterEntries<TEntry>(entries: TEntry[], query: Query<TEntry> | undefined, entryMatcher: (entry: TEntry, query: Partial<TEntry>) => boolean) {
+    function matchEntry(entry: TEntry, partialQuery?: Query<TEntry>): boolean {
+      return (
+        !partialQuery ||
+        ("rules" in partialQuery
+          ? partialQuery.rules[partialQuery.operator === "and" ? "every" : "some"]((rule) => matchEntry(entry, rule))
+          : entryMatcher(entry, partialQuery))
+      );
+    }
+    return entries.filter((entry) => matchEntry(entry, query));
+  }
+  async function getAuthors(query?: Query<(typeof authors)[0]>) {
+    return filterEntries(authors, query, (entry, { key, name, hasBooks }) => {
+      if (key && entry.key !== key) {
+        return false;
+      }
+      if (name && !entry.name.toLocaleLowerCase().includes(name.toLocaleLowerCase())) {
+        return false;
+      }
+      if (hasBooks !== undefined && entry.hasBooks !== hasBooks) {
+        return false;
+      }
+      return true;
+    });
+  }
+  async function getBooks(query?: Query<(typeof books)[0]>) {
+    return filterEntries(books, query, (entry, { key, authorKey, title }) => {
+      if (key && entry.key !== key) {
+        return false;
+      }
+      if (title && !entry.title.toLocaleLowerCase().includes(title.toLocaleLowerCase())) {
+        return false;
+      }
+      if (authorKey && entry.authorKey !== authorKey) {
+        return false;
+      }
+      return true;
+    });
+  }
+  return { getAuthors, getBooks };
+}
+```
+
+<!-- END EXTRACTION -->
+
+Now that we have a service, let's create a hierarchy provider that creates a hierarchy based on the data returned from the service:
+
+<!-- [[include: [Presentation.Hierarchies.CustomHierarchyProviders.Imports, Presentation.Hierarchies.CustomHierarchyProviders.3rdPartyServiceProviderExample], ts]] -->
+<!-- BEGIN EXTRACTION -->
+
+```ts
+import { BeEvent } from "@itwin/core-bentley";
+import { HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";
+
+// Create a fake books service that simulates fetching authors and books data.
+const booksService = createBooksService();
+
+// Create a hierarchy provider that returns a two-level hierarchy, where root nodes are authors and their
+// children are books.
+const provider: HierarchyProvider = {
+  async *getNodes({ parentNode }) {
+    if (!parentNode) {
+      // For root nodes, query authors and return nodes based on them
+      for (const author of await booksService.getAuthors()) {
+        yield {
+          key: { type: "generic", id: `author:${author.key}` },
+          label: author.name,
+          children: author.hasBooks,
+          parentKeys: [],
+        };
+      }
+    } else if (HierarchyNode.isGeneric(parentNode) && parentNode.key.id.startsWith("author:")) {
+      // For author parent node, query books and return nodes based on them
+      for (const book of await booksService.getBooks({ authorKey: parentNode.key.id.slice(7) })) {
+        yield {
+          key: { type: "generic", id: `book:${book.key}` },
+          label: book.title,
+          children: false,
+          parentKeys: [...parentNode.parentKeys, parentNode.key],
+        };
+      }
+    }
+  },
+  async *getNodeInstanceKeys() {},
+  setHierarchyFilter() {},
+  setFormatter() {},
+  hierarchyChanged: new BeEvent(),
+};
+
+// Traverse the hierarchy:
+await traverseHierarchy(provider);
+// Output:
+// J.R.R. Tolkien
+//   The Hobbit
+//   The Fellowship of Ring
+//   The two towers
+// Mark Twain
+//   Adventures of Huckleberry Finn
+//   The Adventures of Tom Sawyer
+// Tom Clancy
+//   The hunt for Red October
+//   Red storm rising
+//   Executive orders
+```
+
+<!-- END EXTRACTION -->
+
+## Implementing node label formatting support
+
+While node labels' formatting is completely hierarchy provider's responsibility, the APIs are built to make it easy to implement:
+
+- We provide 2 built-in formatters:
+
+  - `createDefaultValueFormatter` from `@itwin/presentation-shared` package creates a basic formatter, that's suitable for values that don't have units.
+  - `createValueFormatter` from `@itwin/presentation-core-interop` package creates a formatter that knows how to handle values with units.
+
+- The `ConcatenatedValue` concept makes it easy to create formatted strings that combine multiple separately formatted values.
+
+- The `HierarchyProvider` interface has a notion of `setFormatter` function. This makes formatting the first-class concept in the hierarchy provider, and makes it easy for consumers to assign a formatter based on user preferences, e.g. selected unit system.
+
+With the above APIs at hand, implementing node label formatting is straightforward:
+
+<!-- [[include: [Presentation.Hierarchies.CustomHierarchyProviders.Imports, Presentation.Hierarchies.CustomHierarchyProviders.FormattingProviderImports, Presentation.Hierarchies.CustomHierarchyProviders.FormattingProviderExample], ts]] -->
+<!-- BEGIN EXTRACTION -->
+
+```ts
+import { BeEvent } from "@itwin/core-bentley";
+import { HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";
+
+import { ConcatenatedValue, ConcatenatedValuePart, createDefaultValueFormatter, IPrimitiveValueFormatter, julianToDateTime } from "@itwin/presentation-shared";
+
+// Create a hierarchy provider that returns a single root node with formatted label. The formatter used by the
+// provider can be changed by calling the `setFormatter` method.
+class FormattingHierarchyProvider implements HierarchyProvider {
+  private _formatter: IPrimitiveValueFormatter = createDefaultValueFormatter();
+  public hierarchyChanged = new BeEvent();
+  public async *getNodes(): ReturnType<HierarchyProvider["getNodes"]> {
+    yield {
+      key: { type: "generic", id: `formatted-node` },
+      // We're using `ConcatenatedValue` to simplify formatting complex values consisting of different parts
+      // that may need to be formatted differently
+      label: await ConcatenatedValue.serialize({
+        parts: [
+          "Boolean: ",
+          { type: "Boolean", value: true },
+          " | Integer: ",
+          { type: "Integer", value: 123 },
+          " | Double: ",
+          { type: "Double", value: 4.56 },
+          " | Date/Time: ",
+          { type: "DateTime", extendedType: "ShortDate", value: new Date(Date.UTC(2024, 11, 31)) },
+          " | Point2d: ",
+          { type: "Point2d", value: { x: 1.234, y: 5.678 } },
+        ],
+        partFormatter: async (x) => (ConcatenatedValuePart.isString(x) ? x : this._formatter(x)),
+      }),
+      children: false,
+      parentKeys: [],
+    };
+  }
+  public async *getNodeInstanceKeys() {}
+  public setFormatter(formatter: IPrimitiveValueFormatter | undefined) {
+    this._formatter = formatter ?? createDefaultValueFormatter();
+  }
+  public setHierarchyFilter() {}
+}
+
+const provider = new FormattingHierarchyProvider();
+
+// Default formatter will format the node label to the following value (Date/Time formatted according to the locale and time zone):
+// `Boolean: true | Integer: 123 | Double: 4.56 | Date/Time: 2024-12-31 | Point2d: (1.23, 5.68)`
+console.log((await provider.getNodes().next()).value.label);
+
+provider.setFormatter(async (typedValue) => {
+  switch (typedValue.type) {
+    case "Boolean":
+      return typedValue.value ? "Yes" : "No";
+    case "Integer":
+      return `i${typedValue.value.toLocaleString()}`;
+    case "Double":
+      return typedValue.value.toExponential(1);
+    case "DateTime":
+      return (
+        typeof typedValue.value === "string"
+          ? new Date(typedValue.value)
+          : typeof typedValue.value === "number"
+            ? julianToDateTime(typedValue.value)
+            : typedValue.value
+      ).toISOString();
+    case "Point2d":
+      return `{ x: ${typedValue.value.x.toExponential(1)}, y: ${typedValue.value.y.toExponential(1)} }`;
+  }
+  return typedValue.value.toString();
+});
+
+// With the above formatter, the node label is formatted to the following value:
+// `Boolean: Yes | Integer: i123 | Double: 4.6e+0 | Date/Time: 2024-12-31T00:00:00.000Z | Point2d: { x: 1.2e+0, y: 5.7e+0 }`
+console.log((await provider.getNodes().next()).value.label);
+```
+
+<!-- END EXTRACTION -->
+
+## Implementing hierarchy filtering support
+
+For this example, let's use the books service defined in the [3rd party service-based hierarchy provider example](#3rd-party-service-based-hierarchy-provider-example) section and enhance the provider to support hierarchy filtering.
+
+As described in the [Hierarchy filtering](./HierarchyFiltering.md) learning page, the process of filtering a hierarchy has two major steps:
+
+1. Determine node identifier paths for the target nodes.
+2. Given the node identifier paths, filter the hierarchy.
+
+Let's start with the first step:
+
+<!-- [[include: [Presentation.Hierarchies.CustomHierarchyProviders.Imports, Presentation.Hierarchies.CustomHierarchyProviders.FilteringProviderImports, Presentation.Hierarchies.CustomHierarchyProviders.FilteringProviderExample.PathsLookup], ts]] -->
+<!-- BEGIN EXTRACTION -->
+
+```ts
+import { BeEvent } from "@itwin/core-bentley";
+import { HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";
+
+import { createHierarchyFilteringHelper, GenericNodeKey, HierarchyFilteringPath, HierarchyNodeIdentifier } from "@itwin/presentation-hierarchies";
+
+// A function that matches given string against authors and books, and returns hierarchy paths
+// from root to the matched node. This function must be aware of the hierarchy structure to know what paths
+// to create.
+async function createFilterPaths(filter: string): Promise<HierarchyFilteringPath[]> {
+  const results: HierarchyFilteringPath[] = [];
+  const [matchingAuthors, matchingBooks] = await Promise.all([booksService.getAuthors({ name: filter }), booksService.getBooks({ title: filter })]);
+  for (const author of matchingAuthors) {
+    results.push([{ type: "generic", id: `author:${author.key}` }]);
+  }
+  for (const book of matchingBooks) {
+    results.push([
+      { type: "generic", id: `author:${book.authorKey}` },
+      { type: "generic", id: `book:${book.key}` },
+    ]);
+  }
+  return results;
+}
+```
+
+<!-- END EXTRACTION -->
+
+There could be a number of ways to filter the hierarchy, such as by target instance identifier, by a complex query that uses multiple attributes, or simply by label. The above function filters the hierarchy by node label.
+
+Now that we're able to find the paths, let's enhance our hierarchy provider to support filtering by them:
+
+<!-- [[include: [Presentation.Hierarchies.CustomHierarchyProviders.Imports, Presentation.Hierarchies.CustomHierarchyProviders.FilteringProviderImports, Presentation.Hierarchies.CustomHierarchyProviders.FilteringProviderExample.Provider], ts]] -->
+<!-- BEGIN EXTRACTION -->
+
+```ts
+import { BeEvent } from "@itwin/core-bentley";
+import { HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";
+
+import { createHierarchyFilteringHelper, GenericNodeKey, HierarchyFilteringPath, HierarchyNodeIdentifier } from "@itwin/presentation-hierarchies";
+
+let rootFilter: Parameters<HierarchyProvider["setHierarchyFilter"]>[0];
+const provider: HierarchyProvider = {
+  async *getNodes({ parentNode }) {
+    const filteringHelper = createHierarchyFilteringHelper(rootFilter?.paths, parentNode);
+    const targetNodeKeys = filteringHelper.getChildNodeFilteringIdentifiers();
+    if (!parentNode) {
+      // For root nodes, query authors and return nodes based on them
+      const authors = await booksService.getAuthors(
+        targetNodeKeys
+          ? {
+              rules: targetNodeKeys
+                .filter((key) => HierarchyNodeIdentifier.isGenericNodeIdentifier(key) && key.id.startsWith("author:"))
+                .map(({ id }) => ({ key: id.slice(7) })),
+              operator: "or",
+            }
+          : undefined,
+      );
+      for (const author of authors) {
+        const nodeKey: GenericNodeKey = { type: "generic", id: `author:${author.key}` };
+        yield {
+          key: nodeKey,
+          label: author.name,
+          children: author.hasBooks,
+          parentKeys: [],
+          ...filteringHelper.createChildNodeProps({ nodeKey }),
+        };
+      }
+    } else if (HierarchyNode.isGeneric(parentNode) && parentNode.key.id.startsWith("author:")) {
+      // For author parent node, query books and return nodes based on them
+      const books = await booksService.getBooks({
+        rules: [
+          { authorKey: parentNode.key.id.slice(7) },
+          ...(targetNodeKeys
+            ? [
+                {
+                  rules: targetNodeKeys
+                    .filter((key) => HierarchyNodeIdentifier.isGenericNodeIdentifier(key) && key.id.startsWith("book:"))
+                    .map(({ id }) => ({ key: id.slice(5) })),
+                  operator: "or" as const,
+                },
+              ]
+            : []),
+        ],
+        operator: "and",
+      });
+      for (const book of books) {
+        const nodeKey: GenericNodeKey = { type: "generic", id: `book:${book.key}` };
+        yield {
+          key: nodeKey,
+          label: book.title,
+          children: false,
+          parentKeys: [...parentNode.parentKeys, parentNode.key],
+          ...filteringHelper.createChildNodeProps({ nodeKey }),
+        };
+      }
+    }
+  },
+  setHierarchyFilter(props) {
+    // Here we receive all paths that we want to filter the hierarchy by. The paths start from root, so
+    // we just store them in a variable to use later when querying root nodes.
+    rootFilter = props;
+  },
+  async *getNodeInstanceKeys() {},
+  setFormatter() {},
+  hierarchyChanged: new BeEvent(),
+};
+```
+
+<!-- END EXTRACTION -->
+
+The provider uses target instance keys that it gets through a filtering helper function to filter each hierarchy level. Because we already know exactly what we're looking for, we can effectively apply filtering at query time, rather than doing that on the client side.
+
+With the above provider, we can now filter the books hierarchy by label:
+
+<!-- [[include: [Presentation.Hierarchies.CustomHierarchyProviders.FilteringProviderExample.TraverseFiltered1, Presentation.Hierarchies.CustomHierarchyProviders.FilteringProviderExample.TraverseFiltered2], ts]] -->
+<!-- BEGIN EXTRACTION -->
+
+```ts
+// Apply the filter "of" and traverse the filtered hierarchy. Notice that author node
+// of "The Fellowship of Ring" is included, even though it doesn't match the filter.
+provider.setHierarchyFilter({ paths: await createFilterPaths("of") });
+await traverseHierarchy(provider);
+// Output:
+// J.R.R. Tolkien
+//   The Fellowship of Ring
+// Mark Twain
+//   Adventures of Huckleberry Finn
+//   The Adventures of Tom Sawyer
+
+// Apply the filter "tom" and traverse the filtered hierarchy. Notice that all books
+// of "Tom Clancy" are included, even though they don't match the filter.
+provider.setHierarchyFilter({ paths: await createFilterPaths("tom") });
+await traverseHierarchy(provider);
+// Output:
+// Mark Twain
+//   The Adventures of Tom Sawyer
+// Tom Clancy
+//   The hunt for Red October
+//   Red storm rising
+//   Executive orders
+```
+
+<!-- END EXTRACTION -->

--- a/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
@@ -260,9 +260,9 @@ class MatchingFilteringPathsReducer {
       this._filterTargetOptions = HierarchyFilteringPath.mergeOptions(this._filterTargetOptions, options);
     } else if (path.length > 1) {
       this._filteredChildrenIdentifierPaths.push({ path: path.slice(1), options });
-    }
-    if (options?.autoExpand) {
-      this._needsAutoExpand = true;
+      if (options?.autoExpand) {
+        this._needsAutoExpand = true;
+      }
     }
   }
   public getNodeProps(): Pick<HierarchyNode, "filtering" | "autoExpand"> {

--- a/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
@@ -190,10 +190,7 @@ export function createHierarchyFilteringHelper(
       if (!hasFilter) {
         return undefined;
       }
-      if (filteringProps?.hasFilterTargetAncestor) {
-        return { filtering: { hasFilterTargetAncestor: true } };
-      }
-      const reducer = new MatchingFilteringPathsReducer();
+      const reducer = new MatchingFilteringPathsReducer(filteringProps?.hasFilterTargetAncestor);
       filteringProps.filteredNodePaths.forEach((filteredPath) => {
         const normalizedPath = HierarchyFilteringPath.normalize(filteredPath);
         if (
@@ -218,11 +215,7 @@ export function createHierarchyFilteringHelper(
       if (!hasFilter) {
         return undefined;
       }
-      if (filteringProps?.hasFilterTargetAncestor) {
-        return { filtering: { hasFilterTargetAncestor: true } };
-      }
-
-      const reducer = new MatchingFilteringPathsReducer();
+      const reducer = new MatchingFilteringPathsReducer(filteringProps?.hasFilterTargetAncestor);
       for (const filteredChildrenNodeIdentifierPath of filteringProps.filteredNodePaths) {
         const normalizedPath = HierarchyFilteringPath.normalize(filteredChildrenNodeIdentifierPath);
         /* c8 ignore next 3 */
@@ -254,9 +247,11 @@ class MatchingFilteringPathsReducer {
   private _filterTargetOptions = undefined as HierarchyFilteringPathOptions | undefined;
   private _needsAutoExpand = false;
 
+  public constructor(private _hasFilterTargetAncestor: boolean) {}
+
   public accept({ path, options }: NormalizedFilteringPath) {
     if (path.length === 1) {
-      this._isFilterTarget ||= true;
+      this._isFilterTarget = true;
       this._filterTargetOptions = HierarchyFilteringPath.mergeOptions(this._filterTargetOptions, options);
     } else if (path.length > 1) {
       this._filteredChildrenIdentifierPaths.push({ path: path.slice(1), options });
@@ -267,9 +262,10 @@ class MatchingFilteringPathsReducer {
   }
   public getNodeProps(): Pick<HierarchyNode, "filtering" | "autoExpand"> {
     return {
-      ...(this._isFilterTarget || this._filteredChildrenIdentifierPaths.length > 0
+      ...(this._hasFilterTargetAncestor || this._isFilterTarget || this._filteredChildrenIdentifierPaths.length > 0
         ? {
             filtering: {
+              ...(this._hasFilterTargetAncestor ? { hasFilterTargetAncestor: true } : undefined),
               ...(this._isFilterTarget ? { isFilterTarget: true, filterTargetOptions: this._filterTargetOptions } : undefined),
               ...(this._filteredChildrenIdentifierPaths.length > 0 ? { filteredChildrenIdentifierPaths: this._filteredChildrenIdentifierPaths } : undefined),
             },

--- a/packages/hierarchies/src/hierarchies/HierarchyNode.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyNode.ts
@@ -41,6 +41,8 @@ export type HierarchyNodeFilteringProps = {
 /** @public */
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export namespace HierarchyNodeFilteringProps {
+  /** @deprecated in 1.3. Use `createHierarchyFilteringHelper` and its `createChildNodeProps` function to create filtering props for nodes. */
+  /* c8 ignore start */
   export function create(props: {
     hasFilterTargetAncestor?: boolean;
     filteredChildrenIdentifierPaths?: HierarchyFilteringPath[];
@@ -57,6 +59,7 @@ export namespace HierarchyNodeFilteringProps {
     }
     return undefined;
   }
+  /* c8 ignore end */
 }
 
 /**

--- a/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
@@ -32,7 +32,7 @@ export interface GetHierarchyNodesProps {
    */
   hierarchyLevelSizeLimit?: number | "unbounded";
 
-  /** When set to true ignores the cache and fetches the nodes again. */
+  /** When set to `true` ignores the cache and fetches the nodes again. */
   ignoreCache?: boolean;
 }
 
@@ -49,10 +49,19 @@ export interface HierarchyProvider {
    */
   readonly hierarchyChanged: Event<() => void>;
 
-  /** Gets nodes for the specified parent node. */
+  /**
+   * Gets nodes for the specified parent node. This is THE method to implement, otherwise
+   * the provider doesn't return any nodes.
+   */
   getNodes(props: GetHierarchyNodesProps): AsyncIterableIterator<HierarchyNode>;
 
-  /** Gets instance keys for the specified parent node. */
+  /**
+   * Gets instance keys for the specified parent node.
+   *
+   * The result of this method may be used to determine instances whose nodes would be displayed as children
+   * of the specified parent node. For such use cases calling this method should be more efficient compared
+   * to calling `getNodes`.
+   */
   getNodeInstanceKeys(props: Omit<GetHierarchyNodesProps, "ignoreCache">): AsyncIterableIterator<InstanceKey>;
 
   /**

--- a/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyProvider.ts
@@ -50,7 +50,7 @@ export interface HierarchyProvider {
   readonly hierarchyChanged: Event<() => void>;
 
   /**
-   * Gets nodes for the specified parent node. This is THE method to implement, otherwise
+   * Gets nodes for the specified parent node. This is **the method to implement**, otherwise
    * the provider doesn't return any nodes.
    */
   getNodes(props: GetHierarchyNodesProps): AsyncIterableIterator<HierarchyNode>;

--- a/packages/hierarchies/src/hierarchies/imodel/FilteringHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/FilteringHierarchyDefinition.ts
@@ -3,12 +3,13 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { filter, find, firstValueFrom, from, map, merge, mergeAll, mergeMap, of, reduce, tap, toArray } from "rxjs";
 import { Id64String } from "@itwin/core-bentley";
 import { ECClassHierarchyInspector, InstanceKey } from "@itwin/presentation-shared";
-import { extractFilteringProps, HierarchyFilteringPath, HierarchyFilteringPathOptions } from "../HierarchyFiltering.js";
-import { HierarchyNodeFilteringProps } from "../HierarchyNode.js";
+import { createHierarchyFilteringHelper, HierarchyFilteringPath } from "../HierarchyFiltering.js";
 import { HierarchyNodeIdentifier } from "../HierarchyNodeIdentifier.js";
-import { GenericNodeKey } from "../HierarchyNodeKey.js";
+import { IModelInstanceKey } from "../HierarchyNodeKey.js";
+import { partition } from "../internal/operators/Partition.js";
 import {
   DefineHierarchyLevelProps,
   GenericHierarchyNodeDefinition,
@@ -21,7 +22,7 @@ import {
   NodePostProcessor,
   NodePreProcessor,
 } from "./IModelHierarchyDefinition.js";
-import { ProcessedGroupingHierarchyNode, ProcessedHierarchyNode, SourceHierarchyNode, SourceInstanceHierarchyNode } from "./IModelHierarchyNode.js";
+import { ProcessedGroupingHierarchyNode, ProcessedHierarchyNode, SourceInstanceHierarchyNode } from "./IModelHierarchyNode.js";
 import { defaultNodesParser } from "./TreeNodesReader.js";
 
 interface FilteringHierarchyDefinitionProps {
@@ -109,247 +110,147 @@ export class FilteringHierarchyDefinition implements HierarchyDefinition {
 
   public get parseNode(): NodeParser {
     return async (row: { [columnName: string]: any }, parentNode?: HierarchyDefinitionParentNode): Promise<SourceInstanceHierarchyNode> => {
-      const hasFilterTargetAncestor: boolean = !!row[ECSQL_COLUMN_NAME_HasFilterTargetAncestor];
+      const parsedNode = await (this._source.parseNode ?? defaultNodesParser)(row);
 
-      const { filteredChildrenIdentifierPaths, filterTargetOptions, isFilterTarget } =
+      const filteringHelper = createHierarchyFilteringHelper(this._nodeIdentifierPaths, parentNode);
+      const nodeExtraProps =
         row[ECSQL_COLUMN_NAME_FilterECInstanceId] && row[ECSQL_COLUMN_NAME_FilterClassName]
-          ? await this.getChildrenIdentifierPaths(parentNode?.filtering?.filteredChildrenIdentifierPaths ?? this._nodeIdentifierPaths, {
-              className: row[ECSQL_COLUMN_NAME_FilterClassName],
-              id: row[ECSQL_COLUMN_NAME_FilterECInstanceId],
-            })
-          : { filteredChildrenIdentifierPaths: [], filterTargetOptions: undefined, isFilterTarget: false };
+          ? await (async () => {
+              const rowInstanceKey = { className: row[ECSQL_COLUMN_NAME_FilterClassName], id: row[ECSQL_COLUMN_NAME_FilterECInstanceId] };
+              return filteringHelper.createChildNodePropsAsync({
+                pathMatcher: async (identifier) =>
+                  HierarchyNodeIdentifier.isInstanceNodeIdentifier(identifier) &&
+                  (!identifier.imodelKey || identifier.imodelKey === this._imodelAccess.imodelKey) &&
+                  identifier.id === rowInstanceKey.id &&
+                  (identifier.className === rowInstanceKey.className ||
+                    (await this._imodelAccess.classDerivesFrom(identifier.className, rowInstanceKey.className)) ||
+                    (await this._imodelAccess.classDerivesFrom(rowInstanceKey.className, identifier.className))),
+              });
+            })()
+          : undefined;
+      if (nodeExtraProps?.autoExpand) {
+        parsedNode.autoExpand = true;
+      }
+      if (nodeExtraProps?.filtering) {
+        parsedNode.filtering = nodeExtraProps.filtering;
+      }
 
-      const defaultNode = await (this._source.parseNode ?? defaultNodesParser)(row);
-      return applyFilterAttributes({
-        node: defaultNode,
-        filteredChildrenIdentifierPaths,
-        isFilterTarget,
-        filterTargetOptions,
-        hasFilterTargetAncestor,
-      });
+      return parsedNode;
     };
-  }
-
-  private async getChildrenIdentifierPaths(filteredChildrenNodeIdentifierPaths: HierarchyFilteringPath[], providedIdentifier: InstanceKey) {
-    const { id, className } = providedIdentifier;
-
-    let filteredChildrenIdentifierPaths: HierarchyFilteringPath[] | undefined;
-    let isFilterTarget = false;
-    let filterTargetOptions: HierarchyFilteringPathOptions | undefined;
-    for (const filteredChildrenNodeIdentifierPath of filteredChildrenNodeIdentifierPaths) {
-      const { path, options } = HierarchyFilteringPath.normalize(filteredChildrenNodeIdentifierPath);
-      /* c8 ignore next 3 */
-      if (path.length === 0) {
-        continue;
-      }
-
-      // We need to check if identifiers have the same id and imodelKey and are
-      // of the same class / derived class / is derived from class
-      const identifier = path[0];
-      if (identifier.id !== id) {
-        continue;
-      }
-      if (HierarchyNodeIdentifier.isInstanceNodeIdentifier(identifier)) {
-        if (identifier.imodelKey && identifier.imodelKey !== this._imodelAccess.imodelKey) {
-          continue;
-        }
-        if (
-          identifier.className !== className &&
-          !(await this._imodelAccess.classDerivesFrom(identifier.className, className)) &&
-          !(await this._imodelAccess.classDerivesFrom(className, identifier.className))
-        ) {
-          continue;
-        }
-      }
-      if (!filteredChildrenIdentifierPaths) {
-        filteredChildrenIdentifierPaths = [];
-      }
-      if (path.length > 1) {
-        filteredChildrenIdentifierPaths.push(options ? { path: path.slice(1), options } : path.slice(1));
-      } else if (isFilterTarget) {
-        filterTargetOptions = HierarchyFilteringPath.mergeOptions(filterTargetOptions, options);
-      } else {
-        isFilterTarget = true;
-        filterTargetOptions = options;
-      }
-    }
-    return { filteredChildrenIdentifierPaths, filterTargetOptions, isFilterTarget };
   }
 
   public async defineHierarchyLevel(props: DefineHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
     const sourceDefinitions = await this._source.defineHierarchyLevel(props);
-    const filteringProps = extractFilteringProps(this._nodeIdentifierPaths, props.parentNode);
-    if (!filteringProps) {
+    const filteringHelper = createHierarchyFilteringHelper(this._nodeIdentifierPaths, props.parentNode);
+    const childNodeFilteringIdentifiers = filteringHelper.getChildNodeFilteringIdentifiers();
+    if (!childNodeFilteringIdentifiers) {
       return sourceDefinitions;
     }
 
-    const filteredDefinitions: HierarchyLevelDefinition = [];
-    await Promise.all(
-      sourceDefinitions.map(async (definition) => {
-        let matchedDefinition: HierarchyNodesDefinition | undefined;
-        if (HierarchyNodesDefinition.isGenericNode(definition)) {
-          matchedDefinition = await matchFilters<GenericNodeKey>(
-            definition,
-            filteringProps,
-            async (id) => {
-              return (
-                HierarchyNodeIdentifier.isGenericNodeIdentifier(id) &&
-                (!id.source || id.source === this._imodelAccess.imodelKey) &&
-                id.id === definition.node.key
-              );
-            },
-            this._imodelAccess,
-            (def, matchingFilters) => {
-              const filteredChildrenIdentifierPaths = matchingFilters.reduce(
-                (r, c) => [...r, ...c.childrenIdentifierPaths],
-                new Array<HierarchyFilteringPath>(),
-              );
+    const childNodeFilteringIdentifiersForThisSource = childNodeFilteringIdentifiers.filter((id) => {
+      return (
+        (HierarchyNodeIdentifier.isGenericNodeIdentifier(id) && (!id.source || id.source === this._imodelAccess.imodelKey)) ||
+        (HierarchyNodeIdentifier.isInstanceNodeIdentifier(id) && (!id.imodelKey || id.imodelKey === this._imodelAccess.imodelKey))
+      );
+    });
+
+    const [genericNodeDefinitions, instanceNodeDefinitions] = partition(sourceDefinitions, HierarchyNodesDefinition.isGenericNode);
+    return firstValueFrom(
+      merge(
+        genericNodeDefinitions.pipe(
+          map((definition) => {
+            if (filteringHelper.hasFilterTargetAncestor) {
               return {
-                ...def,
-                node: applyFilterAttributes({
-                  node: def.node,
-                  filteredChildrenIdentifierPaths,
-                  isFilterTarget: matchingFilters.some((mc) => mc.isFilterTarget),
-                  filterTargetOptions: matchingFilters.find((mc) => mc.isFilterTarget)?.filterTargetOptions,
-                  hasFilterTargetAncestor: filteringProps.hasFilterTargetAncestor,
-                }),
+                ...definition,
+                node: {
+                  ...definition.node,
+                  filtering: {
+                    hasFilterTargetAncestor: true,
+                  },
+                },
               };
-            },
-          );
-        } else {
-          matchedDefinition = await matchFilters<InstanceKey>(
-            definition,
-            filteringProps,
-            async (id) => {
-              return (
-                HierarchyNodeIdentifier.isInstanceNodeIdentifier(id) &&
-                (!id.imodelKey || id.imodelKey === this._imodelAccess.imodelKey) &&
-                (await this._imodelAccess.classDerivesFrom(id.className, definition.fullClassName))
-              );
-            },
-            this._imodelAccess,
-            (def, matchingFilters) => applyECInstanceIdsFilter(def, matchingFilters, !!filteringProps.hasFilterTargetAncestor),
-            false,
-          );
-        }
-        if (matchedDefinition) {
-          filteredDefinitions.push(matchedDefinition);
-        }
-      }),
-    );
-    return filteredDefinitions;
-  }
-}
+            }
+            if (
+              childNodeFilteringIdentifiersForThisSource.filter(HierarchyNodeIdentifier.isGenericNodeIdentifier).some(({ id }) => id === definition.node.key)
+            ) {
+              return {
+                ...definition,
+                node: {
+                  ...definition.node,
+                  ...filteringHelper.createChildNodeProps({ pathMatcher: ({ id }) => id === definition.node.key }),
+                },
+              };
+            }
+            return undefined;
+          }),
+          filter((def): def is GenericHierarchyNodeDefinition => !!def),
+        ),
 
-type MatchedFilter<TIdentifier extends HierarchyNodeIdentifier> = {
-  id: TIdentifier;
-  childrenIdentifierPaths: HierarchyFilteringPath[];
-} & ({ isFilterTarget: false } | { isFilterTarget: true; filterTargetOptions?: HierarchyFilteringPathOptions });
+        instanceNodeDefinitions.pipe(
+          mergeMap((definition) => {
+            if (filteringHelper.hasFilterTargetAncestor) {
+              // if we have a filter target ancestor, we don't need to filter the definitions - we use all of them
+              return of(definition);
+            }
 
-async function matchFilters<
-  TIdentifier extends HierarchyNodeIdentifier,
-  TDefinition = TIdentifier extends InstanceKey ? InstanceNodesQueryDefinition : GenericHierarchyNodeDefinition,
->(
-  definition: TDefinition,
-  filteringProps: { filteredNodePaths: HierarchyFilteringPath[]; hasFilterTargetAncestor?: boolean },
-  predicate: (id: HierarchyNodeIdentifier) => Promise<boolean>,
-  classHierarchy: ECClassHierarchyInspector,
-  matchedDefinitionProcessor: (def: TDefinition, matchingFilters: Array<MatchedFilter<TIdentifier>>) => TDefinition,
-  extractPathsAndOptions: boolean = true,
-): Promise<TDefinition | undefined> {
-  const { filteredNodePaths, hasFilterTargetAncestor } = filteringProps;
-  const matchingFilters: Array<MatchedFilter<TIdentifier>> = [];
-  for (const filteredNodePath of filteredNodePaths) {
-    const { path, options } = HierarchyFilteringPath.normalize(filteredNodePath);
-    if (path.length === 0) {
-      continue;
-    }
-    const nodeId = path[0];
-    if (await predicate(nodeId)) {
-      let entry = await findMatchingFilterEntry(matchingFilters, nodeId, classHierarchy);
-      if (!entry) {
-        entry = {
-          // ideally, `predicate` would act as a type guard to guarantee that `id` is `TIdentifier`, but at the moment
-          // async type guards aren't supported
-          id: nodeId as TIdentifier,
-          childrenIdentifierPaths: [],
-          isFilterTarget: false,
-        };
-        matchingFilters.push(entry);
-      }
+            // otherwise, definition queries need to be filtered
+            return from(childNodeFilteringIdentifiersForThisSource.filter(HierarchyNodeIdentifier.isInstanceNodeIdentifier)).pipe(
+              // take only identifiers that match the definition
+              mergeMap(async (pathIdentifier) => {
+                if (
+                  (await this._imodelAccess.classDerivesFrom(pathIdentifier.className, definition.fullClassName)) ||
+                  (await this._imodelAccess.classDerivesFrom(definition.fullClassName, pathIdentifier.className))
+                ) {
+                  return pathIdentifier;
+                }
+                return undefined;
+              }),
+              filter((id): id is IModelInstanceKey => !!id),
 
-      if (!extractPathsAndOptions) {
-        continue;
-      }
+              // make sure that we don't have path identifiers that only differ by class name, where
+              // class names are in the same class hierarchy, e.g.:
+              // [{ className: "bis.Element", id: "0x1" }, { className: "bis.Subject", id: "0x1" }]
+              // are actually the same instance, so we only need to keep one of them, or otherwise the query will
+              // duplicate it
+              reduce(
+                (accObservable, pathIdentifier) =>
+                  accObservable.pipe(
+                    mergeMap((acc) =>
+                      from(acc).pipe(
+                        filter(({ id }) => id === pathIdentifier.id),
+                        mergeMap(
+                          async (id) =>
+                            id.className === pathIdentifier.className ||
+                            (await this._imodelAccess.classDerivesFrom(id.className, pathIdentifier.className)) ||
+                            (await this._imodelAccess.classDerivesFrom(pathIdentifier.className, id.className)),
+                        ),
+                        find((id) => !!id),
+                        map((didFind) => ({ pathIdentifiers: acc, needsInsert: !didFind })),
+                      ),
+                    ),
+                    tap(({ pathIdentifiers, needsInsert }) => {
+                      if (needsInsert) {
+                        pathIdentifiers.push(pathIdentifier);
+                      }
+                    }),
+                    map(({ pathIdentifiers }) => pathIdentifiers),
+                  ),
+                of(new Array<InstanceKey>()),
+              ),
+              mergeAll(),
 
-      if (path.length > 1) {
-        entry.childrenIdentifierPaths.push(options ? { path: path.slice(1), options } : path.slice(1));
-      } else if (entry.isFilterTarget) {
-        entry.filterTargetOptions = HierarchyFilteringPath.mergeOptions(entry.filterTargetOptions, options);
-      } else {
-        Object.assign(entry, { isFilterTarget: true, filterTargetOptions: options });
-      }
-    }
-  }
-  if (hasFilterTargetAncestor || matchingFilters.length > 0) {
-    return matchedDefinitionProcessor(definition, matchingFilters);
-  }
-  return undefined;
-}
+              // only take definitions that have matching path identifiers
+              filter((pathIdentifiers) => pathIdentifiers.length > 0),
 
-async function findMatchingFilterEntry<TEntry extends { id: TIdentifier }, TIdentifier extends HierarchyNodeIdentifier>(
-  filters: TEntry[],
-  nodeId: TIdentifier,
-  classHierarchy: ECClassHierarchyInspector,
-): Promise<TEntry | undefined> {
-  for (const filter of filters) {
-    if (await identifiersEqual(filter.id, nodeId, classHierarchy)) {
-      return filter;
-    }
-  }
-  return undefined;
-}
-
-async function identifiersEqual<TIdentifier extends HierarchyNodeIdentifier>(lhs: TIdentifier, rhs: TIdentifier, classHierarchy: ECClassHierarchyInspector) {
-  if (HierarchyNodeIdentifier.isInstanceNodeIdentifier(lhs) && HierarchyNodeIdentifier.isInstanceNodeIdentifier(rhs)) {
-    return (
-      lhs.id === rhs.id &&
-      (lhs.className === rhs.className ||
-        (await classHierarchy.classDerivesFrom(lhs.className, rhs.className)) ||
-        (await classHierarchy.classDerivesFrom(rhs.className, lhs.className)))
+              // for each definition that we're going to use, apply query-level filter
+              map((pathIdentifiers) => applyECInstanceIdsFilter(definition, pathIdentifiers)),
+            );
+          }),
+        ),
+      ).pipe(toArray()),
     );
   }
-  return HierarchyNodeIdentifier.equal(lhs, rhs);
 }
-
-function applyFilterAttributes<TNode extends SourceHierarchyNode>(props: {
-  node: TNode;
-  filteredChildrenIdentifierPaths: HierarchyFilteringPath[] | undefined;
-  isFilterTarget?: boolean;
-  filterTargetOptions?: HierarchyFilteringPathOptions;
-  hasFilterTargetAncestor: boolean;
-}): TNode {
-  const { node, filteredChildrenIdentifierPaths } = props;
-  const result = { ...node };
-
-  const shouldAutoExpand = !!filteredChildrenIdentifierPaths?.some((childPath) => {
-    return !!HierarchyFilteringPath.normalize(childPath).options?.autoExpand;
-  });
-  if (shouldAutoExpand) {
-    result.autoExpand = true;
-  }
-
-  const filteringProps = HierarchyNodeFilteringProps.create(props);
-  if (filteringProps) {
-    result.filtering = filteringProps;
-  }
-
-  return result;
-}
-
-/** @internal */
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export const ECSQL_COLUMN_NAME_HasFilterTargetAncestor = "HasFilterTargetAncestor";
 
 /** @internal */
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -359,29 +260,22 @@ export const ECSQL_COLUMN_NAME_FilterECInstanceId = "FilterECInstanceId";
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const ECSQL_COLUMN_NAME_FilterClassName = "FilterClassName";
 
-function getClassECInstanceIds(matchingFilters: Array<{ id: InstanceKey }>) {
+function getClassECInstanceIds(filteredInstanceKeys: InstanceKey[]) {
   const classNameECInstanceIds = new Map<string, Id64String[]>();
-  for (const matchingFilter of matchingFilters) {
-    const entry = classNameECInstanceIds.get(matchingFilter.id.className);
+  for (const key of filteredInstanceKeys) {
+    const entry = classNameECInstanceIds.get(key.className);
     if (entry === undefined) {
-      classNameECInstanceIds.set(matchingFilter.id.className, [matchingFilter.id.id]);
+      classNameECInstanceIds.set(key.className, [key.id]);
       continue;
     }
-    entry.push(matchingFilter.id.id);
+    entry.push(key.id);
   }
   return classNameECInstanceIds;
 }
 
 /** @internal */
-export function applyECInstanceIdsFilter(
-  def: InstanceNodesQueryDefinition,
-  matchingFilters: Array<{ id: InstanceKey }>,
-  hasFilterTargetAncestor: boolean,
-): InstanceNodesQueryDefinition {
-  if (matchingFilters.length === 0) {
-    return def;
-  }
-  const matchingFiltersToUse = getClassECInstanceIds(matchingFilters);
+export function applyECInstanceIdsFilter(def: InstanceNodesQueryDefinition, filteredInstanceKeys: InstanceKey[]): InstanceNodesQueryDefinition {
+  const instanceIdsByClass = getClassECInstanceIds(filteredInstanceKeys);
   return {
     ...def,
     query: {
@@ -389,7 +283,7 @@ export function applyECInstanceIdsFilter(
       ctes: [
         ...(def.query.ctes ?? []),
         `FilteringInfo(ECInstanceId, FilterClassName) AS (
-          ${Array.from(matchingFiltersToUse)
+          ${Array.from(instanceIdsByClass)
             .map(
               ([className, ecInstanceIds]) => `
                 SELECT ECInstanceId, '${className}' AS FilterClassName
@@ -403,13 +297,12 @@ export function applyECInstanceIdsFilter(
       ecsql: `
         SELECT
           [q].*,
-          ${hasFilterTargetAncestor ? "1" : "0"} AS [${ECSQL_COLUMN_NAME_HasFilterTargetAncestor}],
           IdToHex([f].[ECInstanceId]) AS [${ECSQL_COLUMN_NAME_FilterECInstanceId}],
           [f].[FilterClassName] AS [${ECSQL_COLUMN_NAME_FilterClassName}]
         FROM (
           ${def.query.ecsql}
         ) [q]
-        ${hasFilterTargetAncestor ? "LEFT " : ""} JOIN FilteringInfo [f] ON [f].[ECInstanceId] = [q].[ECInstanceId]
+        JOIN FilteringInfo [f] ON [f].[ECInstanceId] = [q].[ECInstanceId]
       `,
     },
   };

--- a/packages/hierarchies/src/hierarchies/imodel/PredicateBasedHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/PredicateBasedHierarchyDefinition.ts
@@ -8,7 +8,15 @@ import { Id64String } from "@itwin/core-bentley";
 import { ECClassHierarchyInspector, InstanceKey } from "@itwin/presentation-shared";
 import { HierarchyNode } from "../HierarchyNode.js";
 import { GenericNodeKey, InstancesNodeKey } from "../HierarchyNodeKey.js";
-import { DefineHierarchyLevelProps, HierarchyDefinition, HierarchyDefinitionParentNode, HierarchyLevelDefinition } from "./IModelHierarchyDefinition.js";
+import {
+  DefineHierarchyLevelProps,
+  HierarchyDefinition,
+  HierarchyDefinitionParentNode,
+  HierarchyLevelDefinition,
+  NodeParser,
+  NodePostProcessor,
+  NodePreProcessor,
+} from "./IModelHierarchyDefinition.js";
 
 /**
  * Props for defining child hierarchy level for specific parent instance node.
@@ -129,7 +137,7 @@ export type DefineRootHierarchyLevelProps = Omit<DefineHierarchyLevelProps, "par
  * Props for `createPredicateBasedHierarchyDefinition`.
  * @public
  */
-interface PredicateBasedHierarchyDefinitionProps {
+interface PredicateBasedHierarchyDefinitionProps extends Pick<HierarchyDefinition, "parseNode" | "preProcessNode" | "postProcessNode"> {
   /** Access to ECClass hierarchy in the iModel */
   classHierarchyInspector: ECClassHierarchyInspector;
 
@@ -158,7 +166,21 @@ export function createPredicateBasedHierarchyDefinition(props: PredicateBasedHie
 }
 
 class PredicateBasedHierarchyDefinition implements HierarchyDefinition {
-  public constructor(private _props: PredicateBasedHierarchyDefinitionProps) {}
+  public parseNode: NodeParser | undefined;
+  public preProcessNode: NodePreProcessor | undefined;
+  public postProcessNode: NodePostProcessor | undefined;
+
+  public constructor(private _props: PredicateBasedHierarchyDefinitionProps) {
+    if (this._props.parseNode) {
+      this.parseNode = this._props.parseNode;
+    }
+    if (this._props.preProcessNode) {
+      this.preProcessNode = this._props.preProcessNode;
+    }
+    if (this._props.postProcessNode) {
+      this.postProcessNode = this._props.postProcessNode;
+    }
+  }
 
   /**
    * Create hierarchy level definitions for specific hierarchy level.

--- a/packages/hierarchies/src/presentation-hierarchies.ts
+++ b/packages/hierarchies/src/presentation-hierarchies.ts
@@ -42,5 +42,10 @@ export {
   IModelHierarchyNodeKey,
 } from "./hierarchies/HierarchyNodeKey.js";
 export { GetHierarchyNodesProps, HierarchyProvider, mergeProviders } from "./hierarchies/HierarchyProvider.js";
-export { HierarchyFilteringPath, extractFilteringProps } from "./hierarchies/HierarchyFiltering.js";
+export {
+  createHierarchyFilteringHelper,
+  extractFilteringProps,
+  HierarchyFilteringPath,
+  HierarchyFilteringPathOptions,
+} from "./hierarchies/HierarchyFiltering.js";
 export { getLogger, setLogger } from "./hierarchies/Logging.js";

--- a/packages/hierarchies/src/test/imodel/FilteringHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/FilteringHierarchyDefinition.test.ts
@@ -210,7 +210,7 @@ describe("FilteringHierarchyDefinition", () => {
       });
     });
 
-    it("sets correct filteredChildrenIdentifierPaths when nodes have same id's and different classNames that derive from one another", async () => {
+    it("sets correct filteredChildrenIdentifierPaths when nodes have same ids and different classNames that derive from one another", async () => {
       const sourceFactory = {} as unknown as HierarchyDefinition;
       const classHierarchyInspector = createClassHierarchyInspectorStub();
 
@@ -252,6 +252,35 @@ describe("FilteringHierarchyDefinition", () => {
           { path: [createTestInstanceKey({ id: "0x3" })], options: undefined },
           { path: [createTestInstanceKey({ id: "0x4" })], options: undefined },
         ],
+      });
+    });
+
+    it("sets correct filteredChildrenIdentifierPaths when path identifiers have same ids but different types", async () => {
+      const sourceFactory = {} as unknown as HierarchyDefinition;
+      const classHierarchyInspector = createClassHierarchyInspectorStub();
+
+      const testClass = classHierarchyInspector.stubEntityClass({
+        schemaName: "TestSchema",
+        className: "TestClass",
+        is: async () => true,
+      });
+      const paths: HierarchyNodeIdentifiersPath[] = [
+        [createTestInstanceKey({ id: "0x1", className: testClass.fullName }), createTestInstanceKey({ id: "0x2" })],
+        [createTestGenericNodeKey({ id: "0x1" }), createTestInstanceKey({ id: "0x3" })],
+      ];
+      const filteringFactory = await createFilteringHierarchyDefinition({
+        imodelAccess: { ...classHierarchyInspector, imodelKey: "someKey" },
+        sourceFactory,
+        nodeIdentifierPaths: paths,
+      });
+      const row = {
+        [NodeSelectClauseColumnNames.FullClassName]: "",
+        [ECSQL_COLUMN_NAME_FilterECInstanceId]: "0x1",
+        [ECSQL_COLUMN_NAME_FilterClassName]: testClass.fullName,
+      };
+      const node = await filteringFactory.parseNode(row, undefined);
+      expect(node.filtering).to.deep.eq({
+        filteredChildrenIdentifierPaths: [{ path: [createTestInstanceKey({ id: "0x2" })], options: undefined }],
       });
     });
 

--- a/packages/hierarchies/src/test/imodel/FilteringHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/FilteringHierarchyDefinition.test.ts
@@ -302,7 +302,7 @@ describe("FilteringHierarchyDefinition", () => {
       expect(node.autoExpand).to.be.undefined;
     });
 
-    it("does not set auto-expand when filtered children paths list is provided without `autoExpand` option", async () => {
+    it("does't set auto-expand when filtered children paths list is provided without `autoExpand` option", async () => {
       const paths: HierarchyNodeIdentifiersPath[] = [
         [createTestInstanceKey({ id: "0x1", className: "TestSchema.TestName" }), createTestInstanceKey({ id: "0x2", className: "TestSchema.TestName" })],
       ];
@@ -324,6 +324,23 @@ describe("FilteringHierarchyDefinition", () => {
             createTestInstanceKey({ id: "0x2", className: "TestSchema.TestName" }),
           ],
           options: { autoExpand: false },
+        },
+      ];
+      const filteringFactory = await createFilteringHierarchyDefinition({ nodeIdentifierPaths: paths });
+      const row = {
+        [NodeSelectClauseColumnNames.FullClassName]: "",
+        [ECSQL_COLUMN_NAME_FilterECInstanceId]: "0x1",
+        [ECSQL_COLUMN_NAME_FilterClassName]: "TestSchema.TestName",
+      };
+      const node = await filteringFactory.parseNode(row);
+      expect(node.autoExpand).to.be.undefined;
+    });
+
+    it("doesn't set auto-expand on filter targets", async () => {
+      const paths = [
+        {
+          path: [createTestInstanceKey({ id: "0x1", className: "TestSchema.TestName" })],
+          options: { autoExpand: true },
         },
       ];
       const filteringFactory = await createFilteringHierarchyDefinition({ nodeIdentifierPaths: paths });
@@ -959,14 +976,14 @@ describe("FilteringHierarchyDefinition", () => {
         const filteringFactory = await createFilteringHierarchyDefinition({
           imodelAccess: { ...classHierarchyInspector, imodelKey: "test-imodel-key" },
           sourceFactory,
-          nodeIdentifierPaths: [[createTestGenericNodeKey({ id: "custom 2" })]],
+          nodeIdentifierPaths: [{ path: [createTestGenericNodeKey({ id: "custom 2" })], options: { autoExpand: true } }],
         });
         const result = await filteringFactory.defineHierarchyLevel({ parentNode: undefined });
         expect(result).to.deep.eq([
           {
             node: {
               ...sourceDefinition2.node,
-              filtering: { isFilterTarget: true, filterTargetOptions: undefined },
+              filtering: { isFilterTarget: true, filterTargetOptions: { autoExpand: true } },
             },
           },
         ]);

--- a/packages/hierarchies/src/test/imodel/FilteringHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/FilteringHierarchyDefinition.test.ts
@@ -12,6 +12,7 @@ import { HierarchyNode } from "../../hierarchies/HierarchyNode.js";
 import { HierarchyNodeIdentifiersPath } from "../../hierarchies/HierarchyNodeIdentifier.js";
 import {
   applyECInstanceIdsFilter,
+  applyECInstanceIdsSelector,
   ECSQL_COLUMN_NAME_FilterClassName,
   ECSQL_COLUMN_NAME_FilterECInstanceId,
 } from "../../hierarchies/imodel/FilteringHierarchyDefinition.js";
@@ -1206,7 +1207,7 @@ describe("FilteringHierarchyDefinition", () => {
             },
           },
         });
-        expect(result).to.deep.eq([sourceDefinition]);
+        expect(result).to.deep.eq([applyECInstanceIdsSelector(sourceDefinition)]);
       });
 
       it("returns filtered source instance node query definitions when filter class matches query class", async () => {
@@ -1557,7 +1558,7 @@ describe("FilteringHierarchyDefinition", () => {
         {
           node: {
             ...matchingSourceDefinition.node,
-            filtering: { hasFilterTargetAncestor: true },
+            filtering: { hasFilterTargetAncestor: true, isFilterTarget: true, filterTargetOptions: undefined },
           },
         },
         {

--- a/packages/hierarchies/src/test/imodel/FilteringHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/FilteringHierarchyDefinition.test.ts
@@ -14,7 +14,6 @@ import {
   applyECInstanceIdsFilter,
   ECSQL_COLUMN_NAME_FilterClassName,
   ECSQL_COLUMN_NAME_FilterECInstanceId,
-  ECSQL_COLUMN_NAME_HasFilterTargetAncestor,
 } from "../../hierarchies/imodel/FilteringHierarchyDefinition.js";
 import {
   GenericHierarchyNodeDefinition,
@@ -94,16 +93,17 @@ describe("FilteringHierarchyDefinition", () => {
       });
       const row = {
         [NodeSelectClauseColumnNames.FullClassName]: "",
-        [ECSQL_COLUMN_NAME_HasFilterTargetAncestor]: 1,
         [ECSQL_COLUMN_NAME_FilterECInstanceId]: "0x5",
         [ECSQL_COLUMN_NAME_FilterClassName]: className,
       };
       const node = await filteringFactory.parseNode(row);
       expect(node.filtering).to.deep.eq({
-        filteredChildrenIdentifierPaths: [[createTestInstanceKey({ id: "0x1" }), createTestInstanceKey({ id: "0x2" })], [createTestInstanceKey({ id: "0x3" })]],
+        filteredChildrenIdentifierPaths: [
+          { path: [createTestInstanceKey({ id: "0x1" }), createTestInstanceKey({ id: "0x2" })], options: undefined },
+          { path: [createTestInstanceKey({ id: "0x3" })], options: undefined },
+        ],
         isFilterTarget: true,
         filterTargetOptions: undefined,
-        hasFilterTargetAncestor: true,
       });
     });
 
@@ -125,7 +125,6 @@ describe("FilteringHierarchyDefinition", () => {
       });
       const row = {
         [NodeSelectClauseColumnNames.FullClassName]: "",
-        [ECSQL_COLUMN_NAME_HasFilterTargetAncestor]: 1,
         [ECSQL_COLUMN_NAME_FilterECInstanceId]: "0x5",
         [ECSQL_COLUMN_NAME_FilterClassName]: className,
       };
@@ -137,10 +136,9 @@ describe("FilteringHierarchyDefinition", () => {
       };
       const node = await filteringFactory.parseNode(row, parentNode);
       expect(node.filtering).to.deep.eq({
-        filteredChildrenIdentifierPaths: [[createTestInstanceKey({ id: "0x1" }), createTestInstanceKey({ id: "0x2" })]],
+        filteredChildrenIdentifierPaths: [{ path: [createTestInstanceKey({ id: "0x1" }), createTestInstanceKey({ id: "0x2" })], options: undefined }],
         isFilterTarget: true,
         filterTargetOptions: undefined,
-        hasFilterTargetAncestor: true,
       });
     });
 
@@ -159,7 +157,6 @@ describe("FilteringHierarchyDefinition", () => {
       });
       const row = {
         [NodeSelectClauseColumnNames.FullClassName]: "",
-        [ECSQL_COLUMN_NAME_HasFilterTargetAncestor]: 1,
         [ECSQL_COLUMN_NAME_FilterECInstanceId]: "0x4",
         [ECSQL_COLUMN_NAME_FilterClassName]: className,
       };
@@ -171,8 +168,7 @@ describe("FilteringHierarchyDefinition", () => {
       };
       const node = await filteringFactory.parseNode(row, parentNode);
       expect(node.filtering).to.deep.eq({
-        filteredChildrenIdentifierPaths: [[createTestInstanceKey({ id: "0x2" })]],
-        hasFilterTargetAncestor: true,
+        filteredChildrenIdentifierPaths: [{ path: [createTestInstanceKey({ id: "0x2" })], options: undefined }],
       });
     });
 
@@ -194,7 +190,6 @@ describe("FilteringHierarchyDefinition", () => {
       });
       const row = {
         [NodeSelectClauseColumnNames.FullClassName]: "",
-        [ECSQL_COLUMN_NAME_HasFilterTargetAncestor]: 1,
         [ECSQL_COLUMN_NAME_FilterECInstanceId]: "0x3",
         [ECSQL_COLUMN_NAME_FilterClassName]: className,
       };
@@ -207,9 +202,11 @@ describe("FilteringHierarchyDefinition", () => {
       const node = await filteringFactory.parseNode(row, parentNode);
       expect(node.filtering).to.deep.eq({
         filteredChildrenIdentifierPaths: [
-          [createTestInstanceKey({ id: "0x1" }), createTestInstanceKey({ id: "0x3", className }), createTestInstanceKey({ id: "0x2" })],
+          {
+            path: [createTestInstanceKey({ id: "0x1" }), createTestInstanceKey({ id: "0x3", className }), createTestInstanceKey({ id: "0x2" })],
+            options: undefined,
+          },
         ],
-        hasFilterTargetAncestor: true,
       });
     });
 
@@ -239,7 +236,6 @@ describe("FilteringHierarchyDefinition", () => {
       });
       const row = {
         [NodeSelectClauseColumnNames.FullClassName]: "",
-        [ECSQL_COLUMN_NAME_HasFilterTargetAncestor]: 1,
         [ECSQL_COLUMN_NAME_FilterECInstanceId]: "0x5",
         [ECSQL_COLUMN_NAME_FilterClassName]: class1.fullName,
       };
@@ -252,11 +248,10 @@ describe("FilteringHierarchyDefinition", () => {
       const node = await filteringFactory.parseNode(row, parentNode);
       expect(node.filtering).to.deep.eq({
         filteredChildrenIdentifierPaths: [
-          [createTestInstanceKey({ id: "0x1" }), createTestInstanceKey({ id: "0x2" })],
-          [createTestInstanceKey({ id: "0x3" })],
-          [createTestInstanceKey({ id: "0x4" })],
+          { path: [createTestInstanceKey({ id: "0x1" }), createTestInstanceKey({ id: "0x2" })], options: undefined },
+          { path: [createTestInstanceKey({ id: "0x3" })], options: undefined },
+          { path: [createTestInstanceKey({ id: "0x4" })], options: undefined },
         ],
-        hasFilterTargetAncestor: true,
       });
     });
 
@@ -353,7 +348,6 @@ describe("FilteringHierarchyDefinition", () => {
       });
       const row = {
         [NodeSelectClauseColumnNames.FullClassName]: "",
-        [ECSQL_COLUMN_NAME_HasFilterTargetAncestor]: 1,
         [ECSQL_COLUMN_NAME_FilterECInstanceId]: "0x5",
         [ECSQL_COLUMN_NAME_FilterClassName]: className,
       };
@@ -973,7 +967,10 @@ describe("FilteringHierarchyDefinition", () => {
             node: {
               ...sourceDefinition.node,
               filtering: {
-                filteredChildrenIdentifierPaths: [[createTestGenericNodeKey({ id: "123" })], [createTestGenericNodeKey({ id: "456" })]],
+                filteredChildrenIdentifierPaths: [
+                  { path: [createTestGenericNodeKey({ id: "123" })], options: undefined },
+                  { path: [createTestGenericNodeKey({ id: "456" })], options: undefined },
+                ],
               },
             },
           },
@@ -1013,7 +1010,7 @@ describe("FilteringHierarchyDefinition", () => {
                 filteredChildrenIdentifierPaths: [
                   { path: [createTestGenericNodeKey({ id: "123" })], options: { autoExpand: true } },
                   { path: [createTestGenericNodeKey({ id: "456" })], options: { autoExpand: groupingNode } },
-                  [createTestGenericNodeKey({ id: "789" })],
+                  { path: [createTestGenericNodeKey({ id: "789" })], options: undefined },
                 ],
               },
             },
@@ -1167,13 +1164,21 @@ describe("FilteringHierarchyDefinition", () => {
       });
 
       it("returns filtered source instance node query definitions when filter class matches query class", async () => {
-        const queryClass = classHierarchyInspector.stubEntityClass({ schemaName: "BisCore", className: "SourceQueryClassName", is: async () => false });
+        const queryClass = classHierarchyInspector.stubEntityClass({
+          schemaName: "BisCore",
+          className: "SourceQueryClassName",
+          is: async () => false,
+        });
         const filterPathClass1 = classHierarchyInspector.stubEntityClass({
           schemaName: "BisCore",
           className: "FilterPathClassName1",
           is: async (other) => other === queryClass.fullName,
         });
-        const filterPathClass2 = classHierarchyInspector.stubEntityClass({ schemaName: "BisCore", className: "FilterPathClassName2", is: async () => false });
+        const filterPathClass2 = classHierarchyInspector.stubEntityClass({
+          schemaName: "BisCore",
+          className: "FilterPathClassName2",
+          is: async () => false,
+        });
         const sourceDefinition: InstanceNodesQueryDefinition = {
           fullClassName: queryClass.fullName,
           query: {
@@ -1196,18 +1201,16 @@ describe("FilteringHierarchyDefinition", () => {
         });
         const result = await filteringFactory.defineHierarchyLevel({ parentNode: undefined });
         expect(result).to.deep.eq([
-          applyECInstanceIdsFilter(
-            sourceDefinition,
-            [
-              {
-                id: { className: filterPathClass1.fullName, id: "0x123" },
-              },
-              {
-                id: { className: filterPathClass1.fullName, id: "0x789" },
-              },
-            ],
-            false,
-          ),
+          applyECInstanceIdsFilter(sourceDefinition, [
+            {
+              className: filterPathClass1.fullName,
+              id: "0x123",
+            },
+            {
+              className: filterPathClass1.fullName,
+              id: "0x789",
+            },
+          ]),
         ]);
       });
 
@@ -1239,18 +1242,16 @@ describe("FilteringHierarchyDefinition", () => {
         });
         const result = await filteringFactory.defineHierarchyLevel({ parentNode: undefined });
         expect(result).to.deep.eq([
-          applyECInstanceIdsFilter(
-            sourceDefinition,
-            [
-              {
-                id: { className: filterPathClass1.fullName, id: "0x123" },
-              },
-              {
-                id: { className: filterPathClass2.fullName, id: "0x456" },
-              },
-            ],
-            false,
-          ),
+          applyECInstanceIdsFilter(sourceDefinition, [
+            {
+              className: filterPathClass1.fullName,
+              id: "0x123",
+            },
+            {
+              className: filterPathClass2.fullName,
+              id: "0x456",
+            },
+          ]),
         ]);
       });
 
@@ -1288,15 +1289,12 @@ describe("FilteringHierarchyDefinition", () => {
         });
         const result = await filteringFactory.defineHierarchyLevel({ parentNode: undefined });
         expect(result).to.deep.eq([
-          applyECInstanceIdsFilter(
-            sourceDefinition,
-            [
-              {
-                id: { className: filterPathClass0.fullName, id: "0x123" },
-              },
-            ],
-            false,
-          ),
+          applyECInstanceIdsFilter(sourceDefinition, [
+            {
+              className: filterPathClass0.fullName,
+              id: "0x123",
+            },
+          ]),
         ]);
       });
 
@@ -1311,7 +1309,11 @@ describe("FilteringHierarchyDefinition", () => {
           className: "FilterPathClassName0",
           is: async (other) => other === queryClass.fullName,
         });
-        const filterPathClass1 = classHierarchyInspector.stubEntityClass({ schemaName: "BisCore", className: "FilterPathClassName1", is: async () => false });
+        const filterPathClass1 = classHierarchyInspector.stubEntityClass({
+          schemaName: "BisCore",
+          className: "FilterPathClassName1",
+          is: async () => false,
+        });
         const sourceDefinition: InstanceNodesQueryDefinition = {
           fullClassName: queryClass.fullName,
           query: {
@@ -1334,15 +1336,12 @@ describe("FilteringHierarchyDefinition", () => {
         });
         const result = await filteringFactory.defineHierarchyLevel({ parentNode: undefined });
         expect(result).to.deep.eq([
-          applyECInstanceIdsFilter(
-            sourceDefinition,
-            [
-              {
-                id: { className: queryClass.fullName, id: "0x123" },
-              },
-            ],
-            false,
-          ),
+          applyECInstanceIdsFilter(sourceDefinition, [
+            {
+              className: queryClass.fullName,
+              id: "0x123",
+            },
+          ]),
         ]);
       });
 
@@ -1380,15 +1379,12 @@ describe("FilteringHierarchyDefinition", () => {
         });
         const result = await filteringFactory.defineHierarchyLevel({ parentNode: undefined });
         expect(result).to.deep.eq([
-          applyECInstanceIdsFilter(
-            sourceDefinition,
-            [
-              {
-                id: { className: filterPathClass0.fullName, id: "0x123" },
-              },
-            ],
-            false,
-          ),
+          applyECInstanceIdsFilter(sourceDefinition, [
+            {
+              className: filterPathClass0.fullName,
+              id: "0x123",
+            },
+          ]),
         ]);
       });
 
@@ -1431,15 +1427,12 @@ describe("FilteringHierarchyDefinition", () => {
         });
         const result = await filteringFactory.defineHierarchyLevel({ parentNode: undefined });
         expect(result).to.deep.eq([
-          applyECInstanceIdsFilter(
-            sourceDefinition,
-            [
-              {
-                id: { className: filterPathClass0.fullName, id: "0x123" },
-              },
-            ],
-            false,
-          ),
+          applyECInstanceIdsFilter(sourceDefinition, [
+            {
+              className: filterPathClass0.fullName,
+              id: "0x123",
+            },
+          ]),
         ]);
       });
     });
@@ -1477,15 +1470,12 @@ describe("FilteringHierarchyDefinition", () => {
         },
       });
       expect(result).to.deep.eq([
-        applyECInstanceIdsFilter(
-          sourceDefinition,
-          [
-            {
-              id: { className: childFilterClass.fullName, id: "0x456" },
-            },
-          ],
-          false,
-        ),
+        applyECInstanceIdsFilter(sourceDefinition, [
+          {
+            className: childFilterClass.fullName,
+            id: "0x456",
+          },
+        ]),
       ]);
     });
 
@@ -1517,18 +1507,17 @@ describe("FilteringHierarchyDefinition", () => {
         },
       });
       expect(result).to.deep.eq([
-        // this definition doesn't match parent's `filteredChildrenIdentifierPaths`, but is added because parent is a filter target
+        // both definitions are returned because the parent is filter target
+        {
+          node: {
+            ...matchingSourceDefinition.node,
+            filtering: { hasFilterTargetAncestor: true },
+          },
+        },
         {
           node: {
             ...nonMatchingSourceDefinition.node,
             filtering: { hasFilterTargetAncestor: true },
-          },
-        },
-        // this definition is added with modifications to account for parent's `filteredChildrenIdentifierPaths`
-        {
-          node: {
-            ...matchingSourceDefinition.node,
-            filtering: { hasFilterTargetAncestor: true, isFilterTarget: true, filterTargetOptions: undefined },
           },
         },
       ]);
@@ -1548,13 +1537,14 @@ describe("FilteringHierarchyDefinition", () => {
         },
         [
           {
-            id: { className: "test.class", id: "0x1" },
+            className: "test.class",
+            id: "0x1",
           },
           {
-            id: { className: "test.class", id: "0x5" },
+            className: "test.class",
+            id: "0x5",
           },
         ],
-        true,
       );
       expect(result.fullClassName).to.eq("full-class-name");
       expect(result.query.ctes?.map(trimWhitespace)).to.deep.eq([
@@ -1575,13 +1565,12 @@ describe("FilteringHierarchyDefinition", () => {
         trimWhitespace(`
           SELECT
             [q].*,
-            1 AS [${ECSQL_COLUMN_NAME_HasFilterTargetAncestor}],
             IdToHex([f].[ECInstanceId]) AS [${ECSQL_COLUMN_NAME_FilterECInstanceId}],
             [f].[FilterClassName] AS [${ECSQL_COLUMN_NAME_FilterClassName}]
           FROM (
             source query
           ) [q]
-          LEFT JOIN FilteringInfo [f] ON [f].[ECInstanceId] = [q].[ECInstanceId]
+          JOIN FilteringInfo [f] ON [f].[ECInstanceId] = [q].[ECInstanceId]
         `),
       );
       expect(result.query.bindings).to.deep.eq([{ type: "string", value: "source binding" }]);

--- a/packages/hierarchies/src/test/imodel/IModelHierarchyProvider.test.ts
+++ b/packages/hierarchies/src/test/imodel/IModelHierarchyProvider.test.ts
@@ -12,11 +12,7 @@ import { ECSqlQueryDef, ECSqlQueryReaderOptions, InstanceKey, trimWhitespace, Ty
 import { RowsLimitExceededError } from "../../hierarchies/HierarchyErrors.js";
 import { GroupingHierarchyNode, HierarchyNode, ParentHierarchyNode } from "../../hierarchies/HierarchyNode.js";
 import { GroupingNodeKey } from "../../hierarchies/HierarchyNodeKey.js";
-import {
-  ECSQL_COLUMN_NAME_FilterClassName,
-  ECSQL_COLUMN_NAME_FilterECInstanceId,
-  ECSQL_COLUMN_NAME_HasFilterTargetAncestor,
-} from "../../hierarchies/imodel/FilteringHierarchyDefinition.js";
+import { ECSQL_COLUMN_NAME_FilterClassName, ECSQL_COLUMN_NAME_FilterECInstanceId } from "../../hierarchies/imodel/FilteringHierarchyDefinition.js";
 import { DefineHierarchyLevelProps, HierarchyDefinition, NodeParser } from "../../hierarchies/imodel/IModelHierarchyDefinition.js";
 import { ProcessedHierarchyNode, SourceInstanceHierarchyNode } from "../../hierarchies/imodel/IModelHierarchyNode.js";
 import { createIModelHierarchyProvider } from "../../hierarchies/imodel/IModelHierarchyProvider.js";
@@ -744,7 +740,6 @@ describe("createIModelHierarchyProvider", () => {
                 `
                 SELECT
                     [q].*,
-                    0 AS [${ECSQL_COLUMN_NAME_HasFilterTargetAncestor}],
                     IdToHex([f].[ECInstanceId]) AS [${ECSQL_COLUMN_NAME_FilterECInstanceId}],
                     [f].[FilterClassName] AS [${ECSQL_COLUMN_NAME_FilterClassName}]
                   FROM (QUERY) [q]
@@ -764,7 +759,7 @@ describe("createIModelHierarchyProvider", () => {
           label: "test label",
           children: false,
           filtering: {
-            filteredChildrenIdentifierPaths: [[{ className: "c.d", id: "0x456" }]],
+            filteredChildrenIdentifierPaths: [{ path: [{ className: "c.d", id: "0x456" }], options: undefined }],
           },
         },
       ]);
@@ -893,7 +888,7 @@ describe("createIModelHierarchyProvider", () => {
         },
         children: false,
         filtering: {
-          filteredChildrenIdentifierPaths: [[{ className: "c.d", id: "0x456" }]],
+          filteredChildrenIdentifierPaths: [{ path: [{ className: "c.d", id: "0x456" }], options: undefined }],
         },
       });
 

--- a/packages/hierarchies/src/test/imodel/PredicateBasedHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/PredicateBasedHierarchyDefinition.test.ts
@@ -246,6 +246,45 @@ describe("createPredicateBasedHierarchyDefinition", () => {
       parentNode: rootNode,
     });
   });
+
+  it("uses provided node parser", () => {
+    const parseNode = sinon.stub();
+    const factory = createPredicateBasedHierarchyDefinition({
+      classHierarchyInspector,
+      parseNode,
+      hierarchy: {
+        rootNodes: async () => [],
+        childNodes: [],
+      },
+    });
+    expect(factory.parseNode).to.eq(parseNode);
+  });
+
+  it("uses provided node pre-processor", () => {
+    const preprocessor = sinon.stub();
+    const factory = createPredicateBasedHierarchyDefinition({
+      classHierarchyInspector,
+      preProcessNode: preprocessor,
+      hierarchy: {
+        rootNodes: async () => [],
+        childNodes: [],
+      },
+    });
+    expect(factory.preProcessNode).to.eq(preprocessor);
+  });
+
+  it("uses provided node post-processor", () => {
+    const postprocessor = sinon.stub();
+    const factory = createPredicateBasedHierarchyDefinition({
+      classHierarchyInspector,
+      postProcessNode: postprocessor,
+      hierarchy: {
+        rootNodes: async () => [],
+        childNodes: [],
+      },
+    });
+    expect(factory.postProcessNode).to.eq(postprocessor);
+  });
 });
 
 function createParentNode(src: Partial<NonNullable<DefineHierarchyLevelProps["parentNode"]>>) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1024,6 +1024,9 @@ importers:
       rimraf:
         specifier: catalog:build-tools
         version: 6.0.1
+      rss-parser:
+        specifier: ^3.13.0
+        version: 3.13.0
       rxjs:
         specifier: catalog:rxjs
         version: 7.8.1
@@ -1036,6 +1039,9 @@ importers:
       vite:
         specifier: ^5.2.14
         version: 5.2.14(@types/node@20.12.12)(sass@1.75.0)
+      vite-plugin-node-polyfills:
+        specifier: ^0.22.0
+        version: 0.22.0(rollup@4.24.2)(vite@5.2.14(@types/node@20.12.12)(sass@1.75.0))
       vite-plugin-static-copy:
         specifier: ^1.0.3
         version: 1.0.3(vite@5.2.14(@types/node@20.12.12)(sass@1.75.0))
@@ -3087,12 +3093,12 @@ packages:
     resolution: {integrity: sha512-O3jfIAhqaJxXI2dzF81PLTMhKpFFA0Nyz8kfBnc9WYDJnvdmXK0fVAOSpwpi2mHTow/9FXxY6Kww8+Kbe7/sag==}
     engines: {node: '>=18.0.0'}
 
-  '@oclif/plugin-help@6.2.16':
-    resolution: {integrity: sha512-1x/Bm0LebDouDOfsjkOz+6AXqY6gIZ6JmmU/KuF/GnUmowDvj5i3MFlP9uBTiN8UsOUeT9cdLwnc1kmitHWFTg==}
+  '@oclif/plugin-help@6.2.18':
+    resolution: {integrity: sha512-mDYOl8RmldLkOg9i9YKgyBlpcyi/bNySoIVHJ2EJd2qCmZaXRKQKRW2Zkx92bwjik8jfs/A3EFI+p4DsrXi57g==}
     engines: {node: '>=18.0.0'}
 
-  '@oclif/plugin-not-found@3.2.25':
-    resolution: {integrity: sha512-Hm07ouLZq8I9/V46F2BqWEzFexdjaxGHFbwckxXu3YlVq4/xp6lOJXlF5olu4dbTUaJs532Hth4Uh0OIsp9CSw==}
+  '@oclif/plugin-not-found@3.2.28':
+    resolution: {integrity: sha512-ObkesXE8F4Hj/AzOCQGI39hqDqm+MfaqY5ByG77uhSkMI4dMaDcPjXZSj1Ftn2mkhZiRk70YN3wTCG4HO/8gqw==}
     engines: {node: '>=18.0.0'}
 
   '@oozcitak/dom@1.15.10':
@@ -3435,6 +3441,24 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@rollup/plugin-inject@5.0.5':
+    resolution: {integrity: sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/pluginutils@5.1.3':
+    resolution: {integrity: sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.24.2':
     resolution: {integrity: sha512-ufoveNTKDg9t/b7nqI3lwbCG/9IJMhADBNjjz/Jn6LxIZxD7T5L8l2uO/wD99945F1Oo8FvgbbZJRguyk/BdzA==}
@@ -4448,6 +4472,12 @@ packages:
   as-table@1.0.55:
     resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
 
+  asn1.js@4.10.1:
+    resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
+
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
@@ -4538,6 +4568,12 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  bn.js@4.12.1:
+    resolution: {integrity: sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==}
+
+  bn.js@5.2.1:
+    resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
+
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -4562,14 +4598,40 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  brorand@1.1.0:
+    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
+
   brotli@1.3.3:
     resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
 
   browser-or-node@1.3.0:
     resolution: {integrity: sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==}
 
+  browser-resolve@2.0.0:
+    resolution: {integrity: sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==}
+
   browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
+
+  browserify-aes@1.2.0:
+    resolution: {integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==}
+
+  browserify-cipher@1.0.1:
+    resolution: {integrity: sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==}
+
+  browserify-des@1.0.2:
+    resolution: {integrity: sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==}
+
+  browserify-rsa@4.1.1:
+    resolution: {integrity: sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==}
+    engines: {node: '>= 0.10'}
+
+  browserify-sign@4.2.3:
+    resolution: {integrity: sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==}
+    engines: {node: '>= 0.12'}
+
+  browserify-zlib@0.2.0:
+    resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
   browserslist@4.24.2:
     resolution: {integrity: sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==}
@@ -4582,11 +4644,17 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  buffer-xor@1.0.3:
+    resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
+
   buffer@4.9.2:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  builtin-status-codes@3.0.0:
+    resolution: {integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -4699,6 +4767,10 @@ packages:
   ci-info@4.1.0:
     resolution: {integrity: sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==}
     engines: {node: '>=8'}
+
+  cipher-base@1.0.5:
+    resolution: {integrity: sha512-xq7ICKB4TMHUx7Tz1L9O2SGKOhYMOTR32oir45Bq28/AQTpHogKgHcoYFSdRbMtddl+ozNXfXY9jWcgYKmde0w==}
+    engines: {node: '>= 0.10'}
 
   cjs-module-lexer@1.4.1:
     resolution: {integrity: sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==}
@@ -4814,6 +4886,12 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  console-browserify@1.2.0:
+    resolution: {integrity: sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==}
+
+  constants-browserify@1.0.0:
+    resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
+
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
@@ -4866,6 +4944,18 @@ packages:
     resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
     engines: {node: '>= 10'}
 
+  create-ecdh@4.0.4:
+    resolution: {integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==}
+
+  create-hash@1.2.0:
+    resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
+
+  create-hmac@1.1.7:
+    resolution: {integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==}
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
   cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
@@ -4887,6 +4977,10 @@ packages:
 
   crypt@0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+
+  crypto-browserify@3.12.1:
+    resolution: {integrity: sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==}
+    engines: {node: '>= 0.10'}
 
   css-select@5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
@@ -5040,6 +5134,9 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  des.js@1.1.0:
+    resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
+
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -5096,6 +5193,9 @@ packages:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
     engines: {node: '>=0.3.1'}
 
+  diffie-hellman@5.0.3:
+    resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -5116,6 +5216,10 @@ packages:
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domain-browser@4.23.0:
+    resolution: {integrity: sha512-ArzcM/II1wCCujdCNyQjXrAFwS4mrLh4C7DZWlaI8mdh7h3BfKdNd3bKXITfl2PT9FtfQqaGvhi1vPRQPimjGA==}
+    engines: {node: '>=10'}
 
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
@@ -5165,6 +5269,9 @@ packages:
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
+  elliptic@6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
+
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
 
@@ -5208,6 +5315,9 @@ packages:
 
   ensure-posix-path@1.1.1:
     resolution: {integrity: sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==}
+
+  entities@2.2.0:
+    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -5425,6 +5535,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -5453,6 +5566,9 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  evp_bytestokey@1.0.3:
+    resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
   execa@1.0.0:
     resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
@@ -5880,6 +5996,13 @@ packages:
     resolution: {integrity: sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==}
     engines: {node: '>= 0.4.0'}
 
+  hash-base@3.0.4:
+    resolution: {integrity: sha512-EeeoJKjTyt868liAlVmcv2ZsUfGHlE3Q+BICOXcZiwN3osr5Q/zFGYmTJpoIzuaSTAwndFy+GqhEwlU4L3j4Ow==}
+    engines: {node: '>=4'}
+
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -5890,6 +6013,9 @@ packages:
 
   hex2dec@1.0.1:
     resolution: {integrity: sha512-F9QO0+ZI8r1VZudxw21bD/U5pb2Y9LZY3TsnVqCPaijvw5mIhH5jsH29acLPijl5fECfD8FetJtgX8GN5YPM9Q==}
+
+  hmac-drbg@1.0.1:
+    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -5939,6 +6065,9 @@ packages:
   http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
     engines: {node: '>=10.19.0'}
+
+  https-browserify@1.0.0:
+    resolution: {integrity: sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==}
 
   https-proxy-agent@5.0.0:
     resolution: {integrity: sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==}
@@ -6177,6 +6306,10 @@ packages:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
 
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
+    engines: {node: '>= 0.4'}
+
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
@@ -6303,6 +6436,10 @@ packages:
   isexe@3.1.1:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
+
+  isomorphic-timers-promises@1.0.1:
+    resolution: {integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==}
+    engines: {node: '>=10'}
 
   isomorphic-ws@4.0.1:
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
@@ -6457,8 +6594,8 @@ packages:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
 
-  jsonpath-plus@10.1.0:
-    resolution: {integrity: sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==}
+  jsonpath-plus@10.2.0:
+    resolution: {integrity: sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -6654,6 +6791,9 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
+  magic-string@0.30.12:
+    resolution: {integrity: sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==}
+
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -6692,6 +6832,9 @@ packages:
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
+
+  md5.js@1.3.5:
+    resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
 
   md5@2.3.0:
     resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
@@ -6735,6 +6878,10 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  miller-rabin@4.0.1:
+    resolution: {integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==}
+    hasBin: true
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -6767,6 +6914,12 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
+  minimalistic-crypto-utils@1.0.1:
+    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
   minimatch@10.0.1:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
@@ -6961,6 +7114,10 @@ packages:
     resolution: {integrity: sha512-jn9vOIK/nfqoFCcpK89/VCVaLg1IHE6UVfDOzvqmANaJ/rWCTEdH8RZ1V278nv2jr36BJdyQXIAavBLXpzdlag==}
     engines: {node: '>=14'}
 
+  node-stdlib-browser@1.2.1:
+    resolution: {integrity: sha512-dZezG3D88Lg22DwyjsDuUs7cCT/XGr8WwJgg/S3ZnkcWuPet2Tt/W1d2Eytb1Z73JpZv+XVCDI5TWv6UMRq0Gg==}
+    engines: {node: '>=10'}
+
   nopt@7.2.1:
     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -7048,6 +7205,10 @@ packages:
     resolution: {integrity: sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==}
     engines: {node: '>= 0.4'}
 
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
@@ -7114,6 +7275,9 @@ packages:
   ora@4.1.1:
     resolution: {integrity: sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==}
     engines: {node: '>=8'}
+
+  os-browserify@0.3.0:
+    resolution: {integrity: sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==}
 
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
@@ -7193,9 +7357,16 @@ packages:
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-asn1@5.1.7:
+    resolution: {integrity: sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==}
+    engines: {node: '>= 0.10'}
 
   parse-imports@2.2.1:
     resolution: {integrity: sha512-OL/zLggRp8mFhKL0rNORUTR4yBYujK/uU+xZL+/0Rgm2QE4nLO9v8PzEweSJEbMGKmDRjJE4R3IMJlL2di4JeQ==}
@@ -7227,6 +7398,9 @@ packages:
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -7277,6 +7451,10 @@ packages:
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
+  pbkdf2@3.1.2:
+    resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
+    engines: {node: '>=0.12'}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -7286,6 +7464,10 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
 
   pidtree@0.3.1:
     resolution: {integrity: sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==}
@@ -7312,6 +7494,10 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  pkg-dir@5.0.0:
+    resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
+    engines: {node: '>=10'}
 
   playwright-core@1.48.2:
     resolution: {integrity: sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==}
@@ -7404,6 +7590,10 @@ packages:
     resolution: {integrity: sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==}
     engines: {node: '>=8'}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -7448,11 +7638,17 @@ packages:
   pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
 
+  public-encrypt@4.0.3:
+    resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
+
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
 
   punycode@1.3.2:
     resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
+
+  punycode@1.4.1:
+    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -7469,6 +7665,10 @@ packages:
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
+
+  querystring-es3@0.2.1:
+    resolution: {integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==}
+    engines: {node: '>=0.4.x'}
 
   querystring@0.2.0:
     resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
@@ -7495,6 +7695,9 @@ packages:
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  randomfill@1.0.4:
+    resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -7744,6 +7947,9 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  ripemd160@2.0.2:
+    resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
+
   roarr@2.15.4:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
@@ -7755,6 +7961,9 @@ packages:
 
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rss-parser@3.13.0:
+    resolution: {integrity: sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -7863,8 +8072,15 @@ packages:
     resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
     engines: {node: '>= 0.4'}
 
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sha.js@2.4.11:
+    resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
+    hasBin: true
 
   shallow-equal@1.2.1:
     resolution: {integrity: sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==}
@@ -8021,6 +8237,12 @@ packages:
   stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
+
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
+
+  stream-http@3.2.0:
+    resolution: {integrity: sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -8219,6 +8441,10 @@ packages:
     resolution: {integrity: sha512-bW8EaE6iw3hSt4HB2HpBdHW86Xpb9IUJfqufx4NwEu7OGuIpS0ISj+Yy1Z1Wvhfno6SPNhKRJ1qFXea84HcrOQ==}
     engines: {node: '>= 10.18.0'}
 
+  timers-browserify@2.0.12:
+    resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
+    engines: {node: '>=0.6.0'}
+
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
@@ -8306,6 +8532,9 @@ packages:
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+
+  tty-browserify@0.0.1:
+    resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
 
   tuf-js@2.2.1:
     resolution: {integrity: sha512-GwIJau9XaA8nLVbUXsN3IlFi7WmQ48gBUrl3FTkkL/XLu/POhBzfmX9hd33FNMX1qAsfl6ozO1iMmW9NC8YniA==}
@@ -8438,6 +8667,10 @@ packages:
   url@0.10.3:
     resolution: {integrity: sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==}
 
+  url@0.11.4:
+    resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
+    engines: {node: '>= 0.4'}
+
   use-sync-external-store@1.2.2:
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
     peerDependencies:
@@ -8494,6 +8727,11 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite-plugin-node-polyfills@0.22.0:
+    resolution: {integrity: sha512-F+G3LjiGbG8QpbH9bZ//GSBr9i1InSTkaulfUHFa9jkLqVGORFBoqc2A/Yu5Mmh1kNAbiAeKeK+6aaQUf3x0JA==}
+    peerDependencies:
+      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+
   vite-plugin-static-copy@1.0.3:
     resolution: {integrity: sha512-hBCCz6T0uNI3oF5oJ/Ju73rhoR+ADrJ2iLAea5+wA7kpQ8clYgY8BD+GL0w0BrqsYCbgBITOByBP/3y9Y+h93A==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -8527,6 +8765,9 @@ packages:
         optional: true
       terser:
         optional: true
+
+  vm-browserify@1.1.2:
+    resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
 
   vscode-oniguruma@1.7.0:
     resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
@@ -8701,6 +8942,10 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml2js@0.5.0:
+    resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
@@ -8722,6 +8967,10 @@ packages:
   xmlhttprequest-ssl@2.1.2:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
     engines: {node: '>=0.4.0'}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -8827,7 +9076,7 @@ snapshots:
       debug: 4.3.7(supports-color@8.1.1)
       deep-for-each: 3.0.0
       espree: 9.6.1
-      jsonpath-plus: 10.1.0
+      jsonpath-plus: 10.2.0
       lodash: 4.17.21
       ms: 2.1.3
     transitivePeerDependencies:
@@ -10749,11 +10998,11 @@ snapshots:
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
 
-  '@oclif/plugin-help@6.2.16':
+  '@oclif/plugin-help@6.2.18':
     dependencies:
       '@oclif/core': 4.0.32
 
-  '@oclif/plugin-not-found@3.2.25(@types/node@20.12.12)':
+  '@oclif/plugin-not-found@3.2.28(@types/node@20.12.12)':
     dependencies:
       '@inquirer/prompts': 7.1.0(@types/node@20.12.12)
       '@oclif/core': 4.0.32
@@ -11164,6 +11413,22 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@rollup/plugin-inject@5.0.5(rollup@4.24.2)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.3(rollup@4.24.2)
+      estree-walker: 2.0.2
+      magic-string: 0.30.12
+    optionalDependencies:
+      rollup: 4.24.2
+
+  '@rollup/pluginutils@5.1.3(rollup@4.24.2)':
+    dependencies:
+      '@types/estree': 1.0.6
+      estree-walker: 2.0.2
+      picomatch: 4.0.2
+    optionalDependencies:
+      rollup: 4.24.2
 
   '@rollup/rollup-android-arm-eabi@4.24.2':
     optional: true
@@ -12557,8 +12822,8 @@ snapshots:
       '@azure/storage-blob': 12.25.0
       '@azure/storage-queue': 12.24.0
       '@oclif/core': 4.0.32
-      '@oclif/plugin-help': 6.2.16
-      '@oclif/plugin-not-found': 3.2.25(@types/node@20.12.12)
+      '@oclif/plugin-help': 6.2.18
+      '@oclif/plugin-not-found': 3.2.28(@types/node@20.12.12)
       archiver: 5.3.2
       artillery-engine-playwright: 1.18.0
       artillery-plugin-apdex: 1.12.0(@types/node@20.12.12)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
@@ -12618,6 +12883,20 @@ snapshots:
   as-table@1.0.55:
     dependencies:
       printable-characters: 1.0.42
+
+  asn1.js@4.10.1:
+    dependencies:
+      bn.js: 4.12.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.7
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.5
+      util: 0.12.5
 
   assertion-error@1.1.0: {}
 
@@ -12703,6 +12982,10 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  bn.js@4.12.1: {}
+
+  bn.js@5.2.1: {}
+
   body-parser@1.20.3:
     dependencies:
       bytes: 3.1.2
@@ -12740,13 +13023,64 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  brorand@1.1.0: {}
+
   brotli@1.3.3:
     dependencies:
       base64-js: 1.5.1
 
   browser-or-node@1.3.0: {}
 
+  browser-resolve@2.0.0:
+    dependencies:
+      resolve: 1.22.8
+
   browser-stdout@1.3.1: {}
+
+  browserify-aes@1.2.0:
+    dependencies:
+      buffer-xor: 1.0.3
+      cipher-base: 1.0.5
+      create-hash: 1.2.0
+      evp_bytestokey: 1.0.3
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
+  browserify-cipher@1.0.1:
+    dependencies:
+      browserify-aes: 1.2.0
+      browserify-des: 1.0.2
+      evp_bytestokey: 1.0.3
+
+  browserify-des@1.0.2:
+    dependencies:
+      cipher-base: 1.0.5
+      des.js: 1.1.0
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
+  browserify-rsa@4.1.1:
+    dependencies:
+      bn.js: 5.2.1
+      randombytes: 2.1.0
+      safe-buffer: 5.2.1
+
+  browserify-sign@4.2.3:
+    dependencies:
+      bn.js: 5.2.1
+      browserify-rsa: 4.1.1
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      elliptic: 6.6.1
+      hash-base: 3.0.4
+      inherits: 2.0.4
+      parse-asn1: 5.1.7
+      readable-stream: 2.3.8
+      safe-buffer: 5.2.1
+
+  browserify-zlib@0.2.0:
+    dependencies:
+      pako: 1.0.11
 
   browserslist@4.24.2:
     dependencies:
@@ -12759,6 +13093,8 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  buffer-xor@1.0.3: {}
+
   buffer@4.9.2:
     dependencies:
       base64-js: 1.5.1
@@ -12769,6 +13105,8 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  builtin-status-codes@3.0.0: {}
 
   bytes@3.1.2: {}
 
@@ -12931,6 +13269,11 @@ snapshots:
 
   ci-info@4.1.0: {}
 
+  cipher-base@1.0.5:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
   cjs-module-lexer@1.4.1: {}
 
   classnames@2.3.1: {}
@@ -13034,6 +13377,10 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  console-browserify@1.2.0: {}
+
+  constants-browserify@1.0.0: {}
+
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
@@ -13099,6 +13446,30 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 3.6.2
 
+  create-ecdh@4.0.4:
+    dependencies:
+      bn.js: 4.12.1
+      elliptic: 6.6.1
+
+  create-hash@1.2.0:
+    dependencies:
+      cipher-base: 1.0.5
+      inherits: 2.0.4
+      md5.js: 1.3.5
+      ripemd160: 2.0.2
+      sha.js: 2.4.11
+
+  create-hmac@1.1.7:
+    dependencies:
+      cipher-base: 1.0.5
+      create-hash: 1.2.0
+      inherits: 2.0.4
+      ripemd160: 2.0.2
+      safe-buffer: 5.2.1
+      sha.js: 2.4.11
+
+  create-require@1.1.1: {}
+
   cross-env@7.0.3:
     dependencies:
       cross-spawn: 7.0.3
@@ -13130,6 +13501,21 @@ snapshots:
       which: 2.0.2
 
   crypt@0.0.2: {}
+
+  crypto-browserify@3.12.1:
+    dependencies:
+      browserify-cipher: 1.0.1
+      browserify-sign: 4.2.3
+      create-ecdh: 4.0.4
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      diffie-hellman: 5.0.3
+      hash-base: 3.0.4
+      inherits: 2.0.4
+      pbkdf2: 3.1.2
+      public-encrypt: 4.0.3
+      randombytes: 2.1.0
+      randomfill: 1.0.4
 
   css-select@5.1.0:
     dependencies:
@@ -13268,6 +13654,11 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  des.js@1.1.0:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   destroy@1.2.0: {}
 
   detect-indent@6.1.0: {}
@@ -13324,6 +13715,12 @@ snapshots:
 
   diff@5.2.0: {}
 
+  diffie-hellman@5.0.3:
+    dependencies:
+      bn.js: 4.12.1
+      miller-rabin: 4.0.1
+      randombytes: 2.1.0
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -13352,6 +13749,8 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       entities: 4.5.0
+
+  domain-browser@4.23.0: {}
 
   domelementtype@2.3.0: {}
 
@@ -13398,6 +13797,16 @@ snapshots:
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  elliptic@6.6.1:
+    dependencies:
+      bn.js: 4.12.1
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
 
   emoji-regex@10.4.0: {}
 
@@ -13448,6 +13857,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   ensure-posix-path@1.1.1: {}
+
+  entities@2.2.0: {}
 
   entities@4.5.0: {}
 
@@ -13804,6 +14215,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@2.0.2: {}
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -13819,6 +14232,11 @@ snapshots:
   events@1.1.1: {}
 
   events@3.3.0: {}
+
+  evp_bytestokey@1.0.3:
+    dependencies:
+      md5.js: 1.3.5
+      safe-buffer: 5.2.1
 
   execa@1.0.0:
     dependencies:
@@ -14326,6 +14744,16 @@ snapshots:
 
   has@1.0.4: {}
 
+  hash-base@3.0.4:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -14333,6 +14761,12 @@ snapshots:
   he@1.2.0: {}
 
   hex2dec@1.0.1: {}
+
+  hmac-drbg@1.0.1:
+    dependencies:
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -14396,6 +14830,8 @@ snapshots:
     dependencies:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
+
+  https-browserify@1.0.0: {}
 
   https-proxy-agent@5.0.0:
     dependencies:
@@ -14635,6 +15071,11 @@ snapshots:
 
   is-map@2.0.3: {}
 
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+
   is-negative-zero@2.0.3: {}
 
   is-number-object@1.0.7:
@@ -14730,6 +15171,8 @@ snapshots:
   isexe@2.0.0: {}
 
   isexe@3.1.1: {}
+
+  isomorphic-timers-promises@1.0.1: {}
 
   isomorphic-ws@4.0.1(ws@5.2.4):
     dependencies:
@@ -14902,7 +15345,7 @@ snapshots:
 
   jsonparse@1.3.1: {}
 
-  jsonpath-plus@10.1.0:
+  jsonpath-plus@10.2.0:
     dependencies:
       '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
       '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
@@ -15143,6 +15586,10 @@ snapshots:
 
   lz-string@1.5.0: {}
 
+  magic-string@0.30.12:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
   make-dir@4.0.0:
     dependencies:
       semver: 7.6.3
@@ -15202,6 +15649,12 @@ snapshots:
       escape-string-regexp: 4.0.0
     optional: true
 
+  md5.js@1.3.5:
+    dependencies:
+      hash-base: 3.0.4
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
   md5@2.3.0:
     dependencies:
       charenc: 0.0.2
@@ -15237,6 +15690,11 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  miller-rabin@4.0.1:
+    dependencies:
+      bn.js: 4.12.1
+      brorand: 1.1.0
+
   mime-db@1.52.0: {}
 
   mime-types@2.1.35:
@@ -15254,6 +15712,10 @@ snapshots:
   mimic-response@1.0.1: {}
 
   mimic-response@3.1.0: {}
+
+  minimalistic-assert@1.0.1: {}
+
+  minimalistic-crypto-utils@1.0.1: {}
 
   minimatch@10.0.1:
     dependencies:
@@ -15465,6 +15927,36 @@ snapshots:
     dependencies:
       '@babel/parser': 7.26.1
 
+  node-stdlib-browser@1.2.1:
+    dependencies:
+      assert: 2.1.0
+      browser-resolve: 2.0.0
+      browserify-zlib: 0.2.0
+      buffer: 5.7.1
+      console-browserify: 1.2.0
+      constants-browserify: 1.0.0
+      create-require: 1.1.1
+      crypto-browserify: 3.12.1
+      domain-browser: 4.23.0
+      events: 3.3.0
+      https-browserify: 1.0.0
+      isomorphic-timers-promises: 1.0.1
+      os-browserify: 0.3.0
+      path-browserify: 1.0.1
+      pkg-dir: 5.0.0
+      process: 0.11.10
+      punycode: 1.4.1
+      querystring-es3: 0.2.1
+      readable-stream: 3.6.2
+      stream-browserify: 3.0.0
+      stream-http: 3.2.0
+      string_decoder: 1.3.0
+      timers-browserify: 2.0.12
+      tty-browserify: 0.0.1
+      url: 0.11.4
+      util: 0.12.5
+      vm-browserify: 1.1.2
+
   nopt@7.2.1:
     dependencies:
       abbrev: 2.0.0
@@ -15563,6 +16055,11 @@ snapshots:
 
   object-inspect@1.13.2: {}
 
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+
   object-keys@1.1.1: {}
 
   object.assign@4.1.5:
@@ -15652,6 +16149,8 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
+  os-browserify@0.3.0: {}
+
   os-tmpdir@1.0.2: {}
 
   outdent@0.5.0: {}
@@ -15740,9 +16239,20 @@ snapshots:
 
   pako@0.2.9: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-asn1@5.1.7:
+    dependencies:
+      asn1.js: 4.10.1
+      browserify-aes: 1.2.0
+      evp_bytestokey: 1.0.3
+      hash-base: 3.0.4
+      pbkdf2: 3.1.2
+      safe-buffer: 5.2.1
 
   parse-imports@2.2.1:
     dependencies:
@@ -15779,6 +16289,8 @@ snapshots:
 
   patch-console@2.0.0: {}
 
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -15813,11 +16325,21 @@ snapshots:
 
   pathval@1.1.1: {}
 
+  pbkdf2@3.1.2:
+    dependencies:
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      ripemd160: 2.0.2
+      safe-buffer: 5.2.1
+      sha.js: 2.4.11
+
   pend@1.2.0: {}
 
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
+
+  picomatch@4.0.2: {}
 
   pidtree@0.3.1: {}
 
@@ -15832,6 +16354,10 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  pkg-dir@5.0.0:
+    dependencies:
+      find-up: 5.0.0
 
   playwright-core@1.48.2: {}
 
@@ -15928,6 +16454,8 @@ snapshots:
     dependencies:
       fromentries: 1.3.2
 
+  process@0.11.10: {}
+
   progress@2.0.3: {}
 
   prom-client@14.2.0:
@@ -15986,12 +16514,23 @@ snapshots:
 
   pseudomap@1.0.2: {}
 
+  public-encrypt@4.0.3:
+    dependencies:
+      bn.js: 4.12.1
+      browserify-rsa: 4.1.1
+      create-hash: 1.2.0
+      parse-asn1: 5.1.7
+      randombytes: 2.1.0
+      safe-buffer: 5.2.1
+
   pump@3.0.2:
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
 
   punycode@1.3.2: {}
+
+  punycode@1.4.1: {}
 
   punycode@2.3.1: {}
 
@@ -16000,6 +16539,8 @@ snapshots:
   qs@6.13.0:
     dependencies:
       side-channel: 1.0.6
+
+  querystring-es3@0.2.1: {}
 
   querystring@0.2.0: {}
 
@@ -16018,6 +16559,11 @@ snapshots:
 
   randombytes@2.1.0:
     dependencies:
+      safe-buffer: 5.2.1
+
+  randomfill@1.0.4:
+    dependencies:
+      randombytes: 2.1.0
       safe-buffer: 5.2.1
 
   range-parser@1.2.1: {}
@@ -16293,6 +16839,11 @@ snapshots:
       glob: 11.0.0
       package-json-from-dist: 1.0.1
 
+  ripemd160@2.0.2:
+    dependencies:
+      hash-base: 3.0.4
+      inherits: 2.0.4
+
   roarr@2.15.4:
     dependencies:
       boolean: 3.2.0
@@ -16328,6 +16879,11 @@ snapshots:
       fsevents: 2.3.3
 
   rrweb-cssom@0.7.1: {}
+
+  rss-parser@3.13.0:
+    dependencies:
+      entities: 2.2.0
+      xml2js: 0.5.0
 
   run-parallel@1.2.0:
     dependencies:
@@ -16457,7 +17013,14 @@ snapshots:
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.2
 
+  setimmediate@1.0.5: {}
+
   setprototypeof@1.2.0: {}
+
+  sha.js@2.4.11:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
 
   shallow-equal@1.2.1: {}
 
@@ -16634,6 +17197,18 @@ snapshots:
   statuses@2.0.1: {}
 
   stoppable@1.1.0: {}
+
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  stream-http@3.2.0:
+    dependencies:
+      builtin-status-codes: 3.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      xtend: 4.0.2
 
   string-argv@0.3.2: {}
 
@@ -16912,6 +17487,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  timers-browserify@2.0.12:
+    dependencies:
+      setimmediate: 1.0.5
+
   tiny-inflate@1.0.3: {}
 
   tippy.js@6.3.7:
@@ -16999,6 +17578,8 @@ snapshots:
     dependencies:
       tslib: 1.14.1
       typescript: 5.6.3
+
+  tty-browserify@0.0.1: {}
 
   tuf-js@2.2.1:
     dependencies:
@@ -17135,6 +17716,11 @@ snapshots:
       punycode: 1.3.2
       querystring: 0.2.0
 
+  url@0.11.4:
+    dependencies:
+      punycode: 1.4.1
+      qs: 6.13.0
+
   use-sync-external-store@1.2.2(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -17183,6 +17769,14 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite-plugin-node-polyfills@0.22.0(rollup@4.24.2)(vite@5.2.14(@types/node@20.12.12)(sass@1.75.0)):
+    dependencies:
+      '@rollup/plugin-inject': 5.0.5(rollup@4.24.2)
+      node-stdlib-browser: 1.2.1
+      vite: 5.2.14(@types/node@20.12.12)(sass@1.75.0)
+    transitivePeerDependencies:
+      - rollup
+
   vite-plugin-static-copy@1.0.3(vite@5.2.14(@types/node@20.12.12)(sass@1.75.0)):
     dependencies:
       chokidar: 3.6.0
@@ -17200,6 +17794,8 @@ snapshots:
       '@types/node': 20.12.12
       fsevents: 2.3.3
       sass: 1.75.0
+
+  vm-browserify@1.1.2: {}
 
   vscode-oniguruma@1.7.0: {}
 
@@ -17363,6 +17959,11 @@ snapshots:
 
   xml-name-validator@5.0.0: {}
 
+  xml2js@0.5.0:
+    dependencies:
+      sax: 1.2.1
+      xmlbuilder: 11.0.1
+
   xml2js@0.6.2:
     dependencies:
       sax: 1.2.1
@@ -17382,6 +17983,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
+
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/749

Additionally, added an API that helps with hierarchy filtering implementation. Refactored imodel hierarchy provider to use that API and filtering performance improved by ~25%:

| Benchmark suite | Current: 4f50cafc12c043cafa467d7341640cfff8a9eb2d | Previous: 9374049632acf91de7018d02b49660b11e53caa6 | Deviation | Status |
|-|-|-|-|-|
| `filtering filters with 50000 paths` | `9974.49` ms | `13770.6` ms | `-27.5668%` | ✅ |