### PR TITLE
Hierarchies: Unify hierarchy updates' handling

### DIFF
--- a/.changeset/afraid-panthers-melt.md
+++ b/.changeset/afraid-panthers-melt.md
@@ -1,0 +1,28 @@
+---
+"@itwin/presentation-shared": minor
+---
+
+Added a number of mapped types:
+
+- `Props<TFunc>` obtains the type of the first `TFunc` function argument.
+
+   ```ts
+  function func(props: { x: number, y: string }) {
+    // ...
+  }
+  type FunctionProps = Props(typeof func); // { x: number, y: string }
+   ```
+
+- `EventListener<TEvent>` obtains the event listener type of given event type.
+
+   ```ts
+   type MyEvent = Event<(arg: number) => void>;
+   type MyEventListener = EventListener<MyEvent>; // (arg: number) => void
+   ```
+
+- `EventArgs<TEvent>` obtains the type of the first event listener's argument of given event type.
+
+   ```ts
+   type MyEvent = Event<(arg: { x: number, y: string }) => void>;
+   type MyEventArgs = EventArgs<MyEvent>; // { x: number, y: string }
+   ```

--- a/.changeset/silly-eyes-lie.md
+++ b/.changeset/silly-eyes-lie.md
@@ -1,0 +1,12 @@
+---
+"@itwin/presentation-hierarchies-react": minor
+"@itwin/presentation-hierarchies": minor
+---
+
+Unify hierarchy updates' handling.
+
+Previously, we'd only raise the `HierarchyProvider.hierarchyChanged` event on data source changes. The tree state hooks would listen to this event and trigger a hierarchy update. However, there are a few other reasons for the hierarchy to change - changing formatter or active hierarchy filter. In those situations the event was not raised, but tree state hooks still had to trigger hierarchy update. So we ended up with a mix of event-driven and manual hierarchy updates.
+
+With this change we're clearly stating that a hierarchy provider should trigger its `hierarchyChanged` event whenever something happens that causes the hierarchy to change. That means, the event will be raised when formatter or hierarchy filter is set, and tree state hooks can initiate hierarchy reload from a single place - the `hierarchyChanged` event listener.
+
+To let event listeners know what caused the hierarchy change, the event now has event arguments, which should be set by the hierarchy provider when raising the event. This allows listeners to customize hierarchy reload logic - for example, our tree state hooks always keep existing tree state except when a new hierarchy filter is set, in which case the existing state is discarded.

--- a/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/Localization.test.tsx
+++ b/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/Localization.test.tsx
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
 /* eslint-disable no-duplicate-imports */
+
 import { expect } from "chai";
 import { SchemaContext } from "@itwin/ecschema-metadata";
 import { IModelConnection } from "@itwin/core-frontend";
@@ -12,14 +12,15 @@ import { insertPhysicalModelWithPartition } from "presentation-test-utilities";
 import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor, createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory, createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
-// __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.Localization.TreeRenderer.Imports
-import { ComponentPropsWithoutRef, useCallback } from "react";
-import { Tree } from "@itwin/itwinui-react";
+// __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.Localization.CommonImports
+import { Props } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
 // __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.Localization.Tree.Imports
 import { useIModelUnifiedSelectionTree } from "@itwin/presentation-hierarchies-react";
 // __PUBLISH_EXTRACT_END__
 // __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.Localization.TreeRenderer.Imports
+import { ComponentPropsWithoutRef, useCallback } from "react";
+import { Tree } from "@itwin/itwinui-react";
 import {
   createRenderedTreeNodeData,
   LocalizationContextProvider,
@@ -38,7 +39,7 @@ describe("Hierarchies React", () => {
     describe("Localization", () => {
       stubGetBoundingClientRect();
       // __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.Localization.Strings
-      type IModelAccess = Parameters<typeof useIModelUnifiedSelectionTree>[0]["imodelAccess"];
+      type IModelAccess = Props<typeof useIModelUnifiedSelectionTree>["imodelAccess"];
 
       const localizedStrings = {
         // strings for the `useIModelUnifiedSelectionTree` hook
@@ -59,7 +60,7 @@ describe("Hierarchies React", () => {
 
       let imodel: IModelConnection;
       let access: IModelAccess;
-      let getHierarchyDefinition: Parameters<typeof useIModelUnifiedSelectionTree>[0]["getHierarchyDefinition"];
+      let getHierarchyDefinition: Props<typeof useIModelUnifiedSelectionTree>["getHierarchyDefinition"];
 
       beforeEach(async function () {
         await initialize();
@@ -135,7 +136,7 @@ describe("Hierarchies React", () => {
       it("Tree renderer localization", async function () {
         // __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.Localization.TreeRenderer
         type TreeProps = ComponentPropsWithoutRef<typeof Tree<RenderedTreeNode>>;
-        type TreeRendererProps = Parameters<typeof TreeRenderer>[0];
+        type TreeRendererProps = Props<typeof TreeRenderer>;
 
         function MyTreeRenderer(props: TreeRendererProps) {
           const nodeRenderer = useCallback<TreeProps["nodeRenderer"]>((nodeProps) => {

--- a/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/ReadmeExample.test.tsx
+++ b/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/ReadmeExample.test.tsx
@@ -21,7 +21,7 @@ import { createStorage } from "@itwin/unified-selection";
 import { useEffect, useState } from "react";
 // __PUBLISH_EXTRACT_END__
 // __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.CustomTreeExample.Imports
-import { createBisInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
+import { createBisInstanceLabelSelectClauseFactory, Props } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
 import { buildIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
@@ -103,7 +103,7 @@ describe("Hierarchies React", () => {
         }
         // __PUBLISH_EXTRACT_END__
         // __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.CustomTreeExample
-        type IModelAccess = Parameters<typeof useIModelUnifiedSelectionTree>[0]["imodelAccess"];
+        type IModelAccess = Props<typeof useIModelUnifiedSelectionTree>["imodelAccess"];
 
         // The hierarchy definition describes the hierarchy using ECSQL queries; here it just returns all `BisCore.PhysicalModel` instances
         function getHierarchyDefinition({ imodelAccess }: { imodelAccess: IModelAccess }): HierarchyDefinition {
@@ -159,7 +159,7 @@ describe("Hierarchies React", () => {
       });
 
       it("useIModelUnifiedSelectionTree", async function () {
-        type IModelAccess = Parameters<typeof useIModelUnifiedSelectionTree>[0]["imodelAccess"];
+        type IModelAccess = Props<typeof useIModelUnifiedSelectionTree>["imodelAccess"];
         const getHierarchyDefinition = () => ({
           defineHierarchyLevel: async () => [],
         });

--- a/apps/full-stack-tests/src/hierarchies/HierarchyFiltering.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchyFiltering.test.ts
@@ -29,7 +29,7 @@ import {
   HierarchyProvider,
   mergeProviders,
 } from "@itwin/presentation-hierarchies";
-import { createBisInstanceLabelSelectClauseFactory, ECSqlBinding, InstanceKey } from "@itwin/presentation-shared";
+import { createBisInstanceLabelSelectClauseFactory, ECSqlBinding, InstanceKey, Props } from "@itwin/presentation-shared";
 import { createFileNameFromString } from "@itwin/presentation-testing";
 import { buildIModel, importSchema, withECDb } from "../IModelUtils.js";
 import { initialize, terminate } from "../IntegrationTests.js";
@@ -1906,13 +1906,7 @@ describe("Hierarchies", () => {
   });
 });
 
-function mergeAndFilterProviders({
-  providers,
-  filterProps,
-}: {
-  providers: HierarchyProvider[];
-  filterProps: Parameters<HierarchyProvider["setHierarchyFilter"]>[0];
-}) {
+function mergeAndFilterProviders({ providers, filterProps }: { providers: HierarchyProvider[]; filterProps: Props<HierarchyProvider["setHierarchyFilter"]> }) {
   const mergedProvider = mergeProviders({ providers });
   mergedProvider.setHierarchyFilter(filterProps);
   return mergedProvider;

--- a/apps/full-stack-tests/src/hierarchies/Utils.ts
+++ b/apps/full-stack-tests/src/hierarchies/Utils.ts
@@ -9,9 +9,9 @@ import { Schema, SchemaContext, SchemaInfo, SchemaKey, SchemaMatchType } from "@
 import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
 import { createECSchemaProvider as createECSchemaProviderInterop, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 import { createIModelHierarchyProvider, createLimitingECSqlQueryExecutor, HierarchyDefinition } from "@itwin/presentation-hierarchies";
-import { createCachingECClassHierarchyInspector, Event, IPrimitiveValueFormatter, parseFullClassName } from "@itwin/presentation-shared";
+import { createCachingECClassHierarchyInspector, Event, IPrimitiveValueFormatter, parseFullClassName, Props } from "@itwin/presentation-shared";
 
-type HierarchyProviderProps = Parameters<typeof createIModelHierarchyProvider>[0];
+type HierarchyProviderProps = Props<typeof createIModelHierarchyProvider>;
 type HierarchyFilteringPaths = NonNullable<NonNullable<HierarchyProviderProps["filtering"]>["paths"]>;
 
 export function createSchemaContext(imodel: IModelConnection | IModelDb | ECDb) {
@@ -60,7 +60,7 @@ export function createProvider(
         imodelAccess: ReturnType<typeof createIModelAccess>;
         imodelChanged?: Event<() => void>;
         hierarchy: HierarchyDefinition;
-        localizedStrings?: Parameters<typeof createIModelHierarchyProvider>[0]["localizedStrings"];
+        localizedStrings?: Props<typeof createIModelHierarchyProvider>["localizedStrings"];
         filteredNodePaths?: HierarchyFilteringPaths;
         queryCacheSize?: number;
       }
@@ -71,7 +71,7 @@ export function createProvider(
   ) & {
     imodelChanged?: Event<() => void>;
     hierarchy: HierarchyDefinition;
-    localizedStrings?: Parameters<typeof createIModelHierarchyProvider>[0]["localizedStrings"];
+    localizedStrings?: Props<typeof createIModelHierarchyProvider>["localizedStrings"];
     filteredNodePaths?: HierarchyFilteringPaths;
     queryCacheSize?: number;
   },

--- a/apps/full-stack-tests/src/hierarchies/grouping/AutoExpand.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/AutoExpand.test.ts
@@ -8,7 +8,7 @@ import { Subject } from "@itwin/core-backend";
 import { IModel } from "@itwin/core-common";
 import { IModelConnection } from "@itwin/core-frontend";
 import { createNodesQueryClauseFactory, HierarchyDefinition, NodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
-import { createBisInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
+import { createBisInstanceLabelSelectClauseFactory, Props } from "@itwin/presentation-shared";
 import { buildIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
@@ -16,7 +16,7 @@ import { createIModelAccess, createProvider } from "../Utils.js";
 
 describe("Hierarchies", () => {
   describe("Grouping nodes' autoExpand setting", () => {
-    type ECSqlSelectClauseGroupingParams = NonNullable<Parameters<NodesQueryClauseFactory["createSelectClause"]>[0]["grouping"]>;
+    type ECSqlSelectClauseGroupingParams = NonNullable<Props<NodesQueryClauseFactory["createSelectClause"]>["grouping"]>;
     let subjectClassName: string;
     let emptyIModel: IModelConnection;
 

--- a/apps/full-stack-tests/src/hierarchies/grouping/GroupHiding.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/GroupHiding.test.ts
@@ -8,7 +8,7 @@ import { PhysicalPartition, Subject } from "@itwin/core-backend";
 import { IModel } from "@itwin/core-common";
 import { IModelConnection } from "@itwin/core-frontend";
 import { createNodesQueryClauseFactory, HierarchyDefinition, NodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
-import { createBisInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
+import { createBisInstanceLabelSelectClauseFactory, Props } from "@itwin/presentation-shared";
 import { buildIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
@@ -16,7 +16,7 @@ import { createIModelAccess, createProvider } from "../Utils.js";
 
 describe("Hierarchies", () => {
   describe("Grouping nodes' hiding", () => {
-    type ECSqlSelectClauseGroupingParams = NonNullable<Parameters<NodesQueryClauseFactory["createSelectClause"]>[0]["grouping"]>;
+    type ECSqlSelectClauseGroupingParams = NonNullable<Props<NodesQueryClauseFactory["createSelectClause"]>["grouping"]>;
     let subjectClassName: string;
     let physicalPartitionClassName: string;
     const groupName = "test1";

--- a/apps/full-stack-tests/src/hierarchies/grouping/PropertiesGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/PropertiesGrouping.test.ts
@@ -8,7 +8,7 @@ import { Subject } from "@itwin/core-backend";
 import { IModel } from "@itwin/core-common";
 import { IModelConnection } from "@itwin/core-frontend";
 import { createIModelHierarchyProvider, createNodesQueryClauseFactory, HierarchyDefinition, NodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
-import { createBisInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
+import { createBisInstanceLabelSelectClauseFactory, Props } from "@itwin/presentation-shared";
 import { buildIModel, importSchema, withECDb } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
@@ -16,9 +16,7 @@ import { createIModelAccess, createProvider } from "../Utils.js";
 
 describe("Hierarchies", () => {
   describe("Properties grouping", () => {
-    type ECSqlSelectClausePropertiesGroupingParams = NonNullable<
-      NonNullable<Parameters<NodesQueryClauseFactory["createSelectClause"]>[0]["grouping"]>["byProperties"]
-    >;
+    type ECSqlSelectClausePropertiesGroupingParams = NonNullable<NonNullable<Props<NodesQueryClauseFactory["createSelectClause"]>["grouping"]>["byProperties"]>;
     let subjectClassName: string;
     let emptyIModel: IModelConnection;
 

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/ReadmeExample.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/ReadmeExample.test.ts
@@ -15,7 +15,7 @@ import { SchemaContext } from "@itwin/ecschema-metadata";
 import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
 import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
+import { createCachingECClassHierarchyInspector, Props } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
 
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.ReadmeExampleImports
@@ -66,7 +66,7 @@ function createIModelAccess(imodel: IModelConnection) {
 // __PUBLISH_EXTRACT_END__
 
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.ReadmeExample
-function createProvider(imodelAccess: Parameters<typeof createIModelHierarchyProvider>[0]["imodelAccess"]): HierarchyProvider {
+function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider>["imodelAccess"]): HierarchyProvider {
   // Create a factory for building labels SELECT query clauses according to BIS conventions
   const labelsQueryFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
 

--- a/apps/full-stack-tests/src/unified-selection/SelectionScope.test.ts
+++ b/apps/full-stack-tests/src/unified-selection/SelectionScope.test.ts
@@ -21,6 +21,7 @@ import { IModelConnection } from "@itwin/core-frontend";
 import { ECSchemaRpcInterface } from "@itwin/ecschema-rpcinterface-common";
 import { ECSchemaRpcImpl } from "@itwin/ecschema-rpcinterface-impl";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+import { Props } from "@itwin/presentation-shared";
 import { buildTestIModel, initialize, terminate } from "@itwin/presentation-testing";
 import { computeSelection, SelectableInstanceKey } from "@itwin/unified-selection";
 
@@ -47,7 +48,7 @@ describe("SelectionScope", () => {
     return fs.readFileSync(schemaFile, "utf8");
   }
 
-  async function getSelection(keys: string[], scope: Parameters<typeof computeSelection>[0]["scope"]): Promise<SelectableInstanceKey[]> {
+  async function getSelection(keys: string[], scope: Props<typeof computeSelection>["scope"]): Promise<SelectableInstanceKey[]> {
     const selectables: SelectableInstanceKey[] = [];
     for await (const selectable of computeSelection({ queryExecutor: createECSqlQueryExecutor(iModel), elementIds: keys, scope })) {
       selectables.push(selectable);

--- a/apps/performance-tests/src/hierarchies/RunHierarchyTest.ts
+++ b/apps/performance-tests/src/hierarchies/RunHierarchyTest.ts
@@ -3,10 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { expect } from "chai";
 import { PhysicalElement, SnapshotDb } from "@itwin/core-backend";
 import { createNodesQueryClauseFactory, DefineHierarchyLevelProps, NodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
-import { createBisInstanceLabelSelectClauseFactory, ECClassHierarchyInspector, ECSchemaProvider } from "@itwin/presentation-shared";
-import { expect } from "chai";
+import { createBisInstanceLabelSelectClauseFactory, ECClassHierarchyInspector, ECSchemaProvider, Props } from "@itwin/presentation-shared";
 import { Datasets, IModelName } from "../util/Datasets";
 import { run, RunOptions } from "../util/TestUtilities";
 import { StatelessHierarchyProvider } from "./StatelessHierarchyProvider";
@@ -20,7 +20,7 @@ export function runHierarchyTest(
   testProps: {
     iModelName: IModelName;
     fullClassName?: string;
-    nodeSelectProps?: Partial<Parameters<NodesQueryClauseFactory["createSelectClause"]>[0]>;
+    nodeSelectProps?: Partial<Props<NodesQueryClauseFactory["createSelectClause"]>>;
     expectedNodeCount?: number;
   } & Omit<RunOptions<never>, "setup" | "test" | "cleanup">,
 ) {

--- a/apps/performance-tests/src/unified-selection/SelectionScope.test.ts
+++ b/apps/performance-tests/src/unified-selection/SelectionScope.test.ts
@@ -6,6 +6,7 @@
 import { expect } from "chai";
 import { SnapshotDb } from "@itwin/core-backend";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+import { Props } from "@itwin/presentation-shared";
 import { computeSelection } from "@itwin/unified-selection";
 import { Datasets, IModelName } from "../util/Datasets";
 import { run, RunOptions } from "../util/TestUtilities";
@@ -119,7 +120,7 @@ function runSelectionScopeTest(
   testProps: {
     iModelName: IModelName;
     inputQuery: string;
-    scope: Parameters<typeof computeSelection>[0]["scope"];
+    scope: Props<typeof computeSelection>["scope"];
     expectedCounts?: { className: string; count: number }[];
   } & Omit<RunOptions<never>, "setup" | "test" | "cleanup">,
 ) {

--- a/apps/test-app/frontend/src/components/tree-widget/MultiDataSourceTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/MultiDataSourceTree.tsx
@@ -35,12 +35,13 @@ import {
   IInstanceLabelSelectClauseFactory,
   InstanceKey,
   IPrimitiveValueFormatter,
+  Props,
 } from "@itwin/presentation-shared";
 import { SampleRpcInterface } from "@test-app/common";
 import { MyAppFrontend } from "../../api/MyAppFrontend";
 
-type UseTreeProps = Parameters<typeof useUnifiedSelectionTree>[0];
-type IModelAccess = Parameters<typeof createIModelHierarchyProvider>[0]["imodelAccess"];
+type UseTreeProps = Props<typeof useUnifiedSelectionTree>;
+type IModelAccess = Props<typeof createIModelHierarchyProvider>["imodelAccess"];
 
 export function MultiDataSourceTree({ imodel, ...props }: { imodel: IModelConnection; height: number; width: number }) {
   const [imodelAccess, setIModelAccess] = useState<IModelAccess>();

--- a/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
@@ -21,10 +21,10 @@ import { Presentation } from "@itwin/presentation-frontend";
 import { createLimitingECSqlQueryExecutor, GenericInstanceFilter } from "@itwin/presentation-hierarchies";
 import { HierarchyLevelDetails, PresentationHierarchyNode, TreeRenderer, useIModelUnifiedSelectionTree } from "@itwin/presentation-hierarchies-react";
 import { ModelsTreeDefinition } from "@itwin/presentation-models-tree";
-import { createCachingECClassHierarchyInspector, IPrimitiveValueFormatter } from "@itwin/presentation-shared";
+import { createCachingECClassHierarchyInspector, IPrimitiveValueFormatter, Props } from "@itwin/presentation-shared";
 import { MyAppFrontend } from "../../api/MyAppFrontend";
 
-type UseIModelTreeProps = Parameters<typeof useIModelUnifiedSelectionTree>[0];
+type UseIModelTreeProps = Props<typeof useIModelUnifiedSelectionTree>;
 type IModelAccess = UseIModelTreeProps["imodelAccess"];
 
 export function StatelessTreeV2({ imodel, ...props }: { imodel: IModelConnection; height: number; width: number }) {

--- a/apps/test-app/frontend/src/index.tsx
+++ b/apps/test-app/frontend/src/index.tsx
@@ -12,6 +12,8 @@ import { BentleyCloudRpcManager } from "@itwin/core-common";
 import { ElectronApp } from "@itwin/core-electron/lib/cjs/ElectronFrontend";
 import { IModelApp, IModelAppOptions, IModelConnection } from "@itwin/core-frontend";
 import { ITwinLocalization } from "@itwin/core-i18n";
+// Need this because of https://github.com/microsoft/TypeScript/issues/60556
+import "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_START__ Presentation.Frontend.Imports
 import { createFavoritePropertiesStorage, DefaultFavoritePropertiesStorageTypes, Presentation } from "@itwin/presentation-frontend";
 // __PUBLISH_EXTRACT_END__

--- a/packages/hierarchies-react/README.md
+++ b/packages/hierarchies-react/README.md
@@ -221,7 +221,7 @@ import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shar
 import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor, createNodesQueryClauseFactory, HierarchyDefinition } from "@itwin/presentation-hierarchies";
 
-import { createBisInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
+import { createBisInstanceLabelSelectClauseFactory, Props } from "@itwin/presentation-shared";
 
 import { TreeRenderer, UnifiedSelectionProvider, useIModelUnifiedSelectionTree } from "@itwin/presentation-hierarchies-react";
 import { createStorage } from "@itwin/unified-selection";
@@ -277,7 +277,7 @@ function MyTreeComponent({ imodel }: { imodel: IModelConnection }) {
   );
 }
 
-type IModelAccess = Parameters<typeof useIModelUnifiedSelectionTree>[0]["imodelAccess"];
+type IModelAccess = Props<typeof useIModelUnifiedSelectionTree>["imodelAccess"];
 
 // The hierarchy definition describes the hierarchy using ECSQL queries; here it just returns all `BisCore.PhysicalModel` instances
 function getHierarchyDefinition({ imodelAccess }: { imodelAccess: IModelAccess }): HierarchyDefinition {
@@ -333,13 +333,15 @@ Localization can be enabled for `TreeRenderer` component and [tree state hooks](
 
 Example:
 
-<!-- [[include: [Presentation.HierarchiesReact.Localization.Tree.Imports, Presentation.HierarchiesReact.Localization.Strings, Presentation.HierarchiesReact.Localization.Tree], tsx]] -->
+<!-- [[include: [Presentation.HierarchiesReact.Localization.CommonImports, Presentation.HierarchiesReact.Localization.Tree.Imports, Presentation.HierarchiesReact.Localization.Strings, Presentation.HierarchiesReact.Localization.Tree], tsx]] -->
 <!-- BEGIN EXTRACTION -->
 
 ```tsx
+import { Props } from "@itwin/presentation-shared";
+
 import { useIModelUnifiedSelectionTree } from "@itwin/presentation-hierarchies-react";
 
-type IModelAccess = Parameters<typeof useIModelUnifiedSelectionTree>[0]["imodelAccess"];
+type IModelAccess = Props<typeof useIModelUnifiedSelectionTree>["imodelAccess"];
 
 const localizedStrings = {
   // strings for the `useIModelUnifiedSelectionTree` hook
@@ -375,10 +377,14 @@ function MyTreeComponent({ imodelAccess }: { imodelAccess: IModelAccess }) {
 
 In case the `TreeNodeRenderer` component is used within a custom tree renderer, the tree component should supply localized strings through `LocalizationContextProvider`:
 
-<!-- [[include: [Presentation.HierarchiesReact.Localization.TreeRenderer.Imports, Presentation.HierarchiesReact.Localization.TreeRenderer], tsx]] -->
+<!-- [[include: [Presentation.HierarchiesReact.Localization.CommonImports, Presentation.HierarchiesReact.Localization.TreeRenderer.Imports, Presentation.HierarchiesReact.Localization.TreeRenderer], tsx]] -->
 <!-- BEGIN EXTRACTION -->
 
 ```tsx
+import { Props } from "@itwin/presentation-shared";
+
+import { ComponentPropsWithoutRef, useCallback } from "react";
+import { Tree } from "@itwin/itwinui-react";
 import {
   createRenderedTreeNodeData,
   LocalizationContextProvider,
@@ -388,7 +394,7 @@ import {
 } from "@itwin/presentation-hierarchies-react";
 
 type TreeProps = ComponentPropsWithoutRef<typeof Tree<RenderedTreeNode>>;
-type TreeRendererProps = Parameters<typeof TreeRenderer>[0];
+type TreeRendererProps = Props<typeof TreeRenderer>;
 
 function MyTreeRenderer(props: TreeRendererProps) {
   const nodeRenderer = useCallback<TreeProps["nodeRenderer"]>((nodeProps) => {

--- a/packages/hierarchies-react/README.md
+++ b/packages/hierarchies-react/README.md
@@ -113,7 +113,7 @@ The hook also relies on unified selection storage being provided to it through a
 
 #### Providing unified selection context
 
-The flavor of tree state hooks, that support unified selection integration, relies on unified selection storage being provided to it through a React context. For that, the package delivers the `UnifiedSelectionProvider` component, that should wrap the tree component, using the `useUnifiedSelectionTree` hook:
+Tree state hooks that support unified selection integration (`useUnifiedSelectionTree` & `useIModelUnifiedSelectionTree`), rely on unified selection storage being provided to them through a React context. For that, the package delivers the `UnifiedSelectionProvider` component, that should wrap the tree component using the hooks:
 
 <!-- [[include: [Presentation.HierarchiesReact.SelectionStorage.Imports, Presentation.HierarchiesReact.SelectionStorage], tsx]] -->
 <!-- BEGIN EXTRACTION -->

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -16,6 +16,7 @@ import { IPrimitiveValueFormatter } from '@itwin/presentation-shared';
 import { JSX as JSX_2 } from 'react/jsx-runtime';
 import { JSX as JSX_3 } from 'react/jsx-runtime.js';
 import { NodeData } from '@itwin/itwinui-react';
+import { Props } from '@itwin/presentation-shared';
 import { PropsWithChildren } from 'react';
 import { ReactElement } from 'react';
 import { RefAttributes } from 'react';
@@ -49,7 +50,7 @@ export { HierarchyProvider }
 type IModelAccess = IModelHierarchyProviderProps["imodelAccess"];
 
 // @public (undocumented)
-type IModelHierarchyProviderProps = Parameters<typeof createIModelHierarchyProvider>[0];
+type IModelHierarchyProviderProps = Props<typeof createIModelHierarchyProvider>;
 
 // @public
 export function isPresentationHierarchyNode(node: PresentationTreeNode): node is PresentationHierarchyNode;

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseIModelTree.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseIModelTree.ts
@@ -5,11 +5,12 @@
 
 import { useCallback } from "react";
 import { createIModelHierarchyProvider, HierarchyDefinition, HierarchyFilteringPath } from "@itwin/presentation-hierarchies";
+import { Props } from "@itwin/presentation-shared";
 import { UseUnifiedTreeSelectionProps } from "./internal/UseUnifiedSelection.js";
 import { useTree, UseTreeProps, UseTreeResult, useUnifiedSelectionTree } from "./UseTree.js";
 
 /** @public */
-type IModelHierarchyProviderProps = Parameters<typeof createIModelHierarchyProvider>[0];
+type IModelHierarchyProviderProps = Props<typeof createIModelHierarchyProvider>;
 
 /** @public */
 type IModelAccess = IModelHierarchyProviderProps["imodelAccess"];

--- a/packages/hierarchies-react/src/test/UseIModelTree.test.tsx
+++ b/packages/hierarchies-react/src/test/UseIModelTree.test.tsx
@@ -7,19 +7,19 @@ import { expect } from "chai";
 import { createAsyncIterator } from "presentation-test-utilities";
 import sinon from "sinon";
 import * as td from "testdouble";
-import { BeEvent } from "@itwin/core-bentley";
 import * as presentationHierarchiesModule from "@itwin/presentation-hierarchies";
+import { Props } from "@itwin/presentation-shared";
 import {
   useIModelTree as originalUseIModelTree,
   useIModelUnifiedSelectionTree as originalUseIModelUnifiedSelectionTree,
 } from "../presentation-hierarchies-react/UseIModelTree.js";
-import { createStub, renderHook, waitFor } from "./TestUtils.js";
+import { createHierarchyProviderStub, renderHook, waitFor } from "./TestUtils.js";
 
 // this is needed for mocking external module (see `td.replaceEsm` in `stubIModelHierarchyProviderFactory`)
 const presentationHierarchiesPath = import.meta.resolve("@itwin/presentation-hierarchies");
 
 describe("useIModelTree", () => {
-  type UseIModelTreeProps = Parameters<typeof originalUseIModelTree>[0];
+  type UseIModelTreeProps = Props<typeof originalUseIModelTree>;
   const hierarchyDefinition = {} as presentationHierarchiesModule.HierarchyDefinition;
   const initialProps: UseIModelTreeProps = {
     imodelAccess: {} as UseIModelTreeProps["imodelAccess"],
@@ -47,7 +47,7 @@ describe("useIModelTree", () => {
       expect(result.current.isLoading).to.be.false;
     });
     expect(stubs.createIModelHierarchyProvider).to.be.calledWith(
-      sinon.match((props: Parameters<typeof stubs.createIModelHierarchyProvider>[0]) => {
+      sinon.match((props: Props<typeof stubs.createIModelHierarchyProvider>) => {
         return (
           props.imodelAccess === initialProps.imodelAccess &&
           props.hierarchyDefinition === hierarchyDefinition &&
@@ -69,7 +69,7 @@ describe("useIModelTree", () => {
 });
 
 describe("useIModelUnifiedSelectionTree", () => {
-  type UseIModelTreeProps = Parameters<typeof useIModelUnifiedSelectionTree>[0];
+  type UseIModelTreeProps = Props<typeof useIModelUnifiedSelectionTree>;
   const hierarchyDefinition = {} as presentationHierarchiesModule.HierarchyDefinition;
   const initialProps: UseIModelTreeProps = {
     imodelAccess: {} as UseIModelTreeProps["imodelAccess"],
@@ -98,7 +98,7 @@ describe("useIModelUnifiedSelectionTree", () => {
       expect(result.current.isLoading).to.be.false;
     });
     expect(stubs.createIModelHierarchyProvider).to.be.calledWith(
-      sinon.match((props: Parameters<typeof stubs.createIModelHierarchyProvider>[0]) => {
+      sinon.match((props: Props<typeof stubs.createIModelHierarchyProvider>) => {
         return (
           props.imodelAccess === initialProps.imodelAccess &&
           props.hierarchyDefinition === hierarchyDefinition &&
@@ -120,14 +120,7 @@ describe("useIModelUnifiedSelectionTree", () => {
 });
 
 async function stubIModelHierarchyProviderFactory() {
-  const hierarchyProvider = {
-    hierarchyChanged: new BeEvent(),
-    getNodes: createStub<presentationHierarchiesModule.HierarchyProvider["getNodes"]>(),
-    getNodeInstanceKeys: createStub<presentationHierarchiesModule.HierarchyProvider["getNodeInstanceKeys"]>(),
-    setFormatter: createStub<presentationHierarchiesModule.HierarchyProvider["setFormatter"]>(),
-    setHierarchyFilter: createStub<presentationHierarchiesModule.HierarchyProvider["setHierarchyFilter"]>(),
-    dispose: createStub<() => void>(),
-  };
+  const hierarchyProvider = createHierarchyProviderStub();
   const factory = sinon.fake<Parameters<typeof presentationHierarchiesModule.createIModelHierarchyProvider>, typeof hierarchyProvider>(() => {
     return hierarchyProvider;
   });

--- a/packages/hierarchies/README.md
+++ b/packages/hierarchies/README.md
@@ -78,7 +78,7 @@ import { SchemaContext } from "@itwin/ecschema-metadata";
 import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
 import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
+import { createCachingECClassHierarchyInspector, Props } from "@itwin/presentation-shared";
 
 import {
   createIModelHierarchyProvider,
@@ -120,7 +120,7 @@ function createIModelAccess(imodel: IModelConnection) {
   };
 }
 
-function createProvider(imodelAccess: Parameters<typeof createIModelHierarchyProvider>[0]["imodelAccess"]): HierarchyProvider {
+function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider>["imodelAccess"]): HierarchyProvider {
   // Create a factory for building labels SELECT query clauses according to BIS conventions
   const labelsQueryFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
 

--- a/packages/hierarchies/api/presentation-hierarchies.api.md
+++ b/packages/hierarchies/api/presentation-hierarchies.api.md
@@ -19,6 +19,7 @@ import { InstanceKey } from '@itwin/presentation-shared';
 import { IPrimitiveValueFormatter } from '@itwin/presentation-shared';
 import { OmitOverUnion } from '@itwin/presentation-shared';
 import { PrimitiveValue } from '@itwin/presentation-shared';
+import { Props } from '@itwin/presentation-shared';
 
 // @public
 interface BaseHierarchyNode {
@@ -224,6 +225,16 @@ export interface GroupingHierarchyNode extends BaseHierarchyNode {
 
 // @public
 export type GroupingNodeKey = ClassGroupingNodeKey | LabelGroupingNodeKey | PropertyGroupingNodeKey;
+
+// @public
+interface HierarchyChangedEventArgs {
+    filterChange?: {
+        newFilter: Props<HierarchyProvider["setHierarchyFilter"]>;
+    };
+    formatterChange?: {
+        newFormatter: IPrimitiveValueFormatter | undefined;
+    };
+}
 
 // @public
 export interface HierarchyDefinition {
@@ -462,7 +473,7 @@ export namespace HierarchyNodesDefinition {
 export interface HierarchyProvider {
     getNodeInstanceKeys(props: Omit<GetHierarchyNodesProps, "ignoreCache">): AsyncIterableIterator<InstanceKey>;
     getNodes(props: GetHierarchyNodesProps): AsyncIterableIterator<HierarchyNode>;
-    readonly hierarchyChanged: Event_2<() => void>;
+    readonly hierarchyChanged: Event_2<(args?: HierarchyChangedEventArgs) => void>;
     setFormatter(formatter: IPrimitiveValueFormatter | undefined): void;
     setHierarchyFilter(props: {
         paths: HierarchyFilteringPath[];

--- a/packages/hierarchies/learning/HierarchyFiltering.md
+++ b/packages/hierarchies/learning/HierarchyFiltering.md
@@ -35,9 +35,15 @@ The end result would be:
 
 The process of filtering a hierarchy has two major steps:
 
-1. Determine node identifier paths for the target nodes. While some hierarchy providers may be able to create these paths automatically, the implementations delivered with this library leave this responsibility to the consumers. This decouples hierarchy filtering logic from the type of filtering being done - the paths could be created based on a variety of ways, such as a filter string or a target instance ID, to name a few.
+1. Determine node identifier paths for the target nodes. While some hierarchy providers may be able to create these paths automatically, the implementations delivered with this library leave this responsibility to the consumers.
+2. Given the node identifier paths, the hierarchy provider has the responsibility to filter the hierarchy by implementing the `HierarchyProvider.setHierarchyFilter` method and making sure the given filter is accounted for, when `getNodes` is called. The given paths are used to filter root nodes and each returned node is assigned a `filtering` flag, containing identifier paths for its child nodes.
 
-2. Given the node identifier paths, the hierarchy provider has the responsibility to filter the hierarchy by implementing the `HierarchyProvider.setHierarchyFilter` method and making sure the given filter is accounted for. The given paths are used to filter root nodes and each returned node is assigned a `filtering` flag, containing identifier paths for its child nodes.
+The reasoning for having these two steps separate is twofold:
+
+- It decouples creation of the filtered hierarchy from the type of filtering being done - the paths could be created based on a variety of ways, such as a filter string or a target instance ID, to name a few. And building the filtered hierarchy doesn't depend on the way the paths are created.
+- Hierarchies' filtering is specific in a way that, generally, each hierarchy level has to be queried independently, and target nodes may be located somewhere deep in the hierarchy. Taking the hierarchy defined at the top of this document, for C target node we need to include its ancestors B and A when building their hierarchy levels, even though they aren't our filter targets. So the most efficient way to do that is to first find the filter targets, and then rebuild the paths in a bottom-up manner.
+
+See [Implementing hierarchy filtering support](./CustomHierarchyProviders.md#implementing-hierarchy-filtering-support) for more information on how to implement hierarchy filtering in a custom hierarchy provider.
 
 ## Handling automatic expansion of nodes
 

--- a/packages/hierarchies/learning/imodel/HierarchyProvider.md
+++ b/packages/hierarchies/learning/imodel/HierarchyProvider.md
@@ -22,7 +22,7 @@ import { SchemaContext } from "@itwin/ecschema-metadata";
 import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
 import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
+import { createCachingECClassHierarchyInspector, Props } from "@itwin/presentation-shared";
 
 // Not really part of the package, but we need SchemaContext to create a hierarchy provider. It's
 // recommended to cache the schema context and reuse it across different application's components to

--- a/packages/hierarchies/src/hierarchies/imodel/NodeSelectQueryFactory.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/NodeSelectQueryFactory.ts
@@ -22,6 +22,7 @@ import {
   IInstanceLabelSelectClauseFactory,
   parseFullClassName,
   PrimitiveValue,
+  Props,
 } from "@itwin/presentation-shared";
 import { HierarchyNodeAutoExpandProp } from "./IModelHierarchyNode.js";
 
@@ -737,7 +738,7 @@ function getECSqlComparisonOperator(op: Exclude<GenericInstanceFilterRuleOperato
   }
 }
 
-type JoinRelationshipPath = Parameters<typeof ECSql.createRelationshipPathJoinClause>[0]["path"];
+type JoinRelationshipPath = Props<typeof ECSql.createRelationshipPathJoinClause>["path"];
 function assignRelationshipPathAliases(
   path: GenericInstanceFilterRelationshipStep[],
   pathIndex: number,

--- a/packages/hierarchies/src/test/HierarchyProvider.test.ts
+++ b/packages/hierarchies/src/test/HierarchyProvider.test.ts
@@ -7,7 +7,7 @@ import { expect } from "chai";
 import { collect, createAsyncIterator } from "presentation-test-utilities";
 import sinon from "sinon";
 import { BeEvent } from "@itwin/core-bentley";
-import { InstanceKey } from "@itwin/presentation-shared";
+import { InstanceKey, Props } from "@itwin/presentation-shared";
 import { HierarchyNode, NonGroupingHierarchyNode } from "../hierarchies/HierarchyNode.js";
 import { HierarchyProvider, mergeProviders } from "../hierarchies/HierarchyProvider.js";
 import { createTestGenericNode, createTestGenericNodeKey } from "./Utils.js";
@@ -136,8 +136,8 @@ describe("mergeProviders", () => {
 });
 
 function createTestProvider(props?: {
-  nodes?: (props: Parameters<HierarchyProvider["getNodes"]>[0]) => Partial<NonGroupingHierarchyNode>[];
-  instanceKeys?: (props: Parameters<HierarchyProvider["getNodeInstanceKeys"]>[0]) => InstanceKey[];
+  nodes?: (props: Props<HierarchyProvider["getNodes"]>) => Partial<NonGroupingHierarchyNode>[];
+  instanceKeys?: (props: Props<HierarchyProvider["getNodeInstanceKeys"]>) => InstanceKey[];
   disposable?: boolean;
 }) {
   return {

--- a/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
+++ b/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { defer, from, map, merge, mergeAll, mergeMap, Observable, ObservableInput } from "rxjs";
 import { Id64Array, Id64String } from "@itwin/core-bentley";
 import {
   ClassGroupingNodeKey,
@@ -33,8 +34,8 @@ import {
   ECSqlQueryRow,
   IInstanceLabelSelectClauseFactory,
   InstanceKey,
+  Props,
 } from "@itwin/presentation-shared";
-import { defer, from, map, merge, mergeAll, mergeMap, Observable, ObservableInput } from "rxjs";
 import { ModelsTreeIdsCache } from "./ModelsTreeIdsCache.js";
 
 /** @beta */
@@ -99,7 +100,7 @@ interface ModelsTreeInstanceKeyPathsFromInstanceLabelProps {
 }
 
 export type ModelsTreeInstanceKeyPathsProps = ModelsTreeInstanceKeyPathsFromTargetItemsProps | ModelsTreeInstanceKeyPathsFromInstanceLabelProps;
-type HierarchyProviderProps = Parameters<typeof createIModelHierarchyProvider>[0];
+type HierarchyProviderProps = Props<typeof createIModelHierarchyProvider>;
 type HierarchyFilteringPaths = NonNullable<NonNullable<HierarchyProviderProps["filtering"]>["paths"]>;
 type HierarchyFilteringPath = HierarchyFilteringPaths[number];
 

--- a/packages/shared/api/presentation-shared.api.md
+++ b/packages/shared/api/presentation-shared.api.md
@@ -360,6 +360,13 @@ interface Event_2<TListener extends (...args: any[]) => void = () => void> {
 export { Event_2 as Event }
 
 // @public
+export type EventArgs<TEvent extends Event_2> = Props<EventListener_2<TEvent>>;
+
+// @public
+type EventListener_2<TEvent extends Event_2> = TEvent extends Event_2<infer TListener> ? TListener : never;
+export { EventListener_2 as EventListener }
+
+// @public
 export function formatConcatenatedValue(props: {
     value: ConcatenatedValue | string;
     valueFormatter: IPrimitiveValueFormatter;
@@ -473,6 +480,9 @@ export namespace PrimitiveValue {
 
 // @public
 type PrimitiveValueType = "Id" | Exclude<EC.PrimitiveType, "Binary" | "IGeometry">;
+
+// @public
+export type Props<TFunc extends (...args: any[]) => any> = Parameters<TFunc>[0];
 
 // @public
 type RelationshipPath<TStep extends RelationshipPathStep = RelationshipPathStep> = TStep[];

--- a/packages/shared/api/presentation-shared.exports.csv
+++ b/packages/shared/api/presentation-shared.exports.csv
@@ -19,6 +19,7 @@ public;interface;ECSqlQueryDef
 public;interface;ECSqlQueryExecutor
 public;interface;ECSqlQueryReaderOptions
 public;interface;ECSqlQueryRow
+public;type;EventArgs
 public;function;formatConcatenatedValue
 public;function;getClass
 public;interface;IInstanceLabelSelectClauseFactory
@@ -36,6 +37,7 @@ public;function;parseFullClassName
 public;function;parseInstanceLabel
 public;type;PrimitiveValue
 public;namespace;PrimitiveValue
+public;type;Props
 public;function;releaseMainThread
 public;function;trimWhitespace
 public;function;trimWhitespace

--- a/packages/shared/src/presentation-shared.ts
+++ b/packages/shared/src/presentation-shared.ts
@@ -18,7 +18,7 @@ export {
   parseInstanceLabel,
 } from "./shared/InstanceLabelSelectClauseFactory.js";
 export { ILogger, NOOP_LOGGER, LogFunction, LogLevel } from "./shared/Logging.js";
-export { ArrayElement, OmitOverUnion } from "./shared/MappedTypes.js";
+export { ArrayElement, EventArgs, EventListener, OmitOverUnion, Props } from "./shared/MappedTypes.js";
 export { createCachingECClassHierarchyInspector, EC, getClass, ECClassHierarchyInspector, ECSchemaProvider } from "./shared/Metadata.js";
 export {
   createMainThreadReleaseOnTimePassedHandler,

--- a/packages/shared/src/shared/MappedTypes.ts
+++ b/packages/shared/src/shared/MappedTypes.ts
@@ -3,6 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { Event } from "./Event.js";
+
 /**
  * An utility `Omit` type which works with union types.
  * @public
@@ -14,3 +16,21 @@ export type OmitOverUnion<T, K extends PropertyKey> = T extends T ? Omit<T, K> :
  * @public
  */
 export type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
+
+/**
+ * Returns type of the first `TFunc` parameter.
+ * @public
+ */
+export type Props<TFunc extends (...args: any[]) => any> = Parameters<TFunc>[0];
+
+/**
+ * Returns type of the given `Event` listener.
+ * @public
+ */
+export type EventListener<TEvent extends Event> = TEvent extends Event<infer TListener> ? TListener : never;
+
+/**
+ * Returns type of the given `Event` arguments.
+ * @public
+ */
+export type EventArgs<TEvent extends Event> = Props<EventListener<TEvent>>;


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/709.

Ended up improving the APIs, their docs and existing examples rather than adding new ones. I think hierarchy updates are fairly well covered in these sections of the "Custom hierarchy providers" learning page:
- "iModel-based hierarchy provider example" section shows how to "glue" iModel's txn changes with the `hierarchyChanged` event.
- "Implementing node label formatting support" section shows that `hierarchyChanged` needs to be raised upon formatter change.
- "Implementing hierarchy filtering support" section shows that `hierarchyChanged` needs to be raised upon setting a hierarchy filter.