### PR TITLE
[Tree Node Renderer]: Filter button visibility fix

### DIFF
--- a/.changeset/pink-paws-refuse.md
+++ b/.changeset/pink-paws-refuse.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Clicking on tree node buttons now visually show focus on node.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.css
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.css
@@ -17,6 +17,12 @@
   visibility: visible;
 }
 
+.stateless-tree-node:focus-within {
+  outline: 1px solid var(--iui-color-border-accent);
+  outline-offset: -1px;
+  border-radius: var(--iui-border-radius-1);
+}
+
 .stateless-tree-node-small-spinner {
   height: var(--iui-size-s);
   width: var(--iui-size-s);

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -101,9 +101,6 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
           onExpanded={(_, isExpanded) => {
             expandNode(node.id, isExpanded);
           }}
-          expanderProps={{
-            onMouseDown: (e) => e.preventDefault(),
-          }}
           icon={getIcon ? getIcon(node) : undefined}
           label={getLabel ? getLabel(node) : node.label}
           sublabel={getSublabel ? getSublabel(node) : undefined}

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -101,6 +101,9 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
           onExpanded={(_, isExpanded) => {
             expandNode(node.id, isExpanded);
           }}
+          expanderProps={{
+            onMouseDown: (e) => e.preventDefault(),
+          }}
           icon={getIcon ? getIcon(node) : undefined}
           label={getLabel ? getLabel(node) : node.label}
           sublabel={getSublabel ? getSublabel(node) : undefined}


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/1117

https://github.com/user-attachments/assets/528a1ee2-c5a7-42ee-b322-c2af697bd456

Still need to check if visibility button also causes the same bug.
