### PR TITLE
Components: Fix merged values being set as read-only

### DIFF
--- a/.changeset/funny-toes-happen.md
+++ b/.changeset/funny-toes-happen.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Fixed merged property records being set as read-only.

--- a/apps/full-stack-tests/src/components/properties/PropertyEditors.test.tsx
+++ b/apps/full-stack-tests/src/components/properties/PropertyEditors.test.tsx
@@ -17,7 +17,7 @@ import { buildIModel, importSchema } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { render, waitFor } from "../../RenderUtils.js";
 
-describe("Presentation filter builder value renderer", () => {
+describe("Property editors", () => {
   before(async () => {
     await initialize();
     await UiComponents.initialize(IModelApp.localization);
@@ -131,6 +131,83 @@ describe("Presentation filter builder value renderer", () => {
       expect(commitSpy.firstCall.args[0].newValue.displayValue).to.eq("4.56"); // what user entered
       expect(commitSpy.firstCall.args[0].newValue.value.toFixed(6)).to.eq("0.115824"); // converted to persistence unit - meters
       expect(commitSpy.firstCall.args[0].newValue.roundingError.toFixed(6)).to.eq("0.000127");
+    });
+  });
+
+  it("edits merged values", async function () {
+    const { imodel, schema, ...imodelKeys } = await buildIModel(this, async (builder, mochaContext) => {
+      const mySchema = await importSchema(
+        mochaContext,
+        builder,
+        `
+          <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
+          <ECEntityClass typeName="MyPhysicalObject">
+            <BaseClass>bis:PhysicalElement</BaseClass>
+            <ECProperty propertyName="MyProperty" typeName="double" />
+          </ECEntityClass>
+        `,
+      );
+      const model = insertPhysicalModelWithPartition({ builder, codeValue: "TestPhysicalModel" });
+      const category = insertSpatialCategory({ builder, codeValue: "TestSpatialCategory" });
+      const element1 = insertPhysicalElement({
+        builder,
+        modelId: model.id,
+        categoryId: category.id,
+        classFullName: mySchema.items.MyPhysicalObject.fullName,
+        userLabel: "My element 1",
+        ["MyProperty"]: 1.23,
+      });
+      const element2 = insertPhysicalElement({
+        builder,
+        modelId: model.id,
+        categoryId: category.id,
+        classFullName: mySchema.items.MyPhysicalObject.fullName,
+        userLabel: "My element 2",
+      });
+      return { element1, element2, schema: mySchema };
+    });
+
+    const provider = new PresentationPropertyDataProvider({ imodel });
+    provider.keys = new KeySet([imodelKeys.element1, imodelKeys.element2]);
+
+    const descriptor = await provider.getContentDescriptor();
+    const field = descriptor!.getFieldByDescriptor(
+      {
+        type: FieldDescriptorType.Properties,
+        pathFromSelectToPropertyClass: [],
+        properties: [
+          {
+            class: schema.items.MyPhysicalObject.fullName.replaceAll(".", ":"),
+            name: "MyProperty",
+          },
+        ],
+      },
+      true,
+    );
+    expect(field).to.not.be.undefined;
+
+    const propertyData = await provider.getData();
+    const propertyRecord = propertyData.records[field!.category.name].find((r) => r.property.name === field!.name);
+    expect(propertyRecord).to.not.be.undefined;
+    expect(propertyRecord!.isReadonly).to.not.be.true;
+    expect(propertyRecord!.isDisabled).to.not.be.true;
+
+    // render an editor for the property
+    const commitSpy = sinon.spy();
+    const cancelSpy = sinon.spy();
+    const { findByRole, user } = render(<EditorContainer propertyRecord={propertyRecord!} onCommit={commitSpy} onCancel={cancelSpy} />);
+
+    // ensure the input is editable
+    const input = await findByRole("textbox");
+    await user.clear(input);
+    await user.type(input, "4.56");
+    await user.keyboard("{Enter}");
+    // ensure the commit callback is called with the new value
+    await waitFor(() => {
+      expect(commitSpy).to.have.been.calledOnce;
+      expect(commitSpy.firstCall.args[0].newValue.displayValue).to.eq("4.56");
+      expect(commitSpy.firstCall.args[0].newValue.value).to.eq(4.56);
+      expect(commitSpy.firstCall.args[0].newValue.roundingError).to.eq(0.005);
     });
   });
 });

--- a/apps/test-app/frontend/src/components/properties-widget/PropertiesWidget.tsx
+++ b/apps/test-app/frontend/src/components/properties-widget/PropertiesWidget.tsx
@@ -265,6 +265,7 @@ function FilterablePropertyGrid({
             console.log(`Updated new value`, newValue); // eslint-disable-line no-console
             return true;
           }}
+          editorSystem="new"
         />
       </NavigationPropertyEditorContextProvider>
       {contextMenuArgs && <PropertiesWidgetContextMenu args={contextMenuArgs} dataProvider={dataProvider} onCloseContextMenu={onCloseContextMenu} />}

--- a/packages/components/src/presentation-components/common/ContentBuilder.ts
+++ b/packages/components/src/presentation-components/common/ContentBuilder.ts
@@ -317,7 +317,6 @@ export class InternalPropertyRecordsBuilder implements IContentVisitor {
     };
     const record = new PropertyRecord(value, createPropertyDescriptionFromFieldInfo(createFieldInfo(propertyField, props.parentFieldName)));
     record.isMerged = true;
-    record.isReadonly = true;
     record.autoExpand = propertyField.isNestedContentField() && propertyField.autoExpand;
     this._propertyRecordsProcessor?.(record);
     this.currentPropertiesAppender.append({ record, fieldHierarchy: { field: propertyField, childFields: [] } });

--- a/packages/components/src/test/common/ContentBuilder.test.ts
+++ b/packages/components/src/test/common/ContentBuilder.test.ts
@@ -361,7 +361,6 @@ describe("PropertyRecordsBuilder", () => {
     expect(builder.entries.length).to.eq(1);
     expect(builder.entries[0].property.name).to.eq(fieldName);
     expect(builder.entries[0].isMerged).to.be.true;
-    expect(builder.entries[0].isReadonly).to.be.true;
     expect(builder.entries[0].value).to.deep.eq({
       valueFormat: UiPropertyValueFormat.Primitive,
     });

--- a/packages/components/src/test/propertygrid/DataProvider.test.snap
+++ b/packages/components/src/test/propertygrid/DataProvider.test.snap
@@ -155,7 +155,7 @@ Object {
         "imodelKey": "test-imodel",
         "isDisabled": undefined,
         "isMerged": true,
-        "isReadonly": true,
+        "isReadonly": undefined,
         "links": undefined,
         "property": Object {
           "displayLabel": "Simple Field",
@@ -2056,7 +2056,7 @@ Object {
         "imodelKey": "test-imodel",
         "isDisabled": undefined,
         "isMerged": true,
-        "isReadonly": true,
+        "isReadonly": undefined,
         "links": undefined,
         "property": Object {
           "displayLabel": "Simple Field",


### PR DESCRIPTION
Merged properties should be editable. It's up to the consumers to make sure the edit is applied to all elements whose properties are merged.