### PR TITLE
`hierarchies-react`: Add `getNode` function to tree state hooks

### DIFF
--- a/.changeset/selfish-toes-promise.md
+++ b/.changeset/selfish-toes-promise.md
@@ -1,0 +1,30 @@
+---
+"@itwin/presentation-hierarchies-react": minor
+---
+
+Added `getNode` function to tree state hooks to allow getting a node by id.
+
+Example usage:
+
+```tsx
+function MyTreeComponentInternal({ imodelAccess }: { imodelAccess: IModelAccess }) {
+  const { rootNodes, getNode, expandNode: doExpandNode, ...state } = useTree({
+    // tree props
+  });
+
+  // enhance the default `expandNode` handler to log the action to console
+  const expandNode = React.useCallback(async (nodeId: string, isExpanded: boolean) => {
+    const node = getNode(nodeId);
+    if (node) {
+      console.log(`${isExpanded ? "Expanding" : "Collapsing"} node: ${node.label}`);
+    }
+    doExpandNode(nodeId, isExpanded);
+  }, [getNode, doExpandNode]);
+
+  // render the tree
+  if (!rootNodes || !rootNodes.length) {
+    return "No data to display";
+  }
+  return <TreeRenderer {...state} rootNodes={rootNodes} />;
+}
+```

--- a/packages/hierarchies-react/README.md
+++ b/packages/hierarchies-react/README.md
@@ -28,6 +28,8 @@ All these hooks return the same state object, which contains properties and func
 
 - `isNodeSelected` and `selectNodes` function to inspect and change tree selection.
 
+- `getNode` function to get node by its id.
+
 - `getHierarchyLevelDetails` function to access details of a specific hierarchy level. The returned object provides access to:
 
   - hierarchy level size limit,

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -261,6 +261,7 @@ interface UseTreeProps {
 interface UseTreeResult {
     expandNode: (nodeId: string, isExpanded: boolean) => void;
     getHierarchyLevelDetails: (nodeId: string | undefined) => HierarchyLevelDetails | undefined;
+    getNode: (nodeId: string) => PresentationHierarchyNode | undefined;
     isLoading: boolean;
     isNodeSelected: (nodeId: string) => boolean;
     reloadTree: (options?: ReloadTreeOptions) => void;

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/internal/UseUnifiedSelection.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/internal/UseUnifiedSelection.ts
@@ -29,8 +29,8 @@ export interface UseUnifiedTreeSelectionProps {
 /** @internal */
 export function useUnifiedTreeSelection({
   sourceName,
-  getNode,
-}: UseUnifiedTreeSelectionProps & { getNode: (nodeId: string) => TreeModelNode | TreeModelRootNode | undefined }): TreeSelectionOptions {
+  getTreeModelNode,
+}: UseUnifiedTreeSelectionProps & { getTreeModelNode: (nodeId: string) => TreeModelNode | TreeModelRootNode | undefined }): TreeSelectionOptions {
   const [options, setOptions] = useState<TreeSelectionOptions>(() => ({
     isNodeSelected: /* c8 ignore next */ () => false,
     selectNodes: /* c8 ignore next */ () => {},
@@ -46,14 +46,14 @@ export function useUnifiedTreeSelection({
       return;
     }
 
-    setOptions(createOptions(sourceName, selectionStorage, getNode));
+    setOptions(createOptions(sourceName, selectionStorage, getTreeModelNode));
     return selectionStorage.selectionChangeEvent.addListener((args) => {
       if (args.level > 0) {
         return;
       }
-      setOptions(createOptions(sourceName, selectionStorage, getNode));
+      setOptions(createOptions(sourceName, selectionStorage, getTreeModelNode));
     });
-  }, [selectionStorage, getNode, sourceName]);
+  }, [selectionStorage, getTreeModelNode, sourceName]);
 
   return options;
 }

--- a/packages/hierarchies-react/src/test/UseTree.test.tsx
+++ b/packages/hierarchies-react/src/test/UseTree.test.tsx
@@ -254,6 +254,35 @@ describe("useTree", () => {
     });
   });
 
+  it("`getNode` returns node when `nodeId` refers to a hierarchy node", async () => {
+    const rootNodes = [createTestHierarchyNode({ id: "root-1" })];
+
+    hierarchyProvider.getNodes.callsFake((props) => {
+      return createAsyncIterator(props.parentNode === undefined ? rootNodes : []);
+    });
+    const { result } = renderHook(useTree, { initialProps });
+
+    await waitFor(() => {
+      expect(result.current.rootNodes).to.have.lengthOf(1);
+      expect(result.current.getNode(createNodeId(rootNodes[0]))).to.containSubset({
+        id: createNodeId(rootNodes[0]),
+        nodeData: rootNodes[0],
+      });
+    });
+  });
+
+  it("`getNode` returns undefined when `nodeId` refers to a non-hierarchy node", async () => {
+    hierarchyProvider.getNodes.callsFake(() => {
+      return throwingAsyncIterator(new hierarchiesModule.RowsLimitExceededError(1));
+    });
+    const { result } = renderHook(useTree, { initialProps });
+
+    await waitFor(() => {
+      expect(result.current.rootNodes).to.have.lengthOf(1);
+      expect(result.current.getNode(result.current.rootNodes![0].id)).to.be.undefined;
+    });
+  });
+
   it("expands node", async () => {
     const rootNodes = [createTestHierarchyNode({ id: "root-1", children: true })];
     const childNodes = [createTestHierarchyNode({ id: "child-1" })];

--- a/packages/hierarchies-react/src/test/internal/UseUnifiedSelection.test.tsx
+++ b/packages/hierarchies-react/src/test/internal/UseUnifiedSelection.test.tsx
@@ -19,11 +19,11 @@ describe("useUnifiedSelection", () => {
   const storage = createStorage();
   const imodelKey = "test-key";
   const source = "test-source";
-  const getNode = sinon.stub<[string], TreeModelNode | undefined>();
+  const getTreeModelNode = sinon.stub<[string], TreeModelNode | undefined>();
 
   const initialProps = {
     sourceName: source,
-    getNode,
+    getTreeModelNode,
   };
 
   function Wrapper(props: PropsWithChildren<{}>) {
@@ -32,7 +32,7 @@ describe("useUnifiedSelection", () => {
 
   beforeEach(() => {
     storage.clearStorage({ imodelKey });
-    getNode.reset();
+    getTreeModelNode.reset();
   });
 
   describe("isNodeSelected", () => {
@@ -51,7 +51,7 @@ describe("useUnifiedSelection", () => {
         selectables: [instanceKey],
       });
 
-      getNode.callsFake((id) => (id === "node-1" ? node : undefined));
+      getTreeModelNode.callsFake((id) => (id === "node-1" ? node : undefined));
 
       const { result } = renderHook(useUnifiedTreeSelection, { initialProps });
       expect(result.current.isNodeSelected("node-1")).to.be.false;
@@ -93,7 +93,7 @@ describe("useUnifiedSelection", () => {
         selectables: [selectedInstanceKey],
       });
 
-      getNode.callsFake((id) => nodes.find((node) => node.id === id));
+      getTreeModelNode.callsFake((id) => nodes.find((node) => node.id === id));
 
       const { result } = renderHook(useUnifiedTreeSelection, { initialProps, wrapper: Wrapper });
       expect(result.current.isNodeSelected("node-1")).to.be.true;
@@ -123,7 +123,7 @@ describe("useUnifiedSelection", () => {
         selectables: [{ identifier: "grouping-node", loadInstanceKeys: () => createAsyncIterator([selectedInstanceKey]), data: nodes[1] }],
       });
 
-      getNode.callsFake((id) => nodes.find((node) => node.id === id));
+      getTreeModelNode.callsFake((id) => nodes.find((node) => node.id === id));
 
       const { result } = renderHook(useUnifiedTreeSelection, { initialProps, wrapper: Wrapper });
       expect(result.current.isNodeSelected("node-1")).to.be.false;
@@ -150,7 +150,7 @@ describe("useUnifiedSelection", () => {
         result.current.selectNodes(["node-1"], "add");
       });
 
-      expect(getNode).to.not.be.called;
+      expect(getTreeModelNode).to.not.be.called;
     });
 
     it("adds instance node to selection", () => {
@@ -164,7 +164,7 @@ describe("useUnifiedSelection", () => {
       };
       const nodes = [createTreeModelNode({ id: "node-1", nodeData: createTestHierarchyNode({ id: "node-1", key: instancesNodesKey }) })];
 
-      getNode.callsFake((id) => nodes.find((node) => node.id === id));
+      getTreeModelNode.callsFake((id) => nodes.find((node) => node.id === id));
 
       const { result } = renderHook(useUnifiedTreeSelection, { initialProps, wrapper: Wrapper });
 
@@ -213,7 +213,7 @@ describe("useUnifiedSelection", () => {
       });
       const nodes = [createTreeModelNode({ id: "grouping-node", nodeData: groupingNode })];
 
-      getNode.callsFake((id) => nodes.find((node) => node.id === id));
+      getTreeModelNode.callsFake((id) => nodes.find((node) => node.id === id));
 
       const { result } = renderHook(useUnifiedTreeSelection, { initialProps, wrapper: Wrapper });
 
@@ -245,7 +245,7 @@ describe("useUnifiedSelection", () => {
     it("adds custom node to selection", async () => {
       const hierarchyNode = createTestHierarchyNode({ id: "custom-node" });
       const nodes = [createTreeModelNode({ id: "custom-node", nodeData: hierarchyNode })];
-      getNode.callsFake((id) => nodes.find((node) => node.id === id));
+      getTreeModelNode.callsFake((id) => nodes.find((node) => node.id === id));
 
       const { result } = renderHook(useUnifiedTreeSelection, { initialProps, wrapper: Wrapper });
 
@@ -274,7 +274,7 @@ describe("useUnifiedSelection", () => {
         ],
       };
       const nodes = [createTreeModelNode({ id: "node-1", nodeData: createTestHierarchyNode({ id: "node-1", key: instancesNodesKey }) })];
-      getNode.callsFake((id) => nodes.find((node) => node.id === id));
+      getTreeModelNode.callsFake((id) => nodes.find((node) => node.id === id));
 
       storage.addToSelection({ imodelKey, source, selectables: [instanceKey] });
       changeListener.reset();
@@ -325,7 +325,7 @@ describe("useUnifiedSelection", () => {
         ],
       });
       const nodes = [createTreeModelNode({ id: "grouping-node", nodeData: groupingNode })];
-      getNode.callsFake((id) => nodes.find((node) => node.id === id));
+      getTreeModelNode.callsFake((id) => nodes.find((node) => node.id === id));
 
       storage.addToSelection({
         imodelKey,
@@ -358,7 +358,7 @@ describe("useUnifiedSelection", () => {
     it("removes custom node from selection", async () => {
       const hierarchyNode = createTestHierarchyNode({ id: "custom-node" });
       const nodes = [createTreeModelNode({ id: "custom-node", nodeData: hierarchyNode })];
-      getNode.callsFake((id) => nodes.find((node) => node.id === id));
+      getTreeModelNode.callsFake((id) => nodes.find((node) => node.id === id));
 
       storage.addToSelection({
         imodelKey,
@@ -392,7 +392,7 @@ describe("useUnifiedSelection", () => {
       };
       const nodes = [createTreeModelNode({ id: "node-1", nodeData: createTestHierarchyNode({ id: "node-1", key: instancesNodesKey }) })];
 
-      getNode.callsFake((id) => nodes.find((node) => node.id === id));
+      getTreeModelNode.callsFake((id) => nodes.find((node) => node.id === id));
 
       const { result } = renderHook(useUnifiedTreeSelection, { initialProps, wrapper: Wrapper });
 


### PR DESCRIPTION
Prerequisite for adding a selection predicate (https://github.com/iTwin/viewer-components-react/issues/1099)