### PR TITLE
[components]: Quantity editor should react to format settings change

### DIFF
--- a/.changeset/tired-words-stop.md
+++ b/.changeset/tired-words-stop.md
@@ -1,5 +1,5 @@
 ---
-"@itwin/presentation-components": minor
+"@itwin/presentation-components": patch
 ---
 
 Quantity properties editor now reacts to format settings change and updates value.

--- a/.changeset/tired-words-stop.md
+++ b/.changeset/tired-words-stop.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": minor
+---
+
+Quantity properties editor now reacts to format settings change and updates value.

--- a/packages/components/src/presentation-components/properties/inputs/UseQuantityValueInput.tsx
+++ b/packages/components/src/presentation-components/properties/inputs/UseQuantityValueInput.tsx
@@ -130,7 +130,14 @@ function useFormatterAndParser(koqName: string, schemaContext: SchemaContext) {
     };
     void findFormatterAndParser();
 
-    return IModelApp.quantityFormatter.onActiveFormattingUnitSystemChanged.addListener(findFormatterAndParser);
+    const listeners = [IModelApp.quantityFormatter.onActiveFormattingUnitSystemChanged.addListener(findFormatterAndParser)];
+    if (IModelApp.formatsProvider) {
+      listeners.push(IModelApp.formatsProvider.onFormatsChanged.addListener(findFormatterAndParser));
+    }
+
+    return () => {
+      listeners.forEach((listener) => listener());
+    };
   }, [koqName, schemaContext]);
 
   return {


### PR DESCRIPTION
Updated quantity properties editor to react and rerender value when format settings changes. Tested with https://github.com/iTwin/viewer-components-react/pull/1404