### PR TITLE
`hierarchies`: Update extractions

### DIFF
--- a/packages/hierarchies/learning/CustomHierarchyProviders.md
+++ b/packages/hierarchies/learning/CustomHierarchyProviders.md
@@ -726,7 +726,7 @@ for await (const node of provider.getNodes({ parentNode: undefined, instanceFilt
   console.log(`- ${node.label}`);
 }
 
-// Create a filter to find books whose key contains "OL274" substring or title contains "Hobbit".
+// Create a filter to find books whose key contains "OL274" substring and title contains "Hobbit".
 const createBooksFilter = (): GenericInstanceFilter => ({
   propertyClassNames: ["book"],
   relatedInstances: [],


### PR DESCRIPTION
Turns out our "Validate docs" pipeline wasn't required, so https://github.com/iTwin/presentation/pull/816 merged with failing docs validation.