### PR TITLE
Do not run regression workflow on release PRs

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -15,8 +15,7 @@ jobs:
         env:
             PR_TITLE: ${{ github.event.pull_request.title }}
         run:
-          # [[ $PR_TITLE =~ ^(Release packages) ]]
-          if [[ $PR_TITLE =~ ^(Test Regression) ]]
+          if [[ $PR_TITLE =~ ^(Release packages) ]]
           then
             echo "isReleasePR=true" >> "$GITHUB_OUTPUT";
           else

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -15,8 +15,8 @@ jobs:
         env:
             PR_TITLE: ${{ github.event.pull_request.title }}
         run:
-          # [[ $PR_TITLE =~ ^Release packages ]]
-          if [[ $PR_TITLE =~ ^Test Regression ]]
+          # [[ $PR_TITLE =~ ^(Release packages) ]]
+          if [[ $PR_TITLE =~ ^(Test Regression) ]]
           then
             echo "isReleasePR=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -18,9 +18,9 @@ jobs:
           # [[ $PR_TITLE =~ ^(Release packages) ]]
           if [[ $PR_TITLE =~ ^(Test Regression) ]]
           then
-            echo "isReleasePR=true" >> "$GITHUB_OUTPUT"
+            echo "isReleasePR=true" >> "$GITHUB_OUTPUT";
           else
-            echo "isReleasePR=false" >> "$GITHUB_OUTPUT"
+            echo "isReleasePR=false" >> "$GITHUB_OUTPUT";
           fi
 
   buildPackages:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -25,7 +25,7 @@ jobs:
 
   buildPackages:
     needs: [checkRelease]
-    if: ${{ needs.checkRelease.outputs.isReleasePR == 'true' }}
+    if: ${{ needs.checkRelease.outputs.isReleasePR == 'false' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -5,13 +5,13 @@ on:
     branches: [ "master" ]
 
 jobs:
-  checkPR:
+  checkRelease:
     runs-on: ubuntu-latest
     outputs:
-      isReleasePR: ${{ steps.pr-checker.outputs.isReleasePR }}
+      isReleasePR: ${{ steps.release-checker.outputs.isReleasePR }}
     steps:
       - name: Check for release PR
-        id: pr-checker
+        id: release-checker
         env:
             PR_TITLE: ${{ github.event.pull_request.title }}
         run:
@@ -21,8 +21,8 @@ jobs:
           echo "isReleasePR=IS_RELEASE_PR" >> "$GITHUB_OUTPUT"
 
   buildPackages:
-    needs: [checkPR]
-    if: ${{ needs.checkPR.outputs.isReleasePR == 'true' }}
+    needs: [checkRelease]
+    if: ${{ needs.checkRelease.outputs.isReleasePR == 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -5,7 +5,24 @@ on:
     branches: [ "master" ]
 
 jobs:
+  checkPR:
+    runs-on: ubuntu-latest
+    outputs:
+      isReleasePR: ${{ steps.pr-checker.outputs.isReleasePR }}
+    steps:
+      - name: Check for release PR
+        id: pr-checker
+        env:
+            PR_TITLE: ${{ github.event.pull_request.title }}
+        run:
+          # [[ $PR_TITLE =~ ^Release packages ]]
+          IS_RELEASE_PR=[[ $PR_TITLE =~ ^Test Regression ]]
+          echo $IS_RELEASE_PR
+          echo "isReleasePR=IS_RELEASE_PR" >> "$GITHUB_OUTPUT"
+
   buildPackages:
+    needs: [checkPR]
+    if: ${{ needs.checkPR.outputs.isReleasePR == 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -16,9 +16,12 @@ jobs:
             PR_TITLE: ${{ github.event.pull_request.title }}
         run:
           # [[ $PR_TITLE =~ ^Release packages ]]
-          IS_RELEASE_PR=[[ $PR_TITLE =~ ^Test Regression ]]
-          echo $IS_RELEASE_PR
-          echo "isReleasePR=IS_RELEASE_PR" >> "$GITHUB_OUTPUT"
+          if [[ $PR_TITLE =~ ^Test Regression ]]
+          then
+            echo "isReleasePR=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "isReleasePR=false" >> "$GITHUB_OUTPUT"
+          fi
 
   buildPackages:
     needs: [checkRelease]


### PR DESCRIPTION
Added additional job to regression pipeline that checks if current PR title starts with `Release packages`. It title matches condition regression workflow is skipped. This should disable regression workflow running on release PRs that is failing because local package versions are already bumped and pnpm fails to resolve dependencies.

Closes https://github.com/iTwin/presentation/issues/984