### PR TITLE
[hierarchies-react]: Add ability to edit node labels

### DIFF
--- a/.changeset/brown-peaches-smash.md
+++ b/.changeset/brown-peaches-smash.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": minor
+---
+
+Added `getEditingProps` prop to `<StrataKitTreeRenderer />` component that allows to make node labels editable.

--- a/.changeset/brown-peaches-smash.md
+++ b/.changeset/brown-peaches-smash.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-hierarchies-react": minor
 ---
 
-Added `getEditingProps` prop to `<StrataKitTreeRenderer />` component that allows to make node labels editable.
+Added `getEditingProps` prop to `<StrataKitTreeRenderer />` component that allows to make node labels editable. In order to enter label editing mode `<RenameAction />` component was added.

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 registry=https://registry.npmjs.org/
+@bentley:registry=https://registry.npmjs.org/
 
 resolution-mode=lowest-direct
 auto-install-peers=false

--- a/apps/test-app/frontend/src/components/tree-widget/TreeRendererWithFilterAction.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/TreeRendererWithFilterAction.tsx
@@ -6,7 +6,9 @@
 import { ComponentPropsWithoutRef, useCallback } from "react";
 import { FilterAction, PresentationHierarchyNode, StrataKitTreeRenderer } from "@itwin/presentation-hierarchies-react";
 
-export function TreeRendererWithFilterAction(props: ComponentPropsWithoutRef<typeof StrataKitTreeRenderer>) {
+type TreeRendererProps = ComponentPropsWithoutRef<typeof StrataKitTreeRenderer>;
+
+export function TreeRendererWithFilterAction(props: TreeRendererProps) {
   const { getHierarchyLevelDetails, onFilterClick, getActions, ...treeProps } = props;
   const getAllActions = useCallback(
     (node: PresentationHierarchyNode) => [
@@ -15,6 +17,23 @@ export function TreeRendererWithFilterAction(props: ComponentPropsWithoutRef<typ
     ],
     [getActions, onFilterClick, getHierarchyLevelDetails],
   );
+  const getEditingProps = useCallback<Required<TreeRendererProps>["getEditingProps"]>((node) => {
+    return {
+      onLabelChanged: (newLabel: string) => {
+        // Handle label change
+        // eslint-disable-next-line no-console
+        console.log(`Node label changed from ${node.label} to ${newLabel}`);
+      },
+    };
+  }, []);
 
-  return <StrataKitTreeRenderer {...treeProps} getActions={getAllActions} onFilterClick={onFilterClick} getHierarchyLevelDetails={getHierarchyLevelDetails} />;
+  return (
+    <StrataKitTreeRenderer
+      {...treeProps}
+      getActions={getAllActions}
+      onFilterClick={onFilterClick}
+      getHierarchyLevelDetails={getHierarchyLevelDetails}
+      getEditingProps={getEditingProps}
+    />
+  );
 }

--- a/apps/test-app/frontend/src/components/tree-widget/TreeRendererWithFilterAction.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/TreeRendererWithFilterAction.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ComponentPropsWithoutRef, useCallback } from "react";
-import { FilterAction, PresentationHierarchyNode, StrataKitTreeRenderer } from "@itwin/presentation-hierarchies-react";
+import { FilterAction, PresentationHierarchyNode, RenameAction, StrataKitTreeRenderer } from "@itwin/presentation-hierarchies-react";
 
 type TreeRendererProps = ComponentPropsWithoutRef<typeof StrataKitTreeRenderer>;
 
@@ -14,6 +14,7 @@ export function TreeRendererWithFilterAction(props: TreeRendererProps) {
     (node: PresentationHierarchyNode) => [
       ...(getActions ? getActions(node) : []),
       <FilterAction key="filter" node={node} onFilter={onFilterClick} getHierarchyLevelDetails={getHierarchyLevelDetails} />,
+      <RenameAction key="rename" />,
     ],
     [getActions, onFilterClick, getHierarchyLevelDetails],
   );

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -120,6 +120,7 @@ interface LocalizedStrings {
     loading: string;
     noFilteredChildren: string;
     noFilteredChildrenChangeFilter: string;
+    rename: string;
     resultLimitExceeded: string;
     retry: string;
     rootResultLimitExceeded: string;
@@ -168,6 +169,14 @@ interface ReloadTreeOptions {
     parentNodeId: string | undefined;
     state?: "keep" | "discard" | "reset";
 }
+
+// @alpha
+export const RenameAction: NamedExoticComponent<object>;
+
+// @alpha (undocumented)
+export function RenameContextProvider({ onLabelChanged, children }: PropsWithChildren<{
+    onLabelChanged?: (newLabel: string) => void;
+}>): JSX_2.Element;
 
 // @alpha
 type RendererProps = {
@@ -255,8 +264,6 @@ interface TreeNodeRendererOwnProps {
     getLabel?: (node: PresentationHierarchyNode) => ReactElement | undefined;
     getSublabel?: (node: PresentationHierarchyNode) => ReactElement | undefined;
     node: PresentationHierarchyNode;
-    // (undocumented)
-    onLabelChanged?: (newLabel: string) => void;
     onNodeClick?: (node: PresentationHierarchyNode, isSelected: boolean, event: React.MouseEvent<HTMLElement>) => void;
     onNodeKeyDown?: (node: PresentationHierarchyNode, isSelected: boolean, event: React.KeyboardEvent<HTMLElement>) => void;
 }

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -278,7 +278,7 @@ type TreeNodeRendererProps_2 = ComponentPropsWithoutRef<typeof StrataKitTreeNode
 interface TreeRendererOwnProps {
     errorRenderer?: (props: TreeErrorRendererProps) => ReactElement;
     getEditingProps?: (node: PresentationHierarchyNode) => {
-        onLabelChanged: (newLabel: string) => void;
+        onLabelChanged?: (newLabel: string) => void;
     };
     selectionMode?: SelectionMode_2;
 }

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -278,7 +278,7 @@ type TreeNodeRendererProps_2 = ComponentPropsWithoutRef<typeof StrataKitTreeNode
 interface TreeRendererOwnProps {
     errorRenderer?: (props: TreeErrorRendererProps) => ReactElement;
     getEditingProps?: (node: PresentationHierarchyNode) => {
-        onLabelChanged?: (newLabel: string) => void;
+        onLabelChanged: (newLabel: string) => void;
     };
     selectionMode?: SelectionMode_2;
 }

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -26,22 +26,28 @@ import { RefAttributes } from 'react';
 import { SelectionStorage } from '@itwin/unified-selection';
 import { setLogger } from '@itwin/presentation-hierarchies';
 import { Tree } from '@stratakit/structures';
-import { UseTreeResult as UseTreeResult_2 } from '../UseTree.js';
+
+// @alpha (undocumented)
+interface CommonRendererProps {
+    getHierarchyLevelDetails: (nodeId: string | undefined) => HierarchyLevelDetails | undefined;
+    reloadTree: (options?: ReloadTreeOptions) => void;
+}
+
+// @public
+export type ErrorInfo = GenericErrorInfo | ResultSetTooLargeErrorInfo | NoFilterMatchesErrorInfo;
 
 // @alpha
-interface ErrorNode {
+interface ErrorItem {
     // (undocumented)
-    error: PresentationInfoNode;
+    errorNode: PresentationHierarchyNode;
     // (undocumented)
     expandTo: (expandNode: (nodeId: string) => void) => void;
-    // (undocumented)
-    parent?: PresentationHierarchyNode;
 }
 
 // @alpha
 export const FilterAction: NamedExoticComponent<    {
 onFilter?: (hierarchyLevelDetails: HierarchyLevelDetails) => void;
-} & Partial<Pick<UseTreeResult_2, "getHierarchyLevelDetails">> & {
+} & Pick<TreeRendererProps, "getHierarchyLevelDetails"> & {
 node: PresentationHierarchyNode;
 }>;
 
@@ -54,6 +60,16 @@ type FlatNode = {
 
 // @alpha
 export type FlatTreeNode = FlatNode | PlaceholderNode;
+
+// @public
+export interface GenericErrorInfo {
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    message: string;
+    // (undocumented)
+    type: "Unknown";
+}
 
 export { GenericInstanceFilter }
 
@@ -83,9 +99,6 @@ type IModelAccess = IModelHierarchyProviderProps["imodelAccess"];
 type IModelHierarchyProviderProps = Props<typeof createIModelHierarchyProvider>;
 
 // @public
-export function isPresentationHierarchyNode(node: PresentationTreeNode): node is PresentationHierarchyNode;
-
-// @public
 export function LocalizationContextProvider({ localizedStrings, children }: PropsWithChildren<LocalizationContextProviderProps>): JSX_2.Element;
 
 // @public
@@ -112,6 +125,14 @@ interface LocalizedStrings {
     rootResultLimitExceeded: string;
 }
 
+// @public
+interface NoFilterMatchesErrorInfo {
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    type: "NoFilterMatches";
+}
+
 // @alpha
 interface PlaceholderNode {
     // (undocumented)
@@ -123,21 +144,10 @@ interface PlaceholderNode {
 }
 
 // @public
-export interface PresentationGenericInfoNode {
-    // (undocumented)
-    id: string;
-    // (undocumented)
-    message: string;
-    // (undocumented)
-    parentNodeId: string | undefined;
-    // (undocumented)
-    type: "Unknown";
-}
-
-// @public
 export interface PresentationHierarchyNode {
     // (undocumented)
-    children: true | Array<PresentationTreeNode>;
+    children: true | Array<PresentationHierarchyNode>;
+    error?: ErrorInfo;
     // (undocumented)
     id: string;
     // (undocumented)
@@ -154,43 +164,33 @@ export interface PresentationHierarchyNode {
 }
 
 // @public
-export type PresentationInfoNode = PresentationGenericInfoNode | PresentationResultSetTooLargeInfoNode | PresentationNoFilterMatchesInfoNode;
-
-// @public
-interface PresentationNoFilterMatchesInfoNode {
-    // (undocumented)
-    id: string;
-    // (undocumented)
+interface ReloadTreeOptions {
     parentNodeId: string | undefined;
-    // (undocumented)
-    type: "NoFilterMatches";
+    state?: "keep" | "discard" | "reset";
 }
 
+// @alpha
+type RendererProps = {
+    rootErrorRendererProps: RootErrorRendererProps;
+} | {
+    rootErrorRendererProps: undefined;
+    treeRendererProps?: TreeRendererProps;
+};
+
 // @public
-export interface PresentationResultSetTooLargeInfoNode {
+export interface ResultSetTooLargeErrorInfo {
     // (undocumented)
     id: string;
-    // (undocumented)
-    parentNodeId: string | undefined;
     // (undocumented)
     resultSetSizeLimit: number;
     // (undocumented)
     type: "ResultSetTooLarge";
 }
 
-// @public
-export type PresentationTreeNode = PresentationHierarchyNode | PresentationInfoNode;
-
-// @public
-interface ReloadTreeOptions {
-    parentNodeId: string | undefined;
-    state?: "keep" | "discard" | "reset";
-}
-
-// @alpha (undocumented)
+// @alpha
 type RootErrorRendererProps = {
-    errorNode: ErrorNode;
-} & Pick<ReturnType<typeof useTree>, "getHierarchyLevelDetails" | "reloadTree">;
+    error: ErrorInfo;
+} & CommonRendererProps;
 
 // @public
 type SelectionChangeType = "add" | "replace" | "remove";
@@ -202,6 +202,23 @@ export { SelectionStorage }
 
 export { setLogger }
 
+// @internal
+export function StrataKitRootErrorRenderer({ error, getHierarchyLevelDetails, reloadTree }: StrataKitRootErrorRendererProps): JSX_2.Element;
+
+// @alpha (undocumented)
+type StrataKitRootErrorRendererProps = {
+    error: ErrorInfo;
+} & RootErrorRendererProps;
+
+// @public
+export const StrataKitTreeNodeRenderer: FC<PropsWithRef<TreeNodeRendererProps & RefAttributes<HTMLElement>>>;
+
+// @alpha
+export function StrataKitTreeRenderer({ rootNodes, selectNodes, selectionMode, expandNode, localizedStrings, getHierarchyLevelDetails, onFilterClick, reloadTree, isNodeSelected, errorRenderer, onNodeClick: onNodeClickOverride, onNodeKeyDown: onNodeKeyDownOverride, getEditingProps, ...treeProps }: StrataKitTreeRendererProps): JSX_2.Element;
+
+// @alpha (undocumented)
+type StrataKitTreeRendererProps = TreeRendererProps & Pick<TreeErrorRendererProps, "onFilterClick"> & Omit<TreeNodeRendererProps_2, "node" | "aria-level" | "aria-posinset" | "aria-setsize" | "reloadTree" | "selected" | "error"> & TreeRendererOwnProps & ComponentPropsWithoutRef<typeof LocalizationContextProvider>;
+
 // @alpha
 interface TreeErrorItemProps {
     onFilterClick?: (hierarchyLevelDetails: HierarchyLevelDetails) => void;
@@ -209,7 +226,7 @@ interface TreeErrorItemProps {
         parentNodeId: string | undefined;
         state: "reset";
     }) => void;
-    scrollToElement: (errorNode: ErrorNode) => void;
+    scrollToElement: (errorNode: ErrorItem) => void;
 }
 
 // @alpha
@@ -217,60 +234,61 @@ export function TreeErrorRenderer({ errorList, reloadTree, scrollToElement, getH
 
 // @alpha
 interface TreeErrorRendererOwnProps {
-    errorList: ErrorNode[];
+    errorList: ErrorItem[];
     // (undocumented)
-    renderError?: ({ errorNode, scrollToElement }: {
-        errorNode: ErrorNode;
+    renderError?: ({ errorItem, scrollToElement }: {
+        errorItem: ErrorItem;
         scrollToElement: () => void;
     }) => ReactElement;
 }
 
 // @alpha (undocumented)
-type TreeErrorRendererProps = TreeErrorRendererOwnProps & TreeErrorItemProps & Partial<Pick<ReturnType<typeof useTree>, "getHierarchyLevelDetails">>;
+type TreeErrorRendererProps = TreeErrorRendererOwnProps & TreeErrorItemProps & Pick<TreeRendererProps, "getHierarchyLevelDetails">;
 
 // @alpha (undocumented)
 type TreeNodeProps = ComponentPropsWithoutRef<typeof Tree.Item>;
 
-// @public
-export const TreeNodeRenderer: FC<PropsWithRef<TreeNodeRendererProps & RefAttributes<HTMLElement>>>;
-
 // @alpha (undocumented)
 interface TreeNodeRendererOwnProps {
-    error?: ErrorNode;
     getActions?: (node: PresentationHierarchyNode) => ReactNode[];
     getDecorations?: (node: PresentationHierarchyNode) => ReactNode;
     getLabel?: (node: PresentationHierarchyNode) => ReactElement | undefined;
     getSublabel?: (node: PresentationHierarchyNode) => ReactElement | undefined;
     node: PresentationHierarchyNode;
+    // (undocumented)
+    onLabelChanged?: (newLabel: string) => void;
     onNodeClick?: (node: PresentationHierarchyNode, isSelected: boolean, event: React.MouseEvent<HTMLElement>) => void;
     onNodeKeyDown?: (node: PresentationHierarchyNode, isSelected: boolean, event: React.KeyboardEvent<HTMLElement>) => void;
 }
 
 // @alpha (undocumented)
-type TreeNodeRendererProps = Pick<ReturnType<typeof useTree>, "expandNode"> & Partial<Pick<ReturnType<typeof useTree>, "getHierarchyLevelDetails">> & Omit<TreeNodeProps, "actions" | "label" | "expanded" | "unstable_decorations" | "error"> & Pick<UseTreeResult, "reloadTree"> & TreeNodeRendererOwnProps;
+type TreeNodeRendererProps = Pick<TreeRendererProps, "expandNode" | "reloadTree"> & Omit<TreeNodeProps, "actions" | "label" | "expanded" | "unstable_decorations" | "error"> & TreeNodeRendererOwnProps;
 
 // @alpha (undocumented)
-type TreeNodeRendererProps_2 = ComponentPropsWithoutRef<typeof TreeNodeRenderer>;
-
-// @alpha
-export function TreeRenderer({ rootNodes, selectNodes, selectionMode, rootErrorRenderer, ...treeProps }: TreeRendererProps): JSX_2.Element;
+type TreeNodeRendererProps_2 = ComponentPropsWithoutRef<typeof StrataKitTreeNodeRenderer>;
 
 // @alpha (undocumented)
 interface TreeRendererOwnProps {
     errorRenderer?: (props: TreeErrorRendererProps) => ReactElement;
-    rootErrorRenderer?: (props: RootErrorRendererProps) => ReactElement;
-    rootNodes: PresentationTreeNode[];
+    getEditingProps?: (node: PresentationHierarchyNode) => {
+        onLabelChanged?: (newLabel: string) => void;
+    };
     selectionMode?: SelectionMode_2;
 }
 
-// @alpha (undocumented)
-type TreeRendererProps = Pick<ReturnType<typeof useTree>, "expandNode"> & Partial<Pick<ReturnType<typeof useTree>, "selectNodes" | "isNodeSelected">> & Pick<ReturnType<typeof useTree>, "reloadTree" | "getHierarchyLevelDetails"> & Pick<TreeErrorRendererProps, "onFilterClick"> & Omit<TreeNodeRendererProps_2, "node" | "aria-level" | "aria-posinset" | "aria-setsize" | "reloadTree" | "selected" | "error"> & TreeRendererOwnProps & ComponentPropsWithoutRef<typeof LocalizationContextProvider>;
+// @alpha
+type TreeRendererProps = {
+    rootNodes: PresentationHierarchyNode[];
+    expandNode: (nodeId: string, isExpanded: boolean) => void;
+    selectNodes: (nodeIds: Array<string>, changeType: SelectionChangeType) => void;
+    isNodeSelected: (nodeId: string) => boolean;
+} & CommonRendererProps;
 
 // @alpha
-export function useErrorList(rootNodes: PresentationTreeNode[]): ErrorNode[];
+export function useErrorList(rootNodes: PresentationHierarchyNode[]): ErrorItem[];
 
 // @alpha
-export function useFlatTreeNodeList(rootNodes: PresentationTreeNode[]): FlatTreeNode[];
+export function useFlatTreeNodeList(rootNodes: PresentationHierarchyNode[]): FlatTreeNode[];
 
 // @public
 export function useIModelTree(props: UseIModelTreeProps): UseTreeResult;
@@ -292,7 +310,7 @@ export function useIModelUnifiedSelectionTree(props: UseIModelTreeProps & UseUni
 export function useSelectionHandler(props: UseSelectionHandlerProps): UseSelectionHandlerResult;
 
 // @public
-type UseSelectionHandlerProps = Pick<ReturnType<typeof useTree>, "rootNodes" | "selectNodes"> & {
+type UseSelectionHandlerProps = Pick<TreeRendererProps, "selectNodes" | "rootNodes"> & {
     selectionMode: SelectionMode_2;
 };
 
@@ -323,17 +341,11 @@ interface UseTreeProps {
 }
 
 // @public (undocumented)
-interface UseTreeResult {
-    expandNode: (nodeId: string, isExpanded: boolean) => void;
-    getHierarchyLevelDetails: (nodeId: string | undefined) => HierarchyLevelDetails | undefined;
+type UseTreeResult = {
+    isReloading: boolean;
     getNode: (nodeId: string) => PresentationHierarchyNode | undefined;
-    isLoading: boolean;
-    isNodeSelected: (nodeId: string) => boolean;
-    reloadTree: (options?: ReloadTreeOptions) => void;
-    rootNodes: PresentationTreeNode[] | undefined;
-    selectNodes: (nodeIds: Array<string>, changeType: SelectionChangeType) => void;
     setFormatter: (formatter: IPrimitiveValueFormatter | undefined) => void;
-}
+} & RendererProps;
 
 // @public
 export function useUnifiedSelectionTree({ sourceName, selectionStorage, ...props }: UseTreeProps & UseUnifiedTreeSelectionProps): UseTreeResult;

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
@@ -7,6 +7,8 @@ public;interface;GenericErrorInfo
 public;interface;HierarchyLevelDetails
 public;function;LocalizationContextProvider
 public;interface;PresentationHierarchyNode
+alpha;const;RenameAction
+alpha;function;RenameContextProvider
 public;interface;ResultSetTooLargeErrorInfo
 internal;function;StrataKitRootErrorRenderer
 public;const;StrataKitTreeNodeRenderer

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
@@ -1,18 +1,17 @@
 sep=;
 Release Tag;API Item Type;API Item Name
+public;type;ErrorInfo
 alpha;const;FilterAction
 alpha;type;FlatTreeNode
+public;interface;GenericErrorInfo
 public;interface;HierarchyLevelDetails
-public;function;isPresentationHierarchyNode
 public;function;LocalizationContextProvider
-public;interface;PresentationGenericInfoNode
 public;interface;PresentationHierarchyNode
-public;type;PresentationInfoNode
-public;interface;PresentationResultSetTooLargeInfoNode
-public;type;PresentationTreeNode
+public;interface;ResultSetTooLargeErrorInfo
+internal;function;StrataKitRootErrorRenderer
+public;const;StrataKitTreeNodeRenderer
+alpha;function;StrataKitTreeRenderer
 alpha;function;TreeErrorRenderer
-public;const;TreeNodeRenderer
-alpha;function;TreeRenderer
 alpha;function;useErrorList
 alpha;function;useFlatTreeNodeList
 public;function;useIModelTree

--- a/packages/hierarchies-react/src/presentation-hierarchies-react.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react.ts
@@ -10,6 +10,7 @@ export { HierarchyLevelDetails } from "./presentation-hierarchies-react/Renderer
 export { useIModelTree, useIModelUnifiedSelectionTree } from "./presentation-hierarchies-react/UseIModelTree.js";
 export { StrataKitTreeNodeRenderer } from "./presentation-hierarchies-react/stratakit/TreeNodeRenderer.js";
 export { FilterAction } from "./presentation-hierarchies-react/stratakit/FilterAction.js";
+export { RenameAction, RenameContextProvider } from "./presentation-hierarchies-react/stratakit/RenameAction.js";
 export { StrataKitTreeRenderer } from "./presentation-hierarchies-react/stratakit/TreeRenderer.js";
 export { StrataKitRootErrorRenderer } from "./presentation-hierarchies-react/stratakit/RootErrorRenderer.js";
 export { TreeErrorRenderer } from "./presentation-hierarchies-react/stratakit/TreeErrorRenderer.js";

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/LocalizationContext.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/LocalizationContext.tsx
@@ -85,6 +85,11 @@ export interface LocalizedStrings {
    * Default value: `Retry`.
    */
   retry: string;
+  /**
+   * Label for rename action.
+   * Default value: `Rename`.
+   */
+  rename: string;
 }
 
 /** @internal */
@@ -108,6 +113,7 @@ const defaultLocalizedStrings: LocalizedStrings = {
   increaseHierarchyLimitToUnlimited: "Remove limit",
   increaseHierarchyLimitWithFiltering: "Add Filter",
   retry: "Retry",
+  rename: "Rename",
 };
 
 const localizationContext = createContext<LocalizationContext>({ localizedStrings: defaultLocalizedStrings });

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/RenameAction.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/RenameAction.tsx
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createContext, memo, PropsWithChildren, useCallback, useContext, useMemo, useState } from "react";
+import renameSvg from "@stratakit/icons/rename.svg";
+import { Tree } from "@stratakit/structures";
+import { useLocalizationContext } from "./LocalizationContext.js";
+
+/**
+ * React component that renders a rename action for a tree item.
+ * @alpha
+ */
+export const RenameAction = memo(function RenameAction() {
+  const { localizedStrings } = useLocalizationContext();
+  const context = useRenameContext();
+  const { rename } = localizedStrings;
+
+  const setIsRenaming = context?.setIsRenaming;
+  const handleClick = useCallback(() => {
+    setIsRenaming?.(true);
+  }, [setIsRenaming]);
+
+  if (!context?.onLabelChanged) {
+    return undefined;
+  }
+
+  return <Tree.ItemAction label={rename} onClick={handleClick} icon={renameSvg} />;
+});
+
+interface RenameContext {
+  isRenaming: boolean;
+  setIsRenaming: (isRenaming: boolean) => void;
+  onLabelChanged?: (newLabel: string) => void;
+}
+
+const renameContext = createContext<RenameContext | undefined>(undefined);
+
+/** @internal */
+export const useRenameContext = () => {
+  return useContext(renameContext);
+};
+
+/** @alpha */
+export function RenameContextProvider({ onLabelChanged, children }: PropsWithChildren<{ onLabelChanged?: (newLabel: string) => void }>) {
+  const [isRenaming, setIsRenaming] = useState(false);
+  const value = useMemo(() => ({ isRenaming, setIsRenaming, onLabelChanged }), [isRenaming, onLabelChanged]);
+
+  return <renameContext.Provider value={value}>{children}</renameContext.Provider>;
+}

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeRenderer.tsx
@@ -155,9 +155,7 @@ export function StrataKitTreeRenderer({
 type VirtualTreeItemProps = Omit<TreeNodeRendererProps, "node" | "aria-level" | "aria-posinset" | "aria-setsize"> & {
   start: number;
   node: FlatTreeNode;
-  getEditingProps?: (node: PresentationHierarchyNode) => {
-    onLabelChanged?: (newLabel: string) => void;
-  };
+  getEditingProps?: TreeRendererOwnProps["getEditingProps"];
 };
 
 const VirtualTreeItem = memo(

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeRenderer.tsx
@@ -12,6 +12,7 @@ import { SelectionMode, useSelectionHandler } from "../UseSelectionHandler.js";
 import { useEvent } from "../Utils.js";
 import { ErrorItem, FlatTreeNode, isPlaceholderNode, useErrorList, useFlatTreeNodeList } from "./FlatTreeNode.js";
 import { LocalizationContextProvider } from "./LocalizationContext.js";
+import { RenameContextProvider } from "./RenameAction.js";
 import { TreeErrorRenderer, TreeErrorRendererProps } from "./TreeErrorRenderer.js";
 import { PlaceholderNode, StrataKitTreeNodeRenderer } from "./TreeNodeRenderer.js";
 
@@ -181,26 +182,26 @@ const VirtualTreeItem = memo(
     }
 
     const editingProps = getEditingProps?.(node);
-
     return (
-      <StrataKitTreeNodeRenderer
-        {...props}
-        ref={forwardedRef}
-        style={style}
-        aria-level={node.level}
-        aria-posinset={node.posInLevel}
-        aria-setsize={node.levelSize}
-        node={node}
-        expandNode={expandNode}
-        reloadTree={reloadTree}
-        getDecorations={getDecorations}
-        getActions={getActions}
-        getLabel={getLabel}
-        getSublabel={getSublabel}
-        onNodeClick={onNodeClick}
-        onNodeKeyDown={onNodeKeyDown}
-        onLabelChanged={editingProps?.onLabelChanged}
-      />
+      <RenameContextProvider onLabelChanged={editingProps?.onLabelChanged}>
+        <StrataKitTreeNodeRenderer
+          {...props}
+          ref={forwardedRef}
+          style={style}
+          aria-level={node.level}
+          aria-posinset={node.posInLevel}
+          aria-setsize={node.levelSize}
+          node={node}
+          expandNode={expandNode}
+          reloadTree={reloadTree}
+          getDecorations={getDecorations}
+          getActions={getActions}
+          getLabel={getLabel}
+          getSublabel={getSublabel}
+          onNodeClick={onNodeClick}
+          onNodeKeyDown={onNodeKeyDown}
+        />
+      </RenameContextProvider>
     );
   }),
 );

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeRenderer.tsx
@@ -30,8 +30,8 @@ interface TreeRendererOwnProps {
   errorRenderer?: (props: TreeErrorRendererProps) => ReactElement;
   /** Props that defines if current node supports editing. */
   getEditingProps?: (node: PresentationHierarchyNode) => {
-    /** Callback that is invoked when node label is changed. */
-    onLabelChanged: (newLabel: string) => void;
+    /** Callback that is invoked when node label is changed. If `undefined` node label is not editable. */
+    onLabelChanged?: (newLabel: string) => void;
   };
 }
 

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeRenderer.tsx
@@ -30,8 +30,8 @@ interface TreeRendererOwnProps {
   errorRenderer?: (props: TreeErrorRendererProps) => ReactElement;
   /** Props that defines if current node supports editing. */
   getEditingProps?: (node: PresentationHierarchyNode) => {
-    /** Callback that is invoked when node label is changed. If `undefined` node label is not editable. */
-    onLabelChanged?: (newLabel: string) => void;
+    /** Callback that is invoked when node label is changed. */
+    onLabelChanged: (newLabel: string) => void;
   };
 }
 


### PR DESCRIPTION
Added ability to edit node labels. 
Added `Rename` action that initiates label editing.
![2025-05-22_10-49-57](https://github.com/user-attachments/assets/4967ec44-0e97-4da6-ab28-0ccce134a5fe)
