### PR TITLE
[Hierarchy-react]: expose `TreeRendererProps`

### DIFF
--- a/.changeset/fluffy-oranges-raise.md
+++ b/.changeset/fluffy-oranges-raise.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-hierarchies-react": minor
 ---
 
-Exposed type `TreeRendererProps`
+Exposed the type of tree state hooks' result `treeRendererProps` attribute - `TreeRendererProps`. The type can be useful when creating custom tree renderers.

--- a/.changeset/fluffy-oranges-raise.md
+++ b/.changeset/fluffy-oranges-raise.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Exposed type `TreeRendererProps`

--- a/.changeset/fluffy-oranges-raise.md
+++ b/.changeset/fluffy-oranges-raise.md
@@ -1,5 +1,5 @@
 ---
-"@itwin/presentation-hierarchies-react": patch
+"@itwin/presentation-hierarchies-react": minor
 ---
 
 Exposed type `TreeRendererProps`

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -26,22 +26,28 @@ import { RefAttributes } from 'react';
 import { SelectionStorage } from '@itwin/unified-selection';
 import { setLogger } from '@itwin/presentation-hierarchies';
 import { Tree } from '@stratakit/structures';
-import { UseTreeResult as UseTreeResult_2 } from '../UseTree.js';
+
+// @alpha (undocumented)
+interface CommonRendererProps {
+    getHierarchyLevelDetails: (nodeId: string | undefined) => HierarchyLevelDetails | undefined;
+    reloadTree: (options?: ReloadTreeOptions) => void;
+}
+
+// @public
+export type ErrorInfo = GenericErrorInfo | ResultSetTooLargeErrorInfo | NoFilterMatchesErrorInfo;
 
 // @alpha
-interface ErrorNode {
+interface ErrorItem {
     // (undocumented)
-    error: PresentationInfoNode;
+    errorNode: PresentationHierarchyNode;
     // (undocumented)
     expandTo: (expandNode: (nodeId: string) => void) => void;
-    // (undocumented)
-    parent?: PresentationHierarchyNode;
 }
 
 // @alpha
 export const FilterAction: NamedExoticComponent<    {
 onFilter?: (hierarchyLevelDetails: HierarchyLevelDetails) => void;
-} & Partial<Pick<UseTreeResult_2, "getHierarchyLevelDetails">> & {
+} & Pick<TreeRendererProps, "getHierarchyLevelDetails"> & {
 node: PresentationHierarchyNode;
 }>;
 
@@ -54,6 +60,16 @@ type FlatNode = {
 
 // @alpha
 export type FlatTreeNode = FlatNode | PlaceholderNode;
+
+// @public
+export interface GenericErrorInfo {
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    message: string;
+    // (undocumented)
+    type: "Unknown";
+}
 
 export { GenericInstanceFilter }
 
@@ -83,9 +99,6 @@ type IModelAccess = IModelHierarchyProviderProps["imodelAccess"];
 type IModelHierarchyProviderProps = Props<typeof createIModelHierarchyProvider>;
 
 // @public
-export function isPresentationHierarchyNode(node: PresentationTreeNode): node is PresentationHierarchyNode;
-
-// @public
 export function LocalizationContextProvider({ localizedStrings, children }: PropsWithChildren<LocalizationContextProviderProps>): JSX_2.Element;
 
 // @public
@@ -112,6 +125,14 @@ interface LocalizedStrings {
     rootResultLimitExceeded: string;
 }
 
+// @public
+interface NoFilterMatchesErrorInfo {
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    type: "NoFilterMatches";
+}
+
 // @alpha
 interface PlaceholderNode {
     // (undocumented)
@@ -123,21 +144,10 @@ interface PlaceholderNode {
 }
 
 // @public
-export interface PresentationGenericInfoNode {
-    // (undocumented)
-    id: string;
-    // (undocumented)
-    message: string;
-    // (undocumented)
-    parentNodeId: string | undefined;
-    // (undocumented)
-    type: "Unknown";
-}
-
-// @public
 export interface PresentationHierarchyNode {
     // (undocumented)
-    children: true | Array<PresentationTreeNode>;
+    children: true | Array<PresentationHierarchyNode>;
+    error?: ErrorInfo;
     // (undocumented)
     id: string;
     // (undocumented)
@@ -154,43 +164,33 @@ export interface PresentationHierarchyNode {
 }
 
 // @public
-export type PresentationInfoNode = PresentationGenericInfoNode | PresentationResultSetTooLargeInfoNode | PresentationNoFilterMatchesInfoNode;
-
-// @public
-interface PresentationNoFilterMatchesInfoNode {
-    // (undocumented)
-    id: string;
-    // (undocumented)
+interface ReloadTreeOptions {
     parentNodeId: string | undefined;
-    // (undocumented)
-    type: "NoFilterMatches";
+    state?: "keep" | "discard" | "reset";
 }
 
+// @alpha
+type RendererProps = {
+    rootErrorRendererProps: RootErrorRendererProps;
+} | {
+    rootErrorRendererProps: undefined;
+    treeRendererProps?: TreeRendererProps;
+};
+
 // @public
-export interface PresentationResultSetTooLargeInfoNode {
+export interface ResultSetTooLargeErrorInfo {
     // (undocumented)
     id: string;
-    // (undocumented)
-    parentNodeId: string | undefined;
     // (undocumented)
     resultSetSizeLimit: number;
     // (undocumented)
     type: "ResultSetTooLarge";
 }
 
-// @public
-export type PresentationTreeNode = PresentationHierarchyNode | PresentationInfoNode;
-
-// @public
-interface ReloadTreeOptions {
-    parentNodeId: string | undefined;
-    state?: "keep" | "discard" | "reset";
-}
-
-// @alpha (undocumented)
+// @alpha
 type RootErrorRendererProps = {
-    errorNode: ErrorNode;
-} & Pick<ReturnType<typeof useTree>, "getHierarchyLevelDetails" | "reloadTree">;
+    error: ErrorInfo;
+} & CommonRendererProps;
 
 // @public
 type SelectionChangeType = "add" | "replace" | "remove";
@@ -202,6 +202,23 @@ export { SelectionStorage }
 
 export { setLogger }
 
+// @internal
+export function StrataKitRootErrorRenderer({ error, getHierarchyLevelDetails, reloadTree }: StrataKitRootErrorRendererProps): JSX_2.Element;
+
+// @alpha (undocumented)
+type StrataKitRootErrorRendererProps = {
+    error: ErrorInfo;
+} & RootErrorRendererProps;
+
+// @public
+export const StrataKitTreeNodeRenderer: FC<PropsWithRef<TreeNodeRendererProps & RefAttributes<HTMLElement>>>;
+
+// @alpha
+export function StrataKitTreeRenderer({ rootNodes, selectNodes, selectionMode, expandNode, localizedStrings, getHierarchyLevelDetails, onFilterClick, reloadTree, isNodeSelected, errorRenderer, onNodeClick: onNodeClickOverride, onNodeKeyDown: onNodeKeyDownOverride, ...treeProps }: StrataKitTreeRendererProps): JSX_2.Element;
+
+// @alpha (undocumented)
+type StrataKitTreeRendererProps = TreeRendererProps & Pick<TreeErrorRendererProps, "onFilterClick"> & Omit<TreeNodeRendererProps_2, "node" | "aria-level" | "aria-posinset" | "aria-setsize" | "reloadTree" | "selected" | "error"> & TreeRendererOwnProps & ComponentPropsWithoutRef<typeof LocalizationContextProvider>;
+
 // @alpha
 interface TreeErrorItemProps {
     onFilterClick?: (hierarchyLevelDetails: HierarchyLevelDetails) => void;
@@ -209,7 +226,7 @@ interface TreeErrorItemProps {
         parentNodeId: string | undefined;
         state: "reset";
     }) => void;
-    scrollToElement: (errorNode: ErrorNode) => void;
+    scrollToElement: (errorNode: ErrorItem) => void;
 }
 
 // @alpha
@@ -217,26 +234,22 @@ export function TreeErrorRenderer({ errorList, reloadTree, scrollToElement, getH
 
 // @alpha
 interface TreeErrorRendererOwnProps {
-    errorList: ErrorNode[];
+    errorList: ErrorItem[];
     // (undocumented)
-    renderError?: ({ errorNode, scrollToElement }: {
-        errorNode: ErrorNode;
+    renderError?: ({ errorItem, scrollToElement }: {
+        errorItem: ErrorItem;
         scrollToElement: () => void;
     }) => ReactElement;
 }
 
 // @alpha (undocumented)
-type TreeErrorRendererProps = TreeErrorRendererOwnProps & TreeErrorItemProps & Partial<Pick<ReturnType<typeof useTree>, "getHierarchyLevelDetails">>;
+type TreeErrorRendererProps = TreeErrorRendererOwnProps & TreeErrorItemProps & Pick<TreeRendererProps, "getHierarchyLevelDetails">;
 
 // @alpha (undocumented)
 type TreeNodeProps = ComponentPropsWithoutRef<typeof Tree.Item>;
 
-// @public
-export const TreeNodeRenderer: FC<PropsWithRef<TreeNodeRendererProps & RefAttributes<HTMLElement>>>;
-
 // @alpha (undocumented)
 interface TreeNodeRendererOwnProps {
-    error?: ErrorNode;
     getActions?: (node: PresentationHierarchyNode) => ReactNode[];
     getDecorations?: (node: PresentationHierarchyNode) => ReactNode;
     getLabel?: (node: PresentationHierarchyNode) => ReactElement | undefined;
@@ -247,30 +260,30 @@ interface TreeNodeRendererOwnProps {
 }
 
 // @alpha (undocumented)
-type TreeNodeRendererProps = Pick<ReturnType<typeof useTree>, "expandNode"> & Partial<Pick<ReturnType<typeof useTree>, "getHierarchyLevelDetails">> & Omit<TreeNodeProps, "actions" | "label" | "expanded" | "unstable_decorations" | "error"> & Pick<UseTreeResult, "reloadTree"> & TreeNodeRendererOwnProps;
+type TreeNodeRendererProps = Pick<TreeRendererProps, "expandNode" | "reloadTree"> & Omit<TreeNodeProps, "actions" | "label" | "expanded" | "unstable_decorations" | "error"> & TreeNodeRendererOwnProps;
 
 // @alpha (undocumented)
-type TreeNodeRendererProps_2 = ComponentPropsWithoutRef<typeof TreeNodeRenderer>;
-
-// @alpha
-export function TreeRenderer({ rootNodes, selectNodes, selectionMode, rootErrorRenderer, ...treeProps }: TreeRendererProps): JSX_2.Element;
+type TreeNodeRendererProps_2 = ComponentPropsWithoutRef<typeof StrataKitTreeNodeRenderer>;
 
 // @alpha (undocumented)
 interface TreeRendererOwnProps {
     errorRenderer?: (props: TreeErrorRendererProps) => ReactElement;
-    rootErrorRenderer?: (props: RootErrorRendererProps) => ReactElement;
-    rootNodes: PresentationTreeNode[];
     selectionMode?: SelectionMode_2;
 }
 
-// @alpha (undocumented)
-type TreeRendererProps = Pick<ReturnType<typeof useTree>, "expandNode"> & Partial<Pick<ReturnType<typeof useTree>, "selectNodes" | "isNodeSelected">> & Pick<ReturnType<typeof useTree>, "reloadTree" | "getHierarchyLevelDetails"> & Pick<TreeErrorRendererProps, "onFilterClick"> & Omit<TreeNodeRendererProps_2, "node" | "aria-level" | "aria-posinset" | "aria-setsize" | "reloadTree" | "selected" | "error"> & TreeRendererOwnProps & ComponentPropsWithoutRef<typeof LocalizationContextProvider>;
+// @alpha
+export type TreeRendererProps = {
+    rootNodes: PresentationHierarchyNode[];
+    expandNode: (nodeId: string, isExpanded: boolean) => void;
+    selectNodes: (nodeIds: Array<string>, changeType: SelectionChangeType) => void;
+    isNodeSelected: (nodeId: string) => boolean;
+} & CommonRendererProps;
 
 // @alpha
-export function useErrorList(rootNodes: PresentationTreeNode[]): ErrorNode[];
+export function useErrorList(rootNodes: PresentationHierarchyNode[]): ErrorItem[];
 
 // @alpha
-export function useFlatTreeNodeList(rootNodes: PresentationTreeNode[]): FlatTreeNode[];
+export function useFlatTreeNodeList(rootNodes: PresentationHierarchyNode[]): FlatTreeNode[];
 
 // @public
 export function useIModelTree(props: UseIModelTreeProps): UseTreeResult;
@@ -291,8 +304,8 @@ export function useIModelUnifiedSelectionTree(props: UseIModelTreeProps & UseUni
 // @public
 export function useSelectionHandler(props: UseSelectionHandlerProps): UseSelectionHandlerResult;
 
-// @public
-type UseSelectionHandlerProps = Pick<ReturnType<typeof useTree>, "rootNodes" | "selectNodes"> & {
+// @alpha
+type UseSelectionHandlerProps = Pick<TreeRendererProps, "selectNodes" | "rootNodes"> & {
     selectionMode: SelectionMode_2;
 };
 
@@ -323,17 +336,11 @@ interface UseTreeProps {
 }
 
 // @public (undocumented)
-interface UseTreeResult {
-    expandNode: (nodeId: string, isExpanded: boolean) => void;
-    getHierarchyLevelDetails: (nodeId: string | undefined) => HierarchyLevelDetails | undefined;
+type UseTreeResult = {
+    isReloading: boolean;
     getNode: (nodeId: string) => PresentationHierarchyNode | undefined;
-    isLoading: boolean;
-    isNodeSelected: (nodeId: string) => boolean;
-    reloadTree: (options?: ReloadTreeOptions) => void;
-    rootNodes: PresentationTreeNode[] | undefined;
-    selectNodes: (nodeIds: Array<string>, changeType: SelectionChangeType) => void;
     setFormatter: (formatter: IPrimitiveValueFormatter | undefined) => void;
-}
+} & RendererProps;
 
 // @public
 export function useUnifiedSelectionTree({ sourceName, selectionStorage, ...props }: UseTreeProps & UseUnifiedTreeSelectionProps): UseTreeResult;

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -202,7 +202,7 @@ export { SelectionStorage }
 
 export { setLogger }
 
-// @internal
+// @alpha
 export function StrataKitRootErrorRenderer({ error, getHierarchyLevelDetails, reloadTree }: StrataKitRootErrorRendererProps): JSX_2.Element;
 
 // @alpha (undocumented)

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
@@ -8,7 +8,7 @@ public;interface;HierarchyLevelDetails
 public;function;LocalizationContextProvider
 public;interface;PresentationHierarchyNode
 public;interface;ResultSetTooLargeErrorInfo
-internal;function;StrataKitRootErrorRenderer
+alpha;function;StrataKitRootErrorRenderer
 public;const;StrataKitTreeNodeRenderer
 alpha;function;StrataKitTreeRenderer
 alpha;function;TreeErrorRenderer

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
@@ -1,18 +1,18 @@
 sep=;
 Release Tag;API Item Type;API Item Name
+public;type;ErrorInfo
 alpha;const;FilterAction
 alpha;type;FlatTreeNode
+public;interface;GenericErrorInfo
 public;interface;HierarchyLevelDetails
-public;function;isPresentationHierarchyNode
 public;function;LocalizationContextProvider
-public;interface;PresentationGenericInfoNode
 public;interface;PresentationHierarchyNode
-public;type;PresentationInfoNode
-public;interface;PresentationResultSetTooLargeInfoNode
-public;type;PresentationTreeNode
+public;interface;ResultSetTooLargeErrorInfo
+internal;function;StrataKitRootErrorRenderer
+public;const;StrataKitTreeNodeRenderer
+alpha;function;StrataKitTreeRenderer
 alpha;function;TreeErrorRenderer
-public;const;TreeNodeRenderer
-alpha;function;TreeRenderer
+alpha;type;TreeRendererProps
 alpha;function;useErrorList
 alpha;function;useFlatTreeNodeList
 public;function;useIModelTree

--- a/packages/hierarchies-react/src/presentation-hierarchies-react.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react.ts
@@ -6,7 +6,7 @@
 export { GenericErrorInfo, PresentationHierarchyNode, ErrorInfo, ResultSetTooLargeErrorInfo } from "./presentation-hierarchies-react/TreeNode.js";
 export { useSelectionHandler } from "./presentation-hierarchies-react/UseSelectionHandler.js";
 export { useTree, useUnifiedSelectionTree } from "./presentation-hierarchies-react/UseTree.js";
-export { HierarchyLevelDetails } from "./presentation-hierarchies-react/Renderers.js";
+export { HierarchyLevelDetails, TreeRendererProps } from "./presentation-hierarchies-react/Renderers.js";
 export { useIModelTree, useIModelUnifiedSelectionTree } from "./presentation-hierarchies-react/UseIModelTree.js";
 export { StrataKitTreeNodeRenderer } from "./presentation-hierarchies-react/stratakit/TreeNodeRenderer.js";
 export { FilterAction } from "./presentation-hierarchies-react/stratakit/FilterAction.js";

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseSelectionHandler.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseSelectionHandler.ts
@@ -30,7 +30,7 @@ export type SelectionChangeType = "add" | "replace" | "remove";
 
 /**
  * Props for `useSelectionHandler` hook.
- * @public
+ * @alpha
  */
 type UseSelectionHandlerProps = Pick<TreeRendererProps, "selectNodes" | "rootNodes"> & {
   /** Selection mode that the component is working in. */

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/RootErrorRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/RootErrorRenderer.tsx
@@ -21,7 +21,7 @@ export type StrataKitRootErrorRendererProps = {
 /**
  * A component that renders root node error state.
  *
- * @internal
+ * @alpha
  */
 export function StrataKitRootErrorRenderer({ error, getHierarchyLevelDetails, reloadTree }: StrataKitRootErrorRendererProps) {
   const { localizedStrings } = useLocalizationContext();


### PR DESCRIPTION
In some cases, consumers might want to have some of the required props for `StrataKitTreeRenderer` defined in the same component where `StrataKitTreeRenderer` is returned. With the current implementation that would require some kind of work around to get the ` TreeRendererProps`. This is the case because Pick<ReturnType<useTree>, "TreeRendererProps"> will not return the `TreeRendererProps` as it not always exists. To avoid confusion and to make the consumption easier exposing `TreeRendererProps` would be benefitial.

```ts
function Tree (props: propsType) {
  const useTree = useTree({...props})

  ...

  if (useTree.rootErrorRenderer !== undefined) {
     return <StrataKitRootErrorRenderer {...useTree.rootErrorRenderer} />
  } 

  return <MyTreeRenderer treeRendererProps={useTree.treeRendererProps} /> 
}

function MyTreeRenderer ({treeRendererProps}: {treeRendererProps: TreeRendererProps}) {

   // these are required properties of `StrataKitTreeRenderer` that are not provided from `useTree`
   const onFilterClick = {...}
   const selectionMode = {...}
   const getDecorations = {...}


   return <StrataKitTreeRenderer 
        {...treeRendererProps} 
        onFilterClick={setFilteringOptions}
        selectionMode={"extended"}
        getDecorations={getDecorations}
    />
}

```