### PR TITLE
[shared] Use more unique alias for label select clause

### DIFF
--- a/.changeset/stale-horses-sell.md
+++ b/.changeset/stale-horses-sell.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-shared": patch
+---
+
+Use more distinctive aliases in label select clauses to avoid collisions with aliases in outer FROM clause.

--- a/apps/full-stack-tests/src/hierarchies/InstanceLabelSelectClauseFactorytest.ts
+++ b/apps/full-stack-tests/src/hierarchies/InstanceLabelSelectClauseFactorytest.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { insertPhysicalModelWithPartition } from "presentation-test-utilities";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  createBisInstanceLabelSelectClauseFactory,
+  createDefaultInstanceLabelSelectClauseFactory,
+} from "@itwin/presentation-shared";
+import { initialize, terminate } from "../IntegrationTests.js";
+import { buildTestIModel } from "../TestIModelSetup.js";
+import { createIModelAccess } from "./Utils.js";
+
+describe("NodesQueryClauseFactory", () => {
+  beforeAll(async () => {
+    await initialize();
+  });
+
+  afterAll(async () => {
+    await terminate();
+  });
+
+  it("creates correct labels for BisCore.Model subclasses when outer query uses alias 'e'", async () => {
+    const { imodel } = await buildTestIModel(async (builder) => {
+      insertPhysicalModelWithPartition({ builder, codeValue: "Test model" });
+    });
+    const imodelAccess = createIModelAccess(imodel);
+
+    const labelsQueryFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
+
+    const ecsql = `
+      SELECT ${await labelsQueryFactory.createSelectClause({
+        classAlias: "e",
+        className: "BisCore.GeometricModel3d",
+      })} AS label
+      FROM BisCore.GeometricModel3d e
+    `;
+    const reader = imodel.createQueryReader(ecsql);
+    const rows = await reader.toArray();
+    expect(rows[0].label).to.eq("Test model");
+  });
+
+  it("creates correct labels when outer query uses alias 'c' (same as default label factory's internal alias)", async () => {
+    const { imodel } = await buildTestIModel(async (builder) => {
+      insertPhysicalModelWithPartition({ builder, codeValue: "Test model" });
+    });
+
+    const labelsQueryFactory = createDefaultInstanceLabelSelectClauseFactory();
+
+    const ecsql = `
+      SELECT ${await labelsQueryFactory.createSelectClause({
+        classAlias: "c",
+        className: "BisCore.GeometricModel3d",
+      })} AS label
+      FROM BisCore.GeometricModel3d c
+    `;
+    const reader = imodel.createQueryReader(ecsql);
+    const rows = await reader.toArray();
+    expect(rows[0].label).to.eq("Physical Model [0-H]");
+  });
+});

--- a/apps/full-stack-tests/src/hierarchies/NodesQueryClauseFactory.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/NodesQueryClauseFactory.test.ts
@@ -76,7 +76,7 @@ describe("NodesQueryClauseFactory", () => {
     });
   });
 
-  it("creates correct labels when outer query uses alias 'c' (same as default label factory's internal alias)", async () => {
+  it("creates correct labels when outer query uses common alias 'c'", async () => {
     const { imodel } = await buildTestIModel(async (builder) => {
       insertPhysicalModelWithPartition({ builder, codeValue: "Test model" });
     });

--- a/apps/full-stack-tests/src/hierarchies/NodesQueryClauseFactory.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/NodesQueryClauseFactory.test.ts
@@ -1,0 +1,127 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { insertPhysicalModelWithPartition } from "presentation-test-utilities";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import {
+  createNodesQueryClauseFactory,
+  createPredicateBasedHierarchyDefinition,
+} from "@itwin/presentation-hierarchies";
+import {
+  createBisInstanceLabelSelectClauseFactory,
+  createDefaultInstanceLabelSelectClauseFactory,
+} from "@itwin/presentation-shared";
+import { initialize, terminate } from "../IntegrationTests.js";
+import { buildTestIModel } from "../TestIModelSetup.js";
+import { NodeValidators, validateHierarchy } from "./HierarchyValidation.js";
+import { createIModelAccess, createProvider } from "./Utils.js";
+
+describe("NodesQueryClauseFactory", () => {
+  beforeAll(async () => {
+    await initialize();
+  });
+
+  afterAll(async () => {
+    await terminate();
+  });
+
+  it("creates correct labels for BisCore.Model subclasses when outer query uses alias 'e'", async () => {
+    const { imodel } = await buildTestIModel(async (builder) => {
+      insertPhysicalModelWithPartition({ builder, codeValue: "Test model" });
+    });
+    const imodelAccess = createIModelAccess(imodel);
+
+    const labelsQueryFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
+
+    const nodesQueryFactory = createNodesQueryClauseFactory({
+      imodelAccess,
+      instanceLabelSelectClauseFactory: labelsQueryFactory,
+    });
+
+    const hierarchyDefinition = createPredicateBasedHierarchyDefinition({
+      classHierarchyInspector: imodelAccess,
+      hierarchy: {
+        rootNodes: async () => [
+          {
+            fullClassName: "BisCore.GeometricModel3d",
+            query: {
+              ecsql: `
+                SELECT
+                  ${await nodesQueryFactory.createSelectClause({
+                    ecClassId: { selector: "e.ECClassId" },
+                    ecInstanceId: { selector: "e.ECInstanceId" },
+                    nodeLabel: {
+                      selector: await labelsQueryFactory.createSelectClause({
+                        classAlias: "e",
+                        className: "BisCore.GeometricModel3d",
+                      }),
+                    },
+                  })}
+                FROM BisCore.GeometricModel3d e
+              `,
+            },
+          },
+        ],
+        childNodes: [],
+      },
+    });
+
+    const provider = createProvider({ imodelAccess, hierarchy: hierarchyDefinition });
+
+    await validateHierarchy({
+      provider,
+      expect: [NodeValidators.createForInstanceNode({ label: "Test model", children: false })],
+    });
+  });
+
+  it("creates correct labels when outer query uses alias 'c' (same as default label factory's internal alias)", async () => {
+    const { imodel } = await buildTestIModel(async (builder) => {
+      insertPhysicalModelWithPartition({ builder, codeValue: "Test model" });
+    });
+    const imodelAccess = createIModelAccess(imodel);
+
+    const labelsQueryFactory = createDefaultInstanceLabelSelectClauseFactory();
+
+    const nodesQueryFactory = createNodesQueryClauseFactory({
+      imodelAccess,
+      instanceLabelSelectClauseFactory: labelsQueryFactory,
+    });
+
+    const hierarchyDefinition = createPredicateBasedHierarchyDefinition({
+      classHierarchyInspector: imodelAccess,
+      hierarchy: {
+        rootNodes: async () => [
+          {
+            fullClassName: "BisCore.GeometricModel3d",
+            query: {
+              ecsql: `
+                SELECT
+                  ${await nodesQueryFactory.createSelectClause({
+                    ecClassId: { selector: "c.ECClassId" },
+                    ecInstanceId: { selector: "c.ECInstanceId" },
+                    nodeLabel: {
+                      selector: await labelsQueryFactory.createSelectClause({
+                        classAlias: "c",
+                        className: "BisCore.GeometricModel3d",
+                      }),
+                    },
+                  })}
+                FROM BisCore.GeometricModel3d c
+              `,
+            },
+          },
+        ],
+        childNodes: [],
+      },
+    });
+
+    const provider = createProvider({ imodelAccess, hierarchy: hierarchyDefinition });
+
+    await validateHierarchy({
+      provider,
+      expect: [NodeValidators.createForInstanceNode({ label: "Physical Model [0-H]", children: false })],
+    });
+  });
+});

--- a/packages/shared/src/shared/InstanceLabelSelectClauseFactory.ts
+++ b/packages/shared/src/shared/InstanceLabelSelectClauseFactory.ts
@@ -11,6 +11,9 @@ import {
 } from "./ecsql-snippets/ECSqlValueSelectorSnippets.js";
 import { ECClassHierarchyInspector } from "./Metadata.js";
 
+/** @internal */
+export const ALIAS_PREFIX = "pres_";
+
 /**
  * Props for `IInstanceLabelSelectClauseFactory.createSelectClause`.
  * @public
@@ -108,6 +111,7 @@ export function parseInstanceLabel(value: string | undefined): ConcatenatedValue
  * @public
  */
 export function createDefaultInstanceLabelSelectClauseFactory(): IInstanceLabelSelectClauseFactory {
+  const alias = `${ALIAS_PREFIX}c`;
   return {
     async createSelectClause(props: CreateInstanceLabelSelectClauseProps): Promise<string> {
       return `(
@@ -115,14 +119,14 @@ export function createDefaultInstanceLabelSelectClauseFactory(): IInstanceLabelS
           ${concatenate(props, [
             {
               selector: `COALESCE(
-                ${createRawPropertyValueSelector("c", "DisplayLabel")},
-                ${createRawPropertyValueSelector("c", "Name")}
+                ${createRawPropertyValueSelector(alias, "DisplayLabel")},
+                ${createRawPropertyValueSelector(alias, "Name")}
               )`,
             },
             ...createECInstanceIdSuffixSelectors(props.classAlias),
           ])}
-        FROM [meta].[ECClassDef] AS [c]
-        WHERE [c].[ECInstanceId] = ${createRawPropertyValueSelector(props.classAlias, "ECClassId")}
+        FROM [meta].[ECClassDef] AS [${alias}]
+        WHERE [${alias}].[ECInstanceId] = ${createRawPropertyValueSelector(props.classAlias, "ECClassId")}
       )`;
     },
   };
@@ -249,6 +253,7 @@ export function createBisInstanceLabelSelectClauseFactory(
     classHierarchyInspector: props.classHierarchyInspector,
     clauses,
   });
+  const elementAlias = `${ALIAS_PREFIX}e`;
   clauses.push(
     {
       className: "BisCore.GeometricElement",
@@ -278,9 +283,9 @@ export function createBisInstanceLabelSelectClauseFactory(
     {
       className: "BisCore.Model",
       clause: async ({ classAlias, ...rest }) => `(
-        SELECT ${await factory.createSelectClause({ ...rest, classAlias: "e", className: "BisCore.Element" })}
-        FROM [bis].[Element] AS [e]
-        WHERE [e].[ECInstanceId] = ${createRawPropertyValueSelector(classAlias, "ModeledElement", "Id")}
+        SELECT ${await factory.createSelectClause({ ...rest, classAlias: elementAlias, className: "BisCore.Element" })}
+        FROM [bis].[Element] AS [${elementAlias}]
+        WHERE [${elementAlias}].[ECInstanceId] = ${createRawPropertyValueSelector(classAlias, "ModeledElement", "Id")}
       )`,
     },
   );

--- a/packages/shared/src/test/InstanceLabelSelectClauseFactory.test.ts
+++ b/packages/shared/src/test/InstanceLabelSelectClauseFactory.test.ts
@@ -10,6 +10,7 @@ import {
   createRawPropertyValueSelector,
 } from "../shared/ecsql-snippets/ECSqlValueSelectorSnippets.js";
 import {
+  ALIAS_PREFIX,
   createBisInstanceLabelSelectClauseFactory,
   createClassBasedInstanceLabelSelectClauseFactory,
   createDefaultInstanceLabelSelectClauseFactory,
@@ -62,8 +63,8 @@ describe("createDefaultInstanceLabelSelectClauseFactory", () => {
         SELECT ${createConcatenatedValueJsonSelector([
           {
             selector: `COALESCE(
-              ${createRawPropertyValueSelector("c", "DisplayLabel")},
-              ${createRawPropertyValueSelector("c", "Name")}
+              ${createRawPropertyValueSelector(`${ALIAS_PREFIX}c`, "DisplayLabel")},
+              ${createRawPropertyValueSelector(`${ALIAS_PREFIX}c`, "Name")}
             )`,
           },
           { value: ` [`, type: "String" },
@@ -74,8 +75,8 @@ describe("createDefaultInstanceLabelSelectClauseFactory", () => {
           },
           { value: `]`, type: "String" },
         ])}
-        FROM [meta].[ECClassDef] AS [c]
-        WHERE [c].[ECInstanceId] = [test].[ECClassId]
+        FROM [meta].[ECClassDef] AS [${ALIAS_PREFIX}c]
+        WHERE [${ALIAS_PREFIX}c].[ECInstanceId] = [test].[ECClassId]
       )`),
     );
   });
@@ -306,9 +307,9 @@ describe("BisInstanceLabelSelectClauseFactory", () => {
           IIF(
             [test].[ECClassId] IS (BisCore.Model),
             (
-              SELECT ${await factory.createSelectClause({ classAlias: "e", className: "BisCore.Element" })}
-              FROM [bis].[Element] AS [e]
-              WHERE [e].[ECInstanceId] = [test].[ModeledElement].[Id]
+              SELECT ${await factory.createSelectClause({ classAlias: `${ALIAS_PREFIX}e`, className: "BisCore.Element" })}
+              FROM [bis].[Element] AS [${ALIAS_PREFIX}e]
+              WHERE [${ALIAS_PREFIX}e].[ECInstanceId] = [test].[ModeledElement].[Id]
             ),
             NULL
           ),


### PR DESCRIPTION
Aliases used in label select clauses produces by presentation-shared were very generic `c`, `e` and it was very easy to encounter collision when using Element or Category classes (especially when generating hierarchies with AI). Added prefix to those aliases to avoid these collisions.

Closes https://github.com/iTwin/presentation/issues/1297