### PR TITLE
`hierarchies-react`: Cleanup filtering action buttons

### DIFF
--- a/.changeset/clever-boats-knock.md
+++ b/.changeset/clever-boats-knock.md
@@ -1,0 +1,4 @@
+---
+"@itwin/presentation-hierarchies-react": major
+---
+Moving tree rendering components to a new design systems.

--- a/.changeset/famous-bags-pull.md
+++ b/.changeset/famous-bags-pull.md
@@ -2,5 +2,6 @@
 "@itwin/presentation-hierarchies-react": patch
 ---
 
-Fix tree filter button style.
-Removed filter reset button.
+Changes to tree node action buttons related to filtering:
+- Fix filter button style.
+- Removed "reset filter" button. The filter can be reset through the filter editing dialog.

--- a/.changeset/famous-bags-pull.md
+++ b/.changeset/famous-bags-pull.md
@@ -1,0 +1,6 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Fix tree filter button style.
+Removed filter reset button.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeActionButtons.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeActionButtons.tsx
@@ -9,7 +9,7 @@ import { HierarchyLevelDetails, useTree } from "../UseTree.js";
 import { useLocalizationContext } from "./LocalizationContext.js";
 
 const filterIcon = new URL("@itwin/itwinui-icons/filter.svg", import.meta.url).href;
-const dismissIcon = new URL("@itwin/itwinui-icons/dismiss.svg", import.meta.url).href;
+const activeFilterIcon = new URL("@itwin/itwinui-icons/placeholder.svg", import.meta.url).href; // Placeholder
 
 /** @internal */
 export type ActionButtonProps = {
@@ -25,6 +25,7 @@ export function FilterActionButton({ node, onClick, getHierarchyLevelDetails }: 
 
   return onClick && node.isFilterable ? (
     <IconButton
+      variant={"ghost"}
       style={{ position: "relative" }} // for icons to be visible, should be fixed by kiwi
       className="filtering-action-button"
       label={localizedStrings.filterHierarchyLevel}
@@ -33,25 +34,7 @@ export function FilterActionButton({ node, onClick, getHierarchyLevelDetails }: 
         const hierarchyLevelDetails = getHierarchyLevelDetails?.(node.id);
         hierarchyLevelDetails && onClick(hierarchyLevelDetails);
       }}
-      icon={node.isFiltered ? filterIcon : filterIcon} // currently base filter icon is hollow
+      icon={node.isFiltered ? activeFilterIcon : filterIcon}
     />
   ) : undefined;
-}
-
-/** @internal */
-export function RemoveFilterActionButton({ node, getHierarchyLevelDetails }: ActionButtonProps) {
-  const { localizedStrings } = useLocalizationContext();
-
-  return getHierarchyLevelDetails && node.isFiltered ? (
-    <IconButton
-      style={{ position: "relative" }} // for button to work, should be fixed by kiwi
-      className="filtering-action-button"
-      label={localizedStrings.clearHierarchyLevelFilter}
-      onClick={(e) => {
-        e.stopPropagation();
-        getHierarchyLevelDetails(node.id)?.setInstanceFilter(undefined);
-      }}
-      icon={dismissIcon}
-    />
-  ) : null;
 }

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -8,7 +8,7 @@ import { Spinner, Tree } from "@itwin/itwinui-react/bricks";
 import { isPresentationHierarchyNode, PresentationHierarchyNode, PresentationTreeNode } from "../TreeNode.js";
 import { HierarchyLevelDetails, useTree } from "../UseTree.js";
 import { useLocalizationContext } from "./LocalizationContext.js";
-import { FilterActionButton, RemoveFilterActionButton } from "./TreeActionButtons.js";
+import { FilterActionButton } from "./TreeActionButtons.js";
 import { TreeErrorRenderer } from "./TreeErrorRenderer.js";
 
 /** @alpha */
@@ -80,7 +80,6 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
     const ActionButtons = () => (
       <>
         {actionsRenderer && actionsRenderer(node)}
-        <RemoveFilterActionButton node={node} getHierarchyLevelDetails={getHierarchyLevelDetails} />
         <FilterActionButton node={node} onClick={onFilterClick} getHierarchyLevelDetails={getHierarchyLevelDetails} />
       </>
     );
@@ -96,7 +95,6 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
           expandNode(node.id, isExpanded);
         }}
         onClick={(event) => {
-          event.stopPropagation();
           !treeItemProps["aria-disabled"] && onNodeClick?.(node, !selected, event);
         }}
         onKeyDown={(event) => {


### PR DESCRIPTION
Filter icon style fix
![image](https://github.com/user-attachments/assets/f99dc239-9876-4648-bca5-ddbe058fe381)

Removed filter reset button.