### PR TITLE
[hierarchies-react]: Support custom tree node actions

### DIFF
--- a/.changeset/eager-needles-shave.md
+++ b/.changeset/eager-needles-shave.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": minor
+---
+
+Added `getActions` property to `TreeRenderer` and `TreeNodeRenderer` to allow providing custom actions for tree nodes.

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -72,6 +72,7 @@ interface LocalizedStrings {
     increaseHierarchyLimit: string;
     increaseHierarchyLimitWithFiltering: string;
     loading: string;
+    more: string;
     noFilteredChildren: string;
     resultLimitExceeded: string;
     resultLimitExceededWithFiltering: string;

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -162,6 +162,16 @@ type SelectionMode_2 = "none" | "single" | "extended" | "multiple";
 export { SelectionStorage }
 
 // @public (undocumented)
+interface TreeNodeActionDefinition {
+    // (undocumented)
+    icon: ReactElement;
+    // (undocumented)
+    label: string;
+    // (undocumented)
+    onClick: () => void;
+}
+
+// @public (undocumented)
 type TreeNodeProps = ComponentPropsWithoutRef<typeof TreeNode>;
 
 // @public
@@ -171,6 +181,7 @@ export const TreeNodeRenderer: React.ForwardRefExoticComponent<TreeNodeRendererP
 interface TreeNodeRendererOwnProps {
     actionButtonsClassName?: string;
     filterButtonsVisibility?: "show-on-hover" | "hide";
+    getActions?: (node: PresentationHierarchyNode) => TreeNodeActionDefinition[];
     getIcon?: (node: PresentationHierarchyNode) => ReactElement | undefined;
     getLabel?: (node: PresentationHierarchyNode) => ReactElement | undefined;
     getSublabel?: (node: PresentationHierarchyNode) => ReactElement | undefined;
@@ -195,7 +206,7 @@ type TreeNodeRendererProps_2 = ComponentPropsWithoutRef<typeof TreeNodeRenderer>
 type TreeProps = ComponentPropsWithoutRef<typeof Tree<RenderedTreeNode>>;
 
 // @public
-export function TreeRenderer({ rootNodes, expandNode, selectNodes, isNodeSelected, onFilterClick, getIcon, getLabel, getSublabel, getHierarchyLevelDetails, reloadTree, selectionMode, localizedStrings, size, filterButtonsVisibility, ...treeProps }: TreeRendererProps): JSX_2.Element;
+export function TreeRenderer({ rootNodes, expandNode, selectNodes, isNodeSelected, onFilterClick, getIcon, getLabel, getSublabel, getHierarchyLevelDetails, reloadTree, selectionMode, localizedStrings, size, filterButtonsVisibility, getActions, ...treeProps }: TreeRendererProps): JSX_2.Element;
 
 // @public (undocumented)
 interface TreeRendererOwnProps {
@@ -204,7 +215,7 @@ interface TreeRendererOwnProps {
 }
 
 // @public (undocumented)
-type TreeRendererProps = Pick<ReturnType<typeof useTree>, "rootNodes" | "expandNode"> & Partial<Pick<ReturnType<typeof useTree>, "selectNodes" | "isNodeSelected" | "getHierarchyLevelDetails" | "reloadTree">> & Pick<TreeNodeRendererProps_2, "onFilterClick" | "getIcon" | "getLabel" | "getSublabel" | "filterButtonsVisibility"> & TreeRendererOwnProps & Omit<TreeProps, "data" | "nodeRenderer" | "getNode" | "enableVirtualization"> & ComponentPropsWithoutRef<typeof LocalizationContextProvider>;
+type TreeRendererProps = Pick<ReturnType<typeof useTree>, "rootNodes" | "expandNode"> & Partial<Pick<ReturnType<typeof useTree>, "selectNodes" | "isNodeSelected" | "getHierarchyLevelDetails" | "reloadTree">> & Pick<TreeNodeRendererProps_2, "onFilterClick" | "getIcon" | "getLabel" | "getSublabel" | "filterButtonsVisibility" | "getActions"> & TreeRendererOwnProps & Omit<TreeProps, "data" | "nodeRenderer" | "getNode" | "enableVirtualization"> & ComponentPropsWithoutRef<typeof LocalizationContextProvider>;
 
 // @public @deprecated
 export function UnifiedSelectionProvider({ storage, children }: PropsWithChildren<{

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/LocalizationContext.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/LocalizationContext.tsx
@@ -55,6 +55,11 @@ export interface LocalizedStrings {
    * Default value: `Retry`.
    */
   retry: string;
+  /**
+   * Label for more actions button.
+   * Default value: `More`.
+   */
+  more: string;
 }
 
 /** @internal */
@@ -72,6 +77,7 @@ const defaultLocalizedStrings: LocalizedStrings = {
   increaseHierarchyLimit: "<link>Increase the hierarchy level size limit to {{limit}}.</link>",
   increaseHierarchyLimitWithFiltering: "Or, <link>increase the hierarchy level size limit to {{limit}}.</link>",
   retry: "Retry",
+  more: "More",
 };
 
 const localizationContext = createContext<LocalizationContext>({ localizedStrings: defaultLocalizedStrings });

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -317,6 +317,52 @@ function TreeNodeActions({
   const isClearFilterVisible = getHierarchyLevelDetails && node.isFiltered;
   const isFilterVisible = onFilterClick && node.isFilterable && (filterButtonsVisibility !== "hide" || node.isFiltered);
 
+  const renderAdditionalActions = () => {
+    if (additionalButtons.length === 1) {
+      const button = additionalButtons[0];
+      return (
+        <IconButton
+          styleType="borderless"
+          size="small"
+          label={button.label}
+          onClick={(e) => {
+            e.stopPropagation();
+            button.onClick();
+          }}
+        >
+          {button.icon}
+        </IconButton>
+      );
+    }
+
+    if (additionalButtons.length > 1) {
+      return (
+        <DropdownMenu
+          menuItems={(close) =>
+            additionalButtons.map((button, index) => (
+              <MenuItem
+                key={index}
+                startIcon={button.icon}
+                onClick={() => {
+                  button.onClick();
+                  close();
+                }}
+              >
+                {button.label}
+              </MenuItem>
+            ))
+          }
+        >
+          <IconButton styleType="borderless" size="small" label={localizedStrings.more} onClick={(e) => e.stopPropagation()}>
+            <SvgMore />
+          </IconButton>
+        </DropdownMenu>
+      );
+    }
+
+    return null;
+  };
+
   return (
     <ButtonGroup className={cx("action-buttons", actionButtonsClassName)}>
       {isClearFilterVisible ? (
@@ -348,28 +394,7 @@ function TreeNodeActions({
           {node.isFiltered ? <SvgFilter /> : <SvgFilterHollow />}
         </IconButton>
       ) : null}
-      {additionalButtons.length > 0 ? (
-        <DropdownMenu
-          menuItems={(close) =>
-            additionalButtons.map((button, index) => (
-              <MenuItem
-                key={index}
-                startIcon={button.icon}
-                onClick={() => {
-                  button.onClick();
-                  close();
-                }}
-              >
-                {button.label}
-              </MenuItem>
-            ))
-          }
-        >
-          <IconButton styleType="borderless" size="small" label={localizedStrings.more}>
-            <SvgMore />
-          </IconButton>
-        </DropdownMenu>
-      ) : null}
+      {renderAdditionalActions()}
     </ButtonGroup>
   );
 }

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeRenderer.tsx
@@ -28,7 +28,7 @@ interface TreeRendererOwnProps {
 /** @public */
 type TreeRendererProps = Pick<ReturnType<typeof useTree>, "rootNodes" | "expandNode"> &
   Partial<Pick<ReturnType<typeof useTree>, "selectNodes" | "isNodeSelected" | "getHierarchyLevelDetails" | "reloadTree">> &
-  Pick<TreeNodeRendererProps, "onFilterClick" | "getIcon" | "getLabel" | "getSublabel" | "filterButtonsVisibility"> &
+  Pick<TreeNodeRendererProps, "onFilterClick" | "getIcon" | "getLabel" | "getSublabel" | "filterButtonsVisibility" | "getActions"> &
   TreeRendererOwnProps &
   Omit<TreeProps, "data" | "nodeRenderer" | "getNode" | "enableVirtualization"> &
   ComponentPropsWithoutRef<typeof LocalizationContextProvider>;
@@ -55,6 +55,7 @@ export function TreeRenderer({
   localizedStrings,
   size,
   filterButtonsVisibility,
+  getActions,
   ...treeProps
 }: TreeRendererProps) {
   const { onNodeClick, onNodeKeyDown } = useSelectionHandler({
@@ -78,6 +79,7 @@ export function TreeRenderer({
           getSublabel={getSublabel}
           reloadTree={reloadTree}
           size={size}
+          getActions={getActions}
         />
       );
     },
@@ -93,6 +95,7 @@ export function TreeRenderer({
       getSublabel,
       reloadTree,
       size,
+      getActions,
     ],
   );
 

--- a/packages/hierarchies-react/src/test/itwinui/Tree.test.tsx
+++ b/packages/hierarchies-react/src/test/itwinui/Tree.test.tsx
@@ -5,6 +5,7 @@
 
 import { expect } from "chai";
 import { ComponentPropsWithoutRef } from "react";
+import sinon from "sinon";
 import { MAX_LIMIT_OVERRIDE } from "../../presentation-hierarchies-react/internal/Utils.js";
 import { TreeRenderer } from "../../presentation-hierarchies-react/itwinui/TreeRenderer.js";
 import { PresentationHierarchyNode, PresentationInfoNode, PresentationTreeNode } from "../../presentation-hierarchies-react/TreeNode.js";
@@ -415,6 +416,38 @@ describe("Tree", () => {
     expect(queryByText("root-1")).to.not.be.null;
     await user.click(getByRole("button", { name: "Apply filter" }));
     expect(onFilterClick).to.be.calledOnceWith(hierarchyLevelDetails);
+  });
+
+  it("renders additional actions", async () => {
+    const rootNodes = createNodes([
+      {
+        id: "root-1",
+        isFilterable: true,
+      },
+    ]);
+
+    const hierarchyLevelDetails = {} as unknown as HierarchyLevelDetails;
+    getHierarchyLevelDetails.returns(hierarchyLevelDetails);
+
+    const actionSpy = sinon.spy();
+    const getActions: RequiredTreeProps["getActions"] = () => [
+      {
+        label: "Custom action",
+        onClick: actionSpy,
+        icon: <></>,
+      },
+    ];
+
+    const { user, getByRole, getByText, queryByText } = render(<TreeRenderer rootNodes={rootNodes} {...initialProps} getActions={getActions} />);
+
+    const moreButton = getByRole("button", { name: "More" });
+    await user.click(moreButton);
+    const actionButton = getByText("Custom action");
+    await user.click(actionButton);
+    expect(actionSpy).to.be.calledOnce;
+    await waitFor(() => {
+      expect(queryByText("Custom action")).to.be.null;
+    });
   });
 
   describe("`ResultSetTooLarge` node", () => {

--- a/packages/hierarchies-react/src/test/itwinui/Tree.test.tsx
+++ b/packages/hierarchies-react/src/test/itwinui/Tree.test.tsx
@@ -418,7 +418,7 @@ describe("Tree", () => {
     expect(onFilterClick).to.be.calledOnceWith(hierarchyLevelDetails);
   });
 
-  it("renders additional actions", async () => {
+  it("renders single additional action inline", async () => {
     const rootNodes = createNodes([
       {
         id: "root-1",
@@ -438,15 +438,56 @@ describe("Tree", () => {
       },
     ];
 
+    const { user, getByRole } = render(<TreeRenderer rootNodes={rootNodes} {...initialProps} getActions={getActions} />);
+
+    const actionButton = getByRole("button", { name: "Custom action" });
+    await user.click(actionButton);
+    expect(actionSpy).to.be.calledOnce;
+  });
+
+  it("renders additional actions in dropdown menu", async () => {
+    const rootNodes = createNodes([
+      {
+        id: "root-1",
+        isFilterable: true,
+      },
+    ]);
+
+    const hierarchyLevelDetails = {} as unknown as HierarchyLevelDetails;
+    getHierarchyLevelDetails.returns(hierarchyLevelDetails);
+
+    const actionSpy1 = sinon.spy();
+    const actionSpy2 = sinon.spy();
+    const getActions: RequiredTreeProps["getActions"] = () => [
+      {
+        label: "Custom action 1",
+        onClick: actionSpy1,
+        icon: <></>,
+      },
+      {
+        label: "Custom action 2",
+        onClick: actionSpy2,
+        icon: <></>,
+      },
+    ];
+
     const { user, getByRole, getByText, queryByText } = render(<TreeRenderer rootNodes={rootNodes} {...initialProps} getActions={getActions} />);
 
     const moreButton = getByRole("button", { name: "More" });
     await user.click(moreButton);
-    const actionButton = getByText("Custom action");
-    await user.click(actionButton);
-    expect(actionSpy).to.be.calledOnce;
+    const actionButton1 = getByText("Custom action 1");
+    await user.click(actionButton1);
+    expect(actionSpy1).to.be.calledOnce;
     await waitFor(() => {
-      expect(queryByText("Custom action")).to.be.null;
+      expect(queryByText("Custom action 1")).to.be.null;
+    });
+
+    await user.click(moreButton);
+    const actionButton2 = getByText("Custom action 2");
+    await user.click(actionButton2);
+    expect(actionSpy2).to.be.calledOnce;
+    await waitFor(() => {
+      expect(queryByText("Custom action 2")).to.be.null;
     });
   });
 


### PR DESCRIPTION
Prerequisite for https://github.com/iTwin/viewer-components-react/issues/1367

Added support for custom tree node actions. To keep implementation simple and avoid complications of overflow all additional actions are rendered inside a dropdown menu under `More` button. Only filtering buttons are rendered on node directly.

<img width="456" height="343" alt="image" src="https://github.com/user-attachments/assets/d4213d3e-3019-4c6d-937a-233eec7d8406" />
