### PR TITLE
`core-interop`: Add a `createIModelKey` function to safely create an identifier for an `IModel` in different situations

### DIFF
--- a/.changeset/fresh-dryers-return.md
+++ b/.changeset/fresh-dryers-return.md
@@ -1,0 +1,17 @@
+---
+"@itwin/presentation-core-interop": minor
+---
+
+Add a `createIModelKey` function to safely create an identifier for an `IModel` in different situations.
+
+Example:
+
+```ts
+import { IModelConnection } from "@itwin/core-frontend";
+import { createIModelKey } from "@itwin/presentation-core-interop";
+
+IModelConnection.onOpen.addListener((imodel: IModelConnection) => {
+  const key = createIModelKey(imodel);
+  console.log(`IModel opened: "${key}"`);
+});
+```

--- a/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/Localization.test.tsx
+++ b/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/Localization.test.tsx
@@ -9,7 +9,7 @@ import { SchemaContext } from "@itwin/ecschema-metadata";
 import { IModelConnection } from "@itwin/core-frontend";
 import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
 import { insertPhysicalModelWithPartition } from "presentation-test-utilities";
-import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor, createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory, createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.Localization.CommonImports
@@ -74,7 +74,7 @@ describe("Hierarchies React", () => {
         context.addLocater(new ECSchemaRpcLocater(imodel.getRpcProps()));
         const schemaProvider = createECSchemaProvider(context);
         access = {
-          imodelKey: imodel.key,
+          imodelKey: createIModelKey(imodel),
           ...schemaProvider,
           ...createCachingECClassHierarchyInspector({ schemaProvider, cacheSize: 100 }),
           ...createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 1000),

--- a/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/ReadmeExample.test.tsx
+++ b/apps/full-stack-tests/src/hierarchies-react/learning-snipptets/ReadmeExample.test.tsx
@@ -12,7 +12,7 @@ import { IModelConnection } from "@itwin/core-frontend";
 import { SchemaContext } from "@itwin/ecschema-metadata";
 import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
 import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
-import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor, createNodesQueryClauseFactory, HierarchyDefinition } from "@itwin/presentation-hierarchies";
 // __PUBLISH_EXTRACT_END__
 // __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.SelectionStorage.Imports
@@ -35,12 +35,13 @@ import { stubGetBoundingClientRect } from "../../Utils.js";
 const imodelSchemaContextsCache = new Map<string, SchemaContext>();
 
 function getIModelSchemaContext(imodel: IModelConnection) {
-  let context = imodelSchemaContextsCache.get(imodel.key);
+  const imodelKey = createIModelKey(imodel);
+  let context = imodelSchemaContextsCache.get(imodelKey);
   if (!context) {
     context = new SchemaContext();
     context.addLocater(new ECSchemaRpcLocater(imodel.getRpcProps()));
-    imodelSchemaContextsCache.set(imodel.key, context);
-    imodel.onClose.addListener(() => imodelSchemaContextsCache.delete(imodel.key));
+    imodelSchemaContextsCache.set(imodelKey, context);
+    imodel.onClose.addListener(() => imodelSchemaContextsCache.delete(imodelKey));
   }
   return context;
 }
@@ -48,7 +49,7 @@ function getIModelSchemaContext(imodel: IModelConnection) {
 function createIModelAccess(imodel: IModelConnection) {
   const schemaProvider = createECSchemaProvider(getIModelSchemaContext(imodel));
   return {
-    imodelKey: imodel.key,
+    imodelKey: createIModelKey(imodel),
     ...schemaProvider,
     // while caching for hierarchy inspector is not mandatory, it's recommended to use it to improve performance
     ...createCachingECClassHierarchyInspector({ schemaProvider, cacheSize: 100 }),

--- a/apps/full-stack-tests/src/hierarchies/Utils.ts
+++ b/apps/full-stack-tests/src/hierarchies/Utils.ts
@@ -7,7 +7,7 @@ import { ECDb, IModelDb } from "@itwin/core-backend";
 import { IModelConnection } from "@itwin/core-frontend";
 import { Schema, SchemaContext, SchemaInfo, SchemaKey, SchemaMatchType } from "@itwin/ecschema-metadata";
 import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
-import { createECSchemaProvider as createECSchemaProviderInterop, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+import { createECSchemaProvider as createECSchemaProviderInterop, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
 import { createIModelHierarchyProvider, createLimitingECSqlQueryExecutor, HierarchyDefinition } from "@itwin/presentation-hierarchies";
 import { createCachingECClassHierarchyInspector, Event, IPrimitiveValueFormatter, parseFullClassName, Props } from "@itwin/presentation-shared";
 
@@ -47,7 +47,7 @@ export function createIModelAccess(imodel: IModelConnection | IModelDb | ECDb) {
   const classHierarchyInspector = createCachingECClassHierarchyInspector({ schemaProvider });
   const queryExecutor = createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 123);
   return {
-    imodelKey: imodel instanceof IModelConnection || imodel instanceof IModelDb ? imodel.key : "ecdb",
+    imodelKey: imodel instanceof IModelConnection || imodel instanceof IModelDb ? createIModelKey(imodel) : "ecdb",
     ...schemaProvider,
     ...classHierarchyInspector,
     ...queryExecutor,

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyFiltering.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyFiltering.test.ts
@@ -15,6 +15,7 @@ import { createNodesQueryClauseFactory, GroupingHierarchyNode, HierarchyDefiniti
 import { ECSqlBinding } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyFiltering.FindPathsImports
+import { createIModelKey } from "@itwin/presentation-core-interop";
 import { HierarchyNodeIdentifiersPath } from "@itwin/presentation-hierarchies";
 import { ECSql, ECSqlQueryDef } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
@@ -55,7 +56,7 @@ describe("Hierarchies", () => {
         const { imodel: _, ...elements } = res;
         imodel = res.imodel;
         elementKeys = Object.entries(elements).reduce(
-          (acc, [name, instanceKey]) => ({ ...acc, [name]: { ...instanceKey, imodelKey: imodel.key } }),
+          (acc, [name, instanceKey]) => ({ ...acc, [name]: { ...instanceKey, imodelKey: createIModelKey(imodel) } }),
           {} as { [name: string]: InstanceKey },
         );
         elementIds = Object.entries(elements).reduce((acc, [name, instanceKey]) => ({ ...acc, [name]: instanceKey.id }), {} as { [name: string]: Id64String });
@@ -165,7 +166,7 @@ describe("Hierarchies", () => {
           };
           const result: HierarchyNodeIdentifiersPath[] = [];
           for await (const row of imodelAccess.createQueryReader(query, { rowFormat: "ECSqlPropertyNames" })) {
-            result.push((JSON.parse(row.Path) as InstanceKey[]).reverse().map((key) => ({ ...key, imodelKey: imodel.key })));
+            result.push((JSON.parse(row.Path) as InstanceKey[]).reverse().map((key) => ({ ...key, imodelKey: createIModelKey(imodel) })));
           }
           return result;
         }
@@ -237,7 +238,7 @@ describe("Hierarchies", () => {
           };
           const result: HierarchyNodeIdentifiersPath[] = [];
           for await (const row of imodelAccess.createQueryReader(query, { rowFormat: "ECSqlPropertyNames" })) {
-            result.push((JSON.parse(row.Path) as InstanceKey[]).reverse().map((key) => ({ ...key, imodelKey: imodel.key })));
+            result.push((JSON.parse(row.Path) as InstanceKey[]).reverse().map((key) => ({ ...key, imodelKey: createIModelKey(imodel) })));
           }
           return result;
         }

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/ReadmeExample.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/ReadmeExample.test.ts
@@ -13,7 +13,7 @@ import * as sinon from "sinon";
 import { IModelConnection } from "@itwin/core-frontend";
 import { SchemaContext } from "@itwin/ecschema-metadata";
 import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
-import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
 import { createCachingECClassHierarchyInspector, Props } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
@@ -39,12 +39,13 @@ import { initialize, terminate } from "../../IntegrationTests.js";
 // avoid loading and storing same schemas multiple times.
 const imodelSchemaContextsCache = new Map<string, SchemaContext>();
 function getIModelSchemaContext(imodel: IModelConnection) {
-  let context = imodelSchemaContextsCache.get(imodel.key);
+  const imodelKey = createIModelKey(imodel);
+  let context = imodelSchemaContextsCache.get(imodelKey);
   if (!context) {
     context = new SchemaContext();
     context.addLocater(new ECSchemaRpcLocater(imodel.getRpcProps()));
-    imodelSchemaContextsCache.set(imodel.key, context);
-    imodel.onClose.addListener(() => imodelSchemaContextsCache.delete(imodel.key));
+    imodelSchemaContextsCache.set(imodelKey, context);
+    imodel.onClose.addListener(() => imodelSchemaContextsCache.delete(imodelKey));
   }
   return context;
 }
@@ -53,7 +54,7 @@ function createIModelAccess(imodel: IModelConnection) {
   const schemaProvider = createECSchemaProvider(getIModelSchemaContext(imodel));
   return {
     // The key of the iModel we're accessing
-    imodelKey: imodel.key,
+    imodelKey: createIModelKey(imodel),
     // Schema provider provides access to EC information (metadata)
     ...schemaProvider,
     // While caching for hierarchy inspector is not mandatory, it's recommended to use it to improve performance

--- a/packages/core-interop/README.md
+++ b/packages/core-interop/README.md
@@ -11,6 +11,22 @@ Having this interop layer helps us evolve both sides without affecting one anoth
 
 ## API
 
+### `createIModelKey`
+
+Attempts to create a unique identifier for the given iModel. In majority of cases that's going to be the `key` property, but if it's not set (e.g. when using [BlankConnection](https://www.itwinjs.org/reference/core-frontend/imodelconnection/blankconnection/)) - `name` property is used instead. Finally, if both are empty - the function will throw an error.
+
+Example:
+
+```ts
+import { IModelConnection } from "@itwin/core-frontend";
+import { createIModelKey } from "@itwin/presentation-core-interop";
+
+IModelConnection.onOpen.addListener((imodel: IModelConnection) => {
+  const key = createIModelKey(imodel);
+  console.log(`IModel opened: "${key}"`);
+});
+```
+
 ### `createECSqlQueryExecutor`
 
 Maps an iModel in the form of `itwinjs-core` [IModelDb](https://www.itwinjs.org/reference/core-backend/imodels/imodeldb/) or [IModelConnection](https://www.itwinjs.org/reference/core-frontend/imodelconnection/imodelconnection/) to an instance of `ECSqlQueryExecutor`, used in `@itwin/presentation-hierarchies` and `@itwin/unified-selection` packages.

--- a/packages/core-interop/api/presentation-core-interop.api.md
+++ b/packages/core-interop/api/presentation-core-interop.api.md
@@ -25,6 +25,14 @@ interface CoreECSqlReaderFactory {
 }
 
 // @public
+interface CoreIModel {
+    // (undocumented)
+    key: string;
+    // (undocumented)
+    name: string;
+}
+
+// @public
 interface CoreSchemaContext {
     // (undocumented)
     getSchema(key: SchemaKey): Promise<Schema | undefined>;
@@ -35,6 +43,9 @@ export function createECSchemaProvider(schemaContext: CoreSchemaContext): ECSche
 
 // @public
 export function createECSqlQueryExecutor(imodel: CoreECSqlReaderFactory): ECSqlQueryExecutor;
+
+// @public
+export function createIModelKey(imodel: CoreIModel): string;
 
 // @public
 export function createLogger(coreLogger: ICoreLogger): ILogger;

--- a/packages/core-interop/api/presentation-core-interop.exports.csv
+++ b/packages/core-interop/api/presentation-core-interop.exports.csv
@@ -2,6 +2,7 @@ sep=;
 Release Tag;API Item Type;API Item Name
 public;function;createECSchemaProvider
 public;function;createECSqlQueryExecutor
+public;function;createIModelKey
 public;function;createLogger
 public;function;createValueFormatter
 public;function;registerTxnListeners

--- a/packages/core-interop/src/core-interop/IModelKey.ts
+++ b/packages/core-interop/src/core-interop/IModelKey.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Defines input for `createIModelKey`. Generally, this is an instance of either [IModelDb](https://www.itwinjs.org/reference/core-backend/imodels/imodeldb/)
+ * or [IModelConnection](https://www.itwinjs.org/reference/core-frontend/imodelconnection/imodelconnection/).
+ * @public
+ */
+interface CoreIModel {
+  key: string;
+  name: string;
+}
+
+/**
+ * Attempts to create a unique identifier for the given iModel. In majority of cases that's going to be the `key` property, but if it's not
+ * set (e.g. when using [BlankConnection](https://www.itwinjs.org/reference/core-frontend/imodelconnection/blankconnection/)) - `name` property
+ * is used instead. Finally, if both are empty - the function will throw an error.
+ *
+ * Example:
+ *
+ * ```ts
+ * import { IModelConnection } from "@itwin/core-frontend";
+ * import { createIModelKey } from "@itwin/presentation-core-interop";
+ *
+ * IModelConnection.onOpen.addListener((imodel: IModelConnection) => {
+ *   const key = createIModelKey(imodel);
+ *   console.log(`IModel opened: "${key}"`);
+ * });
+ * ```
+ *
+ * @public
+ */
+export function createIModelKey(imodel: CoreIModel): string {
+  if (imodel.key.length) {
+    return imodel.key;
+  }
+  if (imodel.name.length) {
+    return imodel.name;
+  }
+  throw new Error(`Provided iModel doesn't have a key or name.`);
+}

--- a/packages/core-interop/src/presentation-core-interop.ts
+++ b/packages/core-interop/src/presentation-core-interop.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 export { createValueFormatter } from "./core-interop/Formatting.js";
+export { createIModelKey } from "./core-interop/IModelKey.js";
 export { createLogger } from "./core-interop/Logging.js";
 export { createECSchemaProvider } from "./core-interop/Metadata.js";
 export { createECSqlQueryExecutor } from "./core-interop/QueryExecutor.js";

--- a/packages/core-interop/src/test/IModelKey.test.ts
+++ b/packages/core-interop/src/test/IModelKey.test.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { createIModelKey } from "../core-interop/IModelKey.js";
+
+describe("createIModelKey", () => {
+  it("returns `key` if set", () => {
+    expect(createIModelKey({ key: "k", name: "n" })).to.eq("k");
+  });
+
+  it("returns `name` if `key` is not set", () => {
+    expect(createIModelKey({ key: "", name: "n" })).to.eq("n");
+  });
+
+  it("throws if neither `name` nor `key` are set", () => {
+    expect(() => createIModelKey({ key: "", name: "" })).to.throw();
+  });
+});

--- a/packages/hierarchies-react/README.md
+++ b/packages/hierarchies-react/README.md
@@ -68,7 +68,7 @@ The hook takes 2 required properties:
   import { SchemaContext } from "@itwin/ecschema-metadata";
   import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
   import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
-  import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+  import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
   import { createLimitingECSqlQueryExecutor, createNodesQueryClauseFactory, HierarchyDefinition } from "@itwin/presentation-hierarchies";
 
   // Not really part of the package, but we need SchemaContext to create the tree state. It's
@@ -77,12 +77,13 @@ The hook takes 2 required properties:
   const imodelSchemaContextsCache = new Map<string, SchemaContext>();
 
   function getIModelSchemaContext(imodel: IModelConnection) {
-    let context = imodelSchemaContextsCache.get(imodel.key);
+    const imodelKey = createIModelKey(imodel);
+    let context = imodelSchemaContextsCache.get(imodelKey);
     if (!context) {
       context = new SchemaContext();
       context.addLocater(new ECSchemaRpcLocater(imodel.getRpcProps()));
-      imodelSchemaContextsCache.set(imodel.key, context);
-      imodel.onClose.addListener(() => imodelSchemaContextsCache.delete(imodel.key));
+      imodelSchemaContextsCache.set(imodelKey, context);
+      imodel.onClose.addListener(() => imodelSchemaContextsCache.delete(imodelKey));
     }
     return context;
   }
@@ -90,7 +91,7 @@ The hook takes 2 required properties:
   function createIModelAccess(imodel: IModelConnection) {
     const schemaProvider = createECSchemaProvider(getIModelSchemaContext(imodel));
     return {
-      imodelKey: imodel.key,
+      imodelKey: createIModelKey(imodel),
       ...schemaProvider,
       // while caching for hierarchy inspector is not mandatory, it's recommended to use it to improve performance
       ...createCachingECClassHierarchyInspector({ schemaProvider, cacheSize: 100 }),
@@ -220,7 +221,7 @@ import { IModelConnection } from "@itwin/core-frontend";
 import { SchemaContext } from "@itwin/ecschema-metadata";
 import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
 import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
-import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor, createNodesQueryClauseFactory, HierarchyDefinition } from "@itwin/presentation-hierarchies";
 
 import { createBisInstanceLabelSelectClauseFactory, Props } from "@itwin/presentation-shared";
@@ -235,12 +236,13 @@ import { useEffect, useState } from "react";
 const imodelSchemaContextsCache = new Map<string, SchemaContext>();
 
 function getIModelSchemaContext(imodel: IModelConnection) {
-  let context = imodelSchemaContextsCache.get(imodel.key);
+  const imodelKey = createIModelKey(imodel);
+  let context = imodelSchemaContextsCache.get(imodelKey);
   if (!context) {
     context = new SchemaContext();
     context.addLocater(new ECSchemaRpcLocater(imodel.getRpcProps()));
-    imodelSchemaContextsCache.set(imodel.key, context);
-    imodel.onClose.addListener(() => imodelSchemaContextsCache.delete(imodel.key));
+    imodelSchemaContextsCache.set(imodelKey, context);
+    imodel.onClose.addListener(() => imodelSchemaContextsCache.delete(imodelKey));
   }
   return context;
 }
@@ -248,7 +250,7 @@ function getIModelSchemaContext(imodel: IModelConnection) {
 function createIModelAccess(imodel: IModelConnection) {
   const schemaProvider = createECSchemaProvider(getIModelSchemaContext(imodel));
   return {
-    imodelKey: imodel.key,
+    imodelKey: createIModelKey(imodel),
     ...schemaProvider,
     // while caching for hierarchy inspector is not mandatory, it's recommended to use it to improve performance
     ...createCachingECClassHierarchyInspector({ schemaProvider, cacheSize: 100 }),

--- a/packages/hierarchies/README.md
+++ b/packages/hierarchies/README.md
@@ -76,7 +76,7 @@ Here's a simple example of how to create a hierarchy provider and build a hierar
 import { IModelConnection } from "@itwin/core-frontend";
 import { SchemaContext } from "@itwin/ecschema-metadata";
 import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
-import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
 import { createCachingECClassHierarchyInspector, Props } from "@itwin/presentation-shared";
 
@@ -95,12 +95,13 @@ import { createBisInstanceLabelSelectClauseFactory, ECSqlBinding } from "@itwin/
 // avoid loading and storing same schemas multiple times.
 const imodelSchemaContextsCache = new Map<string, SchemaContext>();
 function getIModelSchemaContext(imodel: IModelConnection) {
-  let context = imodelSchemaContextsCache.get(imodel.key);
+  const imodelKey = createIModelKey(imodel);
+  let context = imodelSchemaContextsCache.get(imodelKey);
   if (!context) {
     context = new SchemaContext();
     context.addLocater(new ECSchemaRpcLocater(imodel.getRpcProps()));
-    imodelSchemaContextsCache.set(imodel.key, context);
-    imodel.onClose.addListener(() => imodelSchemaContextsCache.delete(imodel.key));
+    imodelSchemaContextsCache.set(imodelKey, context);
+    imodel.onClose.addListener(() => imodelSchemaContextsCache.delete(imodelKey));
   }
   return context;
 }
@@ -109,7 +110,7 @@ function createIModelAccess(imodel: IModelConnection) {
   const schemaProvider = createECSchemaProvider(getIModelSchemaContext(imodel));
   return {
     // The key of the iModel we're accessing
-    imodelKey: imodel.key,
+    imodelKey: createIModelKey(imodel),
     // Schema provider provides access to EC information (metadata)
     ...schemaProvider,
     // While caching for hierarchy inspector is not mandatory, it's recommended to use it to improve performance

--- a/packages/hierarchies/learning/imodel/HierarchyFiltering.md
+++ b/packages/hierarchies/learning/imodel/HierarchyFiltering.md
@@ -80,6 +80,7 @@ Let's consider two cases - filtering by label and by target element ID:
   <!-- BEGIN EXTRACTION -->
 
   ```ts
+  import { createIModelKey } from "@itwin/presentation-core-interop";
   import { HierarchyNodeIdentifiersPath } from "@itwin/presentation-hierarchies";
   import { ECSql, ECSqlQueryDef } from "@itwin/presentation-shared";
 
@@ -111,7 +112,7 @@ Let's consider two cases - filtering by label and by target element ID:
     };
     const result: HierarchyNodeIdentifiersPath[] = [];
     for await (const row of imodelAccess.createQueryReader(query, { rowFormat: "ECSqlPropertyNames" })) {
-      result.push((JSON.parse(row.Path) as InstanceKey[]).reverse().map((key) => ({ ...key, imodelKey: imodel.key })));
+      result.push((JSON.parse(row.Path) as InstanceKey[]).reverse().map((key) => ({ ...key, imodelKey: createIModelKey(imodel) })));
     }
     return result;
   }
@@ -132,6 +133,7 @@ Let's consider two cases - filtering by label and by target element ID:
   <!-- BEGIN EXTRACTION -->
 
   ```ts
+  import { createIModelKey } from "@itwin/presentation-core-interop";
   import { HierarchyNodeIdentifiersPath } from "@itwin/presentation-hierarchies";
   import { ECSql, ECSqlQueryDef } from "@itwin/presentation-shared";
 
@@ -163,7 +165,7 @@ Let's consider two cases - filtering by label and by target element ID:
     };
     const result: HierarchyNodeIdentifiersPath[] = [];
     for await (const row of imodelAccess.createQueryReader(query, { rowFormat: "ECSqlPropertyNames" })) {
-      result.push((JSON.parse(row.Path) as InstanceKey[]).reverse().map((key) => ({ ...key, imodelKey: imodel.key })));
+      result.push((JSON.parse(row.Path) as InstanceKey[]).reverse().map((key) => ({ ...key, imodelKey: createIModelKey(imodel) })));
     }
     return result;
   }

--- a/packages/unified-selection/src/unified-selection/EnableUnifiedSelectionSyncWithIModel.ts
+++ b/packages/unified-selection/src/unified-selection/EnableUnifiedSelectionSyncWithIModel.ts
@@ -26,7 +26,7 @@ export interface EnableUnifiedSelectionSyncWithIModelProps {
    * `hilited` and `selectionSet` attributes like this:
    *
    * ```ts
-   * import { createECSqlQueryExecutor, createECSchemaProvider } from "@itwin/presentation-core-interop";
+   * import { createECSqlQueryExecutor, createECSchemaProvider, createIModelKey } from "@itwin/presentation-core-interop";
    * import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
    * import { IModelConnection } from "@itwin/core-frontend";
    *
@@ -34,7 +34,7 @@ export interface EnableUnifiedSelectionSyncWithIModelProps {
    * const imodelAccess = {
    *   ...createECSqlQueryExecutor(imodel),
    *   ...createCachingECClassHierarchyInspector({ schemaProvider: createECSchemaProvider(MyAppFrontend.getSchemaContext(imodel)) }),
-   *   key: imodel.key,
+   *   key: createIModelKey(imodel),
    *   hiliteSet: imodel.hilited,
    *   selectionSet: imodel.selectionSet,
    * };

--- a/packages/unified-selection/src/unified-selection/SelectionStorage.ts
+++ b/packages/unified-selection/src/unified-selection/SelectionStorage.ts
@@ -103,8 +103,10 @@ export interface SelectionStorage {
  *
  * ```ts
  * import { IModelConnection } from "@itwin/core-frontend";
+ * import { createIModelKey } from "@itwin/presentation-core-interop";
+ *
  * IModelConnection.onClose.addListener((imodel) => {
- *   storage.clearStorage(imodel.key);
+ *   storage.clearStorage(createIModelKey(imodel));
  * });
  * ```
  *


### PR DESCRIPTION
Turns out `BlankConnection` always has an empty `key`, so we should fall back to `name`. Provide an utility for that to ensure consistent imodel identifiers.