### PR TITLE
[hierarchies-react] Focus apply filter button

### DIFF
--- a/.changeset/shiny-years-draw.md
+++ b/.changeset/shiny-years-draw.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Made sure `Apply filter` button becomes focused after hierarchy level filter is applied.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -5,7 +5,7 @@
 
 import "./TreeNodeRenderer.css";
 import cx from "classnames";
-import { ComponentPropsWithoutRef, forwardRef, LegacyRef, MutableRefObject, ReactElement, Ref, RefAttributes, useCallback, useRef } from "react";
+import { ComponentPropsWithoutRef, forwardRef, LegacyRef, MutableRefObject, ReactElement, Ref, RefAttributes, useCallback, useEffect, useRef } from "react";
 import { SvgFilter, SvgFilterHollow, SvgRemove } from "@itwin/itwinui-icons-react";
 import { Anchor, ButtonGroup, Flex, IconButton, ProgressRadial, Text, TreeNode } from "@itwin/itwinui-react";
 import { HierarchyNode } from "@itwin/presentation-hierarchies";
@@ -88,69 +88,29 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
     forwardedRef,
   ) => {
     const { localizedStrings } = useLocalizationContext();
-    const applyFilterButtonRef = useRef<HTMLButtonElement>(null);
-    const nodeRef = useRef<HTMLDivElement>(null);
-    const ref = useMergedRefs(forwardedRef, nodeRef);
     if ("type" in node && node.type === "ChildrenPlaceholder") {
-      return <PlaceholderNode {...treeNodeProps} ref={ref} size={size} />;
+      return <PlaceholderNode {...treeNodeProps} ref={forwardedRef} size={size} />;
     }
 
     if (isPresentationHierarchyNode(node)) {
       return (
-        <TreeNode
+        <HierarchyNodeRenderer
           {...treeNodeProps}
-          ref={ref}
+          ref={forwardedRef}
+          node={node}
+          expandNode={expandNode}
+          getIcon={getIcon}
+          getLabel={getLabel}
+          getSublabel={getSublabel}
+          onFilterClick={onFilterClick}
+          onNodeClick={onNodeClick}
+          onNodeKeyDown={onNodeKeyDown}
           isSelected={isSelected}
           isDisabled={isDisabled}
-          className={cx(treeNodeProps.className, "stateless-tree-node", { filtered: node.isFiltered })}
-          onClick={(event) => !isDisabled && onNodeClick?.(node, !isSelected, event)}
-          onKeyDown={(event) => {
-            // Ignore if it is called on the element inside, e.g. checkbox or expander
-            if (!isDisabled && event.target === nodeRef.current) {
-              onNodeKeyDown?.(node, !isSelected, event);
-            }
-          }}
-          onExpanded={(_, isExpanded) => {
-            expandNode(node.id, isExpanded);
-          }}
-          icon={getIcon ? getIcon(node) : undefined}
-          label={getLabel ? getLabel(node) : node.label}
-          sublabel={getSublabel ? getSublabel(node) : undefined}
-        >
-          <ButtonGroup className={cx("action-buttons", actionButtonsClassName)}>
-            {getHierarchyLevelDetails && node.isFiltered ? (
-              <IconButton
-                className="filtering-action-button"
-                styleType="borderless"
-                size="small"
-                label={localizedStrings.clearHierarchyLevelFilter}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  getHierarchyLevelDetails(node.id)?.setInstanceFilter(undefined);
-                  applyFilterButtonRef.current?.focus();
-                }}
-              >
-                <SvgRemove />
-              </IconButton>
-            ) : null}
-            {onFilterClick && node.isFilterable && (filterButtonsVisibility !== "hide" || node.isFiltered) ? (
-              <IconButton
-                ref={applyFilterButtonRef}
-                className="filtering-action-button"
-                styleType="borderless"
-                size="small"
-                label={localizedStrings.filterHierarchyLevel}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  const hierarchyLevelDetails = getHierarchyLevelDetails?.(node.id);
-                  hierarchyLevelDetails && onFilterClick(hierarchyLevelDetails);
-                }}
-              >
-                {node.isFiltered ? <SvgFilter /> : <SvgFilterHollow />}
-              </IconButton>
-            ) : null}
-          </ButtonGroup>
-        </TreeNode>
+          actionButtonsClassName={actionButtonsClassName}
+          getHierarchyLevelDetails={getHierarchyLevelDetails}
+          filterButtonsVisibility={filterButtonsVisibility}
+        />
       );
     }
 
@@ -163,7 +123,7 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
       return (
         <ResultSetTooLargeNode
           {...treeNodeProps}
-          ref={ref}
+          ref={forwardedRef}
           limit={node.resultSetSizeLimit}
           onOverrideLimit={hierarchyLevelDetails ? (limit) => hierarchyLevelDetails.setSizeLimit(limit) : undefined}
           onFilterClick={
@@ -178,14 +138,22 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
     }
 
     if (node.type === "NoFilterMatches") {
-      return <TreeNode {...treeNodeProps} ref={ref} label={localizedStrings.noFilteredChildren} isDisabled={true} onExpanded={/* c8 ignore next */ () => {}} />;
+      return (
+        <TreeNode
+          {...treeNodeProps}
+          ref={forwardedRef}
+          label={localizedStrings.noFilteredChildren}
+          isDisabled={true}
+          onExpanded={/* c8 ignore next */ () => {}}
+        />
+      );
     }
 
     const onRetry = reloadTree ? () => reloadTree({ parentNodeId: node.parentNodeId, state: "reset" }) : undefined;
     return (
       <TreeNode
         {...treeNodeProps}
-        ref={ref}
+        ref={forwardedRef}
         label={<ErrorNodeLabel message={node.message} onRetry={onRetry} />}
         isDisabled={true}
         onExpanded={/* c8 ignore next */ () => {}}
@@ -194,6 +162,100 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
   },
 );
 TreeNodeRenderer.displayName = "TreeNodeRenderer";
+
+const HierarchyNodeRenderer = forwardRef<HTMLDivElement, Omit<TreeNodeRendererProps, "node" | "reloadTree" | "size"> & { node: PresentationHierarchyNode }>(
+  (
+    {
+      node,
+      expandNode,
+      getIcon,
+      getLabel,
+      getSublabel,
+      onFilterClick,
+      onNodeClick,
+      onNodeKeyDown,
+      isSelected,
+      isDisabled,
+      actionButtonsClassName,
+      getHierarchyLevelDetails,
+      filterButtonsVisibility,
+      ...treeNodeProps
+    },
+    forwardedRef,
+  ) => {
+    const { localizedStrings } = useLocalizationContext();
+    const applyFilterButtonRef = useRef<HTMLButtonElement>(null);
+    const nodeRef = useRef<HTMLDivElement>(null);
+    const ref = useMergedRefs(forwardedRef, nodeRef);
+
+    const prevIsFiltered = useRef(node.isFiltered);
+    useEffect(() => {
+      // If the node is filtered, focus the apply filter button
+      if (node.isFiltered && !prevIsFiltered.current) {
+        applyFilterButtonRef.current?.focus();
+      }
+      prevIsFiltered.current = node.isFiltered;
+    }, [node.isFiltered]);
+
+    return (
+      <TreeNode
+        {...treeNodeProps}
+        ref={ref}
+        isSelected={isSelected}
+        isDisabled={isDisabled}
+        className={cx(treeNodeProps.className, "stateless-tree-node", { filtered: node.isFiltered })}
+        onClick={(event) => !isDisabled && onNodeClick?.(node, !isSelected, event)}
+        onKeyDown={(event) => {
+          // Ignore if it is called on the element inside, e.g. checkbox or expander
+          if (!isDisabled && event.target === nodeRef.current) {
+            onNodeKeyDown?.(node, !isSelected, event);
+          }
+        }}
+        onExpanded={(_, isExpanded) => {
+          expandNode(node.id, isExpanded);
+        }}
+        icon={getIcon ? getIcon(node) : undefined}
+        label={getLabel ? getLabel(node) : node.label}
+        sublabel={getSublabel ? getSublabel(node) : undefined}
+      >
+        <ButtonGroup className={cx("action-buttons", actionButtonsClassName)}>
+          {getHierarchyLevelDetails && node.isFiltered ? (
+            <IconButton
+              className="filtering-action-button"
+              styleType="borderless"
+              size="small"
+              label={localizedStrings.clearHierarchyLevelFilter}
+              onClick={(e) => {
+                e.stopPropagation();
+                getHierarchyLevelDetails(node.id)?.setInstanceFilter(undefined);
+                applyFilterButtonRef.current?.focus();
+              }}
+            >
+              <SvgRemove />
+            </IconButton>
+          ) : null}
+          {onFilterClick && node.isFilterable && (filterButtonsVisibility !== "hide" || node.isFiltered) ? (
+            <IconButton
+              ref={applyFilterButtonRef}
+              className="filtering-action-button"
+              styleType="borderless"
+              size="small"
+              label={localizedStrings.filterHierarchyLevel}
+              onClick={(e) => {
+                e.stopPropagation();
+                const hierarchyLevelDetails = getHierarchyLevelDetails?.(node.id);
+                hierarchyLevelDetails && onFilterClick(hierarchyLevelDetails);
+              }}
+            >
+              {node.isFiltered ? <SvgFilter /> : <SvgFilterHollow />}
+            </IconButton>
+          ) : null}
+        </ButtonGroup>
+      </TreeNode>
+    );
+  },
+);
+HierarchyNodeRenderer.displayName = "HierarchyNodeRenderer";
 
 const PlaceholderNode = forwardRef<
   HTMLDivElement,

--- a/packages/hierarchies-react/src/test/itwinui/Tree.test.tsx
+++ b/packages/hierarchies-react/src/test/itwinui/Tree.test.tsx
@@ -274,6 +274,51 @@ describe("Tree", () => {
     expect(applyFilterButton.matches(":focus")).to.be.true;
   });
 
+  it("focuses `Apply filter` button when node becomes filtered", async () => {
+    const rootNodes = createNodes([
+      {
+        id: "root-1",
+        isExpanded: false,
+        isFilterable: true,
+        isFiltered: false,
+        children: [
+          {
+            id: "child-1",
+          },
+        ],
+      },
+    ]);
+
+    const { rerender, getByRole, queryByText } = render(<TreeRenderer rootNodes={rootNodes} {...initialProps} />);
+
+    expect(queryByText("root-1")).to.not.be.null;
+    expect(queryByText("child-1")).to.be.null;
+
+    const rootNode = getByRole("treeitem", { expanded: false });
+    expect(within(rootNode).getByRole("button", { name: "Apply filter" }).matches(":focus")).to.be.false;
+
+    const filteredRootNodes = createNodes([
+      {
+        id: "root-1",
+        isExpanded: false,
+        isFilterable: true,
+        isFiltered: true,
+        children: [
+          {
+            id: "child-1",
+          },
+        ],
+      },
+    ]);
+    rerender(<TreeRenderer rootNodes={filteredRootNodes} {...initialProps} />);
+
+    expect(queryByText("root-1")).to.not.be.null;
+    expect(queryByText("child-1")).to.be.null;
+
+    const filteredRootNode = getByRole("treeitem", { expanded: false });
+    expect(within(filteredRootNode).getByRole("button", { name: "Apply filter" }).matches(":focus")).to.be.true;
+  });
+
   it("renders icon", async () => {
     const rootNodes = createNodes([
       {


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/999

Tree widget e2e tests revealed that `Apply filter` button is not focused after hierarchy filter is applied. Added code to make sure that button is focused when hierarchy level is filtered.