### PR TITLE
[Hierarchies-react]: kiwi tree virtualization

### DIFF
--- a/packages/hierarchies-react/package.json
+++ b/packages/hierarchies-react/package.json
@@ -57,6 +57,7 @@
     "@itwin/presentation-hierarchies": "workspace:^",
     "@itwin/presentation-shared": "workspace:^",
     "@itwin/unified-selection": "workspace:^",
+    "@tanstack/react-virtual": "^3.13.0",
     "classnames": "catalog:react",
     "immer": "^10.1.1",
     "react-error-boundary": "catalog:react",

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
@@ -60,7 +60,7 @@ export function TreeRenderer({ rootNodes, expandNode, localizedStrings, selectNo
 
   return (
     <LocalizationContextProvider localizedStrings={localizedStrings}>
-      <div className="TreeContainerWIP" style={{ height: "100%", width: "100%", overflowY: "auto", position: "relative" }} ref={parentRef}>
+      <div style={{ height: "100%", width: "100%", overflowY: "auto", position: "relative" }} ref={parentRef}>
         <Tree.Root style={{ height: "100%", width: "100%", overflow: "initial" }}>
           {items.map((virtualizedItem) => {
             return (

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
@@ -3,8 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { ComponentPropsWithoutRef, useMemo } from "react";
+import { ComponentPropsWithoutRef, useMemo, useRef } from "react";
 import { Tree } from "@itwin/itwinui-react/bricks";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { PresentationTreeNode } from "../TreeNode.js";
 import { SelectionMode, useSelectionHandler } from "../UseSelectionHandler.js";
 import { useTree } from "../UseTree.js";
@@ -45,16 +46,51 @@ export function TreeRenderer({ rootNodes, expandNode, localizedStrings, selectNo
     selectNodes: selectNodes ?? noopSelectNodes,
     selectionMode: selectionMode ?? "single",
   });
-
+  const parentRef = useRef<HTMLDivElement>(null);
   const flatNodes = useMemo(() => flattenNodes(rootNodes), [rootNodes]);
+
+  const virtualizer = useVirtualizer({
+    count: flatNodes.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 28,
+    overscan: 30,
+  });
+
+  const items = virtualizer.getVirtualItems();
 
   return (
     <LocalizationContextProvider localizedStrings={localizedStrings}>
-      <Tree.Root style={{ height: "100%", width: "100%" }}>
-        {flatNodes.map((flatNode) => (
-          <TreeNodeRenderer {...treeProps} expandNode={expandNode} onNodeClick={onNodeClick} onNodeKeyDown={onNodeKeyDown} node={flatNode} key={flatNode.id} />
-        ))}
-      </Tree.Root>
+      <div className="TreeContainerWIP" style={{ height: "100%", width: "100%", overflowY: "auto", position: "relative" }} ref={parentRef}>
+        <Tree.Root style={{ height: "100%", width: "100%", overflow: "initial" }}>
+          {items.map((virtualizedItem) => {
+            return (
+              <div
+                key={virtualizedItem.key}
+                data-index={virtualizedItem.index}
+                ref={virtualizer.measureElement}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  height: `${virtualizedItem.size}px`,
+                  transform: `translateY(${virtualizedItem.start}px)`,
+                  willChange: "transform",
+                }}
+              >
+                <TreeNodeRenderer
+                  {...treeProps}
+                  expandNode={expandNode}
+                  onNodeClick={onNodeClick}
+                  onNodeKeyDown={onNodeKeyDown}
+                  node={flatNodes[virtualizedItem.index]}
+                  key={flatNodes[virtualizedItem.index].id}
+                />
+              </div>
+            );
+          })}
+        </Tree.Root>
+      </div>
     </LocalizationContextProvider>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,7 +327,7 @@ importers:
         version: 5.0.0-dev.1(eslint@9.13.0)(typescript@5.7.3)
       '@itwin/imodel-components-react':
         specifier: catalog:appui
-        version: 5.1.0(n4p36drt7ekczjbxhh6gvyrnve)
+        version: 5.1.0(vqkky3ckm4phfnyoxeqaauu3vi)
       '@itwin/itwinui-react':
         specifier: catalog:itwinui
         version: 3.17.2(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -345,7 +345,7 @@ importers:
         version: link:../../packages/core-interop
       '@itwin/presentation-frontend':
         specifier: catalog:itwinjs-core
-        version: 5.0.0-dev.49(wyxuqho7x5xpwxd4alb6zqx25m)
+        version: 5.0.0-dev.49(ehrnzcqec66upe7ju7s2vhhuoa)
       '@itwin/presentation-hierarchies':
         specifier: workspace:^
         version: link:../../packages/hierarchies
@@ -907,7 +907,7 @@ importers:
         version: 5.0.0-dev.1(eslint@9.13.0)(typescript@5.7.3)
       '@itwin/imodel-components-react':
         specifier: catalog:appui
-        version: 5.1.0(n4p36drt7ekczjbxhh6gvyrnve)
+        version: 5.1.0(vqkky3ckm4phfnyoxeqaauu3vi)
       '@itwin/itwinui-icons':
         specifier: 5.0.0-alpha.3
         version: 5.0.0-alpha.3
@@ -931,7 +931,7 @@ importers:
         version: link:../../../packages/core-interop
       '@itwin/presentation-frontend':
         specifier: catalog:itwinjs-core
-        version: 5.0.0-dev.49(wyxuqho7x5xpwxd4alb6zqx25m)
+        version: 5.0.0-dev.49(ehrnzcqec66upe7ju7s2vhhuoa)
       '@itwin/presentation-hierarchies':
         specifier: workspace:*
         version: link:../../../packages/hierarchies
@@ -1115,7 +1115,7 @@ importers:
         version: 5.0.0-dev.1(eslint@9.13.0)(typescript@5.7.3)
       '@itwin/imodel-components-react':
         specifier: catalog:appui
-        version: 5.1.0(n4p36drt7ekczjbxhh6gvyrnve)
+        version: 5.1.0(vqkky3ckm4phfnyoxeqaauu3vi)
       '@itwin/itwinui-react':
         specifier: catalog:itwinui
         version: 3.17.2(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1124,7 +1124,7 @@ importers:
         version: 5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)(@itwin/core-common@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)(@itwin/core-geometry@5.0.0-dev.49))(@itwin/core-quantity@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49))(@itwin/ecschema-metadata@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)(@itwin/core-quantity@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)))
       '@itwin/presentation-frontend':
         specifier: catalog:itwinjs-core
-        version: 5.0.0-dev.49(wyxuqho7x5xpwxd4alb6zqx25m)
+        version: 5.0.0-dev.49(ehrnzcqec66upe7ju7s2vhhuoa)
       '@itwin/unified-selection-react':
         specifier: workspace:^
         version: link:../unified-selection-react
@@ -1421,6 +1421,9 @@ importers:
       '@itwin/unified-selection':
         specifier: workspace:^
         version: link:../unified-selection
+      '@tanstack/react-virtual':
+        specifier: ^3.13.0
+        version: 3.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       classnames:
         specifier: catalog:react
         version: 2.5.1
@@ -1809,7 +1812,7 @@ importers:
         version: 5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)(@itwin/core-common@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)(@itwin/core-geometry@5.0.0-dev.49))(@itwin/core-quantity@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49))(@itwin/ecschema-metadata@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)(@itwin/core-quantity@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)))
       '@itwin/presentation-frontend':
         specifier: catalog:itwinjs-core
-        version: 5.0.0-dev.49(wyxuqho7x5xpwxd4alb6zqx25m)
+        version: 5.0.0-dev.49(ehrnzcqec66upe7ju7s2vhhuoa)
       '@itwin/webgl-compatibility':
         specifier: catalog:itwinjs-core
         version: 5.0.0-dev.49
@@ -6852,6 +6855,7 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -10587,7 +10591,7 @@ snapshots:
       '@itwin/core-geometry': 5.0.0-dev.49
       '@itwin/core-quantity': 5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)
       '@itwin/core-react': 5.1.0(@itwin/appui-abstract@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49))(@itwin/core-bentley@5.0.0-dev.49)(@itwin/itwinui-react@3.17.2(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@itwin/imodel-components-react': 5.1.0(n4p36drt7ekczjbxhh6gvyrnve)
+      '@itwin/imodel-components-react': 5.1.0(vqkky3ckm4phfnyoxeqaauu3vi)
       '@itwin/itwinui-icons-react': 2.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-react': 3.17.2(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10808,7 +10812,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@itwin/imodel-components-react@5.1.0(n4p36drt7ekczjbxhh6gvyrnve)':
+  '@itwin/imodel-components-react@5.1.0(vqkky3ckm4phfnyoxeqaauu3vi)':
     dependencies:
       '@itwin/appui-abstract': 5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)
       '@itwin/components-react': 5.1.0(@itwin/appui-abstract@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49))(@itwin/core-bentley@5.0.0-dev.49)(@itwin/core-react@5.1.0(@itwin/appui-abstract@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49))(@itwin/core-bentley@5.0.0-dev.49)(@itwin/itwinui-react@3.17.2(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/itwinui-react@3.17.2(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10899,7 +10903,7 @@ snapshots:
       '@itwin/core-quantity': 5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)
       '@itwin/ecschema-metadata': 5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)(@itwin/core-quantity@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49))
 
-  '@itwin/presentation-frontend@5.0.0-dev.49(wyxuqho7x5xpwxd4alb6zqx25m)':
+  '@itwin/presentation-frontend@5.0.0-dev.49(ehrnzcqec66upe7ju7s2vhhuoa)':
     dependencies:
       '@itwin/core-bentley': 5.0.0-dev.49
       '@itwin/core-common': 5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)(@itwin/core-geometry@5.0.0-dev.49)


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/1205

Explanation on changes:
 - Tree root is now wrapped in a div which contains the scroll, this kind of setup is recommended by tanstack.
 - Tree items are now wrapped in a div with styles that are needed for virtualization, removing it and applying these styles directly on tree items cause stuttering.
 - Transform & willChange is used to improve virtualization performance

Preview:

https://github.com/user-attachments/assets/5ac5980c-8173-4a93-a6c1-3d83e536a793

