### PR TITLE
[Hierarchies] Clarify `depthInPath` docs

### DIFF
--- a/.changeset/yellow-tables-brake.md
+++ b/.changeset/yellow-tables-brake.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies": patch
+---
+
+Update `depthInPath` documentation. Clarified that it does not set auto-expand for node that is at `depthInPath` position.

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyFiltering.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyFiltering.test.ts
@@ -528,7 +528,7 @@ describe("Hierarchies", () => {
           // Path to the element "C"
           path: [elementKeys.a, elementKeys.b, elementKeys.c],
           options: {
-            // Auto-expand the hierarchy up to the specified depth. In this case up to and including element "B"
+            // Auto-expand the hierarchy up to the specified depth. In this case up to element "B"
             autoExpand: { depthInPath: 2 },
           },
         };
@@ -562,7 +562,6 @@ describe("Hierarchies", () => {
                     // B instance node. Has auto-expand flag.
                     nodeType: "instances",
                     label: "B",
-                    autoExpand: true,
                     children: [
                       {
                         // C grouping node. Doesn't have auto-expand flag.

--- a/packages/hierarchies/learning/HierarchyFiltering.md
+++ b/packages/hierarchies/learning/HierarchyFiltering.md
@@ -100,7 +100,7 @@ const filteringPath: HierarchyFilteringPath = {
   // Path to the element "C"
   path: [elementKeys.a, elementKeys.b, elementKeys.c],
   options: {
-    // Auto-expand the hierarchy up to the specified depth. In this case up to and including element "B"
+    // Auto-expand the hierarchy up to the specified depth. In this case up to element "B"
     autoExpand: { depthInPath: 2 },
   },
 };

--- a/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyFiltering.ts
@@ -61,9 +61,11 @@ export interface FilteringPathAutoExpandOption {
 /** @public */
 export interface FilteringPathAutoExpandDepthInPath {
   /**
-   * Depth up to which nodes in the filtering path should be expanded.
+   * Depth that tells which nodes in the filtering path should be expanded.
    *
    * Use when you want to expand up to specific instance node and don't care about grouping nodes.
+   *
+   * **NOTE**: All nodes that are up to `depthInPath` will be expanded. Node at the `depthInPath` position won't be expanded.
    */
   depthInPath: number;
 }
@@ -71,7 +73,7 @@ export interface FilteringPathAutoExpandDepthInPath {
 /** @public */
 export interface FilteringPathAutoExpandDepthInHierarchy {
   /**
-   * Depth up to which nodes in the hierarchy should be expanded.
+   * Depth that tells which nodes in the hierarchy should be expanded.
    *
    * This should take into account the number of grouping nodes in hierarchy.
    *
@@ -86,6 +88,8 @@ export interface FilteringPathAutoExpandDepthInHierarchy {
    * Then you provide `autoExpand: { depthInHierarchy: 2 }`
    *
    * To get the correct depth use `HierarchyNode.parentKeys.length`.
+   *
+   * **NOTE**: All nodes that are up to and including `depthInHierarchy` will be expanded. Node at the `depthInHierarchy` position will be expanded.
    */
   depthInHierarchy: number;
 }
@@ -99,7 +103,7 @@ export interface HierarchyFilteringPathOptions {
    * - If it's an instance of `FilterTargetGroupingNodeInfo`, then all nodes up to the grouping node that matches this property,
    * will have `autoExpand` flag.
    * - If it's an instance of `FilteringPathAutoExpandOption`, then all nodes up to and including `depth` will have `autoExpand` flag.
-   * - If it's an instance of `FilteringPathAutoExpandDepthInPath`, then all nodes up to and including `depthInPath` will have `autoExpand` flag.
+   * - If it's an instance of `FilteringPathAutoExpandDepthInPath`, then all nodes up to `depthInPath` will have `autoExpand` flag.
    * - If it's an instance of `FilteringPathAutoExpandDepthInHierarchy`, then all nodes up to and including `depthInHierarchy` will have `autoExpand` flag.
    */
   autoExpand?:
@@ -390,7 +394,8 @@ class MatchingFilteringPathsReducer {
           : "depth" in this._autoExpandOption
             ? // eslint-disable-next-line @typescript-eslint/no-deprecated
               this._autoExpandOption.depth
-            : this._autoExpandOption.depthInPath;
+            : // With `depthInPath` option we don't want to expand node that is at the `depthInPath` position
+              this._autoExpandOption.depthInPath - 1;
 
       return parentLength < depth;
     }


### PR DESCRIPTION
Clarified `depthInPath` documentation. Previously it wasn't clear if `depthInPath` included the node at position or not. Now it does not. Added tests for this as well. 