### PR TITLE
[hierarchies-react]: Do not show focus outline on mobile devices

### DIFF
--- a/.changeset/honest-rooms-strive.md
+++ b/.changeset/honest-rooms-strive.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Removed tree node outline on mobile devices.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.css
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.css
@@ -20,12 +20,12 @@
   .stateless-tree-node:hover .action-buttons {
     visibility: visible;
   }
-}
 
-.stateless-tree-node:focus-within {
-  outline: 1px solid var(--iui-color-border-accent);
-  outline-offset: -1px;
-  border-radius: var(--iui-border-radius-1);
+  .stateless-tree-node:focus-within {
+    outline: 1px solid var(--iui-color-border-accent);
+    outline-offset: -1px;
+    border-radius: var(--iui-border-radius-1);
+  }
 }
 
 .stateless-tree-node-small-spinner {


### PR DESCRIPTION
Fixes https://github.com/iTwin/viewer-components-react/issues/1323