### PR TITLE
[hierarchies-react]: Fix nodes overlapping

### DIFF
--- a/.changeset/four-shoes-repeat.md
+++ b/.changeset/four-shoes-repeat.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Fix tree nodes overlapping when nodes with and without sublabel are rendered alongside.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
@@ -52,6 +52,7 @@ export function TreeRenderer({ rootNodes, expandNode, localizedStrings, selectNo
   const virtualizer = useVirtualizer({
     count: flatNodes.length,
     getScrollElement: () => parentRef.current,
+    getItemKey: (index) => flatNodes[index].id,
     estimateSize: () => 28,
     overscan: 5,
   });

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
@@ -79,7 +79,7 @@ export function TreeRenderer({ rootNodes, expandNode, localizedStrings, selectNo
                 onNodeClick={onNodeClick}
                 onNodeKeyDown={onNodeKeyDown}
                 node={flatNodes[virtualizedItem.index]}
-                key={flatNodes[virtualizedItem.index].id}
+                key={virtualizedItem.key}
                 data-index={virtualizedItem.index}
               />
             );


### PR DESCRIPTION
Fixed tree nodes overlapping if nodes with and without sublabel are rendered alongside.