### PR TITLE
Fix full stack tests flakiness

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -225,6 +225,7 @@
         "${workspaceFolder}/packages/components/lib/**/*.js",
         "${workspaceFolder}/packages/core-interop/lib/**/*.js",
         "${workspaceFolder}/packages/hierarchies/lib/**/*.js",
+        "${workspaceFolder}/packages/hierarchies-react/lib/**/*.js",
         "${workspaceFolder}/packages/models-tree/lib/**/*.js",
         "${workspaceFolder}/packages/testing/lib/**/*.js",
         "${workspaceFolder}/packages/shared/lib/**/*.js",

--- a/apps/full-stack-tests/scripts/setup-tests.cjs
+++ b/apps/full-stack-tests/scripts/setup-tests.cjs
@@ -7,7 +7,11 @@ const cpx = require("cpx2");
 const fs = require("fs");
 const path = require("path");
 
-cpx.copySync(`assets/**/*`, "lib/assets");
+const libDir = "./lib";
+const cacheDir = path.join(libDir, ".cache");
+fs.mkdirSync(cacheDir, { recursive: true });
+
+cpx.copySync(`assets/**/*`, path.join(libDir, "assets"));
 copyITwinFrontendAssets("lib/public");
 pseudoLocalize("lib/public/locales");
 

--- a/apps/full-stack-tests/src/IntegrationTests.ts
+++ b/apps/full-stack-tests/src/IntegrationTests.ts
@@ -37,12 +37,6 @@ export async function initialize(props?: { backendTimeout?: number }) {
   Logger.setLevel("SQLite", LogLevel.Error);
   Logger.setLevel(PresentationBackendNativeLoggerCategory.ECObjects, LogLevel.Warning);
 
-  const libDir = path.resolve("lib");
-  const hierarchiesCacheDir = path.join(libDir, "cache");
-  if (!fs.existsSync(hierarchiesCacheDir)) {
-    fs.mkdirSync(hierarchiesCacheDir);
-  }
-
   const backendInitProps: PresentationBackendProps = {
     id: `test-${Guid.createValue()}`,
     requestTimeout: props?.backendTimeout ?? 0,


### PR DESCRIPTION
Full stack tests run in parallel, and the ones that use `IModelHost` pass it the `.cache` directory for various caches. The host attempts to create one if it doesn't exist. However, when multiple processes attempt to do that at the same time, we sometimes get an error like this:

```
EEXIST: file already exists, mkdir '{repo-root}\apps\full-stack-tests\lib\.cache'
```

Now we create it up front, when building the tests and setting them up.