### PR TITLE
Change autoExpand option in HierarchyFilteringPathOptions

### DIFF
--- a/.changeset/shiny-poets-draw.md
+++ b/.changeset/shiny-poets-draw.md
@@ -1,0 +1,9 @@
+---
+"@itwin/presentation-hierarchies": minor
+---
+
+`HierarchyFilteringPathOptions.autoExpand` now is now of type:
+```ts
+autoExpand?: { depth: number } | boolean;
+```
+When `depth` is set, only nodes up to specified `depth` in `HierarchyFilteringPath` will have `autoExpand` option set.

--- a/packages/hierarchies/api/presentation-hierarchies.api.md
+++ b/packages/hierarchies/api/presentation-hierarchies.api.md
@@ -48,10 +48,22 @@ export function createHierarchyFilteringHelper(rootLevelFilteringProps: Hierarch
         nodeKey: InstancesNodeKey | GenericNodeKey;
     } | {
         pathMatcher: (identifier: HierarchyNodeIdentifier) => boolean;
-    }) => Pick<HierarchyNode, "filtering" | "autoExpand"> | undefined;
+    }) => (Pick<HierarchyNode, "autoExpand"> & {
+        filtering?: HierarchyNode["filtering"] & {
+            autoExpandDepth?: number;
+        };
+    }) | undefined;
     createChildNodePropsAsync: (props: {
         pathMatcher: (identifier: HierarchyNodeIdentifier) => boolean | Promise<boolean>;
-    }) => Promise<Pick<HierarchyNode, "filtering" | "autoExpand"> | undefined> | Pick<HierarchyNode, "filtering" | "autoExpand"> | undefined;
+    }) => Promise<(Pick<HierarchyNode, "autoExpand"> & {
+        filtering?: HierarchyNode["filtering"] & {
+            autoExpandDepth?: number;
+        };
+    }) | undefined> | (Pick<HierarchyNode, "autoExpand"> & {
+        filtering?: HierarchyNode["filtering"] & {
+            autoExpandDepth?: number;
+        };
+    }) | undefined;
 };
 
 // @public
@@ -181,8 +193,14 @@ export function extractFilteringProps(rootLevelFilteringProps: HierarchyFilterin
 } | undefined;
 
 // @public (undocumented)
+interface FilteringPathAutoExpandOption {
+    depth: number;
+}
+
+// @public (undocumented)
 interface FilterTargetGroupingNodeInfo {
     depth: number;
+    // @deprecated
     key: GroupingNodeKey;
 }
 
@@ -262,7 +280,7 @@ export namespace HierarchyFilteringPath {
 
 // @public (undocumented)
 export interface HierarchyFilteringPathOptions {
-    autoExpand?: boolean | FilterTargetGroupingNodeInfo;
+    autoExpand?: boolean | FilterTargetGroupingNodeInfo | FilteringPathAutoExpandOption;
 }
 
 // @public

--- a/packages/hierarchies/src/hierarchies/imodel/FilteringHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/FilteringHierarchyDefinition.ts
@@ -146,7 +146,9 @@ export class FilteringHierarchyDefinition implements RxjsHierarchyDefinition {
           return (nodeExtraPropsPossiblyPromise instanceof Promise ? from(nodeExtraPropsPossiblyPromise) : of(nodeExtraPropsPossiblyPromise)).pipe(
             map((nodeExtraProps) => {
               if (nodeExtraProps?.autoExpand) {
-                parsedNode.autoExpand = true;
+                const parentLength = parentNode ? 1 + parentNode.parentKeys.length : 0;
+                parsedNode.autoExpand =
+                  nodeExtraProps.filtering?.autoExpandDepth !== undefined && parentLength >= nodeExtraProps.filtering.autoExpandDepth ? undefined : true;
               }
               if (nodeExtraProps?.filtering) {
                 parsedNode.filtering = nodeExtraProps.filtering;


### PR DESCRIPTION
Added option to set `depth` for `HierarchyFilteringPathOptions.autoExpand`
Part of https://github.com/iTwin/viewer-components-react/issues/1319