### PR TITLE
`hierarchies`: Change `NodePreProcessor` and `NodePostProcessor` function types to take a props object instead of a node

### DIFF
--- a/.changeset/wacky-birds-watch.md
+++ b/.changeset/wacky-birds-watch.md
@@ -1,0 +1,31 @@
+---
+"@itwin/presentation-hierarchies": major
+---
+
+Change `NodePreProcessor` and `NodePostProcessor` function types to take a props object instead of a node.
+
+In addition, the props object now contains the `parentNode` property, which provides access to the parent node of the current node being processed. This allows for more context-aware processing of nodes within the hierarchy.
+
+The change breaks consumers that have `HierarchyDefinition` implementations with `preProcessNode` or `postProcessNode` functions defined. Reacting to the change is straightforward:
+
+```ts
+const myHierarchyDefinition: HierarchyDefinition = {
+  // Before:
+  preProcessNode: async (node) => {
+    // process node
+  },
+  postProcessNode: async (node) => {
+    // process node
+  },
+
+  // After:
+  preProcessNode: async ({ node, parentNode }) => {
+    // process node with access to parentNode
+  },
+  postProcessNode: async ({ node, parentNode }) => {
+    // process node with access to parentNode
+  },
+
+  // ... the rest of implementation
+};
+```

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyDefinitions.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyDefinitions.test.ts
@@ -177,7 +177,7 @@ describe("Hierarchies", () => {
             // Otherwise, return an empty array to indicate that there are no children
             return [];
           },
-          async preProcessNode(node) {
+          async preProcessNode({ node }) {
             // The pre-processor queries an external service to get an external ID for the node
             // and either adds it to the node's extended data or omits the node from the hierarchy
             // if the external ID is not found.
@@ -237,7 +237,7 @@ describe("Hierarchies", () => {
             // Otherwise, return an empty array to indicate that there are no children
             return [];
           },
-          async postProcessNode(node) {
+          async postProcessNode({ node }) {
             // All instance nodes will have an iconId assigned in the query, but grouping nodes won't - do it here
             if (HierarchyNode.isClassGroupingNode(node)) {
               return { ...node, extendedData: { ...node.extendedData, iconId: "icon-class-group" } };

--- a/apps/test-app/frontend/src/components/tree-widget/MultiDataSourceTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/MultiDataSourceTree.tsx
@@ -295,7 +295,7 @@ function createModelsHierarchyDefinition({ imodelAccess }: { imodelAccess: IMode
         },
       ],
     },
-    postProcessNode: async (node) => {
+    postProcessNode: async ({ node }) => {
       if (HierarchyNode.isClassGroupingNode(node)) {
         return { ...node, extendedData: { nodeType: "model-class" } };
       }

--- a/packages/hierarchies/api/presentation-hierarchies.api.md
+++ b/packages/hierarchies/api/presentation-hierarchies.api.md
@@ -580,10 +580,16 @@ export type NodeParser = (props: {
 }) => SourceInstanceHierarchyNode | Promise<SourceInstanceHierarchyNode>;
 
 // @public
-export type NodePostProcessor = (node: ProcessedHierarchyNode) => Promise<ProcessedHierarchyNode>;
+export type NodePostProcessor = (props: {
+    node: ProcessedHierarchyNode;
+    parentNode?: ParentHierarchyNode;
+}) => Promise<ProcessedHierarchyNode>;
 
 // @public
-export type NodePreProcessor = <TNode extends ProcessedGenericHierarchyNode | ProcessedInstanceHierarchyNode>(node: TNode) => Promise<TNode | undefined>;
+export type NodePreProcessor = <TNode extends ProcessedGenericHierarchyNode | ProcessedInstanceHierarchyNode>(props: {
+    node: TNode;
+    parentNode?: ParentHierarchyNode;
+}) => Promise<TNode | undefined>;
 
 // @public
 export enum NodeSelectClauseColumnNames {

--- a/packages/hierarchies/learning/imodel/HierarchyDefinition.md
+++ b/packages/hierarchies/learning/imodel/HierarchyDefinition.md
@@ -154,7 +154,7 @@ const hierarchyDefinition: HierarchyDefinition = {
     // Otherwise, return an empty array to indicate that there are no children
     return [];
   },
-  async preProcessNode(node) {
+  async preProcessNode({ node }) {
     // The pre-processor queries an external service to get an external ID for the node
     // and either adds it to the node's extended data or omits the node from the hierarchy
     // if the external ID is not found.
@@ -215,7 +215,7 @@ const hierarchyDefinition: HierarchyDefinition = {
     // Otherwise, return an empty array to indicate that there are no children
     return [];
   },
-  async postProcessNode(node) {
+  async postProcessNode({ node }) {
     // All instance nodes will have an iconId assigned in the query, but grouping nodes won't - do it here
     if (HierarchyNode.isClassGroupingNode(node)) {
       return { ...node, extendedData: { ...node.extendedData, iconId: "icon-class-group" } };

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyDefinition.ts
@@ -5,7 +5,7 @@
 
 import { GenericInstanceFilter } from "@itwin/core-common";
 import { ECClassHierarchyInspector, ECSchemaProvider, ECSqlQueryDef } from "@itwin/presentation-shared";
-import { NonGroupingHierarchyNode } from "../HierarchyNode.js";
+import { NonGroupingHierarchyNode, ParentHierarchyNode } from "../HierarchyNode.js";
 import {
   ProcessedGenericHierarchyNode,
   ProcessedHierarchyNode,
@@ -85,7 +85,13 @@ export type NodeParser = (props: {
  *
  * @public
  */
-export type NodePreProcessor = <TNode extends ProcessedGenericHierarchyNode | ProcessedInstanceHierarchyNode>(node: TNode) => Promise<TNode | undefined>;
+export type NodePreProcessor = <TNode extends ProcessedGenericHierarchyNode | ProcessedInstanceHierarchyNode>(props: {
+  /** Node to be pre-processed. */
+  node: TNode;
+
+  /** The parent node whose child node is being pre-processed. */
+  parentNode?: ParentHierarchyNode;
+}) => Promise<TNode | undefined>;
 
 /**
  * A type for a function that post-processes given node. Unless the function decides not to make any modifications,
@@ -93,7 +99,13 @@ export type NodePreProcessor = <TNode extends ProcessedGenericHierarchyNode | Pr
  *
  * @public
  */
-export type NodePostProcessor = (node: ProcessedHierarchyNode) => Promise<ProcessedHierarchyNode>;
+export type NodePostProcessor = (props: {
+  /** Node to be post-processed. */
+  node: ProcessedHierarchyNode;
+
+  /** The parent node whose child node is being post-processed. */
+  parentNode?: ParentHierarchyNode;
+}) => Promise<ProcessedHierarchyNode>;
 
 /**
  * A type of node that can be passed to `HierarchyDefinition.defineHierarchyLevel`. This basically means

--- a/packages/hierarchies/src/hierarchies/imodel/SearchHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/SearchHierarchyDefinition.ts
@@ -48,8 +48,8 @@ export class SearchHierarchyDefinition implements RxjsHierarchyDefinition {
   }
 
   public get preProcessNode(): RxjsNodePreProcessor {
-    return (node) =>
-      (this._source.preProcessNode ? this._source.preProcessNode(node) : of(node)).pipe(
+    return (props) =>
+      (this._source.preProcessNode ? this._source.preProcessNode(props) : of(props.node)).pipe(
         filter((processedNode) => {
           if (processedNode.processingParams?.hideInHierarchy && processedNode.search?.isSearchTarget && !processedNode.search.hasSearchTargetAncestor) {
             // we want to hide target nodes if they have `hideInHierarchy` param, but only if they're not under another search target
@@ -61,8 +61,8 @@ export class SearchHierarchyDefinition implements RxjsHierarchyDefinition {
   }
 
   public get postProcessNode(): RxjsNodePostProcessor {
-    return (node) =>
-      (this._source.postProcessNode ? this._source.postProcessNode(node) : of(node)).pipe(
+    return (props) =>
+      (this._source.postProcessNode ? this._source.postProcessNode(props) : of(props.node)).pipe(
         map((processedNode) => {
           const parentKeysWithoutGroupingNodesLength = processedNode.parentKeys.filter((key) => !HierarchyNodeKey.isGrouping(key)).length;
           const parentKeysLength = processedNode.parentKeys.length;

--- a/packages/hierarchies/src/hierarchies/internal/RxjsHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/internal/RxjsHierarchyDefinition.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { filter, from, Observable } from "rxjs";
+import { ParentHierarchyNode } from "../HierarchyNode.js";
 import {
   DefineHierarchyLevelProps,
   HierarchyDefinition,
@@ -35,7 +36,10 @@ export type RxjsNodeParser = (props: {
  *
  * @internal
  */
-export type RxjsNodePreProcessor = <TNode extends ProcessedGenericHierarchyNode | ProcessedInstanceHierarchyNode>(node: TNode) => Observable<TNode>;
+export type RxjsNodePreProcessor = <TNode extends ProcessedGenericHierarchyNode | ProcessedInstanceHierarchyNode>(props: {
+  node: TNode;
+  parentNode?: ParentHierarchyNode;
+}) => Observable<TNode>;
 
 /**
  * A type for a function that post-processes given node. Unless the function decides not to make any modifications,
@@ -43,7 +47,7 @@ export type RxjsNodePreProcessor = <TNode extends ProcessedGenericHierarchyNode 
  *
  * @internal
  */
-export type RxjsNodePostProcessor = (node: ProcessedHierarchyNode) => Observable<ProcessedHierarchyNode>;
+export type RxjsNodePostProcessor = (props: { node: ProcessedHierarchyNode; parentNode?: ParentHierarchyNode }) => Observable<ProcessedHierarchyNode>;
 
 /**
  * An interface for a factory that knows how define a hierarchy based on a given parent node.
@@ -95,9 +99,9 @@ export function getRxjsHierarchyDefinition(hierarchyDefinition: HierarchyDefinit
         }
       : undefined,
     preProcessNode: hierarchyDefinition.preProcessNode
-      ? (node) => from(hierarchyDefinition.preProcessNode!(node)).pipe(filter((preprocessedNode) => !!preprocessedNode))
+      ? (props) => from(hierarchyDefinition.preProcessNode!(props)).pipe(filter((preprocessedNode) => !!preprocessedNode))
       : undefined,
-    postProcessNode: hierarchyDefinition.postProcessNode ? (node) => from(hierarchyDefinition.postProcessNode!(node)) : undefined,
+    postProcessNode: hierarchyDefinition.postProcessNode ? (props) => from(hierarchyDefinition.postProcessNode!(props)) : undefined,
     defineHierarchyLevel: (props) => from(hierarchyDefinition.defineHierarchyLevel(props)),
   };
 }

--- a/packages/hierarchies/src/test/imodel/SearchHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/SearchHierarchyDefinition.test.ts
@@ -304,7 +304,7 @@ describe("SearchHierarchyDefinition", () => {
     it("returns given node when source factory has no pre-processor", async () => {
       const node = createTestProcessedGenericNode();
       const searchFactory = await createSearchHierarchyDefinition();
-      const result = await firstValueFrom(searchFactory.preProcessNode(node));
+      const result = await firstValueFrom(searchFactory.preProcessNode({ node }));
       expect(result).to.eq(node);
     });
 
@@ -318,8 +318,8 @@ describe("SearchHierarchyDefinition", () => {
       const searchFactory = await createSearchHierarchyDefinition({
         sourceFactory,
       });
-      const result = await firstValueFrom(searchFactory.preProcessNode(inputNode));
-      expect(stub).to.be.calledOnceWithExactly(inputNode);
+      const result = await firstValueFrom(searchFactory.preProcessNode({ node: inputNode }));
+      expect(stub).to.be.calledOnceWithExactly({ node: inputNode });
       expect(result).to.eq(sourceFactoryNode);
     });
 
@@ -336,7 +336,7 @@ describe("SearchHierarchyDefinition", () => {
         },
       };
       const searchFactory = await createSearchHierarchyDefinition();
-      const result = await firstValueFrom(searchFactory.preProcessNode(inputNode));
+      const result = await firstValueFrom(searchFactory.preProcessNode({ node: inputNode }));
       expect(result).to.eq(inputNode);
     });
 
@@ -353,7 +353,7 @@ describe("SearchHierarchyDefinition", () => {
         },
       };
       const searchFactory = await createSearchHierarchyDefinition();
-      const result = await firstValueFrom(searchFactory.preProcessNode(inputNode).pipe(toArray()));
+      const result = await firstValueFrom(searchFactory.preProcessNode({ node: inputNode }).pipe(toArray()));
       expect(result).to.deep.eq([]);
     });
   });
@@ -362,7 +362,7 @@ describe("SearchHierarchyDefinition", () => {
     it("returns given node when source factory has no post-processor", async () => {
       const node = createTestProcessedGenericNode();
       const searchFactory = await createSearchHierarchyDefinition();
-      const result = await firstValueFrom(searchFactory.postProcessNode(node));
+      const result = await firstValueFrom(searchFactory.postProcessNode({ node }));
       expect(result).to.eq(node);
     });
 
@@ -376,8 +376,8 @@ describe("SearchHierarchyDefinition", () => {
       const searchFactory = await createSearchHierarchyDefinition({
         sourceFactory,
       });
-      const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
-      expect(stub).to.be.calledOnceWithExactly(inputNode);
+      const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
+      expect(stub).to.be.calledOnceWithExactly({ node: inputNode });
       expect(result).to.eq(sourceFactoryNode);
     });
 
@@ -394,7 +394,7 @@ describe("SearchHierarchyDefinition", () => {
       const searchFactory = await createSearchHierarchyDefinition({
         targetPaths: [{ path: [inputNode.key.instanceKeys[0]], options: { autoExpand: true } }],
       });
-      const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+      const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
       expect(result.autoExpand).to.be.true;
     });
 
@@ -421,7 +421,7 @@ describe("SearchHierarchyDefinition", () => {
           const searchFactory = await createSearchHierarchyDefinition({
             targetPaths: [{ path: [inputNode.key.instanceKeys[0]], options: { reveal } }],
           });
-          const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+          const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
           expect(result.autoExpand).to.be.undefined;
         });
 
@@ -435,7 +435,7 @@ describe("SearchHierarchyDefinition", () => {
             ],
           });
           const searchFactory = await createSearchHierarchyDefinition({ targetPaths: [{ path: [inputNode.key], options: { reveal } }] });
-          const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+          const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
           expect(result.autoExpand).to.be.undefined;
         });
       });
@@ -470,7 +470,7 @@ describe("SearchHierarchyDefinition", () => {
             const searchFactory = await createSearchHierarchyDefinition({
               targetPaths: [{ path: [inputNode.key.instanceKeys[0], { id: "child", type: "generic" }], options: { reveal } }],
             });
-            const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+            const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
             expect(result.autoExpand).to.eq(expectation);
           });
 
@@ -483,7 +483,7 @@ describe("SearchHierarchyDefinition", () => {
             const searchFactory = await createSearchHierarchyDefinition({
               targetPaths: [{ path: [inputNode.key, { id: "child", type: "generic" }], options: { reveal } }],
             });
-            const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+            const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
             expect(result.autoExpand).to.eq(expectation);
           });
         });
@@ -517,7 +517,7 @@ describe("SearchHierarchyDefinition", () => {
               },
             ],
           });
-          const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+          const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
           expect(result.autoExpand).to.eq(undefined);
         });
       });
@@ -527,7 +527,7 @@ describe("SearchHierarchyDefinition", () => {
       it("doesn't set auto-expand on grouping nodes if none of the children have target children search paths", async () => {
         const inputNode = createGroupingNode();
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.undefined;
       });
 
@@ -542,7 +542,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.undefined;
       });
 
@@ -559,7 +559,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.undefined;
       });
 
@@ -579,7 +579,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.true;
       });
 
@@ -594,7 +594,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.undefined;
       });
 
@@ -609,7 +609,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.true;
       });
 
@@ -629,7 +629,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.undefined;
       });
 
@@ -649,7 +649,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.true;
       });
 
@@ -677,7 +677,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.true;
       });
 
@@ -705,7 +705,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.true;
       });
 
@@ -733,7 +733,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.true;
       });
 
@@ -761,7 +761,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.undefined;
       });
 
@@ -789,7 +789,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.true;
       });
 
@@ -813,7 +813,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.true;
       });
 
@@ -836,7 +836,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(result.autoExpand).to.be.true;
       });
 
@@ -859,7 +859,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(!!result.autoExpand).to.be.false;
       });
 
@@ -882,7 +882,7 @@ describe("SearchHierarchyDefinition", () => {
           ],
         };
         const searchFactory = await createSearchHierarchyDefinition();
-        const result = await firstValueFrom(searchFactory.postProcessNode(inputNode));
+        const result = await firstValueFrom(searchFactory.postProcessNode({ node: inputNode }));
         expect(!!result.autoExpand).to.be.false;
       });
     };

--- a/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
+++ b/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
@@ -176,7 +176,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
     });
   }
 
-  public async postProcessNode(node: ProcessedHierarchyNode): Promise<ProcessedHierarchyNode> {
+  public async postProcessNode({ node }: { node: ProcessedHierarchyNode }): Promise<ProcessedHierarchyNode> {
     if (ProcessedHierarchyNode.isGroupingNode(node)) {
       return {
         ...node,


### PR DESCRIPTION
Part of https://github.com/iTwin/presentation/issues/1197:

> Add parent node in node pre and post processors