### PR TITLE
Itiwnui-react upgrade

### DIFF
--- a/.changeset/neat-carpets-melt.md
+++ b/.changeset/neat-carpets-melt.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Add missing `ref` to the placeholder and error nodes to have correct styling in virtualized small tree.

--- a/.changeset/thick-books-itch.md
+++ b/.changeset/thick-books-itch.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Do not clear filter in `UniqueValuesSelector` when value is selected.

--- a/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
@@ -150,16 +150,16 @@ function Tree({ imodel, imodelAccess, height, width }: { imodel: IModelConnectio
     }
 
     return (
-      <Flex.Item alignSelf="flex-start" style={{ width: "100%", overflow: "auto" }}>
-        <TreeRenderer
-          rootNodes={rootNodes ?? []}
-          {...treeProps}
-          reloadTree={reloadTree}
-          onFilterClick={setFilteringOptions}
-          getIcon={getIcon}
-          selectionMode={"extended"}
-        />
-      </Flex.Item>
+      <TreeRenderer
+        {...treeProps}
+        rootNodes={rootNodes ?? []}
+        reloadTree={reloadTree}
+        onFilterClick={setFilteringOptions}
+        getIcon={getIcon}
+        selectionMode={"extended"}
+        size="small"
+        style={{ height: "100%", width: "100%" }}
+      />
     );
   };
 

--- a/packages/components/src/presentation-components/properties/inputs/UniquePropertyValuesSelector.tsx
+++ b/packages/components/src/presentation-components/properties/inputs/UniquePropertyValuesSelector.tsx
@@ -96,12 +96,14 @@ export function UniquePropertyValuesSelector(props: UniquePropertyValuesSelector
       }}
       emptyStateMessage={emptyContent}
       value={selectedValues}
+      clearFilterOnOptionToggle={false}
       inputProps={{
         placeholder: translate("unique-values-property-editor.select-values"),
         size: "small",
         value: searchInput,
         onChange: (e) => setSearchInput(e.target.value),
       }}
+      onHide={() => setSearchInput("")}
     />
   );
 }

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -77,7 +77,7 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
     const nodeRef = useRef<HTMLDivElement>(null);
     const ref = useMergedRefs(forwardedRef, nodeRef);
     if ("type" in node && node.type === "ChildrenPlaceholder") {
-      return <PlaceholderNode {...treeNodeProps} />;
+      return <PlaceholderNode {...treeNodeProps} ref={ref} />;
     }
 
     if (isPresentationHierarchyNode(node)) {
@@ -143,6 +143,7 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
       return (
         <ResultSetTooLargeNode
           {...treeNodeProps}
+          ref={ref}
           limit={node.resultSetSizeLimit}
           onOverrideLimit={getHierarchyLevelDetails ? (limit) => getHierarchyLevelDetails(node.parentNodeId)?.setSizeLimit(limit) : undefined}
           onFilterClick={

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,8 +118,8 @@ catalogs:
       specifier: ^2.1.0
       version: 2.1.0
     '@itwin/itwinui-react':
-      specifier: ^3.15.5
-      version: 3.15.5
+      specifier: ^3.16.0
+      version: 3.16.0
   react:
     '@types/react':
       specifier: ^18.3.3
@@ -345,7 +345,7 @@ importers:
         version: 4.17.5(m4fjunlvgtc3a3ttswq43eb6wi)
       '@itwin/itwinui-react':
         specifier: catalog:itwinui
-        version: 3.15.5(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.16.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/presentation-backend':
         specifier: catalog:itwinjs-core
         version: 4.10.1(@itwin/core-backend@4.10.1(@itwin/core-bentley@4.10.1)(@itwin/core-common@4.10.1(@itwin/core-bentley@4.10.1)(@itwin/core-geometry@4.10.1))(@itwin/core-geometry@4.10.1)(@opentelemetry/api@1.9.0))(@itwin/core-bentley@4.10.1)(@itwin/core-common@4.10.1(@itwin/core-bentley@4.10.1)(@itwin/core-geometry@4.10.1))(@itwin/core-quantity@4.10.1(@itwin/core-bentley@4.10.1))(@itwin/ecschema-metadata@4.10.1(@itwin/core-bentley@4.10.1)(@itwin/core-quantity@4.10.1(@itwin/core-bentley@4.10.1)))(@itwin/presentation-common@4.10.1(@itwin/core-bentley@4.10.1)(@itwin/core-common@4.10.1(@itwin/core-bentley@4.10.1)(@itwin/core-geometry@4.10.1))(@itwin/core-quantity@4.10.1(@itwin/core-bentley@4.10.1))(@itwin/ecschema-metadata@4.10.1(@itwin/core-bentley@4.10.1)(@itwin/core-quantity@4.10.1(@itwin/core-bentley@4.10.1))))
@@ -928,7 +928,7 @@ importers:
         version: 2.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-react':
         specifier: catalog:itwinui
-        version: 3.15.5(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.16.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/presentation-common':
         specifier: catalog:itwinjs-core
         version: 4.10.1(@itwin/core-bentley@4.10.1)(@itwin/core-common@4.10.1(@itwin/core-bentley@4.10.1)(@itwin/core-geometry@4.10.1))(@itwin/core-quantity@4.10.1(@itwin/core-bentley@4.10.1))(@itwin/ecschema-metadata@4.10.1(@itwin/core-bentley@4.10.1)(@itwin/core-quantity@4.10.1(@itwin/core-bentley@4.10.1)))
@@ -1115,7 +1115,7 @@ importers:
         version: 4.17.5(m4fjunlvgtc3a3ttswq43eb6wi)
       '@itwin/itwinui-react':
         specifier: catalog:itwinui
-        version: 3.15.5(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.16.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/presentation-common':
         specifier: catalog:itwinjs-core
         version: 4.10.1(@itwin/core-bentley@4.10.1)(@itwin/core-common@4.10.1(@itwin/core-bentley@4.10.1)(@itwin/core-geometry@4.10.1))(@itwin/core-quantity@4.10.1(@itwin/core-bentley@4.10.1))(@itwin/ecschema-metadata@4.10.1(@itwin/core-bentley@4.10.1)(@itwin/core-quantity@4.10.1(@itwin/core-bentley@4.10.1)))
@@ -1445,7 +1445,7 @@ importers:
         version: 4.10.1(@types/node@20.12.12)
       '@itwin/itwinui-react':
         specifier: catalog:itwinui
-        version: 3.15.5(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.16.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/dom':
         specifier: catalog:test-tools
         version: 10.3.2
@@ -2898,8 +2898,8 @@ packages:
       react: '>=16.8.6 < 19.0.0'
       react-dom: '>=16.8.6 < 19.0.0'
 
-  '@itwin/itwinui-react@3.15.5':
-    resolution: {integrity: sha512-AqoFWFGwgZUrGzxn1J8Ea/DKOcXUt0haLjZBQ3lPeCmO6tNQow9NrbHWn+B9KiMAENADwgS9ElqTseDrSRksig==}
+  '@itwin/itwinui-react@3.16.0':
+    resolution: {integrity: sha512-mjQ+gpOEI0zOo5iITybvr0XW+72EB5WH9Xnt8Xi4uz51riLM/6wveqmVJgQcMPpWXfODm97uZQmZ0atGwhykNQ==}
     peerDependencies:
       react: '>= 17.0.0 < 19.0.0'
       react-dom: '>=17.0.0 < 19.0.0'
@@ -10464,7 +10464,7 @@ snapshots:
       '@itwin/imodel-components-react': 4.17.5(m4fjunlvgtc3a3ttswq43eb6wi)
       '@itwin/itwinui-icons-react': 2.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@itwin/itwinui-react': 3.15.5(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@itwin/itwinui-react': 3.16.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-react-v2': '@itwin/itwinui-react@2.12.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
       '@itwin/itwinui-variables': 3.3.0
       classnames: 2.3.1
@@ -10516,7 +10516,7 @@ snapshots:
       '@itwin/core-bentley': 4.10.1
       '@itwin/core-react': 4.17.5(@itwin/appui-abstract@4.10.1(@itwin/core-bentley@4.10.1))(@itwin/core-bentley@4.10.1)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-icons-react': 2.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@itwin/itwinui-react': 3.15.5(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@itwin/itwinui-react': 3.16.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-variables': 3.3.0
       classnames: 2.3.1
       immer: 9.0.6
@@ -10630,7 +10630,7 @@ snapshots:
       '@itwin/appui-abstract': 4.10.1(@itwin/core-bentley@4.10.1)
       '@itwin/core-bentley': 4.10.1
       '@itwin/itwinui-icons-react': 2.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@itwin/itwinui-react': 3.15.5(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@itwin/itwinui-react': 3.16.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-variables': 3.3.0
       classnames: 2.3.1
       dompurify: 2.5.7
@@ -10714,7 +10714,7 @@ snapshots:
       '@itwin/core-quantity': 4.10.1(@itwin/core-bentley@4.10.1)
       '@itwin/core-react': 4.17.5(@itwin/appui-abstract@4.10.1(@itwin/core-bentley@4.10.1))(@itwin/core-bentley@4.10.1)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-icons-react': 2.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@itwin/itwinui-react': 3.15.5(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@itwin/itwinui-react': 3.16.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-variables': 3.3.0
       classnames: 2.3.1
       react: 18.3.1
@@ -10745,7 +10745,7 @@ snapshots:
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tippy.js: 6.3.7
 
-  '@itwin/itwinui-react@3.15.5(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@itwin/itwinui-react@3.16.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react': 0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalogs:
   itwinui:
     "@itwin/itwinui-icons-react": "^2.9.0"
     "@itwin/itwinui-illustrations-react": "^2.1.0"
-    "@itwin/itwinui-react": "^3.15.5"
+    "@itwin/itwinui-react": "^3.16.0"
 
   react:
     "classnames": "^2.5.1"


### PR DESCRIPTION
Upgraded itwinui-react to the latest version.
Added missing `ref` props to placeholder and error nodes renderer in `TreeNodeRenderer` from `hierarchies-react`
Updated `UniqueValuesSelector` to not clear filter when value is selected. Added filter cleanup on dropdown menu close to make it consistent with default behavior.