### PR TITLE
Adjust how `isReloading` is determined

### DIFF
--- a/.changeset/proud-jeans-bow.md
+++ b/.changeset/proud-jeans-bow.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-hierarchies-react": patch
 ---
 
-Adjust how `useUnifiedSelectionTree` determines `isReloading` value. `IsReloading` is now set to `true` if root nodes are being loaded.
+Adjust how `useTree` and other variants of it determines `isReloading` value. `isReloading` is now set to `true` if root nodes are being loaded.

--- a/.changeset/proud-jeans-bow.md
+++ b/.changeset/proud-jeans-bow.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Adjust how `useUnifiedSelectionTree` determines `isReloading` value. `IsReloading` is now set to `true` if root nodes are being loaded.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/UseTree.ts
@@ -316,7 +316,7 @@ function useTreeInternal({
 
   return {
     ...renderProps,
-    isReloading: isFiltering,
+    isReloading: !!state.model.rootNode.isLoading || isFiltering,
     getTreeModelNode,
     getNode,
     setFormatter,

--- a/packages/hierarchies-react/src/test/UseTree.test.tsx
+++ b/packages/hierarchies-react/src/test/UseTree.test.tsx
@@ -157,10 +157,8 @@ describe("useTree", () => {
     };
 
     const promise = new ResolvablePromise<hierarchiesModule.HierarchyNodeIdentifiersPath[]>();
-    const getFilteredPaths1 = sinon.stub().callsFake(async () => promise);
-
     const { result, rerender } = renderHook(useTree, {
-      initialProps: { getHierarchyProvider: () => customHierarchyProvider, getFilteredPaths: getFilteredPaths1 },
+      initialProps: { getHierarchyProvider: () => customHierarchyProvider, getFilteredPaths: () => promise },
     });
     await waitFor(() => {
       expect(getNodesCallCount).to.eq(0);
@@ -174,8 +172,7 @@ describe("useTree", () => {
     let treeRenderProps = getTreeRendererProps(result.current);
     expect(treeRenderProps?.rootNodes).to.have.lengthOf(2);
 
-    const getFilteredPaths2 = sinon.stub().callsFake(async () => promise);
-    rerender({ getHierarchyProvider: () => customHierarchyProvider, getFilteredPaths: getFilteredPaths2 });
+    rerender({ getHierarchyProvider: () => customHierarchyProvider, getFilteredPaths: () => promise });
     await waitFor(() => {
       expect(getNodesCallCount).to.eq(1);
       expect(result.current.isReloading).to.be.true;

--- a/packages/hierarchies-react/src/test/UseTree.test.tsx
+++ b/packages/hierarchies-react/src/test/UseTree.test.tsx
@@ -141,9 +141,8 @@ describe("useTree", () => {
       async *getNodes() {
         if (getNodesCallCount < 1) {
           ++getNodesCallCount;
-          for (const node of [rootNode1, rootNode2]) {
-            yield node;
-          }
+          yield rootNode1;
+          yield rootNode2;
         } else {
           await new Promise((res) => setTimeout(res, 50));
           for (const node of [rootNode1]) {

--- a/packages/hierarchies-react/src/test/UseTree.test.tsx
+++ b/packages/hierarchies-react/src/test/UseTree.test.tsx
@@ -145,9 +145,7 @@ describe("useTree", () => {
           yield rootNode2;
         } else {
           await new Promise((res) => setTimeout(res, 50));
-          for (const node of [rootNode1]) {
-            yield node;
-          }
+          yield rootNode1;
         }
       },
       setHierarchyFilter() {


### PR DESCRIPTION
We can determine if skeleton tree should be loaded if `treeRendererProps?.rootNodes === undefined` or `isReloading === true` (https://github.com/iTwin/contextual-tree-control-react/blob/b080b65804ca66cb18c197c200749c1171e93557/packages/resources-browser-react/src/resources-browser-react/components/ResourcesBrowserTree.tsx#L46). 
There is a problem when using filtering - tree flickers. Right now `isReloading` is set to true only while filtering paths are being retrieved and set.  Before [this](https://github.com/iTwin/presentation/pull/961/files?diff=split&w=0#diff-0f1fbbfa5df647ea9653681a8e33c21da1ede66f6df3c570bf1a65f09aad4aff:~:text=isReloading%3A%20isFiltering%2C) we had additional condition that checked if root nodes were loading. This condition helped with flickering problem, adding it back.