### PR TITLE
Re-export get/set logger functions from `presentation-hierarchies`

### DIFF
--- a/.changeset/young-forks-punch.md
+++ b/.changeset/young-forks-punch.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": minor
+---
+
+Re-export `getLogger` and `setLogger` functions from `@itwin/presentation-hierarchies` to allow setting a logger.

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -8,6 +8,7 @@ import { ComponentPropsWithoutRef } from 'react';
 import { createIModelHierarchyProvider } from '@itwin/presentation-hierarchies';
 import { FC } from 'react';
 import { GenericInstanceFilter } from '@itwin/presentation-hierarchies';
+import { getLogger } from '@itwin/presentation-hierarchies';
 import { HierarchyDefinition } from '@itwin/presentation-hierarchies';
 import { HierarchyFilteringPath } from '@itwin/presentation-hierarchies';
 import { HierarchyNode } from '@itwin/presentation-hierarchies';
@@ -23,6 +24,7 @@ import { ReactElement } from 'react';
 import { ReactNode } from 'react';
 import { RefAttributes } from 'react';
 import { SelectionStorage } from '@itwin/unified-selection';
+import { setLogger } from '@itwin/presentation-hierarchies';
 import { Tree } from '@itwin/itwinui-react/bricks';
 import { UseTreeResult as UseTreeResult_2 } from '../UseTree.js';
 
@@ -54,6 +56,8 @@ type FlatNode = {
 export type FlatTreeNode = FlatNode | PlaceholderNode;
 
 export { GenericInstanceFilter }
+
+export { getLogger }
 
 // @public
 export interface HierarchyLevelDetails {
@@ -195,6 +199,8 @@ type SelectionChangeType = "add" | "replace" | "remove";
 type SelectionMode_2 = "none" | "single" | "extended" | "multiple";
 
 export { SelectionStorage }
+
+export { setLogger }
 
 // @alpha
 interface TreeErrorItemProps {

--- a/packages/hierarchies-react/src/presentation-hierarchies-react.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react.ts
@@ -21,5 +21,5 @@ export { TreeErrorRenderer } from "./presentation-hierarchies-react/itwinui/Tree
 export { useFlatTreeNodeList, useErrorList, FlatTreeNode } from "./presentation-hierarchies-react/itwinui/FlatTreeNode.js";
 export { LocalizationContextProvider } from "./presentation-hierarchies-react/itwinui/LocalizationContext.js";
 
-export { GenericInstanceFilter, HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";
+export { GenericInstanceFilter, HierarchyNode, HierarchyProvider, getLogger, setLogger } from "@itwin/presentation-hierarchies";
 export { SelectionStorage } from "@itwin/unified-selection";


### PR DESCRIPTION
`@itwin/presentation-hierarchies` is a direct dependency for `presentation-hierarchies-react`, so there's no way to set a logger to the underlying `presentation-hierarchies` for `presentation-hierarchies-react` consumers without it re-exporting those functions.