### PR TITLE
Specify concrete version in peer deps for workspace packages

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -78,7 +78,7 @@
     "@itwin/itwinui-react": "^3.0.0",
     "@itwin/presentation-common": "^4.4.0 || ^5.0.0",
     "@itwin/presentation-frontend": "^4.4.0 || ^5.0.0",
-    "@itwin/unified-selection-react": "workspace:^",
+    "@itwin/unified-selection-react": "^1.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
   },

--- a/packages/unified-selection-react/package.json
+++ b/packages/unified-selection-react/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@itwin/unified-selection": "workspace:^",
+    "@itwin/unified-selection": "^1.3.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
   },


### PR DESCRIPTION
Having `workspace:^` on a workspace peer dep causes a major version bump whenever there's a change in peer dep package.