### PR TITLE
`hierarchies-react`: Rename tree node action components for clarity

### DIFF
--- a/.changeset/gentle-socks-shout.md
+++ b/.changeset/gentle-socks-shout.md
@@ -1,0 +1,8 @@
+---
+"@itwin/presentation-hierarchies-react": major
+---
+
+**Breaking change:** Rename tree node action components for clarity.
+
+- `FilterAction` -> `TreeNodeFilterAction`
+- `RenameAction` -> `TreeNodeRenameAction`

--- a/apps/test-app/frontend/src/components/tree-widget/TreeRendererWithFilterAction.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/TreeRendererWithFilterAction.tsx
@@ -6,14 +6,14 @@
 import { ComponentProps, forwardRef, memo, useCallback, useMemo } from "react";
 import {
   ErrorItemRenderer,
-  FilterAction,
   PresentationHierarchyNode,
-  RenameAction,
   StrataKitTreeRenderer,
   StrataKitTreeRendererAttributes,
   TreeActionBase,
   TreeActionBaseAttributes,
   TreeErrorRenderer,
+  TreeNodeFilterAction,
+  TreeNodeRenameAction,
 } from "@itwin/presentation-hierarchies-react";
 import addSvg from "@stratakit/icons/add.svg";
 import { unstable_ErrorRegion as ErrorRegion } from "@stratakit/structures";
@@ -49,17 +49,20 @@ export const TreeRendererWithFilterAction = forwardRef<StrataKitTreeRendererAttr
   const getInlineActions = useCallback<Required<TreeRendererProps>["getInlineActions"]>(
     ({ targetNode, selectedNodes }) => [
       <CustomAction key="custom" node={targetNode} selectedNodes={selectedNodes} />,
-      <FilterAction key="filter" node={targetNode} onFilter={onFilterClick} getHierarchyLevelDetails={getHierarchyLevelDetails} />,
-      <RenameAction key="rename" node={targetNode} />,
+      <TreeNodeFilterAction key="filter" node={targetNode} onFilter={onFilterClick} getHierarchyLevelDetails={getHierarchyLevelDetails} />,
+      <TreeNodeRenameAction key="rename" node={targetNode} />,
     ],
     [onFilterClick, getHierarchyLevelDetails],
   );
-  const getMenuActions = useCallback<Required<TreeRendererProps>["getMenuActions"]>(({ targetNode }) => [<RenameAction key="rename" node={targetNode} />], []);
+  const getMenuActions = useCallback<Required<TreeRendererProps>["getMenuActions"]>(
+    ({ targetNode }) => [<TreeNodeRenameAction key="rename" node={targetNode} />],
+    [],
+  );
   const getContextMenuActions = useCallback<Required<TreeRendererProps>["getContextMenuActions"]>(
     ({ targetNode, selectedNodes }) => [
       <CustomAction key="custom" node={targetNode} selectedNodes={selectedNodes} />,
-      <FilterAction key="filter" node={targetNode} onFilter={onFilterClick} getHierarchyLevelDetails={getHierarchyLevelDetails} />,
-      <RenameAction key="rename" node={targetNode} />,
+      <TreeNodeFilterAction key="filter" node={targetNode} onFilter={onFilterClick} getHierarchyLevelDetails={getHierarchyLevelDetails} />,
+      <TreeNodeRenameAction key="rename" node={targetNode} />,
     ],
     [onFilterClick, getHierarchyLevelDetails],
   );

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -74,13 +74,6 @@ interface ErrorItemRendererProps extends Pick<TreeRendererProps, "getHierarchyLe
 }
 
 // @alpha
-export const FilterAction: NamedExoticComponent<    {
-onFilter?: (hierarchyLevelDetails: HierarchyLevelDetails) => void;
-} & TreeActionBaseAttributes & Pick<TreeRendererProps, "getHierarchyLevelDetails"> & {
-node: PresentationHierarchyNode;
-}>;
-
-// @alpha
 interface FlatPlaceholderItem {
     // (undocumented)
     id: string;
@@ -212,11 +205,6 @@ interface ReloadTreeOptions {
 }
 
 // @alpha
-export const RenameAction: NamedExoticComponent<TreeActionBaseAttributes & {
-node: PresentationHierarchyNode;
-}>;
-
-// @alpha
 type RendererProps = {
     rootErrorRendererProps: RootErrorRendererProps;
 } | {
@@ -308,6 +296,18 @@ interface TreeErrorRendererOwnProps {
 // @alpha (undocumented)
 type TreeErrorRendererProps = TreeErrorRendererOwnProps & TreeErrorItemProps & Pick<TreeRendererProps, "getHierarchyLevelDetails">;
 
+// @alpha
+export const TreeNodeFilterAction: NamedExoticComponent<    {
+onFilter?: (hierarchyLevelDetails: HierarchyLevelDetails) => void;
+} & TreeActionBaseAttributes & Pick<TreeRendererProps, "getHierarchyLevelDetails"> & {
+node: PresentationHierarchyNode;
+}>;
+
+// @alpha
+export const TreeNodeRenameAction: NamedExoticComponent<TreeActionBaseAttributes & {
+node: PresentationHierarchyNode;
+}>;
+
 // @alpha (undocumented)
 interface TreeRendererOwnProps {
     errorRenderer?: (props: TreeErrorRendererProps) => ReactElement;
@@ -326,13 +326,11 @@ interface TreeRendererOwnProps {
         targetNode: PresentationHierarchyNode;
         selectedNodes: PresentationHierarchyNode[];
     }) => ReactNode[];
-    // (undocumented)
     getTreeItemProps?: (node: PresentationHierarchyNode) => Partial<Omit<StrataKitTreeItemProps, "selected" | "aria-level" | "aria-posinset" | "aria-setsize">>;
     // (undocumented)
     id?: string;
     selectionMode?: SelectionMode_2;
     treeLabel: string;
-    // (undocumented)
     treeRootProps?: Partial<Omit<ComponentProps<typeof Tree.Root>, "style">>;
 }
 

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.exports.csv
@@ -2,13 +2,11 @@ sep=;
 Release Tag;API Item Type;API Item Name
 public;type;ErrorInfo
 alpha;function;ErrorItemRenderer
-alpha;const;FilterAction
 alpha;type;FlatTreeItem
 public;interface;GenericErrorInfo
 public;interface;HierarchyLevelDetails
 public;function;LocalizationContextProvider
 public;interface;PresentationHierarchyNode
-alpha;const;RenameAction
 public;interface;ResultSetTooLargeErrorInfo
 alpha;function;StrataKitRootErrorRenderer
 alpha;const;StrataKitTreeRenderer
@@ -16,6 +14,8 @@ alpha;interface;StrataKitTreeRendererAttributes
 alpha;const;TreeActionBase
 alpha;interface;TreeActionBaseAttributes
 alpha;function;TreeErrorRenderer
+alpha;const;TreeNodeFilterAction
+alpha;const;TreeNodeRenameAction
 alpha;type;TreeRendererProps
 alpha;function;useErrorList
 alpha;function;useFlatTreeItems

--- a/packages/hierarchies-react/src/presentation-hierarchies-react.ts
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react.ts
@@ -10,8 +10,8 @@ export { useNodeHighlighting } from "./presentation-hierarchies-react/UseNodeHig
 export { HierarchyLevelDetails, TreeRendererProps } from "./presentation-hierarchies-react/Renderers.js";
 export { useIModelTree, useIModelUnifiedSelectionTree } from "./presentation-hierarchies-react/UseIModelTree.js";
 export { TreeActionBase, TreeActionBaseAttributes } from "./presentation-hierarchies-react/stratakit/TreeAction.js";
-export { FilterAction } from "./presentation-hierarchies-react/stratakit/FilterAction.js";
-export { RenameAction } from "./presentation-hierarchies-react/stratakit/RenameAction.js";
+export { TreeNodeFilterAction } from "./presentation-hierarchies-react/stratakit/TreeNodeFilterAction.js";
+export { TreeNodeRenameAction } from "./presentation-hierarchies-react/stratakit/TreeNodeRenameAction.js";
 export { StrataKitTreeRenderer, StrataKitTreeRendererAttributes } from "./presentation-hierarchies-react/stratakit/TreeRenderer.js";
 export { StrataKitRootErrorRenderer } from "./presentation-hierarchies-react/stratakit/RootErrorRenderer.js";
 export { TreeErrorRenderer } from "./presentation-hierarchies-react/stratakit/TreeErrorRenderer.js";

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeNodeFilterAction.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeNodeFilterAction.tsx
@@ -11,7 +11,7 @@ import { useLocalizationContext } from "./LocalizationContext.js";
 import { TreeActionBase, TreeActionBaseAttributes } from "./TreeAction.js";
 
 /** @alpha */
-export type FilterActionProps = {
+type TreeNodeFilterActionProps = {
   /** Action to perform when the filter button is clicked for this node. */
   onFilter?: (hierarchyLevelDetails: HierarchyLevelDetails) => void;
 } & TreeActionBaseAttributes &
@@ -19,14 +19,20 @@ export type FilterActionProps = {
 
 /**
  * React component that renders a filter action for a tree item.
+ *
+ * The action calls the `onFilter` callback prop when clicked.
+ *
+ * @see `getMenuActions`, `getInlineActions`, `getContextMenuActions` props of `TreeRenderer` to add this action
+ * to tree items.
+ *
  * @alpha
  */
-export const FilterAction = memo(function FilterAction({
+export const TreeNodeFilterAction = memo(function TreeNodeFilterAction({
   node,
   onFilter,
   getHierarchyLevelDetails,
   ...actionAttributes
-}: FilterActionProps & { node: PresentationHierarchyNode }) {
+}: TreeNodeFilterActionProps & { node: PresentationHierarchyNode }) {
   const { localizedStrings } = useLocalizationContext();
   const { filterHierarchyLevel, filterHierarchyLevelActiveDescription } = localizedStrings;
 

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeNodeRenameAction.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeNodeRenameAction.tsx
@@ -11,12 +11,21 @@ import { TreeActionBase, TreeActionBaseAttributes } from "./TreeAction.js";
 
 /**
  * React component that renders a rename action for a tree item.
- * The tree component must have `getEditingProps.onLabelChanged` prop set to enable renaming functionality. When the rename is completed, the `onLabelChanged` function is called to make the actual data update.
+ *
+ * The tree component must have `getEditingProps.onLabelChanged` prop set to enable renaming functionality. When
+ * rename is completed, the `onLabelChanged` function is called to make the actual data update.
+ *
+ * @see `getMenuActions`, `getInlineActions`, `getContextMenuActions` props of `TreeRenderer` to add this action
+ * to tree items.
+ *
  * @alpha
  */
-export const RenameAction = memo(function RenameAction({ node, ...actionAttributes }: TreeActionBaseAttributes & { node: PresentationHierarchyNode }) {
+export const TreeNodeRenameAction = memo(function TreeNodeRenameAction({
+  node,
+  ...actionAttributes
+}: TreeActionBaseAttributes & { node: PresentationHierarchyNode }) {
   const { localizedStrings } = useLocalizationContext();
-  const context = useRenameContext();
+  const context = useTreeNodeRenameContext();
   const { rename } = localizedStrings;
 
   const canRename = context?.canRename(node) ?? false;
@@ -28,7 +37,7 @@ export const RenameAction = memo(function RenameAction({ node, ...actionAttribut
   return <TreeActionBase {...actionAttributes} label={rename} onClick={handleClick} icon={renameSvg} hide={!canRename} />;
 });
 
-interface RenameContext {
+interface TreeNodeRenameContext {
   renameParameters?: {
     nodeId: string;
     commit: (newLabel: string) => void;
@@ -38,20 +47,20 @@ interface RenameContext {
   cancelRename: () => void;
 }
 
-const renameContext = createContext<RenameContext | undefined>(undefined);
+const treeNodeRenameContext = createContext<TreeNodeRenameContext | undefined>(undefined);
 
 /** @internal */
-export const useRenameContext = () => {
-  return useContext(renameContext);
+export const useTreeNodeRenameContext = () => {
+  return useContext(treeNodeRenameContext);
 };
 
 /** @internal */
-export function RenameContextProvider({ value, children }: PropsWithChildren<{ value: RenameContext }>) {
-  return <renameContext.Provider value={value}>{children}</renameContext.Provider>;
+export function TreeNodeRenameContextProvider({ value, children }: PropsWithChildren<{ value: TreeNodeRenameContext }>) {
+  return <treeNodeRenameContext.Provider value={value}>{children}</treeNodeRenameContext.Provider>;
 }
 
 /** @internal */
-export function useNodeRenameContextValue({
+export function useTreeNodeRenameContextValue({
   getEditingProps,
 }: {
   getEditingProps?: (node: PresentationHierarchyNode) => { onLabelChanged?: (newLabel: string) => void };

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeNodeRenderer.tsx
@@ -25,11 +25,11 @@ import { DropdownMenu, Tree } from "@stratakit/structures";
 import { TreeRendererProps } from "../Renderers.js";
 import { PresentationHierarchyNode } from "../TreeNode.js";
 import { useLocalizationContext } from "./LocalizationContext.js";
-import { useRenameContext } from "./RenameAction.js";
 import { TreeActionBase, TreeActionBaseAttributes } from "./TreeAction.js";
+import { useTreeNodeRenameContext } from "./TreeNodeRenameAction.js";
 
 /** @internal */
-export interface TreeNodeRendererOwnProps extends Pick<TreeRendererProps, "expandNode" | "reloadTree"> {
+interface TreeNodeRendererOwnProps extends Pick<TreeRendererProps, "expandNode" | "reloadTree"> {
   /** Node that is rendered. */
   node: PresentationHierarchyNode;
   /**
@@ -69,15 +69,13 @@ export type TreeNodeRendererProps = StrataKitTreeItemProps & TreeNodeRendererOwn
  * A component that renders given `FlatTreeNode` using the `Tree.Item` component from `@itwin/itwinui-react`. The
  * `FlatTreeNode` objects for this renderer are generally created using the `useFlatTreeNodeList` hook.
  *
- * @see `TreeRenderer`
- * @see https://itwinui.bentley.com/docs/tree
  * @internal
  */
 export const StrataKitTreeNodeRenderer: FC<PropsWithRef<TreeNodeRendererProps & RefAttributes<HTMLElement>>> = memo(
   forwardRef<HTMLElement, TreeNodeRendererProps>(function HierarchyNode(props, forwardedRef) {
     const { node, decorations, inlineActions, menuActions, contextMenuActions, expandNode, reloadTree, ...treeItemProps } = props;
     const { localizedStrings } = useLocalizationContext();
-    const renameContext = useRenameContext();
+    const renameContext = useTreeNodeRenameContext();
     const [contextMenuProps, setContextMenuProps] = useState<{ position: { x: number; y: number }; actions: ReactNode[] } | undefined>(undefined);
 
     const label = treeItemProps.label ?? node.label;

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeRenderer.tsx
@@ -28,8 +28,8 @@ import { SelectionMode, useSelectionHandler } from "../UseSelectionHandler.js";
 import { useEvent, useMergedRefs } from "../Utils.js";
 import { ErrorItem, findPathToNode, FlatTreeItem, FlatTreeNodeItem, isPlaceholderItem, useErrorList, useFlatTreeItems } from "./FlatTreeNode.js";
 import { LocalizationContextProvider } from "./LocalizationContext.js";
-import { RenameContextProvider, useNodeRenameContextValue } from "./RenameAction.js";
 import { TreeErrorRenderer, TreeErrorRendererProps } from "./TreeErrorRenderer.js";
+import { TreeNodeRenameContextProvider, useTreeNodeRenameContextValue } from "./TreeNodeRenameAction.js";
 import { PlaceholderNode, StrataKitTreeItemProps, StrataKitTreeNodeRenderer, TreeNodeRendererProps } from "./TreeNodeRenderer.js";
 
 /** @alpha */
@@ -54,8 +54,10 @@ interface TreeRendererOwnProps {
     onLabelChanged?: (newLabel: string) => void;
   };
 
+  /** Custom props for the root Tree component. */
   treeRootProps?: Partial<Omit<ComponentProps<typeof Tree.Root>, "style">>;
 
+  /** A callback that returns tree item props for specific node. */
   getTreeItemProps?: (node: PresentationHierarchyNode) => Partial<Omit<StrataKitTreeItemProps, "selected" | "aria-level" | "aria-posinset" | "aria-setsize">>;
 
   /**
@@ -172,7 +174,7 @@ export const StrataKitTreeRenderer: FC<PropsWithoutRef<StrataKitTreeRendererProp
     scrollToNode.current = undefined;
   }, [flatItems, virtualizer]);
 
-  const renameContext = useNodeRenameContextValue({
+  const renameContext = useTreeNodeRenameContextValue({
     getEditingProps,
   });
 
@@ -228,7 +230,7 @@ export const StrataKitTreeRenderer: FC<PropsWithoutRef<StrataKitTreeRendererProp
           {...treeRootProps}
           style={{ height: virtualizer.getTotalSize(), minHeight: "100%", width: "100%", position: "relative", overflow: "hidden" }}
         >
-          <RenameContextProvider value={renameContext}>
+          <TreeNodeRenameContextProvider value={renameContext}>
             {items.map((virtualizedItem) => {
               const item = flatItems[virtualizedItem.index];
               const selected = isNodeSelected?.(item.id) ?? false;
@@ -252,7 +254,7 @@ export const StrataKitTreeRenderer: FC<PropsWithoutRef<StrataKitTreeRendererProp
                 />
               );
             })}
-          </RenameContextProvider>
+          </TreeNodeRenameContextProvider>
         </Tree.Root>
       </div>
     </LocalizationContextProvider>


### PR DESCRIPTION
Part of https://github.com/iTwin/presentation/issues/932.

Based on [this comment](https://github.com/iTwin/presentation/issues/932#issuecomment-2829940754):

> `FilterAction` is not very obvious. Maybe rename to `FilterTreeNodeAction` or `TreeNodeFilterAction`?