### PR TITLE
[hierarchies-react] Add tree node tooltip

### DIFF
--- a/.changeset/public-flies-show.md
+++ b/.changeset/public-flies-show.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Show tooltip with full label on tree nodes.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -224,6 +224,8 @@ const HierarchyNodeRenderer = forwardRef<HTMLDivElement, HierarchyNodeRendererPr
         icon={getIcon ? getIcon(node) : undefined}
         label={getLabel ? getLabel(node) : node.label}
         sublabel={getSublabel ? getSublabel(node) : undefined}
+        // TODO: review if this is needed when horizontal scroll is enabled back after fix for issue: https://github.com/iTwin/iTwinUI/issues/2330
+        title={node.label}
       >
         <TreeNodeActions
           node={node}


### PR DESCRIPTION
Added tooltip for tree nodes. Used native browser tooltips through `title` prop so it should not block interactions with other nodes. Fixes https://github.com/iTwin/viewer-components-react/issues/1422

<img width="400" height="260" alt="image" src="https://github.com/user-attachments/assets/bf86e775-9e0e-491f-bee5-534a4d3cb1e2" />
