### PR TITLE
Fix autoExpand depth not working correctly with grouping nodes

### DIFF
--- a/.changeset/bright-poets-hug.md
+++ b/.changeset/bright-poets-hug.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies": patch
+---
+
+Fixed `HierarchyFilteringPathOptions.autoExpand` depth option not working properly with grouping nodes.

--- a/.changeset/bright-poets-hug.md
+++ b/.changeset/bright-poets-hug.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-hierarchies": patch
 ---
 
-Fixed `HierarchyFilteringPathOptions.autoExpand` depth option not working properly with grouping nodes.
+Fixed `HierarchyFilteringPathOptions.autoExpand` depth option not working properly with grouping nodes. Added `includeGroupingNodes` attribute to `FilteringPathAutoExpandOption`, which allows auto-expanding only desired gouping nodes, when set together with `depth` value.

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyFiltering.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyFiltering.test.ts
@@ -324,7 +324,154 @@ describe("Hierarchies", () => {
         ]);
       });
 
-      it("sets auto-expand flag to parent nodes of the filter target until a given grouping node", async function () {
+      it("sets auto-expand flag to parent nodes of the filter target until specified depth when depth includes grouping nodes", async function () {
+        const imodelAccess = createIModelAccess(imodel);
+        const queryClauseFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess }),
+        });
+        // Define a hierarchy such that all elements except root are grouped by label.
+        const hierarchyDefinition: HierarchyDefinition = {
+          defineHierarchyLevel: async ({ parentNode }) => {
+            if (!parentNode) {
+              return [
+                {
+                  fullClassName: "BisCore.PhysicalElement",
+                  query: {
+                    ecsql: `
+                      SELECT ${await queryClauseFactory.createSelectClause({
+                        ecClassId: { selector: "this.ECClassId" },
+                        ecInstanceId: { selector: "this.ECInstanceId" },
+                        nodeLabel: { selector: "this.UserLabel" },
+                      })}
+                      FROM BisCore.PhysicalElement this
+                      WHERE this.Parent IS NULL
+                    `,
+                  },
+                },
+              ];
+            }
+
+            assert(HierarchyNode.isInstancesNode(parentNode));
+            return [
+              {
+                fullClassName: "BisCore.PhysicalElement",
+                query: {
+                  ecsql: `
+                    SELECT ${await queryClauseFactory.createSelectClause({
+                      ecClassId: { selector: "this.ECClassId" },
+                      ecInstanceId: { selector: "this.ECInstanceId" },
+                      nodeLabel: { selector: "this.UserLabel" },
+                      grouping: { byLabel: true, byClass: true },
+                    })}
+                    FROM BisCore.PhysicalElement this
+                    WHERE this.Parent.Id = ?
+                  `,
+                  bindings: [{ type: "id", value: parentNode.key.instanceKeys[0].id }],
+                },
+              },
+            ];
+          },
+        };
+
+        async function getSelectedGroupingNode(): Promise<GroupingHierarchyNode> {
+          const provider = createIModelHierarchyProvider({ imodelAccess, hierarchyDefinition });
+          return firstValueFrom(
+            from(provider.getNodes({ parentNode: undefined })).pipe(
+              expand((parentNode) => provider.getNodes({ parentNode })),
+              filter((node) => HierarchyNode.isGroupingNode(node)),
+              first(
+                (node) =>
+                  InstanceKey.equals(node.groupedInstanceKeys[0], elementKeys.c) &&
+                  node.parentKeys.length > 0 &&
+                  node.parentKeys[node.parentKeys.length - 1].type !== "instances",
+              ),
+            ),
+          );
+        }
+
+        // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyFiltering.AutoExpandUntilDepthWithGrouping.FilteringPath
+        // Hierarchy has two grouping nodes under C element: one class grouping and one label grouping node.
+        // Get grouping node that groups the "C" element and is the nearest grouping node to it
+        const groupingNode = await getSelectedGroupingNode();
+        const filteringPath: HierarchyFilteringPath = {
+          // Path to the element "C"
+          path: [elementKeys.a, elementKeys.b, elementKeys.c],
+          options: {
+            // Auto-expand the hierarchy up to the last grouping node. The `depth` attribute equals to the number of parents.
+            autoExpand: { includeGroupingNodes: true, depth: groupingNode.parentKeys.length },
+          },
+        };
+        // __PUBLISH_EXTRACT_END__
+
+        // Construct a hierarchy provider for the filtered hierarchy
+        const hierarchyProvider = createIModelHierarchyProvider({
+          imodelAccess,
+          hierarchyDefinition,
+          filtering: {
+            paths: [filteringPath],
+          },
+        });
+
+        // Collect the hierarchy & confirm we get what we expect - a hierarchy from root element "A" to target element "C"
+        // Note that all nodes before grouping node for label "C" have `autoExpand` flag.
+        expect(await collectHierarchy(hierarchyProvider)).to.deep.eq([
+          {
+            // Root node. Has auto-expand flag.
+            nodeType: "instances",
+            label: "A",
+            autoExpand: true,
+            children: [
+              {
+                // B class grouping node. Has auto-expand flag.
+                nodeType: "class-grouping",
+                label: "Physical Object",
+                autoExpand: true,
+                children: [
+                  {
+                    // B label grouping node. Has auto-expand flag.
+                    nodeType: "label-grouping",
+                    label: "B",
+                    autoExpand: true,
+                    children: [
+                      {
+                        // B instance node. Has auto-expand flag.
+                        nodeType: "instances",
+                        label: "B",
+                        autoExpand: true,
+                        children: [
+                          {
+                            // C class grouping node. Has auto-expand flag.
+                            nodeType: "class-grouping",
+                            label: "Physical Object",
+                            autoExpand: true,
+                            children: [
+                              {
+                                // C label grouping node. Doesn't have auto-expand flag.
+                                nodeType: "label-grouping",
+                                label: "C",
+                                // Child is the filter target
+                                children: [
+                                  {
+                                    nodeType: "instances",
+                                    label: "C",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ]);
+      });
+
+      it("sets auto-expand flag to parent nodes of the filter target until specified depth", async function () {
         const imodelAccess = createIModelAccess(imodel);
         const queryClauseFactory = createNodesQueryClauseFactory({
           imodelAccess,
@@ -374,27 +521,13 @@ describe("Hierarchies", () => {
           },
         };
 
-        async function getSelectedGroupingNode(): Promise<GroupingHierarchyNode> {
-          const provider = createIModelHierarchyProvider({ imodelAccess, hierarchyDefinition });
-          return firstValueFrom(
-            from(provider.getNodes({ parentNode: undefined })).pipe(
-              expand((parentNode) => provider.getNodes({ parentNode })),
-              filter((node) => HierarchyNode.isGroupingNode(node)),
-              first((node) => InstanceKey.equals(node.groupedInstanceKeys[0], elementKeys.c)),
-            ),
-          );
-        }
-
-        // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyFiltering.AutoExpandUntilGroupingNode.FilteringPath
-        // Get a grouping node that groups the "C" element
-        const groupingNode = await getSelectedGroupingNode();
+        // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyFiltering.AutoExpandUntilDepthWithoutGrouping.FilteringPath
         const filteringPath: HierarchyFilteringPath = {
           // Path to the element "C"
           path: [elementKeys.a, elementKeys.b, elementKeys.c],
-          // Supply grouping node attributes with the path to the "C" element.
           options: {
-            // Auto-expand the hierarchy up to the grouping node. The `depth` attribute equals to the number of parents.
-            autoExpand: { key: groupingNode.key, depth: groupingNode.parentKeys.length },
+            // Auto-expand the hierarchy up to the specified depth. In this case up to and including element "B"
+            autoExpand: { depth: 2 },
           },
         };
         // __PUBLISH_EXTRACT_END__

--- a/packages/hierarchies/api/presentation-hierarchies.api.md
+++ b/packages/hierarchies/api/presentation-hierarchies.api.md
@@ -272,11 +272,6 @@ export interface HierarchyFilteringPathOptions {
     autoExpand?: boolean | FilterTargetGroupingNodeInfo | FilteringPathAutoExpandOption;
 }
 
-// @public (undocumented)
-export namespace HierarchyFilteringPathOptions {
-    export function mergeAutoExpandOptions(lhs: HierarchyFilteringPathOptions["autoExpand"], rhs: HierarchyFilteringPathOptions["autoExpand"]): HierarchyFilteringPathOptions["autoExpand"];
-}
-
 // @public
 export type HierarchyLevelDefinition = HierarchyNodesDefinition[];
 

--- a/packages/hierarchies/api/presentation-hierarchies.api.md
+++ b/packages/hierarchies/api/presentation-hierarchies.api.md
@@ -183,6 +183,7 @@ export function extractFilteringProps(rootLevelFilteringProps: HierarchyFilterin
 // @public (undocumented)
 interface FilteringPathAutoExpandOption {
     depth: number;
+    includeGroupingNodes?: boolean;
 }
 
 // @public (undocumented)
@@ -269,6 +270,11 @@ export namespace HierarchyFilteringPath {
 // @public (undocumented)
 export interface HierarchyFilteringPathOptions {
     autoExpand?: boolean | FilterTargetGroupingNodeInfo | FilteringPathAutoExpandOption;
+}
+
+// @public (undocumented)
+export namespace HierarchyFilteringPathOptions {
+    export function mergeAutoExpandOptions(lhs: HierarchyFilteringPathOptions["autoExpand"], rhs: HierarchyFilteringPathOptions["autoExpand"]): HierarchyFilteringPathOptions["autoExpand"];
 }
 
 // @public
@@ -586,6 +592,7 @@ export type NodePreProcessor = <TNode extends ProcessedGenericHierarchyNode | Pr
 type NodeProps = Pick<HierarchyNode, "autoExpand" | "filtering"> & {
     filtering?: {
         autoExpandDepth?: number;
+        includeGroupingNodes?: boolean;
     };
 };
 

--- a/packages/hierarchies/api/presentation-hierarchies.exports.csv
+++ b/packages/hierarchies/api/presentation-hierarchies.exports.csv
@@ -21,6 +21,7 @@ public;interface;HierarchyDefinition
 public;type;HierarchyFilteringPath
 public;namespace;HierarchyFilteringPath
 public;interface;HierarchyFilteringPathOptions
+public;namespace;HierarchyFilteringPathOptions
 public;type;HierarchyLevelDefinition
 public;type;HierarchyNode
 public;namespace;HierarchyNode

--- a/packages/hierarchies/api/presentation-hierarchies.exports.csv
+++ b/packages/hierarchies/api/presentation-hierarchies.exports.csv
@@ -21,7 +21,6 @@ public;interface;HierarchyDefinition
 public;type;HierarchyFilteringPath
 public;namespace;HierarchyFilteringPath
 public;interface;HierarchyFilteringPathOptions
-public;namespace;HierarchyFilteringPathOptions
 public;type;HierarchyLevelDefinition
 public;type;HierarchyNode
 public;namespace;HierarchyNode

--- a/packages/hierarchies/learning/HierarchyFiltering.md
+++ b/packages/hierarchies/learning/HierarchyFiltering.md
@@ -91,7 +91,42 @@ const filteringPath: HierarchyFilteringPath = {
 Additionally, you might not want to add `autoExpand` flag to every node in `HierarchyFilteringPath`. For such cases hierarchies may be expanded up to desired depth, which can be achieved by setting the `autoExpand` property to `{ depth: number }`, where depth represents node's depth in the hierarchy excluding grouping nodes:
 
 <!-- [[include: [Presentation.Hierarchies.HierarchyFiltering.HierarchyFilteringPathImport, Presentation.Hierarchies.HierarchyFiltering.AutoExpandUntilDepthWithoutGrouping.FilteringPath], ts]] -->
+<!-- BEGIN EXTRACTION -->
+
+```ts
+import { HierarchyFilteringPath } from "@itwin/presentation-hierarchies";
+
+const filteringPath: HierarchyFilteringPath = {
+  // Path to the element "C"
+  path: [elementKeys.a, elementKeys.b, elementKeys.c],
+  options: {
+    // Auto-expand the hierarchy up to the specified depth. In this case up to and including element "B"
+    autoExpand: { depth: 2 },
+  },
+};
+```
+
+<!-- END EXTRACTION -->
 
 Also, hierarchies may contain grouping nodes, which don't represent anything by themselves, which means they can't be a filter target. In some cases it may be necessary to auto-expand the hierarchy up to a desired grouping node (and not auto-expand grouping nodes below them), which can be achieved by setting the `autoExpand` property to `{ depth: number, includeGroupingNodes: true }`, where depth represents grouping node depth in the hierarchy:
 
 <!-- [[include: [Presentation.Hierarchies.HierarchyFiltering.HierarchyFilteringPathImport, Presentation.Hierarchies.HierarchyFiltering.AutoExpandUntilDepthWithGrouping.FilteringPath], ts]] -->
+<!-- BEGIN EXTRACTION -->
+
+```ts
+import { HierarchyFilteringPath } from "@itwin/presentation-hierarchies";
+
+// Hierarchy has two grouping nodes under C element: one class grouping and one label grouping node.
+// Get grouping node that groups the "C" element and is the nearest grouping node to it
+const groupingNode = await getSelectedGroupingNode();
+const filteringPath: HierarchyFilteringPath = {
+  // Path to the element "C"
+  path: [elementKeys.a, elementKeys.b, elementKeys.c],
+  options: {
+    // Auto-expand the hierarchy up to the last grouping node. The `depth` attribute equals to the number of parents.
+    autoExpand: { includeGroupingNodes: true, depth: groupingNode.parentKeys.length },
+  },
+};
+```
+
+<!-- END EXTRACTION -->

--- a/packages/hierarchies/learning/HierarchyFiltering.md
+++ b/packages/hierarchies/learning/HierarchyFiltering.md
@@ -88,25 +88,10 @@ const filteringPath: HierarchyFilteringPath = {
 
 <!-- END EXTRACTION -->
 
-Additionally, hierarchies may contain grouping nodes, which don't represent anything by themselves, which means they can't be a filter target. However, in some cases it may be necessary to auto-expand the hierarchy up to a grouping node, which can be achieved by setting the `autoExpand` property to a grouping node's identifier - its key and depth in the hierarchy:
+Additionally, you might not want to add `autoExpand` flag to every node in `HierarchyFilteringPath`. For such cases hierarchies may be expanded up to desired depth, which can be achieved by setting the `autoExpand` property to `{ depth: number }`, where depth represents node's depth in the hierarchy excluding grouping nodes:
 
-<!-- [[include: [Presentation.Hierarchies.HierarchyFiltering.HierarchyFilteringPathImport, Presentation.Hierarchies.HierarchyFiltering.AutoExpandUntilGroupingNode.FilteringPath], ts]] -->
-<!-- BEGIN EXTRACTION -->
+<!-- [[include: [Presentation.Hierarchies.HierarchyFiltering.HierarchyFilteringPathImport, Presentation.Hierarchies.HierarchyFiltering.AutoExpandUntilDepthWithoutGrouping.FilteringPath], ts]] -->
 
-```ts
-import { HierarchyFilteringPath } from "@itwin/presentation-hierarchies";
+Also, hierarchies may contain grouping nodes, which don't represent anything by themselves, which means they can't be a filter target. In some cases it may be necessary to auto-expand the hierarchy up to a desired grouping node (and not auto-expand grouping nodes below them), which can be achieved by setting the `autoExpand` property to `{ depth: number, includeGroupingNodes: true }`, where depth represents grouping node depth in the hierarchy:
 
-// Get a grouping node that groups the "C" element
-const groupingNode = await getSelectedGroupingNode();
-const filteringPath: HierarchyFilteringPath = {
-  // Path to the element "C"
-  path: [elementKeys.a, elementKeys.b, elementKeys.c],
-  // Supply grouping node attributes with the path to the "C" element.
-  options: {
-    // Auto-expand the hierarchy up to the grouping node. The `depth` attribute equals to the number of parents.
-    autoExpand: { key: groupingNode.key, depth: groupingNode.parentKeys.length },
-  },
-};
-```
-
-<!-- END EXTRACTION -->
+<!-- [[include: [Presentation.Hierarchies.HierarchyFiltering.HierarchyFilteringPathImport, Presentation.Hierarchies.HierarchyFiltering.AutoExpandUntilDepthWithGrouping.FilteringPath], ts]] -->

--- a/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
@@ -11,7 +11,7 @@ import { GenericNodeKey, GroupingNodeKey, HierarchyNodeKey, InstancesNodeKey } f
 export interface FilterTargetGroupingNodeInfo {
   /**
    * Key of the grouping node.
-   * @deprecated in 1.6. This option is no longer needed.
+   * @deprecated in 1.6. Use `FilteringPathAutoExpandOption` with `includeGroupingNodes` set to true instead.
    */
   key: GroupingNodeKey;
 
@@ -25,8 +25,26 @@ export interface FilterTargetGroupingNodeInfo {
 export interface FilteringPathAutoExpandOption {
   /**
    * Depth up to which nodes in the hierarchy should be expanded.
+   *
+   * If `includeGroupingNodes` is set to true, then depth should take into account the number of grouping nodes in hierarchy.
    */
   depth: number;
+  /**
+   * Whether or not `depth` includes grouping nodes.
+   *
+   * Use when you want to autoExpand only some of the grouping nodes.
+   *
+   * **Use case example:**
+   *
+   * You want to `autoExpand` only `Node1` and `GroupingNode1` in the following hierarchy:
+   * - Node1
+   *   - GroupingNode1
+   *     - GroupingNode2
+   *       - Element1
+   *       - Element2
+   * Then you provide `autoExpand: { depth: 2, includeGroupingNodes: true }`
+   */
+  includeGroupingNodes?: boolean;
 }
 
 /** @public */
@@ -40,6 +58,47 @@ export interface HierarchyFilteringPathOptions {
    * - If it's an instance of `FilteringPathAutoExpandOption`, then all nodes up to and including `depth` will have `autoExpand` flag.
    */
   autoExpand?: boolean | FilterTargetGroupingNodeInfo | FilteringPathAutoExpandOption;
+}
+/** @public */
+
+export namespace HierarchyFilteringPathOptions {
+  /**
+   * Merges two given `HierarchyFilteringPathOptions.autoExpand` values.
+   *
+   * For the `autoExpand` attribute, the merge chooses to auto-expand as deep as the deepest input:
+   * - if any one of the inputs is `true`, return `true`,
+   * - else if only one of the inputs is an object, return it,
+   * - else if both inputs are falsy, return `false` or `undefined`,
+   * - else:
+   *    - if only one of them has `includeGroupingNodes` set to `true` or `key` defined, return it,
+   *    - else return the one with greater `depth`.
+   * @public
+   */
+  export function mergeAutoExpandOptions(
+    lhs: HierarchyFilteringPathOptions["autoExpand"],
+    rhs: HierarchyFilteringPathOptions["autoExpand"],
+  ): HierarchyFilteringPathOptions["autoExpand"] {
+    if (rhs === true || lhs === true) {
+      return true;
+    }
+    if (!rhs || !lhs) {
+      return !!rhs ? rhs : lhs;
+    }
+
+    if (!("key" in lhs) && !lhs.includeGroupingNodes) {
+      if (!("key" in rhs) && !rhs.includeGroupingNodes) {
+        return { depth: lhs.depth > rhs.depth ? lhs.depth : rhs.depth };
+      }
+      return { depth: lhs.depth };
+    }
+    if (!("key" in rhs) && !rhs.includeGroupingNodes) {
+      return { depth: rhs.depth };
+    }
+    if (rhs.depth > lhs.depth) {
+      return rhs;
+    }
+    return lhs.depth > rhs.depth ? lhs : rhs;
+  }
 }
 
 /**
@@ -67,11 +126,7 @@ export namespace HierarchyFilteringPath {
    * - else if one of the inputs is `undefined`, the other one is returned.
    * - else, merge each option individually.
    *
-   * For the `autoExpand` attribute, the merge chooses to auto-expand as deep as the deepest input:
-   * - if any one of the inputs is `true`, return `true`,
-   * - else if both inputs are objects, return the one with the greater `depth` attribute.
-   * - else if one input is an object, return it.
-   * - else, return `false` or `undefined`.
+   * To know how specific attributes get merged, look at `HierarchyFilteringPathOptions`.
    *
    * @public
    */
@@ -84,18 +139,7 @@ export namespace HierarchyFilteringPath {
     }
 
     return {
-      autoExpand: ((): HierarchyFilteringPathOptions["autoExpand"] => {
-        if (rhs.autoExpand === true || lhs.autoExpand === true) {
-          return true;
-        }
-        if (typeof lhs.autoExpand === "object") {
-          if (typeof rhs.autoExpand === "object" && rhs.autoExpand.depth > lhs.autoExpand.depth) {
-            return rhs.autoExpand;
-          }
-          return lhs.autoExpand;
-        }
-        return rhs.autoExpand;
-      })(),
+      autoExpand: HierarchyFilteringPathOptions.mergeAutoExpandOptions(lhs.autoExpand, rhs.autoExpand),
     };
   }
 }
@@ -257,7 +301,7 @@ export function createHierarchyFilteringHelper(
 }
 
 /** @public */
-export type NodeProps = Pick<HierarchyNode, "autoExpand" | "filtering"> & { filtering?: { autoExpandDepth?: number } };
+export type NodeProps = Pick<HierarchyNode, "autoExpand" | "filtering"> & { filtering?: { autoExpandDepth?: number; includeGroupingNodes?: boolean } };
 
 type NormalizedFilteringPath = ReturnType<(typeof HierarchyFilteringPath)["normalize"]>;
 
@@ -265,7 +309,7 @@ class MatchingFilteringPathsReducer {
   private _filteredChildrenIdentifierPaths = new Array<NormalizedFilteringPath>();
   private _isFilterTarget = false;
   private _filterTargetOptions = undefined as HierarchyFilteringPathOptions | undefined;
-  private _needsAutoExpand: boolean | { depth: number } = false;
+  private _needsAutoExpand: HierarchyFilteringPathOptions["autoExpand"] = false;
 
   public constructor(private _hasFilterTargetAncestor: boolean) {}
 
@@ -275,14 +319,7 @@ class MatchingFilteringPathsReducer {
       this._filterTargetOptions = HierarchyFilteringPath.mergeOptions(this._filterTargetOptions, options);
     } else if (path.length > 1) {
       this._filteredChildrenIdentifierPaths.push({ path: path.slice(1), options });
-      if (options?.autoExpand) {
-        if (
-          !this._needsAutoExpand ||
-          (this._needsAutoExpand !== true && (options.autoExpand === true || this._needsAutoExpand.depth < options.autoExpand.depth))
-        ) {
-          this._needsAutoExpand = options.autoExpand;
-        }
-      }
+      this._needsAutoExpand = HierarchyFilteringPathOptions.mergeAutoExpandOptions(options?.autoExpand, this._needsAutoExpand);
     }
   }
   public getNodeProps(): NodeProps {
@@ -293,7 +330,12 @@ class MatchingFilteringPathsReducer {
               ...(this._hasFilterTargetAncestor ? { hasFilterTargetAncestor: true } : undefined),
               ...(this._isFilterTarget ? { isFilterTarget: true, filterTargetOptions: this._filterTargetOptions } : undefined),
               ...(this._filteredChildrenIdentifierPaths.length > 0 ? { filteredChildrenIdentifierPaths: this._filteredChildrenIdentifierPaths } : undefined),
-              ...(this._needsAutoExpand && this._needsAutoExpand !== true ? { autoExpandDepth: this._needsAutoExpand.depth } : undefined),
+              ...(this._needsAutoExpand && this._needsAutoExpand !== true
+                ? {
+                    autoExpandDepth: this._needsAutoExpand.depth,
+                    includeGroupingNodes: "key" in this._needsAutoExpand || this._needsAutoExpand.includeGroupingNodes ? true : false,
+                  }
+                : undefined),
             },
           }
         : undefined),

--- a/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
@@ -59,8 +59,8 @@ export interface HierarchyFilteringPathOptions {
    */
   autoExpand?: boolean | FilterTargetGroupingNodeInfo | FilteringPathAutoExpandOption;
 }
-/** @public */
 
+/** @public */
 export namespace HierarchyFilteringPathOptions {
   /**
    * Merges two given `HierarchyFilteringPathOptions.autoExpand` values.

--- a/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
@@ -81,9 +81,6 @@ namespace HierarchyFilteringPathOptions {
     if (!("key" in rhs) && !rhs.includeGroupingNodes) {
       return rhs;
     }
-    if (rhs.depth > lhs.depth) {
-      return rhs;
-    }
     return lhs.depth > rhs.depth ? lhs : rhs;
   }
 }

--- a/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
@@ -74,7 +74,7 @@ namespace HierarchyFilteringPathOptions {
 
     if (!("key" in lhs) && !lhs.includeGroupingNodes) {
       if (!("key" in rhs) && !rhs.includeGroupingNodes) {
-        return { depth: lhs.depth > rhs.depth ? lhs.depth : rhs.depth };
+        return lhs.depth > rhs.depth ? lhs : rhs;
       }
       return lhs;
     }

--- a/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
@@ -60,20 +60,7 @@ export interface HierarchyFilteringPathOptions {
   autoExpand?: boolean | FilterTargetGroupingNodeInfo | FilteringPathAutoExpandOption;
 }
 
-/** @public */
-export namespace HierarchyFilteringPathOptions {
-  /**
-   * Merges two given `HierarchyFilteringPathOptions.autoExpand` values.
-   *
-   * For the `autoExpand` attribute, the merge chooses to auto-expand as deep as the deepest input:
-   * - if any one of the inputs is `true`, return `true`,
-   * - else if only one of the inputs is an object, return it,
-   * - else if both inputs are falsy, return `false` or `undefined`,
-   * - else:
-   *    - if only one of them has `includeGroupingNodes` set to `true` or `key` defined, return it,
-   *    - else return the one with greater `depth`.
-   * @public
-   */
+namespace HierarchyFilteringPathOptions {
   export function mergeAutoExpandOptions(
     lhs: HierarchyFilteringPathOptions["autoExpand"],
     rhs: HierarchyFilteringPathOptions["autoExpand"],
@@ -126,7 +113,13 @@ export namespace HierarchyFilteringPath {
    * - else if one of the inputs is `undefined`, the other one is returned.
    * - else, merge each option individually.
    *
-   * To know how specific attributes get merged, look at `HierarchyFilteringPathOptions`.
+   * For the `autoExpand` attribute, the merge chooses to auto-expand as deep as the deepest input:
+   * - if any one of the inputs is `true`, return `true`,
+   * - else if only one of the inputs is an object, return it,
+   * - else if both inputs are falsy, return `false` or `undefined`,
+   * - else:
+   *    - if only one of the inputs has `includeGroupingNodes` set to `true` or `key` defined, return the one that has only `depth` set,
+   *    - else return the one with greater `depth`.
    *
    * @public
    */

--- a/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
@@ -76,10 +76,10 @@ namespace HierarchyFilteringPathOptions {
       if (!("key" in rhs) && !rhs.includeGroupingNodes) {
         return { depth: lhs.depth > rhs.depth ? lhs.depth : rhs.depth };
       }
-      return { depth: lhs.depth };
+      return lhs;
     }
     if (!("key" in rhs) && !rhs.includeGroupingNodes) {
-      return { depth: rhs.depth };
+      return rhs;
     }
     if (rhs.depth > lhs.depth) {
       return rhs;

--- a/packages/hierarchies/src/hierarchies/imodel/FilteringHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/FilteringHierarchyDefinition.ts
@@ -79,7 +79,10 @@ export class FilteringHierarchyDefinition implements RxjsHierarchyDefinition {
 
         // If grouping node's child has `autoExpandUntil` flag,
         // auto-expand the grouping node only if it's depth is lower than that of the grouping node in associated with the target.
-        const nodeDepth = node.parentKeys.filter((key) => ("key" in childAutoExpand ? true : !HierarchyNodeKey.isGrouping(key))).length;
+        const nodeDepth =
+          "key" in childAutoExpand || childAutoExpand.includeGroupingNodes
+            ? node.parentKeys.length
+            : node.parentKeys.filter((key) => !HierarchyNodeKey.isGrouping(key)).length;
         const filterTargetDepth = childAutoExpand.depth;
         if (nodeDepth < filterTargetDepth) {
           return true;
@@ -146,7 +149,11 @@ export class FilteringHierarchyDefinition implements RxjsHierarchyDefinition {
           return (nodeExtraPropsPossiblyPromise instanceof Promise ? from(nodeExtraPropsPossiblyPromise) : of(nodeExtraPropsPossiblyPromise)).pipe(
             map((nodeExtraProps) => {
               if (nodeExtraProps?.autoExpand) {
-                const parentLength = parentNode ? 1 + parentNode.parentKeys.filter((key) => !HierarchyNodeKey.isGrouping(key)).length : 0;
+                const parentLength = !parentNode
+                  ? 0
+                  : nodeExtraProps.filtering?.includeGroupingNodes
+                    ? 1 + parentNode.parentKeys.length
+                    : 1 + parentNode.parentKeys.filter((key) => !HierarchyNodeKey.isGrouping(key)).length;
                 parsedNode.autoExpand =
                   nodeExtraProps.filtering?.autoExpandDepth !== undefined && parentLength >= nodeExtraProps.filtering.autoExpandDepth ? undefined : true;
               }

--- a/packages/hierarchies/src/hierarchies/imodel/FilteringHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/FilteringHierarchyDefinition.ts
@@ -8,7 +8,7 @@ import { Id64String } from "@itwin/core-bentley";
 import { ECClassHierarchyInspector, InstanceKey } from "@itwin/presentation-shared";
 import { createHierarchyFilteringHelper, HierarchyFilteringPath } from "../HierarchyFiltering.js";
 import { HierarchyNodeIdentifier } from "../HierarchyNodeIdentifier.js";
-import { IModelInstanceKey } from "../HierarchyNodeKey.js";
+import { HierarchyNodeKey, IModelInstanceKey } from "../HierarchyNodeKey.js";
 import {
   DefineHierarchyLevelProps,
   GenericHierarchyNodeDefinition,
@@ -79,7 +79,7 @@ export class FilteringHierarchyDefinition implements RxjsHierarchyDefinition {
 
         // If grouping node's child has `autoExpandUntil` flag,
         // auto-expand the grouping node only if it's depth is lower than that of the grouping node in associated with the target.
-        const nodeDepth = node.parentKeys.length;
+        const nodeDepth = node.parentKeys.filter((key) => !HierarchyNodeKey.isGrouping(key)).length;
         const filterTargetDepth = childAutoExpand.depth;
         if (nodeDepth < filterTargetDepth) {
           return true;
@@ -146,7 +146,7 @@ export class FilteringHierarchyDefinition implements RxjsHierarchyDefinition {
           return (nodeExtraPropsPossiblyPromise instanceof Promise ? from(nodeExtraPropsPossiblyPromise) : of(nodeExtraPropsPossiblyPromise)).pipe(
             map((nodeExtraProps) => {
               if (nodeExtraProps?.autoExpand) {
-                const parentLength = parentNode ? 1 + parentNode.parentKeys.length : 0;
+                const parentLength = parentNode ? 1 + parentNode.parentKeys.filter((key) => !HierarchyNodeKey.isGrouping(key)).length : 0;
                 parsedNode.autoExpand =
                   nodeExtraProps.filtering?.autoExpandDepth !== undefined && parentLength >= nodeExtraProps.filtering.autoExpandDepth ? undefined : true;
               }

--- a/packages/hierarchies/src/hierarchies/imodel/FilteringHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/FilteringHierarchyDefinition.ts
@@ -79,7 +79,7 @@ export class FilteringHierarchyDefinition implements RxjsHierarchyDefinition {
 
         // If grouping node's child has `autoExpandUntil` flag,
         // auto-expand the grouping node only if it's depth is lower than that of the grouping node in associated with the target.
-        const nodeDepth = node.parentKeys.filter((key) => !HierarchyNodeKey.isGrouping(key)).length;
+        const nodeDepth = node.parentKeys.filter((key) => ("key" in childAutoExpand ? true : !HierarchyNodeKey.isGrouping(key))).length;
         const filterTargetDepth = childAutoExpand.depth;
         if (nodeDepth < filterTargetDepth) {
           return true;

--- a/packages/hierarchies/src/test/HierarchyFiltering.test.ts
+++ b/packages/hierarchies/src/test/HierarchyFiltering.test.ts
@@ -11,6 +11,9 @@ describe("HierarchyFilteringPath", () => {
     describe("autoExpand", () => {
       const optionsInOrderOfPriority: Array<HierarchyFilteringPathOptions | undefined> = [
         { autoExpand: true },
+        { autoExpand: { depth: 2 } },
+        { autoExpand: { depth: 1 } },
+        { autoExpand: { depth: 3, includeGroupingNodes: true } },
         {
           autoExpand: {
             key: {

--- a/packages/hierarchies/src/test/imodel/FilteringHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/FilteringHierarchyDefinition.test.ts
@@ -852,6 +852,30 @@ describe("FilteringHierarchyDefinition", () => {
         expect(result.autoExpand).to.be.undefined;
       });
 
+      it("sets auto-expand when node has hierarchy depth smaller than the filter target", async () => {
+        const groupingNode = createGroupingNode();
+        const inputNode: ProcessedGroupingHierarchyNode = {
+          ...groupingNode,
+          parentKeys: [createTestNodeKey()],
+          children: [
+            {
+              ...createTestProcessedInstanceNode(),
+              filtering: {
+                isFilterTarget: true,
+                filterTargetOptions: {
+                  autoExpand: {
+                    depth: 2,
+                  },
+                },
+              },
+            },
+          ],
+        };
+        const filteringFactory = await createFilteringHierarchyDefinition();
+        const result = await firstValueFrom(filteringFactory.postProcessNode(inputNode));
+        expect(result.autoExpand).to.be.true;
+      });
+
       it("sets auto-expand when node has hierarchy depth smaller than the filter target and same key", async () => {
         const groupingNode = createGroupingNode();
         const inputNode: ProcessedGroupingHierarchyNode = {

--- a/packages/hierarchies/src/test/imodel/FilteringHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/FilteringHierarchyDefinition.test.ts
@@ -488,6 +488,47 @@ describe("FilteringHierarchyDefinition", () => {
       expect(node.autoExpand).to.be.true;
     });
 
+    it("sets auto-expand when all filtered children paths autoExpand depth is greater than parent keys length and includeGroupingNodes is set to true", async () => {
+      const paths: HierarchyFilteringPath[] = [
+        {
+          path: [
+            createTestInstanceKey({ id: "0x1", className: "TestSchema.TestName" }),
+            createTestInstanceKey({ id: "0x2", className: "TestSchema.TestName" }),
+            createTestInstanceKey({ id: "0x3", className: "TestSchema.TestName" }),
+          ],
+          options: { autoExpand: { depth: 3, includeGroupingNodes: true } },
+        },
+      ];
+      const filteringFactory = await createFilteringHierarchyDefinition({ nodeIdentifierPaths: paths });
+      const row = {
+        [NodeSelectClauseColumnNames.FullClassName]: "",
+        [ECSQL_COLUMN_NAME_FilterECInstanceId]: "0x2",
+        [ECSQL_COLUMN_NAME_FilterClassName]: "TestSchema.TestName",
+      };
+      const node = await firstValueFrom(
+        filteringFactory.parseNode(row, {
+          key: { type: "instances", instanceKeys: [{ id: "0x1", className: "TestSchema.TestName" }] },
+          label: "",
+          parentKeys: [
+            {
+              type: "class-grouping",
+              className: "Generic.PhysicalObject",
+            },
+          ],
+          filtering: {
+            filteredChildrenIdentifierPaths: paths.map((path) => {
+              const normalizedPath = HierarchyFilteringPath.normalize(path);
+              return {
+                path: normalizedPath.path.slice(1),
+                options: normalizedPath.options,
+              };
+            }),
+          },
+        }),
+      );
+      expect(node.autoExpand).to.be.true;
+    });
+
     it("sets auto-expand on root node when all filtered children paths autoExpand depth is greater than 1", async () => {
       const paths: HierarchyFilteringPath[] = [
         {

--- a/packages/hierarchies/src/test/imodel/FilteringHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/FilteringHierarchyDefinition.test.ts
@@ -447,6 +447,47 @@ describe("FilteringHierarchyDefinition", () => {
       expect(node.autoExpand).to.be.true;
     });
 
+    it("sets auto-expand when all filtered children paths autoExpand depth is greater than parent keys length and grouping nodes are present", async () => {
+      const paths: HierarchyFilteringPath[] = [
+        {
+          path: [
+            createTestInstanceKey({ id: "0x1", className: "TestSchema.TestName" }),
+            createTestInstanceKey({ id: "0x2", className: "TestSchema.TestName" }),
+            createTestInstanceKey({ id: "0x3", className: "TestSchema.TestName" }),
+          ],
+          options: { autoExpand: { depth: 2 } },
+        },
+      ];
+      const filteringFactory = await createFilteringHierarchyDefinition({ nodeIdentifierPaths: paths });
+      const row = {
+        [NodeSelectClauseColumnNames.FullClassName]: "",
+        [ECSQL_COLUMN_NAME_FilterECInstanceId]: "0x2",
+        [ECSQL_COLUMN_NAME_FilterClassName]: "TestSchema.TestName",
+      };
+      const node = await firstValueFrom(
+        filteringFactory.parseNode(row, {
+          key: { type: "instances", instanceKeys: [{ id: "0x1", className: "TestSchema.TestName" }] },
+          label: "",
+          parentKeys: [
+            {
+              type: "class-grouping",
+              className: "Generic.PhysicalObject",
+            },
+          ],
+          filtering: {
+            filteredChildrenIdentifierPaths: paths.map((path) => {
+              const normalizedPath = HierarchyFilteringPath.normalize(path);
+              return {
+                path: normalizedPath.path.slice(1),
+                options: normalizedPath.options,
+              };
+            }),
+          },
+        }),
+      );
+      expect(node.autoExpand).to.be.true;
+    });
+
     it("sets auto-expand on root node when all filtered children paths autoExpand depth is greater than 1", async () => {
       const paths: HierarchyFilteringPath[] = [
         {


### PR DESCRIPTION
With `HierarchyFilteringPathOptions.autoExpand` set to `{ depth: number }` some nodes were not getting autoExpand propery set to `true`. 
If each node in hierarchy would be grouped and we had these filtered paths:
```ts
const filterPaths: HierarchyFilteringPath[] = [
  { path: [element, element2, element3], options: { autoExpand: { depth: 2 } } }
]
```
We would expect `element2` to have `autoExpand` set to `true`. But it didn't.

Added `includeGroupingNodes` to `FilteringPathAutoExpandOption` which allows expanding only desired grouping nodes.