### PR TITLE
[components]: Properly dispose resources

### DIFF
--- a/.changeset/swift-hats-fail.md
+++ b/.changeset/swift-hats-fail.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Make sure resource that use `dispose` method instead of `Symbol.dispose` are properly disposed.

--- a/packages/components/src/presentation-components/common/Utils.ts
+++ b/packages/components/src/presentation-components/common/Utils.ts
@@ -277,3 +277,20 @@ export function mapPresentationFrontendSelectionScopeToUnifiedSelectionScope(
   }
   throw new Error(`Unknown selection scope: "${scopeProps.id}"`);
 }
+
+/**
+ * A helper that disposes the given object, if it's disposable.
+ *
+ * The first option is to dispose using the deprecated `dispose` method if it exists on the object.
+ * If not, we use the new `Symbol.dispose` method. If that doesn't exist either, the object is
+ * considered as non-disposable and nothing is done with it.
+ *
+ * @internal
+ */
+export function safeDispose(disposable: {} | { [Symbol.dispose]: () => void } | { dispose: () => void }) {
+  if ("dispose" in disposable) {
+    disposable.dispose();
+  } else if (Symbol.dispose in disposable) {
+    disposable[Symbol.dispose]();
+  }
+}

--- a/packages/components/src/presentation-components/propertygrid/UseUnifiedSelection.tsx
+++ b/packages/components/src/presentation-components/propertygrid/UseUnifiedSelection.tsx
@@ -13,7 +13,7 @@ import { KeySet } from "@itwin/presentation-common";
 import { createIModelKey } from "@itwin/presentation-core-interop";
 import { Presentation, SelectionChangeEventArgs, SelectionHandler } from "@itwin/presentation-frontend";
 import { SelectionStorage } from "@itwin/unified-selection";
-import { createKeySetFromSelectables } from "../common/Utils.js";
+import { createKeySetFromSelectables, safeDispose } from "../common/Utils.js";
 import { IPresentationPropertyDataProvider } from "./DataProvider.js";
 
 const DEFAULT_REQUESTED_CONTENT_INSTANCES_LIMIT = 100;
@@ -170,7 +170,7 @@ function initUnifiedSelectionFromPresentationFrontend({
 
   updateProviderSelection(handler);
   return () => {
-    handler[Symbol.dispose]();
+    safeDispose(handler);
   };
 }
 

--- a/packages/components/src/test/propertygrid/UseUnifiedSelection.test.tsx
+++ b/packages/components/src/test/propertygrid/UseUnifiedSelection.test.tsx
@@ -170,7 +170,8 @@ describe("usePropertyDataProviderWithUnifiedSelection", () => {
       });
 
       unmount();
-      expect(selectionHandler[Symbol.dispose]).to.be.called;
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      expect(selectionHandler.dispose).to.be.called;
     });
   });
 


### PR DESCRIPTION
Some resource used from `itwinjs-core` do not have `Symbol.dispose` in 4.x versions. Need to make sure that we check if resource supports the new `Symbol.dispose` for disposal to work properly.