### PR TITLE
[Components]: fix quantity editor not displaying 0

### DIFF
--- a/.changeset/icy-seas-bake.md
+++ b/.changeset/icy-seas-bake.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-components": patch
 ---
 
-Fix `QuantityPropertyEditor` not displaying 0
+Fix quantities-enabled numeric property editor rendering just the unit when the raw value is `0`, e.g. "ft" instead of expected "0 ft".

--- a/.changeset/icy-seas-bake.md
+++ b/.changeset/icy-seas-bake.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+Fix `QuantityPropertyEditor` not displaying 0

--- a/packages/components/src/presentation-components/properties/inputs/UseQuantityValueInput.tsx
+++ b/packages/components/src/presentation-components/properties/inputs/UseQuantityValueInput.tsx
@@ -59,9 +59,10 @@ export function useQuantityValueInput({ initialRawValue, schemaContext, koqName 
     ({ newHighPrecisionFormatter, newParser, newDefaultFormatter }) => {
       setState((prev): State => {
         /* v8 ignore next 1 -- @preserve */
-        const defaultValue = initialRawValueRef.current
-          ? newDefaultFormatter.applyFormatting(initialRawValueRef.current)
-          : newHighPrecisionFormatter.unitConversions[0].label;
+        const defaultValue =
+          initialRawValueRef.current !== undefined
+            ? newDefaultFormatter.applyFormatting(initialRawValueRef.current)
+            : newHighPrecisionFormatter.unitConversions[0].label;
         const newFormattedValue =
           prev.quantityValue.rawValue !== undefined
             ? newHighPrecisionFormatter.applyFormatting(prev.quantityValue.rawValue)

--- a/packages/components/src/presentation-components/properties/inputs/UseQuantityValueInput.tsx
+++ b/packages/components/src/presentation-components/properties/inputs/UseQuantityValueInput.tsx
@@ -60,8 +60,8 @@ export function useQuantityValueInput({ initialRawValue, schemaContext, koqName 
       setState((prev): State => {
         /* v8 ignore next 1 -- @preserve */
         const defaultValue =
-          initialRawValueRef.current !== undefined
-            ? newDefaultFormatter.applyFormatting(initialRawValueRef.current)
+          prev.quantityValue.rawValue !== undefined
+            ? newDefaultFormatter.applyFormatting(prev.quantityValue.rawValue)
             : newHighPrecisionFormatter.unitConversions[0].label;
         const newFormattedValue =
           prev.quantityValue.rawValue !== undefined

--- a/packages/components/src/test/properties/inputs/UseQuantityValueInput.test.tsx
+++ b/packages/components/src/test/properties/inputs/UseQuantityValueInput.test.tsx
@@ -94,7 +94,9 @@ describe("UseQuantityValueInput", () => {
   });
 
   it("renders with formatted value when initial raw value is 0", async () => {
-    const { queryByDisplayValue } = render(<TestInput schemaContext={schemaContext} koqName="testKOQ" initialRawValue={0} />);
+    const { queryByDisplayValue } = render(
+      <TestInput schemaContext={schemaContext} koqName="testKOQ" initialRawValue={0} />,
+    );
     await waitFor(() => expect(queryByDisplayValue("0 unit")).not.toBeNull());
   });
 

--- a/packages/components/src/test/properties/inputs/UseQuantityValueInput.test.tsx
+++ b/packages/components/src/test/properties/inputs/UseQuantityValueInput.test.tsx
@@ -83,6 +83,11 @@ describe("UseQuantityValueInput", () => {
     await waitFor(() => expect(queryByDisplayValue("2.5 unit")).not.toBeNull());
   });
 
+  it("renders with formatted value when initial raw value is 0", async () => {
+    const { queryByDisplayValue } = render(<TestInput schemaContext={schemaContext} koqName="testKOQ" initialRawValue={0} />);
+    await waitFor(() => expect(queryByDisplayValue("0 unit")).not.toBeNull());
+  });
+
   it("renders disabled input if cannot create formatter", async () => {
     getFormatterSpecStub.mockResolvedValue(undefined);
     const { getByRole } = render(<TestInput schemaContext={schemaContext} koqName="testKOQ" initialRawValue={2.5} />);


### PR DESCRIPTION
Fixes an issue where quantities-enabled numeric property editor would render just the unit when the raw value is `0`, e.g. "ft" instead of expected "0 ft".