### PR TITLE
[hierarchies-react]: Fixes for Tree component on touch devices

### DIFF
--- a/.changeset/long-news-push.md
+++ b/.changeset/long-news-push.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Fix hierarchy level size exceeds limit info message wrapping in narrow Tree on Safari browser.

--- a/.changeset/selfish-chefs-raise.md
+++ b/.changeset/selfish-chefs-raise.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Do not require two clicks to expand node with filter buttons on touch devices.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.css
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.css
@@ -11,10 +11,15 @@
   visibility: hidden;
 }
 
-.stateless-tree-node:hover .action-buttons,
 .stateless-tree-node.filtered .action-buttons,
 .stateless-tree-node:focus-within .action-buttons {
   visibility: visible;
+}
+
+@media (hover: hover) {
+  .stateless-tree-node:hover .action-buttons {
+    visibility: visible;
+  }
 }
 
 .stateless-tree-node:focus-within {

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -286,7 +286,7 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
     return {
       title: messageWithLimit,
       element: (
-        <Text as="span" style={{ textWrap: "wrap" }}>
+        <Text as="span" style={{ whiteSpace: "pre-wrap" }}>
           {messageWithLimit}
         </Text>
       ),
@@ -301,12 +301,12 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
     element: (
       <div>
         {textBefore ? (
-          <Text as="span" style={{ textWrap: "wrap" }}>
+          <Text as="span" style={{ whiteSpace: "pre-wrap" }}>
             {textBefore}
           </Text>
         ) : null}
         <Anchor
-          style={{ textWrap: "wrap" }}
+          style={{ whiteSpace: "pre-wrap" }}
           underline
           onClick={(e) => {
             e.stopPropagation();
@@ -316,7 +316,7 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
           {innerText}
         </Anchor>
         {textAfter ? (
-          <Text as="span" style={{ textWrap: "wrap" }}>
+          <Text as="span" style={{ whiteSpace: "pre-wrap" }}>
             {textAfter}
           </Text>
         ) : null}

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -286,7 +286,7 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
     return {
       title: messageWithLimit,
       element: (
-        <Text as="span" style={{ whiteSpace: "pre-wrap" }}>
+        <Text as="span" style={{ whiteSpace: "normal" }}>
           {messageWithLimit}
         </Text>
       ),
@@ -301,12 +301,12 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
     element: (
       <div>
         {textBefore ? (
-          <Text as="span" style={{ whiteSpace: "pre-wrap" }}>
+          <Text as="span" style={{ whiteSpace: "normal" }}>
             {textBefore}
           </Text>
         ) : null}
         <Anchor
-          style={{ whiteSpace: "pre-wrap" }}
+          style={{ whiteSpace: "normal" }}
           underline
           onClick={(e) => {
             e.stopPropagation();
@@ -316,7 +316,7 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
           {innerText}
         </Anchor>
         {textAfter ? (
-          <Text as="span" style={{ whiteSpace: "pre-wrap" }}>
+          <Text as="span" style={{ whiteSpace: "normal" }}>
             {textAfter}
           </Text>
         ) : null}


### PR DESCRIPTION
This PR includes couple fixes for Tree component on touch devices:
- Fixed tree node requiring two click to expand on touch devices when node has filtering buttons. https://github.com/iTwin/viewer-components-react/issues/1156
- Fixed hierarchy level size exceeded message not being wrapped on Safari. Previous example didn't work on all browsers https://github.com/iTwin/presentation/pull/866