### PR TITLE
[Hierarchy-react]: focus outline on tree nodes

### DIFF
--- a/.changeset/good-bobcats-matter.md
+++ b/.changeset/good-bobcats-matter.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Fix focus outline for tree items not being visible on action items click.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.css
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.css
@@ -3,7 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-.stateless-tree-node:focus-within {
-  outline: 2px solid var(--iui-color-border-accent);
+.stateless-tree-node:focus-within::before {
+  content: "";
+  z-index: 1;
+  pointer-events: none;
+  outline: 2px solid var(--ids-color-border-accent-strong);
   outline-offset: -1px;
+  position: absolute;
+  inset: 0px;
 }

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.css
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.css
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.stateless-tree-node:focus-within {
+  outline: 2px solid var(--iui-color-border-accent);
+  outline-offset: -1px;
+}

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import "./TreeNodeRenderer.css";
 import {
   ComponentPropsWithoutRef,
   forwardRef,
@@ -135,6 +136,7 @@ export const TreeNodeRenderer: ForwardRefExoticComponent<TreeNodeRendererProps &
     return (
       <Tree.Item
         {...treeItemProps}
+        className={"stateless-tree-node"}
         ref={ref}
         aria-level={node.level}
         aria-posinset={node.posInLevel}


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/1215

Current version: 
![image](https://github.com/user-attachments/assets/d2d48b50-2963-4a5f-9531-8d1f4e1aa7f7)

Because kiwi tree uses outline with offset -1px, we have to use `before` to have outline not hidden behind action buttons.

Ps. Kiwi tree currently does not handle padding correctly and outline is not fully visible in some cases, added outline mimics the outline kiwi tree provides with keyboard navigation. The issue of not fully visible outlines should be fixed on kiwi's side 