### PR TITLE
Unified selection: Add a "Selection scopes" section to migration guide

### DIFF
--- a/.changeset/hungry-berries-sort.md
+++ b/.changeset/hungry-berries-sort.md
@@ -1,0 +1,10 @@
+---
+"@itwin/unified-selection": minor
+---
+
+Export `SelectionScope` type to make it easier for consumers to define "active scope" type.
+
+APIs that use this type:
+
+- The `scope` prop of `computeSelection` function.
+- Return type of `activeScopeProvider` callback prop of `enableUnifiedSelectionSyncWithIModel` function.

--- a/packages/unified-selection/api/unified-selection.api.md
+++ b/packages/unified-selection/api/unified-selection.api.md
@@ -35,9 +35,7 @@ export function computeSelection(props: ComputeSelectionProps): AsyncIterableIte
 interface ComputeSelectionProps {
     elementIds: Id64Arg;
     queryExecutor: ECSqlQueryExecutor;
-    scope: ElementSelectionScopeProps | {
-        id: SelectionScope;
-    } | SelectionScope;
+    scope: SelectionScope;
 }
 
 // @public
@@ -114,7 +112,7 @@ export function enableUnifiedSelectionSyncWithIModel(props: EnableUnifiedSelecti
 
 // @public
 interface EnableUnifiedSelectionSyncWithIModelProps {
-    activeScopeProvider: () => ComputeSelectionProps["scope"];
+    activeScopeProvider: () => SelectionScope;
     cachingHiliteSetProvider?: CachingHiliteSetProvider | (Omit<CachingHiliteSetProvider, "dispose"> & {
         [Symbol.dispose]: () => void;
     });
@@ -196,7 +194,12 @@ export namespace Selectables {
 }
 
 // @public
-type SelectionScope = "element" | "model" | "category" | "functional";
+export type SelectionScope = ElementSelectionScopeProps | {
+    id: SelectionScopeIdentifier;
+} | SelectionScopeIdentifier;
+
+// @public
+type SelectionScopeIdentifier = "element" | "model" | "category" | "functional";
 
 // @public
 export interface SelectionStorage {

--- a/packages/unified-selection/api/unified-selection.exports.csv
+++ b/packages/unified-selection/api/unified-selection.exports.csv
@@ -15,6 +15,7 @@ public;type;SelectableIdentifier
 public;interface;SelectableInstanceKey
 public;interface;Selectables
 public;namespace;Selectables
+public;type;SelectionScope
 public;interface;SelectionStorage
 public;interface;StorageSelectionChangeEventArgs
 public;type;StorageSelectionChangesListener

--- a/packages/unified-selection/learning/MigrationGuide.md
+++ b/packages/unified-selection/learning/MigrationGuide.md
@@ -20,7 +20,7 @@ Before the deprecation, we made sure that migration is as smooth as possible by 
 
    The [Tree](./SyncWithTree.md), [Table](./SyncWithTable.md) and [Property grid](./SyncWithPropertyGrid.md) components simply got a new `selectionStorage` prop, which tells them to use the new system (click on the links for specific APIs). For Table and Property grid components, the new prop is optional to keep them backwards compatible - in that case they continue working with the deprecated API.
 
-   The [viewWithUnifiedSelection](https://www.itwinjs.org/reference/presentation-components/viewport/viewwithunifiedselection/) HOC was deprecated in favor of the `enableUnifiedSelectionSyncWithIModel` provided by this package. The API is quite a bit different, but it's more clear about what it does and is more flexible in how it can be used. See the [SyncWithIModelConnection](./SyncWithIModelConnection.md) learning page for more information and example for using in a React app.
+   The [viewWithUnifiedSelection](https://www.itwinjs.org/reference/presentation-components/viewport/viewwithunifiedselection/) HOC was deprecated in favor of the `enableUnifiedSelectionSyncWithIModel` provided by this package. The API is quite a bit different, but it's more clear about what it does and is more flexible in how it can be used. See the [iModel selection synchronization with unified selection](./SyncWithIModelConnection.md) learning page for more information and example for using it in a React app.
 
 2. Existing components, that haven't migrated to the new system, continue working as expected.
 
@@ -52,7 +52,7 @@ Before the deprecation, we made sure that migration is as smooth as possible by 
 
 The old system has a [SelectionManager](https://www.itwinjs.org/reference/presentation-frontend/unifiedselection/selectionmanager/) class, whose singleton instance could be accessed through a call to `Presentation.selection` on the frontend. The instance acted both - as an entry point to hilite and selection scope APIS, and as a selection storage with all its modification and listening APIs.
 
-The new system has a more modular approach. The hilite and selection scope APIs are now separate (see [Computing selection based on selection scope](#computing-selection-based-on-selection-scope) and [Computing hilite set](#computing-hilite-set) sections), and the selection management APIs are very similar and are located on the `SelectionStorage` type.
+The new system has a more modular approach. The hilite and selection scope APIs are now separate (see [Selection scopes](#selection-scopes) and [Hilite sets](#hilite-sets) sections), and the selection management APIs are very similar and are located on the `SelectionStorage` type.
 
 An example of [SelectionManager](https://www.itwinjs.org/reference/presentation-frontend/unifiedselection/selectionmanager/) API usage:
 
@@ -106,9 +106,39 @@ const onButtonClick = () => {
 };
 ```
 
-## Computing selection based on selection scope
+## Selection scopes
 
-As mentioned in the [Managing unified selection directly](#managing-unified-selection-directly) section, the [SelectionManager](https://www.itwinjs.org/reference/presentation-frontend/unifiedselection/selectionmanager/) was an entry point to selection scopes' functionality. So you'd do something like this:
+There are several situations where application components need to interact with selection scopes' APIs:
+
+- Get available selection scopes list.
+- Get / set the active selection scope.
+- Compute selection based on picked elements and selection scope.
+
+The following sections provide examples of how to migrate from the old system to the new one for each of these use cases.
+
+### Getting available selection scopes
+
+The old system provided a way to get a hardcoded list of available selection scopes by making a call to [SelectionScopesManager.getSelectionScopes](https://www.itwinjs.org/reference/presentation-frontend/unifiedselection/selectionscopesmanager/getselectionscopes/). This call resulted in a trip to the backend and the result was hard to predict to consumers - for example, a new scope may become available unexpectedly, without consumers' consent.
+
+```ts
+const scopes: SelectionScope[] = await Presentation.selection.scopes.getSelectionScopes(iModelConnection);
+```
+
+The new system doesn't define a list of available scopes for the consumers. Instead, it defines a `SelectionScope` type to describe a selection scope, and consumers are free to define the scopes they want to use. In fact, the new system doesn't care about such list of scopes at all - it only cares about the "active" selection scope.
+
+### Get / set the active selection scope
+
+Similar to the above, the old system provided a way to get / set the active selection scope through the [SelectionScopesManager](https://www.itwinjs.org/reference/presentation-frontend/unifiedselection/selectionscopesmanager/) and, more specifically, its [activeScope](https://www.itwinjs.org/reference/presentation-frontend/unifiedselection/selectionscopesmanager/activescope/) property:
+
+```ts
+const activeScope = Presentation.selection.scopes.activeScope;
+```
+
+There is no such global "active" selection scope in the new system and in case consumers even need this - maintaining it is now their responsibility. Some applications may not care about selection scopes and simply pass some default scope straight to `enableUnifiedSelectionSyncWithIModel`. Some may not even need unified selection sync.
+
+### Computing selection based on selection scope
+
+In some rare cases, consumers need to compute selection based on the picked elements and an arbitrary selection scope. To achieve that in the old system, you'd do something like this:
 
 ```ts
 const selection: KeySet = await Presentation.selection.scopes.computeSelection(iModelConnection, elementIds, { id: "element", ancestorLevel: 1 });
@@ -124,48 +154,199 @@ const selection: AsyncIterableIterator<SelectableInstanceKey> = computeSelection
 });
 ```
 
-## Computing hilite set
+### AppUI integration
+
+It may not be obvious how everything fits together in a real-world, [AppUI](https://www.itwinjs.org/reference/appui-react/)-driven iTwin.js application. This is mostly due to very obscure dependencies between components in AppUI and legacy Presentation packages. Hopefully, the new system makes things easier to understand and integrate.
+
+The setup in the old system consisted of the following steps:
+
+```ts
+// 1. Call this when iModel connection is opened:
+async function initializeSelectionScopes(imodel: IModelConnection) {
+  const availableScopes = await Presentation.selection.scopes.getSelectionScopes(imodel);
+  UiFramework.dispatchActionToStore(
+    SessionStateActionId.SetAvailableSelectionScopes,
+    availableScopes
+  );
+}
+
+// 2. Sync AppUI's active selection scope to Presentation's `SelectionScopesManager` - call this when initializing the app:
+async function syncActiveSelectionScope() {
+  Presentation.selection.scopes.activeScope = UiFramework.getActiveSelectionScope();
+  SyncUiEventDispatcher.onSyncUiEvent.addListener((args: UiSyncEventArgs) => {
+    if (args.eventIds.has(SessionStateActionId.SetSelectionScope)) {
+      Presentation.selection.scopes.activeScope = UiFramework.getActiveSelectionScope();
+    }
+  });
+}
+
+// 3. Render `<SelectionScopeField />` AppUI component in status bar by returning it from a `UiItemsProvider`:
+class MyStatusbarItemsProvider implements UiItemsProvider {
+  public provideStatusBarItems(): StatusBarItem[] {
+    return [
+      StatusBarItemUtilities.createCustomItem(
+        "SelectionScope",
+        StatusBarSection.Right,
+        30,
+        <SelectionScopeField />,
+      ),
+    ];
+  }
+}
+// The `<SelectionScopeField />` component, when rendered without props, uses deprecated Redux store APIs to access available
+// selection scopes (set in step #1), and maintain the active selection scope and update it in Redux store, making the value
+// accessible through the deprecated `UiFramework.getActiveSelectionScope()` function (see step #2).
+
+// 4. Finally, the consumer has to wrap `ViewportComponent` with the deprecated `viewWithUnifiedSelection` React HOC to create
+// a unified selection-enabled viewport component, which uses `Presentation.selection.scopes.activeScope` to compute selection
+// when users pick elements in the viewport.
+const UnifiedSelectionViewport = viewWithUnifiedSelection(ViewportComponent);
+function MyViewport(props: { imodel: IModelConnection; initialViewState: ViewState }) {
+  return <UnifiedSelectionViewport imodel={props.imodel} viewState={props.initialViewState} />;
+}
+```
+
+The recommended setup in the new system is to rely on React context to do the job:
+
+```ts
+// 1. Define a React context to set up available scopes and maintain the active scope:
+const availableScopes: { [id: string]: { label: string; def: SelectionScope } } = {
+  element: {
+    label: "Element",
+    def: { id: "element" },
+  },
+  assembly: {
+    label: "Assembly",
+    def: { id: "element", ancestorLevel: 1 },
+  },
+};
+const selectionScopesContext = React.createContext<{
+  availableScopes: typeof availableScopes,
+  activeScope: { id: string; def: SelectionScope; }
+  onScopeChange: (scopeId: string) => void;
+}>({
+  availableScopes: { element: { label: "Element", def: "element" } },
+  activeScope: { id: "element", def: "element" },
+  onScopeChange: () => {},
+});
+export function SelectionScopesContextProvider({ children }: React.PropsWithChildren<{}>) {
+  const [activeScope, setActiveScope] = React.useState<{ id: string; def: SelectionScope }>({ id: "element", def: availableScopes["element"].def });
+  const onScopeChange = React.useCallback(
+    (scopeId: string) => {
+      setActiveScope({ id: scopeId, def: availableScopes[scopeId].def });
+    },
+    []
+  );
+  return (
+    <selectionScopesContext.Provider value={{ availableScopes, activeScope, onScopeChange }}>
+      {children}
+    </selectionScopesContext.Provider>
+  );
+}
+export function useSelectionScopesContext() {
+  return React.useContext(selectionScopesContext);
+}
+
+// 2. Provide the context to AppUI components by wrapping `<ConfigurableUiContent />` with our `SelectionScopesContextProvider`:
+function MyApp() {
+  // ... possibly some initialization logic here
+  return (
+    <SelectionScopesContextProvider>
+      <ConfigurableUiContent />
+    </SelectionScopesContextProvider>
+  );
+}
+
+// 3. Render `<SelectionScopeField />` that uses the above context:
+import { SelectionScopeField as AppUiSelectionScopeField } from "@itwin/appui-react";
+function SelectionScopeField() {
+  const ctx = useSelectionScopesContext();
+  const selectionScopes = React.useMemo(
+    () => Object.entries(ctx.availableScopes).map(([id, { label }]) => ({ id, label })),
+    [],
+  );
+  return (
+    <AppUiSelectionScopeField
+      selectionScopes={selectionScopes}
+      activeScope={ctx.activeScope.id}
+      onChange={ctx.onScopeChange}
+    />
+  );
+}
+// Then, just provide the field to AppUI system as usual.
+
+// 4. Enable unified selection synchronization in the top-level iModel-driven component:
+function MyIModelComponent({ imodel, selectionStorage }: { imodel: IModelConnection; selectionStorage: SelectionStorage }) {
+  const ctx = useSelectionScopesContext();
+  const activeScope = ctx.activeScope.def;
+  const activeScopeRef = React.useRef<SelectionScope>(activeScope);
+  React.useEffect(() => {
+    activeScopeRef.current = activeScope;
+  }, [activeScope]);
+  React.useEffect(
+    () => enableUnifiedSelectionSyncWithIModel({
+      imodelAccess: createIModelAccess(imodel),
+      selectionStorage,
+      activeScopeProvider: () => activeScopeRef.current,
+    }),
+    [imodel, selectionStorage],
+  );
+
+  // ... render the rest of the component
+}
+```
+
+While it may seem that the new approach is more verbose, it's actually more flexible and easier to understand. The new system doesn't rely on global state and doesn't require any specific APIs to be called in a specific order. It's also more clear about what's happening and what's being passed around.
+
+## Hilite sets
 
 There are two situations where hilite set computation is needed:
 
-1. For the "active" selection. This is a more common case, where the result is cached upon request and invalidated when the selection changes.
+- For the "active" selection.
+- For arbitrary elements / selectables.
 
-   In the old system, you'd do something like this:
+The following sections provide examples of how to migrate from the old system to the new one for each of these use cases.
 
-   ```ts
-   const hiliteSet: AsyncIterableIterator<HiliteSet> = Presentation.selection.getHiliteSetIterator(iModelConnection);
-   ```
+### Getting hilite set for the "active" selection
 
-   In the new system, a hilite set provider has to be created. The provider holds the cached result and can be shared across components to avoid excessive requests.
+This is a more common case, where the result is cached upon request and invalidated when the selection changes.
 
-   ```ts
-   using provider = createCachingHiliteSetProvider({
-     // this is called to get iModel access based on the iModel key
-     imodelProvider: (imodelKey) => getIModelAccessByKey(imodelKey),
-     selectionStorage,
-   });
-   const hiliteSet: AsyncIterableIterator<HiliteSet> = provider.getHiliteSet({ imodelKey: createIModelKey(imodel) });
-   ```
+In the old system, you'd do something like this:
 
-2. For arbitrary elements / selectables.
+```ts
+const hiliteSet: AsyncIterableIterator<HiliteSet> = Presentation.selection.getHiliteSetIterator(iModelConnection);
+```
 
-   In the old system, you'd do something like this:
+In the new system, a hilite set provider has to be created. The provider holds the cached result and can be shared across components to avoid excessive requests.
 
-   ```ts
-   const provider = HiliteSetProvider.create({
-     imodel: iModelConnection,
-   });
-   const hiliteSet: AsyncIterableIterator<HiliteSet> = provider.getHiliteSetIterator(new KeySet(selectables));
-   ```
+```ts
+using provider = createCachingHiliteSetProvider({
+  // this is called to get iModel access based on the iModel key
+  imodelProvider: (imodelKey) => getIModelAccessByKey(imodelKey),
+  selectionStorage,
+});
+const hiliteSet: AsyncIterableIterator<HiliteSet> = provider.getHiliteSet({ imodelKey: createIModelKey(imodel) });
+```
 
-   The new system is very similar:
+### Getting hilite set for arbitrary elements / selectables
 
-   ```ts
-   const provider = createHiliteSetProvider({
-     imodelAccess: {
-       ...createECSchemaProvider(imodelSchemaContext),
-       ...createECSqlQueryExecutor(imodel),
-     },
-   });
-   const hiliteSet: AsyncIterableIterator<HiliteSet> = provider.getHiliteSet({ selectables });
-   ```
+In the old system, you'd do something like this:
+
+```ts
+const provider = HiliteSetProvider.create({
+  imodel: iModelConnection,
+});
+const hiliteSet: AsyncIterableIterator<HiliteSet> = provider.getHiliteSetIterator(new KeySet(selectables));
+```
+
+The new system is very similar:
+
+```ts
+const provider = createHiliteSetProvider({
+  imodelAccess: {
+    ...createECSchemaProvider(imodelSchemaContext),
+    ...createECSqlQueryExecutor(imodel),
+  },
+});
+const hiliteSet: AsyncIterableIterator<HiliteSet> = provider.getHiliteSet({ selectables });
+```

--- a/packages/unified-selection/src/unified-selection.ts
+++ b/packages/unified-selection/src/unified-selection.ts
@@ -14,6 +14,6 @@ export {
 export { SelectionStorage, createStorage } from "./unified-selection/SelectionStorage.js";
 export { createHiliteSetProvider, HiliteSet, HiliteSetProvider } from "./unified-selection/HiliteSetProvider.js";
 export { createCachingHiliteSetProvider, CachingHiliteSetProvider } from "./unified-selection/CachingHiliteSetProvider.js";
-export { computeSelection } from "./unified-selection/SelectionScope.js";
+export { computeSelection, SelectionScope } from "./unified-selection/SelectionScope.js";
 export { enableUnifiedSelectionSyncWithIModel } from "./unified-selection/EnableUnifiedSelectionSyncWithIModel.js";
 export { StorageSelectionChangeType, StorageSelectionChangeEventArgs, StorageSelectionChangesListener } from "./unified-selection/SelectionChangeEvent.js";

--- a/packages/unified-selection/src/unified-selection/EnableUnifiedSelectionSyncWithIModel.ts
+++ b/packages/unified-selection/src/unified-selection/EnableUnifiedSelectionSyncWithIModel.ts
@@ -11,7 +11,7 @@ import { CachingHiliteSetProvider, createCachingHiliteSetProvider } from "./Cach
 import { createHiliteSetProvider, HiliteSet, HiliteSetProvider } from "./HiliteSetProvider.js";
 import { SelectableInstanceKey, Selectables } from "./Selectable.js";
 import { StorageSelectionChangeEventArgs, StorageSelectionChangeType } from "./SelectionChangeEvent.js";
-import { computeSelection, ComputeSelectionProps } from "./SelectionScope.js";
+import { computeSelection, SelectionScope } from "./SelectionScope.js";
 import { SelectionStorage } from "./SelectionStorage.js";
 import { CoreIModelHiliteSet, CoreIModelSelectionSet, CoreSelectableIds, CoreSelectionSetEventType, CoreSelectionSetEventUnsafe } from "./types/IModel.js";
 import { safeDispose } from "./Utils.js";
@@ -60,7 +60,7 @@ export interface EnableUnifiedSelectionSyncWithIModelProps {
   selectionStorage: SelectionStorage;
 
   /** Active selection scope provider. */
-  activeScopeProvider: () => ComputeSelectionProps["scope"];
+  activeScopeProvider: () => SelectionScope;
 
   /**
    * A caching hilite set provider used to retrieve hilite sets for an iModel. If not provided, a new `CachingHiliteSetProvider`
@@ -97,7 +97,7 @@ export class IModelSelectionHandler {
   private _selectionStorage: SelectionStorage;
   private _hiliteSetProvider: HiliteSetProvider;
   private _cachingHiliteSetProvider: NonNullable<EnableUnifiedSelectionSyncWithIModelProps["cachingHiliteSetProvider"]>;
-  private _activeScopeProvider: () => ComputeSelectionProps["scope"];
+  private _activeScopeProvider: () => SelectionScope;
 
   private _isSuspended: boolean;
   private _cancelOngoingChanges = new Subject<void>();

--- a/packages/unified-selection/src/unified-selection/SelectionScope.ts
+++ b/packages/unified-selection/src/unified-selection/SelectionScope.ts
@@ -12,7 +12,7 @@ import { formIdBindings, genericExecuteQuery } from "./Utils.js";
  * Available selection scopes.
  * @public
  */
-export type SelectionScope = "element" | "model" | "category" | "functional";
+type SelectionScopeIdentifier = "element" | "model" | "category" | "functional";
 
 /**
  * Props for computing element selection.
@@ -33,6 +33,13 @@ export interface ElementSelectionScopeProps {
 }
 
 /**
+ * A union of types that can be used to define a selection scope.
+ * @public
+ * @since 1.4.0
+ */
+export type SelectionScope = ElementSelectionScopeProps | { id: SelectionScopeIdentifier } | SelectionScopeIdentifier;
+
+/**
  * Props for `computeSelection`.
  * @public
  */
@@ -42,7 +49,7 @@ export interface ComputeSelectionProps {
   /** IDs of elements to compute selection for. */
   elementIds: Id64Arg;
   /** Selection scope to compute selection with. */
-  scope: ElementSelectionScopeProps | { id: SelectionScope } | SelectionScope;
+  scope: SelectionScope;
 }
 
 /**


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/900.

The guide is based on this PR in `viewer` repo: https://github.com/iTwin/viewer/pull/346.