### PR TITLE
[Hierarchy-react]: kiwi tree sub label

### DIFF
--- a/.changeset/plenty-boats-judge.md
+++ b/.changeset/plenty-boats-judge.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Fix `treeRenderer` property `getSublabel` not being used.

--- a/apps/test-app/frontend/package.json
+++ b/apps/test-app/frontend/package.json
@@ -33,7 +33,7 @@
     "@itwin/itwinui-icons-react": "catalog:itwinui",
     "@itwin/itwinui-icons": "5.0.0-alpha.4",
     "@itwin/itwinui-react": "catalog:itwinui",
-    "@itwin/itwinui-react-v5": "npm:@itwin/itwinui-react@5.0.0-alpha.7",
+    "@itwin/itwinui-react-v5": "npm:@itwin/itwinui-react@5.0.0-alpha.8",
     "@itwin/presentation-common": "catalog:itwinjs-core",
     "@itwin/presentation-components": "workspace:*",
     "@itwin/presentation-core-interop": "workspace:*",

--- a/packages/hierarchies-react/package.json
+++ b/packages/hierarchies-react/package.json
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "@itwin/itwinui-icons": "5.0.0-alpha.4",
-    "@itwin/itwinui-react": "5.0.0-alpha.7",
+    "@itwin/itwinui-react": "5.0.0-alpha.8",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
   },
@@ -80,7 +80,7 @@
   "devDependencies": {
     "@itwin/build-tools": "catalog:build-tools",
     "@itwin/itwinui-icons": "5.0.0-alpha.4",
-    "@itwin/itwinui-react": "5.0.0-alpha.7",
+    "@itwin/itwinui-react": "5.0.0-alpha.8",
     "@testing-library/dom": "catalog:test-tools",
     "@testing-library/react": "catalog:test-tools",
     "@testing-library/user-event": "catalog:test-tools",

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeErrorRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeErrorRenderer.tsx
@@ -134,7 +134,7 @@ function ErrorNodeLabel({ message, onRetry }: { message: string; onRetry?: () =>
   const { localizedStrings } = useLocalizationContext();
   return (
     <div style={{ display: "flex" }}>
-      <Text>{message}</Text>
+      <Text variant={"display-lg"}>{message}</Text>
       {onRetry ? <Anchor onClick={onRetry}>{localizedStrings?.retry}</Anchor> : null}
     </div>
   );
@@ -151,7 +151,7 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
       title: messageWithLimit,
       element: (
         <div style={{ display: "flex" }}>
-          <Text>{messageWithLimit}</Text>
+          <Text variant={"display-lg"}>{messageWithLimit}</Text>
         </div>
       ),
     };
@@ -164,7 +164,7 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
     title: messageWithLimit.replace(fullText, innerText),
     element: (
       <div style={{ display: "flex" }}>
-        {textBefore ? <Text>{textBefore}</Text> : null}
+        {textBefore ? <Text variant={"display-lg"}>{textBefore}</Text> : null}
         <Anchor
           // underline props does not exist in v5
           onClick={(e) => {
@@ -174,7 +174,7 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
         >
           {innerText}
         </Anchor>
-        {textAfter ? <Text>{textAfter}</Text> : null}
+        {textAfter ? <Text variant={"display-lg"}>{textAfter}</Text> : null}
       </div>
     ),
   };

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeErrorRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeErrorRenderer.tsx
@@ -134,7 +134,7 @@ function ErrorNodeLabel({ message, onRetry }: { message: string; onRetry?: () =>
   const { localizedStrings } = useLocalizationContext();
   return (
     <div style={{ display: "flex" }}>
-      <Text variant={"display-lg"}>{message}</Text>
+      <Text variant={"body-sm"}>{message}</Text>
       {onRetry ? <Anchor onClick={onRetry}>{localizedStrings?.retry}</Anchor> : null}
     </div>
   );
@@ -151,7 +151,7 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
       title: messageWithLimit,
       element: (
         <div style={{ display: "flex" }}>
-          <Text variant={"display-lg"}>{messageWithLimit}</Text>
+          <Text variant={"body-sm"}>{messageWithLimit}</Text>
         </div>
       ),
     };
@@ -164,7 +164,7 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
     title: messageWithLimit.replace(fullText, innerText),
     element: (
       <div style={{ display: "flex" }}>
-        {textBefore ? <Text variant={"display-lg"}>{textBefore}</Text> : null}
+        {textBefore ? <Text variant={"body-sm"}>{textBefore}</Text> : null}
         <Anchor
           // underline props does not exist in v5
           onClick={(e) => {
@@ -174,7 +174,7 @@ function createLocalizedMessage(message: string, limit: number, onClick?: () => 
         >
           {innerText}
         </Anchor>
-        {textAfter ? <Text variant={"display-lg"}>{textAfter}</Text> : null}
+        {textAfter ? <Text variant={"body-sm"}>{textAfter}</Text> : null}
       </div>
     ),
   };

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -70,6 +70,7 @@ export const TreeNodeRenderer: ForwardRefExoticComponent<TreeNodeRendererProps &
       expandNode,
       getIcon,
       getLabel,
+      getSublabel,
       onFilterClick,
       onNodeClick,
       onNodeKeyDown,
@@ -142,6 +143,7 @@ export const TreeNodeRenderer: ForwardRefExoticComponent<TreeNodeRendererProps &
         aria-posinset={node.posInLevel}
         aria-setsize={node.levelSize}
         label={getLabel ? getLabel(node) : node.label}
+        description={getSublabel ? getSublabel(node) : undefined}
         selected={selected}
         expanded={node.isExpanded || node.children === true || node.children.length > 0 ? node.isExpanded : undefined}
         onExpandedChange={(isExpanded) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,8 +918,8 @@ importers:
         specifier: catalog:itwinui
         version: 3.17.2(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/itwinui-react-v5':
-        specifier: npm:@itwin/itwinui-react@5.0.0-alpha.7
-        version: '@itwin/itwinui-react@5.0.0-alpha.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
+        specifier: npm:@itwin/itwinui-react@5.0.0-alpha.8
+        version: '@itwin/itwinui-react@5.0.0-alpha.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
       '@itwin/presentation-common':
         specifier: catalog:itwinjs-core
         version: 5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)(@itwin/core-common@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)(@itwin/core-geometry@5.0.0-dev.49))(@itwin/core-quantity@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49))(@itwin/ecschema-metadata@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)(@itwin/core-quantity@5.0.0-dev.49(@itwin/core-bentley@5.0.0-dev.49)))
@@ -1444,8 +1444,8 @@ importers:
         specifier: 5.0.0-alpha.4
         version: 5.0.0-alpha.4
       '@itwin/itwinui-react':
-        specifier: 5.0.0-alpha.7
-        version: 5.0.0-alpha.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 5.0.0-alpha.8
+        version: 5.0.0-alpha.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/dom':
         specifier: catalog:test-tools
         version: 10.3.2
@@ -2996,8 +2996,8 @@ packages:
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
 
-  '@itwin/itwinui-react@5.0.0-alpha.7':
-    resolution: {integrity: sha512-2vTZrWChBrcxK/U41DtYixRun02ylSKgCFRrBhsnXZlAirnYBJGZo97+9+lvPjjVXFsYEqSJfIPitouCaJZM3w==}
+  '@itwin/itwinui-react@5.0.0-alpha.8':
+    resolution: {integrity: sha512-hgKlTs6KvEmiY2AI3R6G48yjAHulbA6jEBuhJQS2lFxFevFpF6sht0VufI9UkTEu7vh83Y5o06EMBCfEYIhD0A==}
     peerDependencies:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
@@ -10855,7 +10855,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@itwin/itwinui-react@5.0.0-alpha.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@itwin/itwinui-react@5.0.0-alpha.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@ariakit/react': 0.4.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       classnames: 2.5.1


### PR DESCRIPTION
Updated itwinUI to alpha.8, this makes `variant` a required prop for text, which we use in node errors.

Sub label visuals:
![image](https://github.com/user-attachments/assets/ffd83680-8698-4818-ae8c-4039069932d5)

Error nodes are still broken, but chose a variant that would not brake it further (with text size). This should be fixed when we get tree error items.
![image](https://github.com/user-attachments/assets/805c5eaa-09c8-4abb-abd6-dca4bd749e18)

