### PR TITLE
`components`: Fix latest PR breaking compatibility with old iTwin.js core versions

### DIFF
--- a/packages/components/src/presentation-components/propertygrid/DataProvider.ts
+++ b/packages/components/src/presentation-components/propertygrid/DataProvider.ts
@@ -770,7 +770,7 @@ function shouldDestructureArrayField(field: Field) {
   return (
     field.isNestedContentField() ||
     /* This is only needed for pre-5.8.1 iTwin.js core */
-    (field.parent && (!field.isPropertiesField() || !field.isArrayPropertiesField()))
+    (field.parent && (!field.isPropertiesField() || (field.isArrayPropertiesField && !field.isArrayPropertiesField())))
   );
 }
 

--- a/packages/components/src/presentation-components/propertygrid/DataProvider.ts
+++ b/packages/components/src/presentation-components/propertygrid/DataProvider.ts
@@ -770,7 +770,7 @@ function shouldDestructureArrayField(field: Field) {
   return (
     field.isNestedContentField() ||
     /* This is only needed for pre-5.8.1 iTwin.js core */
-    (field.parent && (!field.isPropertiesField() || !field.isArrayPropertiesField || !field.isArrayPropertiesField()))
+    (field.parent && (!field.isPropertiesField() || !field.isArrayPropertiesField?.()))
   );
 }
 
@@ -874,7 +874,7 @@ function destructureRecords(records: FieldHierarchyRecord[]) {
         if (entry.record.value.items.length > 0) {
           const item = entry.record.value.items[0];
           const fieldHierarchy =
-            entry.fieldHierarchy.field.isPropertiesField() && entry.fieldHierarchy.field.isArrayPropertiesField()
+            entry.fieldHierarchy.field.isPropertiesField() && entry.fieldHierarchy.field.isArrayPropertiesField?.()
               ? { ...entry.fieldHierarchy, field: entry.fieldHierarchy.field.itemsField }
               : entry.fieldHierarchy;
           records.splice(i, 0, { ...entry, fieldHierarchy, record: item });

--- a/packages/components/src/presentation-components/propertygrid/DataProvider.ts
+++ b/packages/components/src/presentation-components/propertygrid/DataProvider.ts
@@ -770,7 +770,7 @@ function shouldDestructureArrayField(field: Field) {
   return (
     field.isNestedContentField() ||
     /* This is only needed for pre-5.8.1 iTwin.js core */
-    (field.parent && (!field.isPropertiesField() || !field.isArrayPropertiesField?.()))
+    (field.parent && (!field.isPropertiesField() || !field.isArrayPropertiesField || !field.isArrayPropertiesField()))
   );
 }
 

--- a/packages/components/src/presentation-components/propertygrid/DataProvider.ts
+++ b/packages/components/src/presentation-components/propertygrid/DataProvider.ts
@@ -770,7 +770,7 @@ function shouldDestructureArrayField(field: Field) {
   return (
     field.isNestedContentField() ||
     /* This is only needed for pre-5.8.1 iTwin.js core */
-    (field.parent && (!field.isPropertiesField() || (field.isArrayPropertiesField && !field.isArrayPropertiesField())))
+    (field.parent && (!field.isPropertiesField() || !field.isArrayPropertiesField?.()))
   );
 }
 


### PR DESCRIPTION
https://github.com/iTwin/presentation/pull/1296 calls `PropertiesField.isArrayPropertiesField()`, but that function is not available on older iTwin.js Core versions...