### PR TITLE
Components: Fix content data providers not reacting to formats' changes

### DIFF
--- a/.changeset/clean-steaks-matter.md
+++ b/.changeset/clean-steaks-matter.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Fix content data providers not reacting to formats' changes, resulting in content components (table, property grid) showing property values, formatted with stale formatting settings.

--- a/packages/components/api/presentation-components.api.md
+++ b/packages/components/api/presentation-components.api.md
@@ -102,6 +102,7 @@ export interface CacheInvalidationProps {
     content?: boolean;
     descriptor?: boolean;
     descriptorConfiguration?: boolean;
+    formatting?: boolean;
     size?: boolean;
 }
 

--- a/packages/components/src/test/common/ContentDataProvider.test.ts
+++ b/packages/components/src/test/common/ContentDataProvider.test.ts
@@ -9,6 +9,7 @@ import * as sinon from "sinon";
 import { PrimitiveValue, PropertyDescription, PropertyRecord } from "@itwin/appui-abstract";
 import { BeEvent, BeUiEvent } from "@itwin/core-bentley";
 import { FormattingUnitSystemChangedArgs, IModelApp, IModelConnection, QuantityFormatter } from "@itwin/core-frontend";
+import { FormatsChangedArgs, FormatsProvider } from "@itwin/core-quantity";
 import {
   ClientDiagnosticsAttribute,
   combineFieldNames,
@@ -70,6 +71,7 @@ describe("ContentDataProvider", () => {
   >();
   const onRulesetModified: RulesetManager["onRulesetModified"] = new BeEvent<(curr: RegisteredRuleset, prev: Ruleset) => void>();
   const onActiveFormattingUnitSystemChanged: QuantityFormatter["onActiveFormattingUnitSystemChanged"] = new BeUiEvent<FormattingUnitSystemChangedArgs>();
+  const onFormatsChanged: FormatsProvider["onFormatsChanged"] = new BeUiEvent<FormatsChangedArgs>();
 
   const rulesetManager = {
     onRulesetModified,
@@ -92,6 +94,9 @@ describe("ContentDataProvider", () => {
     sinon.stub(Presentation, "presentation").get(() => presentationManager);
     sinon.stub(IModelApp, "quantityFormatter").get(() => ({
       onActiveFormattingUnitSystemChanged,
+    }));
+    sinon.stub(IModelApp, "formatsProvider").get(() => ({
+      onFormatsChanged,
     }));
 
     provider = new Provider({ imodel, ruleset: rulesetId, displayType });
@@ -718,7 +723,12 @@ describe("ContentDataProvider", () => {
 
     it("invalidates cache when active unit system change", async () => {
       onActiveFormattingUnitSystemChanged.raiseEvent({ system: "metric" });
-      expect(invalidateCacheSpy).to.be.calledOnceWith({ content: true });
+      expect(invalidateCacheSpy).to.be.calledOnceWith({ formatting: true });
+    });
+
+    it("invalidates cache when formatting settings change", async () => {
+      onFormatsChanged.raiseEvent({ formatsChanged: "all" });
+      expect(invalidateCacheSpy).to.be.calledOnceWith({ formatting: true });
     });
   });
 


### PR DESCRIPTION
https://github.com/iTwin/viewer-components-react/pull/1404 revealed that property widget doesn't automatically update with new format settings when they change in the formats provider.