### PR TITLE
[hierarchies-react]: Fix hierarchy level size limit message in narrow tree

### DIFF
--- a/.changeset/stupid-mugs-dress.md
+++ b/.changeset/stupid-mugs-dress.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Updated hierarchy level size exceeded info message styling in narrow tree component to avoid cutting out text.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -225,6 +225,7 @@ const ResultSetTooLargeNode = forwardRef<HTMLDivElement, Omit<TreeNodeProps, "on
         className="stateless-tree-node"
         label={<ResultSetTooLargeNodeLabel limit={limit} onFilterClick={onFilterClick} onOverrideLimit={onOverrideLimit} />}
         onExpanded={/* c8 ignore next */ () => {}}
+        isDisabled={true}
       />
     );
   },
@@ -285,9 +286,9 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
     return {
       title: messageWithLimit,
       element: (
-        <Flex flexDirection="row" gap="3xs">
-          <Text>{messageWithLimit}</Text>
-        </Flex>
+        <Text as="span" style={{ textWrap: "wrap" }}>
+          {messageWithLimit}
+        </Text>
       ),
     };
   }
@@ -298,9 +299,14 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
   return {
     title: messageWithLimit.replace(fullText, innerText),
     element: (
-      <Flex flexDirection="row" gap="3xs">
-        {textBefore ? <Text>{textBefore}</Text> : null}
+      <div>
+        {textBefore ? (
+          <Text as="span" style={{ textWrap: "wrap" }}>
+            {textBefore}
+          </Text>
+        ) : null}
         <Anchor
+          style={{ textWrap: "wrap" }}
           underline
           onClick={(e) => {
             e.stopPropagation();
@@ -309,8 +315,12 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
         >
           {innerText}
         </Anchor>
-        {textAfter ? <Text>{textAfter}</Text> : null}
-      </Flex>
+        {textAfter ? (
+          <Text as="span" style={{ textWrap: "wrap" }}>
+            {textAfter}
+          </Text>
+        ) : null}
+      </div>
     ),
   };
 }


### PR DESCRIPTION
Fixes https://github.com/iTwin/viewer-components-react/issues/1158

| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/a41a116b-9d19-49b2-8dfc-9189273a6970) | ![image](https://github.com/user-attachments/assets/20e52964-ab2a-4de4-80f6-5d950d536b7e) |

