### PR TITLE
[Hierarchies-react]: expose custom error rendering & transform flat nodes/error functions to hooks

### DIFF
--- a/.changeset/rude-rivers-post.md
+++ b/.changeset/rude-rivers-post.md
@@ -1,0 +1,6 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Exposed `TreeErrorRenderer`.
+`TreeRenderer` now takes `renderError` to render custom errors.

--- a/.changeset/stupid-cameras-obey.md
+++ b/.changeset/stupid-cameras-obey.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Fix `ResultSetTooLarge` error suggesting filtering when parent node is not filterable.

--- a/.changeset/tame-years-make.md
+++ b/.changeset/tame-years-make.md
@@ -1,0 +1,7 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Changed flat tree building functions to hooks.
+`flattenNodes` => `useFlattenNodes`.
+`getErrors` => `useErrorList`.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react.ts
@@ -18,7 +18,8 @@ export { useIModelTree, useIModelUnifiedSelectionTree } from "./presentation-hie
 export { TreeNodeRenderer } from "./presentation-hierarchies-react/itwinui/TreeNodeRenderer.js";
 export { TreeItemAction, useFilterAction } from "./presentation-hierarchies-react/itwinui/TreeActionButton.js";
 export { TreeRenderer } from "./presentation-hierarchies-react/itwinui/TreeRenderer.js";
-export { flattenNodes, FlatTreeNode } from "./presentation-hierarchies-react/itwinui/FlatTreeNode.js";
+export { TreeErrorRenderer } from "./presentation-hierarchies-react/itwinui/TreeErrorRenderer.js";
+export { useFlattenNodes, useErrorList, FlatTreeNode } from "./presentation-hierarchies-react/itwinui/FlatTreeNode.js";
 export { LocalizationContextProvider } from "./presentation-hierarchies-react/itwinui/LocalizationContext.js";
 
 export { GenericInstanceFilter, HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/FlatTreeNode.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/FlatTreeNode.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { useMemo } from "react";
 import { isPresentationHierarchyNode, PresentationHierarchyNode, PresentationInfoNode, PresentationTreeNode } from "../TreeNode.js";
 
 /** @alpha */
@@ -35,8 +36,8 @@ export function isPlaceholderNode(node: FlatTreeNode): node is PlaceholderNode {
 }
 
 /** @alpha */
-export function flattenNodes(rootNodes: PresentationTreeNode[]) {
-  return getFlatNodes(rootNodes, 1);
+export function useFlattenNodes(rootNodes: PresentationTreeNode[]) {
+  return useMemo(() => getFlatNodes(rootNodes, 1), [rootNodes]);
 }
 
 function getFlatNodes(nodes: PresentationTreeNode[], level: number) {
@@ -60,16 +61,21 @@ function getFlatNodes(nodes: PresentationTreeNode[], level: number) {
   return flatNodes;
 }
 
-export function getErrors(rootNodes: PresentationTreeNode[]): ErrorNode[] {
-  return rootNodes.flatMap((rootNode) => {
-    if (!isPresentationHierarchyNode(rootNode)) {
-      return [{ parent: undefined, error: rootNode, expandTo: (expandNode) => expandTo(expandNode, []) }];
-    }
-    if (rootNode.children === true) {
-      return [];
-    }
-    return getErrorNodes(rootNode, !rootNode.isExpanded ? [rootNode.id] : []);
-  });
+/** @alpha */
+export function useErrorList(rootNodes: PresentationTreeNode[]): ErrorNode[] {
+  return useMemo(
+    () =>
+      rootNodes.flatMap((rootNode) => {
+        if (!isPresentationHierarchyNode(rootNode)) {
+          return [{ parent: undefined, error: rootNode, expandTo: (expandNode) => expandTo(expandNode, []) }];
+        }
+        if (rootNode.children === true) {
+          return [];
+        }
+        return getErrorNodes(rootNode, !rootNode.isExpanded ? [rootNode.id] : []);
+      }),
+    [rootNodes],
+  );
 }
 
 function getErrorNodes(parent: PresentationHierarchyNode, path: string[]) {

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeErrorRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeErrorRenderer.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { ReactElement } from "react";
 import { Anchor, unstable_ErrorRegion as ErrorRegion, Text } from "@itwin/itwinui-react/bricks";
 import { MAX_LIMIT_OVERRIDE } from "../internal/Utils.js";
 import { HierarchyLevelDetails, useTree } from "../UseTree.js";
@@ -10,25 +11,34 @@ import { ErrorNode } from "./FlatTreeNode.js";
 import { useLocalizationContext } from "./LocalizationContext.js";
 
 /** @alpha */
-export interface TreeErrorItemProps {
+interface TreeErrorItemProps {
   /** A callback to reload a hierarchy level when an error occurs and `retry` button is clicked. */
   reloadTree?: (options: { parentNodeId: string | undefined; state: "reset" }) => void;
   /** Action to perform when the filter button is clicked for this node. */
   onFilterClick?: (hierarchyLevelDetails: HierarchyLevelDetails) => void;
 }
-
+/** @alpha */
 interface TreeErrorRendererOwnProps {
+  /** List of errors to be displayed */
   errorList: ErrorNode[];
+  // Callback to render custom error messages. Component should be wrapped in `ErrorRegion.Item` from itwinUI.
+  renderError?: ({ error, scrollToElement }: { error: ErrorNode } & Pick<LinkedNodeProps, "scrollToElement">) => ReactElement;
 }
 
-type TreeErrorRendererProps = TreeErrorRendererOwnProps &
+/** @alpha */
+export type TreeErrorRendererProps = TreeErrorRendererOwnProps &
   TreeErrorItemProps &
   Partial<Pick<ReturnType<typeof useTree>, "getHierarchyLevelDetails">> &
   Pick<LinkedNodeProps, "scrollToElement">;
 
-export function TreeErrorRenderer({ errorList, reloadTree, scrollToElement, getHierarchyLevelDetails, onFilterClick }: TreeErrorRendererProps) {
+/** @alpha */
+export function TreeErrorRenderer({ errorList, reloadTree, scrollToElement, getHierarchyLevelDetails, onFilterClick, renderError }: TreeErrorRendererProps) {
   const { localizedStrings } = useLocalizationContext();
   const errorItems = errorList.map((errorNode) => {
+    if (renderError) {
+      return renderError({ error: errorNode, scrollToElement });
+    }
+
     if (errorNode.error.type === "ResultSetTooLarge") {
       return (
         <ResultSetTooLarge

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
@@ -10,9 +10,9 @@ import { PresentationTreeNode } from "../TreeNode.js";
 import { SelectionMode, useSelectionHandler } from "../UseSelectionHandler.js";
 import { useTree } from "../UseTree.js";
 import { useEvent } from "../Utils.js";
-import { ErrorNode, flattenNodes, getErrors } from "./FlatTreeNode.js";
+import { ErrorNode, useErrorList, useFlattenNodes } from "./FlatTreeNode.js";
 import { LocalizationContextProvider } from "./LocalizationContext.js";
-import { TreeErrorItemProps, TreeErrorRenderer } from "./TreeErrorRenderer.js";
+import { TreeErrorRenderer, TreeErrorRendererProps } from "./TreeErrorRenderer.js";
 import { TreeNodeRenderer } from "./TreeNodeRenderer.js";
 
 /** @alpha */
@@ -31,7 +31,7 @@ interface TreeRendererOwnProps {
 /** @alpha */
 type TreeRendererProps = Pick<ReturnType<typeof useTree>, "expandNode"> &
   Partial<Pick<ReturnType<typeof useTree>, "selectNodes" | "isNodeSelected" | "getHierarchyLevelDetails" | "reloadTree">> &
-  Pick<TreeErrorItemProps, "onFilterClick"> &
+  Pick<TreeErrorRendererProps, "onFilterClick" | "renderError"> &
   Omit<TreeNodeRendererProps, "node" | "reloadTree" | "selected" | "error"> &
   TreeRendererOwnProps &
   ComponentPropsWithoutRef<typeof LocalizationContextProvider>;
@@ -57,6 +57,7 @@ export function TreeRenderer({
   getDecorations,
   getLabel,
   getSublabel,
+  renderError,
   ...treeProps
 }: TreeRendererProps) {
   const { onNodeClick, onNodeKeyDown } = useSelectionHandler({
@@ -66,8 +67,8 @@ export function TreeRenderer({
   });
   const scrollToNode = useRef<string | undefined>(undefined);
   const parentRef = useRef<HTMLDivElement>(null);
-  const flatNodes = useMemo(() => flattenNodes(rootNodes), [rootNodes]);
-  const errorList = useMemo(() => getErrors(rootNodes), [rootNodes]);
+  const flatNodes = useFlattenNodes(rootNodes);
+  const errorList = useErrorList(rootNodes);
 
   const handleNodeClick = useEvent(onNodeClick);
   const handleKeyDown = useEvent(onNodeKeyDown);
@@ -117,6 +118,7 @@ export function TreeRenderer({
   return (
     <LocalizationContextProvider localizedStrings={localizedStrings}>
       <TreeErrorRenderer
+        renderError={renderError}
         errorList={errorList}
         scrollToElement={scrollToElement}
         getHierarchyLevelDetails={getHierarchyLevelDetails}


### PR DESCRIPTION
Preview:
![image](https://github.com/user-attachments/assets/39e79772-d6a4-452c-82ae-08b578116afb)

Related issue:
https://github.com/orgs/iTwin/projects/20/views/14?pane=issue&itemId=98495356&issue=iTwin%7Cviewer-components-react%7C1194
![image](https://github.com/user-attachments/assets/59aae6ea-7ebf-4c89-b7a6-c8a8ab4d7aaa)
