### PR TITLE
`hierarchies-react`: Fix a greedy regular expression in `TreeNodeRenderer` that renders a "result set too large" error node

### DIFF
--- a/.changeset/five-experts-mix.md
+++ b/.changeset/five-experts-mix.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Fix a greedy regular expression in `TreeNodeRenderer` that renders a "result set too large" error node.

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/itwinui/TreeNodeRenderer.tsx
@@ -443,7 +443,7 @@ function ResultSetTooLargeNodeLabel({ onFilterClick, onOverrideLimit, limit }: R
 function createLocalizedMessage(message: string, limit: number, onClick?: () => void) {
   const limitStr = limit.toLocaleString(undefined, { useGrouping: true });
   const messageWithLimit = message.replace("{{limit}}", limitStr);
-  const exp = new RegExp("<link>(.*)</link>");
+  const exp = new RegExp("<link>(.*?)</link>");
   const match = messageWithLimit.match(exp);
 
   if (!match) {


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/security/code-scanning/4