### PR TITLE
[hierarchies-react] Rename input label

### DIFF
--- a/.changeset/upset-candies-drop.md
+++ b/.changeset/upset-candies-drop.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Added accessible name for tree node rename input.

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -153,6 +153,7 @@ interface LocalizedStrings {
     issuesFound: string;
     loading: string;
     more: string;
+    newLabel: string;
     noFilteredChildren: string;
     noFilteredChildrenChangeFilter: string;
     noIssuesFound: string;

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/LocalizationContext.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/LocalizationContext.tsx
@@ -115,6 +115,11 @@ export interface LocalizedStrings {
    * Default value: `Cancel`.
    */
   cancel: string;
+  /**
+   * Label for tree node rename input.
+   * Default value: `New label`.
+   */
+  newLabel: string;
 }
 
 /** @internal */
@@ -144,6 +149,7 @@ const defaultLocalizedStrings: LocalizedStrings = {
   more: "More",
   confirm: "Confirm",
   cancel: "Cancel",
+  newLabel: "New label",
 };
 
 const localizationContext = createContext<LocalizationContext>({ localizedStrings: defaultLocalizedStrings });

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeNodeRenderer.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeNodeRenderer.tsx
@@ -273,6 +273,7 @@ function LabelEditor({
           <TextBox.Input
             id={inputId}
             ref={inputRef}
+            aria-label={localizedStrings.newLabel}
             value={newLabelValue}
             onChange={(event) => {
               setNewLabelValue(event.target.value);


### PR DESCRIPTION
Added accessible name for tree node rename input.