### PR TITLE
[hierarchies-react]: Avoid leaking props

### DIFF
--- a/.changeset/thirty-ends-sit.md
+++ b/.changeset/thirty-ends-sit.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Avoid leaking custom props to the `PlaceholderNode` that are causing console errors.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeRenderer.tsx
@@ -178,7 +178,7 @@ type VirtualTreeItemProps = Omit<TreeNodeRendererProps, "node" | "aria-level" | 
 
 const VirtualTreeItem = memo(
   forwardRef<HTMLElement, VirtualTreeItemProps>(function VirtualTreeItem(
-    { start, node, getDecorations, getActions, getLabel, getSublabel, ...props },
+    { start, node, getDecorations, getActions, getLabel, getSublabel, expandNode, error, reloadTree, onNodeClick, onNodeKeyDown, ...props },
     forwardedRef,
   ) {
     const style: CSSProperties = useMemo(
@@ -206,10 +206,15 @@ const VirtualTreeItem = memo(
         aria-posinset={node.posInLevel}
         aria-setsize={node.levelSize}
         node={node}
+        expandNode={expandNode}
+        error={error}
+        reloadTree={reloadTree}
         getDecorations={getDecorations}
         getActions={getActions}
         getLabel={getLabel}
         getSublabel={getSublabel}
+        onNodeClick={onNodeClick}
+        onNodeKeyDown={onNodeKeyDown}
       />
     );
   }),


### PR DESCRIPTION
Some of our component props were passed down to `PlaceholderNode` component that resulted in console errors.