### PR TITLE
[hierarchies-react]: Link tree nodes with errors

### DIFF
--- a/.changeset/eager-wolves-wonder.md
+++ b/.changeset/eager-wolves-wonder.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Link TreeNode containing error with the error rendered in TreeErrorRenderer.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeNodeRenderer.tsx
@@ -163,7 +163,7 @@ export const StrataKitTreeNodeRenderer: FC<PropsWithRef<TreeNodeRendererProps & 
         )}
         actions={actions}
         unstable_decorations={decorations}
-        error={!!node.error}
+        error={node.error ? node.error.id : undefined}
       />
     );
   }),


### PR DESCRIPTION
Linked tree nodes containing errors with the errors rendering in TreeErrorRenderer.
Additionally this resolves ```Warning: Received `false` for a non-boolean attribute `error`.``` error log in the console 