### PR TITLE
[Hierarchies-react]: add dropdown button actions

### DIFF
--- a/.changeset/real-pets-cover.md
+++ b/.changeset/real-pets-cover.md
@@ -6,6 +6,6 @@
 
 - `label`: Action item's label.
 - `action`: The action performed when the button is clicked.
-- `show`* A boolean determining whether the button should be displayed.
+- `show` A boolean determining whether the button should be displayed.
 - `isDropdownAction`: Specifies whether the action is rendered as a dropdown menu item or a standalone button.
 - `icon`: The button's icon.

--- a/.changeset/real-pets-cover.md
+++ b/.changeset/real-pets-cover.md
@@ -1,0 +1,11 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+`TreeRenderer` and `TreeNodeRenderer` now take actions as specification function array.
+
+- `label`: Action item's label.
+- `action`: The action performed when the button is clicked.
+- `show`* A boolean determining whether the button should be displayed.
+- `isDropdownAction`: Specifies whether the action is rendered as a dropdown menu item or a standalone button.
+- `icon`: The button's icon.

--- a/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
@@ -19,7 +19,13 @@ import {
 import { createECSchemaProvider, createECSqlQueryExecutor, registerTxnListeners } from "@itwin/presentation-core-interop";
 import { Presentation } from "@itwin/presentation-frontend";
 import { createLimitingECSqlQueryExecutor, GenericInstanceFilter } from "@itwin/presentation-hierarchies";
-import { HierarchyLevelDetails, PresentationHierarchyNode, TreeRenderer, useIModelUnifiedSelectionTree } from "@itwin/presentation-hierarchies-react";
+import {
+  createFilterAction,
+  HierarchyLevelDetails,
+  PresentationHierarchyNode,
+  TreeRenderer,
+  useIModelUnifiedSelectionTree,
+} from "@itwin/presentation-hierarchies-react";
 import { ModelsTreeDefinition } from "@itwin/presentation-models-tree";
 import { createCachingECClassHierarchyInspector, IPrimitiveValueFormatter, Props } from "@itwin/presentation-shared";
 import { useUnifiedSelectionContext } from "@itwin/unified-selection-react";
@@ -164,11 +170,15 @@ function Tree({ imodel, imodelAccess, height, width }: { imodel: IModelConnectio
         onFilterClick={setFilteringOptions}
         getIcon={getIcon}
         actions={[
+          createFilterAction({ onFilter: setFilteringOptions, getHierarchyLevelDetails: treeProps.getHierarchyLevelDetails, label: "Apply filter" }),
           () => {
-            return { label: "Fake button 1", action: () => {}, show: true, isDropdownAction: true };
+            return { label: "Fake button 1", action: () => {}, show: false };
           },
           () => {
-            return { label: "Fake button 2", action: () => {}, show: true, isDropdownAction: true };
+            return { label: "Fake button 2", action: () => {}, show: true };
+          },
+          () => {
+            return { label: "Fake button 2", action: () => {}, show: true };
           },
         ]}
         selectionMode={"extended"}

--- a/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
@@ -163,6 +163,14 @@ function Tree({ imodel, imodelAccess, height, width }: { imodel: IModelConnectio
         reloadTree={reloadTree}
         onFilterClick={setFilteringOptions}
         getIcon={getIcon}
+        actions={[
+          () => {
+            return { label: "Fake button 1", action: () => {}, show: true, isDropdownAction: true };
+          },
+          () => {
+            return { label: "Fake button 2", action: () => {}, show: true, isDropdownAction: true };
+          },
+        ]}
         selectionMode={"extended"}
         style={{ height: "100%", width: "100%" }}
       />

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -125,7 +125,7 @@ export const TreeLevelRenderer: ({ nodes, isNodeSelected, ...rest }: TreeNodesRe
 export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererProps_2 & RefAttributes<HTMLDivElement>>;
 
 // @alpha
-export function TreeRenderer({ rootNodes, expandNode, localizedStrings, selectNodes, isNodeSelected, selectionMode, onFilterClick, getHierarchyLevelDetails, ...treeProps }: TreeRendererProps): JSX_2.Element;
+export function TreeRenderer({ rootNodes, expandNode, localizedStrings, selectNodes, isNodeSelected, selectionMode, ...treeProps }: TreeRendererProps): JSX_2.Element;
 
 // @public @deprecated
 export function UnifiedSelectionProvider({ storage, children }: PropsWithChildren<{

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -21,6 +21,9 @@ import { RefAttributes } from 'react';
 import { SelectionStorage } from '@itwin/unified-selection';
 import { Tree } from '@itwin/itwinui-react/bricks';
 
+// @alpha (undocumented)
+export function createFilterAction({ onFilter, getHierarchyLevelDetails, label }: FilterActionProps): (node: PresentationHierarchyNode) => TreeItemAction;
+
 export { GenericInstanceFilter }
 
 // @public
@@ -104,13 +107,25 @@ export { SelectionStorage }
 export const TreeErrorRenderer: React.ForwardRefExoticComponent<TreeErrorRendererProps & RefAttributes<HTMLDivElement>>;
 
 // @alpha (undocumented)
+export interface TreeItemAction {
+    // (undocumented)
+    action: () => void;
+    // (undocumented)
+    icon?: string;
+    // (undocumented)
+    label: string;
+    // (undocumented)
+    show: boolean;
+}
+
+// @alpha (undocumented)
 export const TreeLevelRenderer: ({ nodes, isNodeSelected, ...rest }: TreeNodesRendererProps) => ReactElement[];
 
 // @public
 export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererProps_2 & RefAttributes<HTMLDivElement>>;
 
 // @alpha
-export function TreeRenderer({ rootNodes, expandNode, localizedStrings, selectNodes, isNodeSelected, selectionMode, actions, onFilterClick, getHierarchyLevelDetails, ...treeProps }: TreeRendererProps): JSX_2.Element;
+export function TreeRenderer({ rootNodes, expandNode, localizedStrings, selectNodes, isNodeSelected, selectionMode, onFilterClick, getHierarchyLevelDetails, ...treeProps }: TreeRendererProps): JSX_2.Element;
 
 // @public @deprecated
 export function UnifiedSelectionProvider({ storage, children }: PropsWithChildren<{

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -110,7 +110,7 @@ export const TreeLevelRenderer: ({ nodes, isNodeSelected, ...rest }: TreeNodesRe
 export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererProps_2 & RefAttributes<HTMLDivElement>>;
 
 // @alpha
-export function TreeRenderer({ rootNodes, expandNode, localizedStrings, selectNodes, isNodeSelected, selectionMode, ...treeProps }: TreeRendererProps): JSX_2.Element;
+export function TreeRenderer({ rootNodes, expandNode, localizedStrings, selectNodes, isNodeSelected, selectionMode, actions, onFilterClick, getHierarchyLevelDetails, ...treeProps }: TreeRendererProps): JSX_2.Element;
 
 // @public @deprecated
 export function UnifiedSelectionProvider({ storage, children }: PropsWithChildren<{

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
@@ -1,5 +1,6 @@
 sep=;
 Release Tag;API Item Type;API Item Name
+alpha;function;createFilterAction
 public;interface;HierarchyLevelDetails
 public;function;isPresentationHierarchyNode
 public;function;LocalizationContextProvider
@@ -9,6 +10,7 @@ public;type;PresentationInfoNode
 public;interface;PresentationResultSetTooLargeInfoNode
 public;type;PresentationTreeNode
 alpha;const;TreeErrorRenderer
+alpha;interface;TreeItemAction
 alpha;const;TreeLevelRenderer
 public;const;TreeNodeRenderer
 alpha;function;TreeRenderer

--- a/packages/hierarchies-react/src/presentation-hierarchies-react.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react.ts
@@ -18,6 +18,7 @@ export { useIModelTree, useIModelUnifiedSelectionTree } from "./presentation-hie
 export { TreeErrorRenderer } from "./presentation-hierarchies-react/itwinui/TreeErrorRenderer.js";
 export { TreeLevelRenderer } from "./presentation-hierarchies-react/itwinui/TreeLevelRenderer.js";
 export { TreeNodeRenderer } from "./presentation-hierarchies-react/itwinui/TreeNodeRenderer.js";
+export { TreeItemAction, createFilterAction } from "./presentation-hierarchies-react/itwinui/TreeActionButton.js";
 export { TreeRenderer } from "./presentation-hierarchies-react/itwinui/TreeRenderer.js";
 export { LocalizationContextProvider } from "./presentation-hierarchies-react/itwinui/LocalizationContext.js";
 

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeActionButton.css
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeActionButton.css
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.tree-action-item-invisible {
+  visibility: hidden;
+}

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeActionButton.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeActionButton.tsx
@@ -30,13 +30,7 @@ export type FilterActionProps = {
 /** @internal */
 export function TreeActionButton({ show, label, action, icon }: TreeItemAction) {
   return (
-    <IconButton
-      className={`tree-action-item${!show ? "-invisible" : ""}`}
-      variant={"ghost"}
-      onClick={action}
-      label={label}
-      icon={icon ?? placeholderIcon}
-    />
+    <IconButton className={`tree-action-item${!show ? "-invisible" : ""}`} variant={"ghost"} onClick={action} label={label} icon={icon ?? placeholderIcon} />
   );
 }
 

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeActionButton.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeActionButton.tsx
@@ -7,17 +7,24 @@ import "./TreeActionButton.css";
 import { IconButton } from "@itwin/itwinui-react/bricks";
 import { PresentationHierarchyNode } from "../TreeNode.js";
 import { HierarchyLevelDetails, useTree } from "../UseTree.js";
-import { TreeItemAction } from "./TreeNodeRenderer.js";
 
 const filterIcon = new URL("@itwin/itwinui-icons/filter.svg", import.meta.url).href;
 const placeholderIcon = new URL("@itwin/itwinui-icons/placeholder.svg", import.meta.url).href; // TODO: active filter icon/placeholder icon if button was not given an icon
 
-/** @internal */
-export type ActionProps = {
-  /** Action to perform when the filter button is clicked for this node. */
-  onClick?: (hierarchyLevelDetails: HierarchyLevelDetails) => void;
+/** @alpha */
+export interface TreeItemAction {
+  label: string;
+  action: () => void;
+  show: boolean;
+  icon?: string;
+}
 
-  label?: string;
+/** @alpha */
+export type FilterActionProps = {
+  /** Action to perform when the filter button is clicked for this node. */
+  onFilter?: (hierarchyLevelDetails: HierarchyLevelDetails) => void;
+
+  label: string;
 } & Partial<Pick<ReturnType<typeof useTree>, "getHierarchyLevelDetails">>;
 
 /** @internal */
@@ -33,16 +40,16 @@ export function TreeActionButton({ show, label, action, icon }: TreeItemAction) 
   );
 }
 
-/** @internal */
-export function getFilterAction({ onClick, getHierarchyLevelDetails, label }: ActionProps): (node: PresentationHierarchyNode) => TreeItemAction {
+/** @alpha */
+export function createFilterAction({ onFilter, getHierarchyLevelDetails, label }: FilterActionProps): (node: PresentationHierarchyNode) => TreeItemAction {
   return (node) => {
     return {
-      label: label ?? "Filter action", //TODO: fix naming
+      label,
       action: () => {
         const hierarchyLevelDetails = getHierarchyLevelDetails?.(node.id);
-        hierarchyLevelDetails && onClick?.(hierarchyLevelDetails);
+        hierarchyLevelDetails && onFilter?.(hierarchyLevelDetails);
       },
-      show: !!onClick && node.isFilterable,
+      show: !!onFilter && node.isFilterable,
       isDropdownAction: false,
       icon: node.isFiltered ? placeholderIcon : filterIcon,
     };

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeActionButton.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeActionButton.tsx
@@ -33,7 +33,7 @@ export function TreeActionButton({ show, label, action, icon }: TreeItemAction) 
     <IconButton
       className={`tree-action-item${!show ? "-invisible" : ""}`}
       variant={"ghost"}
-      onClick={() => action()}
+      onClick={action}
       label={label}
       icon={icon ?? placeholderIcon}
     />

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeActionButton.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeActionButton.tsx
@@ -3,12 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import "./TreeActionButton.css";
+import { IconButton } from "@itwin/itwinui-react/bricks";
 import { PresentationHierarchyNode } from "../TreeNode.js";
 import { HierarchyLevelDetails, useTree } from "../UseTree.js";
 import { TreeItemAction } from "./TreeNodeRenderer.js";
 
 const filterIcon = new URL("@itwin/itwinui-icons/filter.svg", import.meta.url).href;
-const activeFilterIcon = new URL("@itwin/itwinui-icons/placeholder.svg", import.meta.url).href; // Placeholder
+const placeholderIcon = new URL("@itwin/itwinui-icons/placeholder.svg", import.meta.url).href; // TODO: active filter icon/placeholder icon if button was not given an icon
 
 /** @internal */
 export type ActionProps = {
@@ -17,6 +19,19 @@ export type ActionProps = {
 
   label?: string;
 } & Partial<Pick<ReturnType<typeof useTree>, "getHierarchyLevelDetails">>;
+
+/** @internal */
+export function TreeActionButton({ show, label, action, icon }: TreeItemAction) {
+  return (
+    <IconButton
+      className={`tree-action-item${!show ? "-invisible" : ""}`}
+      variant={"ghost"}
+      onClick={() => action()}
+      label={label}
+      icon={icon ?? placeholderIcon}
+    />
+  );
+}
 
 /** @internal */
 export function getFilterAction({ onClick, getHierarchyLevelDetails, label }: ActionProps): (node: PresentationHierarchyNode) => TreeItemAction {
@@ -29,7 +44,7 @@ export function getFilterAction({ onClick, getHierarchyLevelDetails, label }: Ac
       },
       show: !!onClick && node.isFilterable,
       isDropdownAction: false,
-      icon: node.isFiltered ? activeFilterIcon : filterIcon,
+      icon: node.isFiltered ? placeholderIcon : filterIcon,
     };
   };
 }

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeActionButtons.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeActionButtons.tsx
@@ -3,37 +3,33 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { IconButton } from "@itwin/itwinui-react/bricks";
 import { PresentationHierarchyNode } from "../TreeNode.js";
 import { HierarchyLevelDetails, useTree } from "../UseTree.js";
-import { useLocalizationContext } from "./LocalizationContext.js";
+import { TreeItemAction } from "./TreeNodeRenderer.js";
 
 const filterIcon = new URL("@itwin/itwinui-icons/filter.svg", import.meta.url).href;
 const activeFilterIcon = new URL("@itwin/itwinui-icons/placeholder.svg", import.meta.url).href; // Placeholder
 
 /** @internal */
-export type ActionButtonProps = {
-  /** Node on which action is going to be performed */
-  node: PresentationHierarchyNode;
+export type ActionProps = {
   /** Action to perform when the filter button is clicked for this node. */
   onClick?: (hierarchyLevelDetails: HierarchyLevelDetails) => void;
+
+  label?: string;
 } & Partial<Pick<ReturnType<typeof useTree>, "getHierarchyLevelDetails">>;
 
 /** @internal */
-export function FilterActionButton({ node, onClick, getHierarchyLevelDetails }: ActionButtonProps) {
-  const { localizedStrings } = useLocalizationContext();
-
-  return onClick && node.isFilterable ? (
-    <IconButton
-      variant={"ghost"}
-      className="filtering-action-button"
-      label={localizedStrings.filterHierarchyLevel}
-      onClick={(e) => {
-        e.stopPropagation();
+export function getFilterAction({ onClick, getHierarchyLevelDetails, label }: ActionProps): (node: PresentationHierarchyNode) => TreeItemAction {
+  return (node) => {
+    return {
+      label: label ?? "Filter action", //TODO: fix naming
+      action: () => {
         const hierarchyLevelDetails = getHierarchyLevelDetails?.(node.id);
-        hierarchyLevelDetails && onClick(hierarchyLevelDetails);
-      }}
-      icon={node.isFiltered ? activeFilterIcon : filterIcon}
-    />
-  ) : undefined;
+        hierarchyLevelDetails && onClick?.(hierarchyLevelDetails);
+      },
+      show: !!onClick && node.isFilterable,
+      isDropdownAction: false,
+      icon: node.isFiltered ? activeFilterIcon : filterIcon,
+    };
+  };
 }

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -95,15 +95,18 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
         return undefined;
       }
       const dropdownActions = actions?.filter((action) => action(node).isDropdownAction);
-
       if (dropdownActions.length === 0) {
         return undefined;
       }
 
-      if (dropdownActions.length === 1) {
-        const actionInfo = dropdownActions[0](node);
-        return <TreeActionButton {...actionInfo} />;
+      const visibleDropdownActions = dropdownActions?.filter((action) => action(node).show);
+      if (visibleDropdownActions.length === 0) {
+        return <TreeActionButton {...dropdownActions[0](node)} />;
       }
+      if (visibleDropdownActions.length === 1) {
+        return <TreeActionButton {...visibleDropdownActions[0](node)} />;
+      }
+
       return (
         <DropdownMenu.Root>
           <DropdownMenu.Button render={<IconButton icon={dropdownIcon} label="Tree actions dropdown" variant="ghost" />} />

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -13,7 +13,7 @@ import { TreeErrorRenderer } from "./TreeErrorRenderer.js";
 const placeholderIcon = new URL("@itwin/itwinui-icons/placeholder.svg", import.meta.url).href;
 const dropdownIcon = new URL("@itwin/itwinui-icons/more-horizontal.svg", import.meta.url).href;
 
-/** @public */
+/** @alpha */
 export interface TreeItemAction {
   label: string;
   action: () => void;
@@ -91,10 +91,14 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
     }
 
     const DropdownActionsMenu = () => {
-      if (!actions) {
+      if (!actions || actions.length === 0) {
         return undefined;
       }
       const dropdownActions = actions?.filter((action) => action(node).isDropdownAction);
+
+      if (dropdownActions.length === 0) {
+        return undefined;
+      }
 
       if (dropdownActions.length === 1 && dropdownActions[0](node).show) {
         return (

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -8,9 +8,9 @@ import { DropdownMenu, IconButton, Spinner, Tree } from "@itwin/itwinui-react/br
 import { isPresentationHierarchyNode, PresentationHierarchyNode, PresentationTreeNode } from "../TreeNode.js";
 import { HierarchyLevelDetails, useTree } from "../UseTree.js";
 import { useLocalizationContext } from "./LocalizationContext.js";
+import { TreeActionButton } from "./TreeActionButton.js";
 import { TreeErrorRenderer } from "./TreeErrorRenderer.js";
 
-const placeholderIcon = new URL("@itwin/itwinui-icons/placeholder.svg", import.meta.url).href;
 const dropdownIcon = new URL("@itwin/itwinui-icons/more-horizontal.svg", import.meta.url).href;
 
 /** @alpha */
@@ -100,15 +100,9 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
         return undefined;
       }
 
-      if (dropdownActions.length === 1 && dropdownActions[0](node).show) {
-        return (
-          <IconButton
-            variant={"ghost"}
-            onClick={() => dropdownActions[0](node).action()}
-            label={dropdownActions[0](node).label}
-            icon={dropdownActions[0](node).icon ?? placeholderIcon}
-          ></IconButton>
-        );
+      if (dropdownActions.length === 1) {
+        const actionInfo = dropdownActions[0](node);
+        return <TreeActionButton {...actionInfo} />;
       }
       return (
         <DropdownMenu.Root>
@@ -137,17 +131,9 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
 
       return (
         <>
-          {buttonActions.map((action) => {
+          {buttonActions.map((action, index) => {
             const actionInfo = action(node);
-            return (
-              <IconButton
-                variant={"ghost"}
-                key={actionInfo.label}
-                onClick={() => actionInfo.action()}
-                label={actionInfo.label}
-                icon={actionInfo.icon ?? placeholderIcon}
-              />
-            );
+            return <TreeActionButton key={index} {...actionInfo} />;
           })}
         </>
       );

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -91,11 +91,8 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
     }
 
     const DropdownActionsMenu = () => {
-      if (!actions || actions.length === 0) {
-        return undefined;
-      }
       const dropdownActions = actions?.filter((action) => action(node).isDropdownAction);
-      if (dropdownActions.length === 0) {
+      if (!dropdownActions || dropdownActions.length === 0) {
         return undefined;
       }
 

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
@@ -9,6 +9,7 @@ import { PresentationTreeNode } from "../TreeNode.js";
 import { SelectionMode, useSelectionHandler } from "../UseSelectionHandler.js";
 import { useTree } from "../UseTree.js";
 import { LocalizationContextProvider } from "./LocalizationContext.js";
+import { getFilterAction } from "./TreeActionButtons.js";
 import { TreeLevelRenderer } from "./TreeLevelRenderer.js";
 import { TreeNodeRenderer } from "./TreeNodeRenderer.js";
 
@@ -39,7 +40,18 @@ type TreeRendererProps = Pick<ReturnType<typeof useTree>, "expandNode"> &
  * @see https://itwinui.bentley.com/docs/tree
  * @alpha
  */
-export function TreeRenderer({ rootNodes, expandNode, localizedStrings, selectNodes, isNodeSelected, selectionMode, ...treeProps }: TreeRendererProps) {
+export function TreeRenderer({
+  rootNodes,
+  expandNode,
+  localizedStrings,
+  selectNodes,
+  isNodeSelected,
+  selectionMode,
+  actions,
+  onFilterClick,
+  getHierarchyLevelDetails,
+  ...treeProps
+}: TreeRendererProps) {
   const { onNodeClick, onNodeKeyDown } = useSelectionHandler({
     rootNodes,
     selectNodes: selectNodes ?? noopSelectNodes,
@@ -51,6 +63,9 @@ export function TreeRenderer({ rootNodes, expandNode, localizedStrings, selectNo
       <Tree.Root style={{ height: "100%", width: "100%" }}>
         <TreeLevelRenderer
           {...treeProps}
+          actions={[...(actions || []), getFilterAction({ onClick: onFilterClick, getHierarchyLevelDetails, label: localizedStrings?.filterHierarchyLevel })]}
+          onFilterClick={onFilterClick}
+          getHierarchyLevelDetails={getHierarchyLevelDetails}
           nodes={rootNodes}
           expandNode={expandNode}
           onNodeClick={onNodeClick}

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
@@ -9,7 +9,7 @@ import { PresentationTreeNode } from "../TreeNode.js";
 import { SelectionMode, useSelectionHandler } from "../UseSelectionHandler.js";
 import { useTree } from "../UseTree.js";
 import { LocalizationContextProvider } from "./LocalizationContext.js";
-import { getFilterAction } from "./TreeActionButtons.js";
+import { getFilterAction } from "./TreeActionButton.js";
 import { TreeLevelRenderer } from "./TreeLevelRenderer.js";
 import { TreeNodeRenderer } from "./TreeNodeRenderer.js";
 

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
@@ -39,17 +39,7 @@ type TreeRendererProps = Pick<ReturnType<typeof useTree>, "expandNode"> &
  * @see https://itwinui.bentley.com/docs/tree
  * @alpha
  */
-export function TreeRenderer({
-  rootNodes,
-  expandNode,
-  localizedStrings,
-  selectNodes,
-  isNodeSelected,
-  selectionMode,
-  onFilterClick,
-  getHierarchyLevelDetails,
-  ...treeProps
-}: TreeRendererProps) {
+export function TreeRenderer({ rootNodes, expandNode, localizedStrings, selectNodes, isNodeSelected, selectionMode, ...treeProps }: TreeRendererProps) {
   const { onNodeClick, onNodeKeyDown } = useSelectionHandler({
     rootNodes,
     selectNodes: selectNodes ?? noopSelectNodes,
@@ -61,8 +51,6 @@ export function TreeRenderer({
       <Tree.Root style={{ height: "100%", width: "100%" }}>
         <TreeLevelRenderer
           {...treeProps}
-          onFilterClick={onFilterClick}
-          getHierarchyLevelDetails={getHierarchyLevelDetails}
           nodes={rootNodes}
           expandNode={expandNode}
           onNodeClick={onNodeClick}

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
@@ -9,7 +9,6 @@ import { PresentationTreeNode } from "../TreeNode.js";
 import { SelectionMode, useSelectionHandler } from "../UseSelectionHandler.js";
 import { useTree } from "../UseTree.js";
 import { LocalizationContextProvider } from "./LocalizationContext.js";
-import { getFilterAction } from "./TreeActionButton.js";
 import { TreeLevelRenderer } from "./TreeLevelRenderer.js";
 import { TreeNodeRenderer } from "./TreeNodeRenderer.js";
 
@@ -47,7 +46,6 @@ export function TreeRenderer({
   selectNodes,
   isNodeSelected,
   selectionMode,
-  actions,
   onFilterClick,
   getHierarchyLevelDetails,
   ...treeProps
@@ -63,7 +61,6 @@ export function TreeRenderer({
       <Tree.Root style={{ height: "100%", width: "100%" }}>
         <TreeLevelRenderer
           {...treeProps}
-          actions={[...(actions || []), getFilterAction({ onClick: onFilterClick, getHierarchyLevelDetails, label: localizedStrings?.filterHierarchyLevel })]}
           onFilterClick={onFilterClick}
           getHierarchyLevelDetails={getHierarchyLevelDetails}
           nodes={rootNodes}


### PR DESCRIPTION
When multiple actions are provided:
![image](https://github.com/user-attachments/assets/f3ab9d90-ae3a-4f6c-9d46-69781cb0a0c7)
![image](https://github.com/user-attachments/assets/d5002c36-cacb-460d-909e-b0c85f680f0b)
When one action is provided:
![image](https://github.com/user-attachments/assets/fcf82e7c-59d9-4106-9dff-ac0af8fa8063)
When no actions are provided:
![image](https://github.com/user-attachments/assets/3bb857c5-cbd0-4012-894b-70047dba2eb0)

Keeping icon button position in the same place when other icon buttons are not displayed:
![image](https://github.com/user-attachments/assets/e3bf8fb3-2261-493e-99e6-ca9898ff9c6b)
![image](https://github.com/user-attachments/assets/3cb64156-3d87-43d2-aad2-79fecdc14f78)
When dropdown actions exist but none are visible for a node.
![image](https://github.com/user-attachments/assets/de3c7ac5-804f-4f44-a3fa-6d2e294aa55c)

