### PR TITLE
Full stack tests: Cleanup imodel & ecdb build utils

### DIFF
--- a/apps/full-stack-tests/src/ECDbUtils.ts
+++ b/apps/full-stack-tests/src/ECDbUtils.ts
@@ -294,11 +294,17 @@ export async function buildTestECDb<TResult extends {} | undefined>(
   const name = createFileNameFromString(testName);
   const outputFilePath = setupOutputFileLocation(name);
   const ecdb = new ECDb();
-  ecdb.createDb(outputFilePath);
-  const res = await setup?.(new ECDbBuilder(ecdb, outputFilePath), testName);
-  ecdb.saveChanges("Created test ECDb");
+  let setupResult: TResult | undefined;
+  try {
+    ecdb.createDb(outputFilePath);
+    setupResult = await setup?.(new ECDbBuilder(ecdb, outputFilePath), testName);
+    ecdb.saveChanges("Created test ECDb");
+  } catch (e) {
+    ecdb[Symbol.dispose]();
+    throw e;
+  }
   return {
-    ...(res as TResult),
+    ...(setupResult as TResult),
     ecdb,
     [Symbol.dispose]() {
       ecdb[Symbol.dispose]();

--- a/apps/full-stack-tests/src/ECDbUtils.ts
+++ b/apps/full-stack-tests/src/ECDbUtils.ts
@@ -14,7 +14,6 @@ import {
   limitFilePathLength,
   setupOutputFileLocation,
 } from "./FilenameUtils.js";
-import { safeDispose } from "./Utils.js";
 
 import type { ECSqlWriteStatement } from "@itwin/core-backend";
 import type { Id64String } from "@itwin/core-bentley";
@@ -207,7 +206,7 @@ function isBinding(value: ECSqlBinding | PrimitiveValue): value is ECSqlBinding 
   return typeof value === "object" && "type" in value && "value" in value;
 }
 
-export async function createECDb<TResult extends {}>(
+async function createECDb<TResult extends {}>(
   testName: string | undefined,
   setup: (db: ECDbBuilder) => Promise<TResult>,
 ): Promise<TResult & { ecdb: ECDb; ecdbPath: string }> {
@@ -282,26 +281,27 @@ export async function createChangedDbs<
   };
 }
 
-export async function withECDb(
-  setup: (db: ECDbBuilder, testName: string) => Promise<void>,
-  use: (db: ECDb) => Promise<void>,
-): Promise<void>;
-export async function withECDb<TResult extends {}>(
-  setup: (db: ECDbBuilder, testName: string) => Promise<TResult>,
-  use: (db: ECDb, res: TResult) => Promise<void>,
-): Promise<void>;
-export async function withECDb<TResult extends {} | undefined>(
-  setup: (db: ECDbBuilder, testName: string) => Promise<TResult | undefined>,
-  use: (db: ECDb, res: TResult | undefined) => Promise<void>,
-) {
+export async function buildTestECDb<TResult extends {} | undefined>(
+  setup: (ecdbBuilder: ECDbBuilder, testName: string) => TResult | Promise<TResult>,
+): Promise<TResult & { ecdb: ECDb } & Disposable>;
+export async function buildTestECDb(
+  setup?: (ecdbBuilder: ECDbBuilder, testName: string) => void | Promise<void>,
+): Promise<{ ecdb: ECDb } & Disposable>;
+export async function buildTestECDb<TResult extends {} | undefined>(
+  setup?: (ecdbBuilder: ECDbBuilder, testName: string) => TResult | Promise<TResult>,
+): Promise<TResult & { ecdb: ECDb } & Disposable> {
   const testName = getTestName();
   const name = createFileNameFromString(testName);
-  const outputFile = setupOutputFileLocation(name);
-  using db = new ECDb();
-
-  db.createDb(outputFile);
-  const res = await setup(new ECDbBuilder(db, outputFile), testName);
-  db.saveChanges("Created test ECDb");
-  await use(db, res);
-  safeDispose(db);
+  const outputFilePath = setupOutputFileLocation(name);
+  const ecdb = new ECDb();
+  ecdb.createDb(outputFilePath);
+  const res = await setup?.(new ECDbBuilder(ecdb, outputFilePath), testName);
+  ecdb.saveChanges("Created test ECDb");
+  return {
+    ...(res as TResult),
+    ecdb,
+    [Symbol.dispose]() {
+      ecdb[Symbol.dispose]();
+    },
+  };
 }

--- a/apps/full-stack-tests/src/IModelUtils.ts
+++ b/apps/full-stack-tests/src/IModelUtils.ts
@@ -5,74 +5,12 @@
 
 import { IModelDb, IModelJsFs, SnapshotDb, StandaloneDb } from "@itwin/core-backend";
 import { OpenMode } from "@itwin/core-bentley";
-import { Code } from "@itwin/core-common";
 import { IModelConnection } from "@itwin/core-frontend";
 import { Schema, SchemaContext } from "@itwin/ecschema-metadata";
 import { createFileNameFromString, getTestName, setupOutputFileLocation } from "./FilenameUtils.js";
 
 import type { ECDb } from "@itwin/core-backend";
-import type { Id64String } from "@itwin/core-bentley";
-import type {
-  BisCodeSpec,
-  CodeScopeProps,
-  ElementAspectProps,
-  ElementProps,
-  ModelProps,
-  RelationshipProps,
-} from "@itwin/core-common";
 import type { SchemaInfo, SchemaKey, SchemaMatchType } from "@itwin/ecschema-metadata";
-
-export interface IIModelBuilder {
-  insertModel<TProps extends ModelProps>(props: TProps): Id64String;
-  insertElement<TProps extends ElementProps>(props: TProps): Id64String;
-  insertAspect<TProps extends ElementAspectProps>(props: TProps): Id64String;
-  insertRelationship<TProps extends RelationshipProps>(props: TProps): Id64String;
-  createCode(scopeModelId: CodeScopeProps, codeSpecName: BisCodeSpec, codeValue: string): Code;
-  importSchema(schemaXml: string): Promise<void>;
-  deleteElement(elementId: Id64String): void;
-  updateElement<TProps extends ElementProps>(props: Partial<Omit<TProps, "id">> & { id: Id64String }): void;
-}
-
-export class TestIModelBuilderImpl implements IIModelBuilder {
-  private _imodel: IModelDb;
-
-  constructor(iModel: IModelDb) {
-    this._imodel = iModel;
-  }
-
-  public insertModel<TProps extends ModelProps>(props: TProps): Id64String {
-    return this._imodel.models.insertModel(props);
-  }
-
-  public insertElement<TProps extends ElementProps>(props: TProps): Id64String {
-    return this._imodel.elements.insertElement(props);
-  }
-
-  public insertAspect<TProps extends ElementAspectProps>(props: TProps): Id64String {
-    return this._imodel.elements.insertAspect(props);
-  }
-
-  public insertRelationship<TProps extends RelationshipProps>(props: TProps): Id64String {
-    return this._imodel.relationships.insertInstance(props);
-  }
-
-  public deleteElement(elementId: Id64String): void {
-    this._imodel.elements.deleteElement(elementId);
-  }
-
-  public updateElement<TProps extends ElementProps>(props: Partial<Omit<TProps, "id">> & { id: Id64String }): void {
-    this._imodel.elements.updateElement(props);
-  }
-
-  public createCode(scopeModelId: CodeScopeProps, codeSpecName: BisCodeSpec, codeValue: string): Code {
-    const codeSpec = this._imodel.codeSpecs.getByName(codeSpecName);
-    return new Code({ spec: codeSpec.id, scope: scopeModelId, value: codeValue });
-  }
-
-  public async importSchema(schemaXml: string) {
-    await this._imodel.importSchemaStrings([schemaXml]);
-  }
-}
 
 /**
  * Create test iModel and returns a connection to it.
@@ -80,55 +18,58 @@ export class TestIModelBuilderImpl implements IIModelBuilder {
  * **Note:** do not call this function outside `it` block without name. It uses `expect.getState().currentTestName` to determine the test name.
  */
 export async function buildTestIModel<TResult extends {} | void>(
-  cb: (builder: IIModelBuilder, testName: string) => TResult | Promise<TResult>,
-): Promise<TResult & { imodel: TestIModelConnection }>;
+  cb: (imodel: IModelDb, testName: string) => TResult | Promise<TResult>,
+): Promise<TResult & { imodelConnection: TestIModelConnection }>;
 export async function buildTestIModel<TResult extends {} | void>(
   name: string,
-  cb: (builder: IIModelBuilder, testName: string) => TResult | Promise<TResult>,
-): Promise<TResult & { imodel: TestIModelConnection }>;
+  cb: (imodel: IModelDb, testName: string) => TResult | Promise<TResult>,
+): Promise<TResult & { imodelConnection: TestIModelConnection }>;
 export async function buildTestIModel(
-  cb?: (builder: IIModelBuilder, testName: string) => void | Promise<void>,
-): Promise<{ imodel: TestIModelConnection }>;
+  cb?: (imodel: IModelDb, testName: string) => void | Promise<void>,
+): Promise<{ imodelConnection: TestIModelConnection }>;
 export async function buildTestIModel(
   name: string,
-  cb?: (builder: IIModelBuilder, testName: string) => void | Promise<void>,
-): Promise<{ imodel: TestIModelConnection }>;
+  cb?: (imodel: IModelDb, testName: string) => void | Promise<void>,
+): Promise<{ imodelConnection: TestIModelConnection }>;
 export async function buildTestIModel<TResult extends {} | void>(
-  nameOrCb?: string | ((builder: IIModelBuilder, testName: string) => TResult | Promise<TResult>),
-  cb?: (builder: IIModelBuilder, testName: string) => TResult | Promise<TResult>,
-): Promise<TResult & { imodel: TestIModelConnection }> {
+  nameOrCb?: string | ((imodel: IModelDb, testName: string) => TResult | Promise<TResult>),
+  cb?: (imodel: IModelDb, testName: string) => TResult | Promise<TResult>,
+): Promise<TResult & { imodelConnection: TestIModelConnection }> {
   const name = typeof nameOrCb === "string" ? nameOrCb : getTestName();
   const callback = typeof nameOrCb === "function" ? nameOrCb : cb;
   const fileName = createFileNameFromString(`${name}.bim`);
   const outputFile = setupOutputFileLocation(fileName);
   const db = SnapshotDb.createEmpty(outputFile, { rootSubject: { name } });
-  const builder = new TestIModelBuilderImpl(db);
   let result!: TResult;
   try {
     if (callback) {
-      result = await callback(builder, name);
+      result = await callback(db, name);
     }
   } finally {
     db.saveChanges("Created test IModel");
     db.close();
   }
-  return { ...result, imodel: TestIModelConnection.openFile(outputFile) };
+  return { ...result, imodelConnection: TestIModelConnection.openFile(outputFile) };
 }
 
 async function cloneIModel<TResult extends {}>(
   sourceIModelPath: string,
   targetIModelName: string,
-  setup: (db: IIModelBuilder) => Promise<TResult>,
-): Promise<TResult & { imodel: IModelConnection; imodelPath: string }> {
+  setup: (db: IModelDb) => Promise<TResult>,
+): Promise<TResult & { imodelConnection: IModelConnection; imodelPath: string }> {
   const targetIModelPath = setupOutputFileLocation(`${targetIModelName}.bim`);
   IModelJsFs.existsSync(targetIModelPath) && IModelJsFs.unlinkSync(targetIModelPath);
   IModelJsFs.copySync(sourceIModelPath, targetIModelPath);
 
   const imodel = StandaloneDb.openFile(targetIModelPath, OpenMode.ReadWrite);
   try {
-    const res = await setup(new TestIModelBuilderImpl(imodel));
+    const res = await setup(imodel);
     imodel.saveChanges("Updated cloned iModel");
-    return { ...res, imodel: new TestIModelConnection(imodel, targetIModelPath), imodelPath: targetIModelPath };
+    return {
+      ...res,
+      imodelConnection: new TestIModelConnection(imodel, targetIModelPath),
+      imodelPath: targetIModelPath,
+    };
   } catch (e) {
     imodel.close();
     throw e;
@@ -136,12 +77,12 @@ async function cloneIModel<TResult extends {}>(
 }
 
 export async function createChangedIModels<TResultBase extends {}, TResultChangeset1 extends {}>(
-  setupBase: (imodel: IIModelBuilder) => Promise<TResultBase>,
-  setupChangeset1: (imodel: IIModelBuilder, before: TResultBase) => Promise<TResultChangeset1>,
+  setupBase: (imodel: IModelDb) => Promise<TResultBase>,
+  setupChangeset1: (imodel: IModelDb, before: TResultBase) => Promise<TResultChangeset1>,
 ) {
   const testName = getTestName();
   const base = await buildTestIModel(`${testName}-base`, setupBase);
-  const baseIModelPath = base.imodel.filePath;
+  const baseIModelPath = base.imodelConnection.filePath;
   const changeset1 = await cloneIModel(baseIModelPath, `${testName}-changeset1`, async (ecdb) =>
     setupChangeset1(ecdb, base),
   );
@@ -149,8 +90,8 @@ export async function createChangedIModels<TResultBase extends {}, TResultChange
     base,
     changeset1,
     async [Symbol.asyncDispose]() {
-      await base.imodel.close();
-      await changeset1.imodel.close();
+      await base.imodelConnection.close();
+      await changeset1.imodelConnection.close();
     },
   };
 }

--- a/apps/full-stack-tests/src/SchemaUtils.ts
+++ b/apps/full-stack-tests/src/SchemaUtils.ts
@@ -15,7 +15,9 @@ export async function importSchema(
   testNameOrSchemaProps:
     | string
     | { schemaName: string; schemaAlias: string; schemaVersion?: `${string}.${string}.${string}` },
-  imodel: { importSchema: (xml: string) => Promise<void> | void },
+  imodel:
+    | { importSchemaStrings: (xmls: string[]) => Promise<void> }
+    | { importSchema: (xml: string) => Promise<void> | void },
   schemaContentXml: string,
 ) {
   const schemaProps = ((): {
@@ -36,7 +38,11 @@ export async function importSchema(
   })();
 
   const schemaXml = getFullSchemaXml({ ...schemaProps, schemaContentXml });
-  await imodel.importSchema(schemaXml);
+  if ("importSchemaStrings" in imodel) {
+    await imodel.importSchemaStrings([schemaXml]);
+  } else {
+    await imodel.importSchema(schemaXml);
+  }
 
   const parsedSchema = new XMLParser({
     ignoreAttributes: false,

--- a/apps/full-stack-tests/src/components/properties/ErrorHandling.test.tsx
+++ b/apps/full-stack-tests/src/components/properties/ErrorHandling.test.tsx
@@ -76,11 +76,11 @@ describe("Learning snippets", () => {
       // set up imodel for the test
       let elementKey: InstanceKey | undefined;
 
-      const { imodel } = await buildTestIModel(async (builder) => {
-        const categoryKey = insertSpatialCategory({ builder, codeValue: "My Category" });
-        const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "My Model" });
+      const { imodelConnection } = await buildTestIModel(async (imodel) => {
+        const categoryKey = insertSpatialCategory({ imodel, codeValue: "My Category" });
+        const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "My Model" });
         elementKey = insertPhysicalElement({
-          builder,
+          imodel,
           userLabel: "My Element",
           modelId: modelKey.id,
           categoryId: categoryKey.id,
@@ -89,7 +89,7 @@ describe("Learning snippets", () => {
       assert(elementKey !== undefined);
 
       // render the component
-      const { container, rerender } = render(<MyPropertyGrid imodel={imodel} elementKey={elementKey} />);
+      const { container, rerender } = render(<MyPropertyGrid imodel={imodelConnection} elementKey={elementKey} />);
       // cspell:disable-next-line
       await ensurePropertyGridHasPropertyRecord(container, "$élêçtèd Ítêm(s)", "User Label", "My Element");
 
@@ -106,7 +106,7 @@ describe("Learning snippets", () => {
       }
 
       // re-render the component, ensure we now get an error
-      rerender(<MyPropertyGrid imodel={imodel} elementKey={{ ...elementKey }} />);
+      rerender(<MyPropertyGrid imodel={imodelConnection} elementKey={{ ...elementKey }} />);
       await ensureHasError(container, "Network error");
       consoleStub.mockRestore();
     });

--- a/apps/full-stack-tests/src/components/properties/PresentationFilterBuilderValueRenderer.test.tsx
+++ b/apps/full-stack-tests/src/components/properties/PresentationFilterBuilderValueRenderer.test.tsx
@@ -38,10 +38,10 @@ describe("Presentation filter builder value renderer", () => {
 
   it("renders 'PresentationFilterBuilderValueRenderer' with correct property values when selected classes are provided", async () => {
     let schemaAlias = "";
-    const imodel = await buildTestIModel(async (builder, testName) => {
+    const result = await buildTestIModel(async (imodel, testName) => {
       const schema = await importSchema(
         testName,
-        builder,
+        imodel,
         `
           <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
           <ECEntityClass typeName="MyPhysicalObjectParent">
@@ -57,10 +57,10 @@ describe("Presentation filter builder value renderer", () => {
         `,
       );
       schemaAlias = schema.schemaAlias;
-      const physicalModel = insertPhysicalModelWithPartition({ builder, codeValue: "TestPhysicalModel" });
-      const category = insertSpatialCategory({ builder, codeValue: "Test SpatialCategory" });
+      const physicalModel = insertPhysicalModelWithPartition({ imodel, codeValue: "TestPhysicalModel" });
+      const category = insertSpatialCategory({ imodel, codeValue: "Test SpatialCategory" });
       const parentElement = insertPhysicalElement({
-        builder,
+        imodel,
         modelId: physicalModel.id,
         categoryId: category.id,
         classFullName: schema.items.MyPhysicalObjectParent.fullName,
@@ -68,7 +68,7 @@ describe("Presentation filter builder value renderer", () => {
         ["PropertyName"]: "Parent",
       });
       const element1 = insertPhysicalElement({
-        builder,
+        imodel,
         modelId: physicalModel.id,
         categoryId: category.id,
         classFullName: schema.items.MyPhysicalObject1.fullName,
@@ -77,7 +77,7 @@ describe("Presentation filter builder value renderer", () => {
         ["PropertyName"]: "Value1",
       });
       const element2 = insertPhysicalElement({
-        builder,
+        imodel,
         modelId: physicalModel.id,
         categoryId: category.id,
         classFullName: schema.items.MyPhysicalObject2.fullName,
@@ -95,12 +95,12 @@ describe("Presentation filter builder value renderer", () => {
     };
 
     const keys = new KeySet([
-      { id: imodel.element1.id, className: imodel.element1.className },
-      { id: imodel.element2.id, className: imodel.element2.className },
+      { id: result.element1.id, className: result.element1.className },
+      { id: result.element2.id, className: result.element2.className },
     ]);
 
     const testDescriptor = await Presentation.presentation.getContentDescriptor({
-      imodel: imodel.imodel,
+      imodel: result.imodelConnection,
       rulesetOrId: {
         id: `Test descriptor ruleset`,
         rules: [{ ruleType: "Content", specifications: [{ specType: "SelectedNodeInstances" }] }],
@@ -115,14 +115,14 @@ describe("Presentation filter builder value renderer", () => {
     }
 
     const selectedClasses: ClassInfo[] = [
-      { id: imodel.element1.id, name: imodel.element1.className, label: "Test Class" },
+      { id: result.element1.id, name: result.element1.className, label: "Test Class" },
     ];
 
     const { baseElement, findByRole, user } = render(
       <PresentationFilterBuilderValueRenderer
         property={testProperty}
         onChange={() => {}}
-        imodel={imodel.imodel}
+        imodel={result.imodelConnection}
         descriptor={testDescriptor}
         descriptorInputKeys={keys}
         selectedClasses={selectedClasses}
@@ -141,10 +141,10 @@ describe("Presentation filter builder value renderer", () => {
 
   it("renders 'PresentationFilterBuilderValueRenderer' with correct property values when selected classes are provided without keys", async () => {
     let schemaAlias = "";
-    const imodel = await buildTestIModel(async (builder, testName) => {
+    const result = await buildTestIModel(async (imodel, testName) => {
       const schema = await importSchema(
         testName,
-        builder,
+        imodel,
         `
           <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
           <ECEntityClass typeName="MyPhysicalObjectParent">
@@ -160,10 +160,10 @@ describe("Presentation filter builder value renderer", () => {
         `,
       );
       schemaAlias = schema.schemaAlias;
-      const physicalModel = insertPhysicalModelWithPartition({ builder, codeValue: "TestPhysicalModel" });
-      const category = insertSpatialCategory({ builder, codeValue: "Test SpatialCategory" });
+      const physicalModel = insertPhysicalModelWithPartition({ imodel, codeValue: "TestPhysicalModel" });
+      const category = insertSpatialCategory({ imodel, codeValue: "Test SpatialCategory" });
       const parentElement = insertPhysicalElement({
-        builder,
+        imodel,
         modelId: physicalModel.id,
         categoryId: category.id,
         classFullName: schema.items.MyPhysicalObjectParent.fullName,
@@ -171,7 +171,7 @@ describe("Presentation filter builder value renderer", () => {
         ["PropertyName"]: "Parent",
       });
       const element1 = insertPhysicalElement({
-        builder,
+        imodel,
         modelId: physicalModel.id,
         categoryId: category.id,
         classFullName: schema.items.MyPhysicalObject1.fullName,
@@ -180,7 +180,7 @@ describe("Presentation filter builder value renderer", () => {
         ["PropertyName"]: "Value1",
       });
       const element2 = insertPhysicalElement({
-        builder,
+        imodel,
         modelId: physicalModel.id,
         categoryId: category.id,
         classFullName: schema.items.MyPhysicalObject2.fullName,
@@ -198,12 +198,12 @@ describe("Presentation filter builder value renderer", () => {
     };
 
     const keys = new KeySet([
-      { id: imodel.element1.id, className: imodel.element1.className },
-      { id: imodel.element2.id, className: imodel.element2.className },
+      { id: result.element1.id, className: result.element1.className },
+      { id: result.element2.id, className: result.element2.className },
     ]);
 
     const testDescriptor = await Presentation.presentation.getContentDescriptor({
-      imodel: imodel.imodel,
+      imodel: result.imodelConnection,
       rulesetOrId: {
         id: `Test descriptor ruleset`,
         rules: [{ ruleType: "Content", specifications: [{ specType: "SelectedNodeInstances" }] }],
@@ -218,14 +218,14 @@ describe("Presentation filter builder value renderer", () => {
     }
 
     const selectedClasses: ClassInfo[] = [
-      { id: imodel.element1.id, name: imodel.element1.className, label: "Test Class" },
+      { id: result.element1.id, name: result.element1.className, label: "Test Class" },
     ];
 
     const { baseElement, findByRole, user } = render(
       <PresentationFilterBuilderValueRenderer
         property={testProperty}
         onChange={() => {}}
-        imodel={imodel.imodel}
+        imodel={result.imodelConnection}
         descriptor={testDescriptor}
         selectedClasses={selectedClasses}
         operator={"is-equal"}

--- a/apps/full-stack-tests/src/components/properties/PropertyEditors.test.tsx
+++ b/apps/full-stack-tests/src/components/properties/PropertyEditors.test.tsx
@@ -39,10 +39,10 @@ describe("Property editors", () => {
   });
 
   it("renders property values with koq's overridden through `IModelApp.formatsProvider`", async () => {
-    const { imodel, schema, ...imodelKeys } = await buildTestIModel(async (builder, testName) => {
+    const { imodelConnection, schema, ...imodelKeys } = await buildTestIModel(async (imodel, testName) => {
       const mySchema = await importSchema(
         testName,
-        builder,
+        imodel,
         `
           <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
           <ECSchemaReference name="Units" version="01.00.09" alias="u" />
@@ -54,10 +54,10 @@ describe("Property editors", () => {
           </ECEntityClass>
         `,
       );
-      const model = insertPhysicalModelWithPartition({ builder, codeValue: "TestPhysicalModel" });
-      const category = insertSpatialCategory({ builder, codeValue: "TestSpatialCategory" });
+      const model = insertPhysicalModelWithPartition({ imodel, codeValue: "TestPhysicalModel" });
+      const category = insertSpatialCategory({ imodel, codeValue: "TestSpatialCategory" });
       const element = insertPhysicalElement({
-        builder,
+        imodel,
         modelId: model.id,
         categoryId: category.id,
         classFullName: mySchema.items.MyPhysicalObject.fullName,
@@ -84,7 +84,7 @@ describe("Property editors", () => {
       onFormatsChanged: new BeEvent(),
     };
 
-    const provider = new PresentationPropertyDataProvider({ imodel });
+    const provider = new PresentationPropertyDataProvider({ imodel: imodelConnection });
     provider.keys = new KeySet([imodelKeys.element]);
 
     const descriptor = await provider.getContentDescriptor();
@@ -110,7 +110,7 @@ describe("Property editors", () => {
     const commitSpy = vi.fn();
     const cancelSpy = vi.fn();
     const { getByPlaceholderText, findByRole, user } = render(
-      <SchemaMetadataContextProvider imodel={imodel} schemaContextProvider={(x) => x.schemaContext}>
+      <SchemaMetadataContextProvider imodel={imodelConnection} schemaContextProvider={(x) => x.schemaContext}>
         <EditorContainer propertyRecord={propertyRecord!} onCommit={commitSpy} onCancel={cancelSpy} />
       </SchemaMetadataContextProvider>,
     );
@@ -131,10 +131,10 @@ describe("Property editors", () => {
   });
 
   it("edits merged values", async () => {
-    const { imodel, schema, ...imodelKeys } = await buildTestIModel(async (builder, testName) => {
+    const { imodelConnection, schema, ...imodelKeys } = await buildTestIModel(async (imodel, testName) => {
       const mySchema = await importSchema(
         testName,
-        builder,
+        imodel,
         `
           <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
           <ECEntityClass typeName="MyPhysicalObject">
@@ -143,10 +143,10 @@ describe("Property editors", () => {
           </ECEntityClass>
         `,
       );
-      const model = insertPhysicalModelWithPartition({ builder, codeValue: "TestPhysicalModel" });
-      const category = insertSpatialCategory({ builder, codeValue: "TestSpatialCategory" });
+      const model = insertPhysicalModelWithPartition({ imodel, codeValue: "TestPhysicalModel" });
+      const category = insertSpatialCategory({ imodel, codeValue: "TestSpatialCategory" });
       const element1 = insertPhysicalElement({
-        builder,
+        imodel,
         modelId: model.id,
         categoryId: category.id,
         classFullName: mySchema.items.MyPhysicalObject.fullName,
@@ -154,7 +154,7 @@ describe("Property editors", () => {
         ["MyProperty"]: 1.23,
       });
       const element2 = insertPhysicalElement({
-        builder,
+        imodel,
         modelId: model.id,
         categoryId: category.id,
         classFullName: mySchema.items.MyPhysicalObject.fullName,
@@ -163,7 +163,7 @@ describe("Property editors", () => {
       return { element1, element2, schema: mySchema };
     });
 
-    const provider = new PresentationPropertyDataProvider({ imodel });
+    const provider = new PresentationPropertyDataProvider({ imodel: imodelConnection });
     provider.keys = new KeySet([imodelKeys.element1, imodelKeys.element2]);
 
     const descriptor = await provider.getContentDescriptor();

--- a/apps/full-stack-tests/src/components/properties/PropertyPaneDataProvider.test.ts
+++ b/apps/full-stack-tests/src/components/properties/PropertyPaneDataProvider.test.ts
@@ -53,10 +53,10 @@ describe("PropertyDataProvider", async () => {
       });
 
       it("creates empty result when properties requested for 0 instances", async () => {
-        const { imodel } = await buildTestIModel(async (builder) => {
-          insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
+        const { imodelConnection } = await buildTestIModel(async (imodel) => {
+          insertSpatialCategory({ imodel, fullClassNameSeparator: ":", codeValue: "My Category" });
         });
-        using provider = createProvider({ imodel, ruleset: DEFAULT_PROPERTY_GRID_RULESET });
+        using provider = createProvider({ imodel: imodelConnection, ruleset: DEFAULT_PROPERTY_GRID_RULESET });
         provider.keys = new KeySet();
         const properties = await provider.getData();
         expect(Object.keys(properties.records)).toHaveLength(0);
@@ -67,18 +67,18 @@ describe("PropertyDataProvider", async () => {
         let modelKey: InstanceKey;
         let elementKey: InstanceKey;
 
-        const { imodel } = await buildTestIModel(async (builder) => {
-          categoryKey = insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
-          modelKey = insertPhysicalModelWithPartition({ builder, fullClassNameSeparator: ":", codeValue: "My Model" });
+        const { imodelConnection } = await buildTestIModel(async (imodel) => {
+          categoryKey = insertSpatialCategory({ imodel, fullClassNameSeparator: ":", codeValue: "My Category" });
+          modelKey = insertPhysicalModelWithPartition({ imodel, fullClassNameSeparator: ":", codeValue: "My Model" });
           elementKey = insertPhysicalElement({
-            builder,
+            imodel,
             fullClassNameSeparator: ":",
             userLabel: "My Element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           });
         });
-        using provider = createProvider({ imodel, ruleset: DEFAULT_PROPERTY_GRID_RULESET });
+        using provider = createProvider({ imodel: imodelConnection, ruleset: DEFAULT_PROPERTY_GRID_RULESET });
         provider.keys = new KeySet([elementKey!]);
         const properties = await provider.getData();
         expect((properties.label.value as PrimitiveValue).displayValue).toContain("My Element");
@@ -114,18 +114,18 @@ describe("PropertyDataProvider", async () => {
         let modelKey: InstanceKey;
         let elementKey: InstanceKey;
 
-        const { imodel } = await buildTestIModel(async (builder) => {
-          categoryKey = insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
-          modelKey = insertPhysicalModelWithPartition({ builder, fullClassNameSeparator: ":", codeValue: "My Model" });
+        const { imodelConnection } = await buildTestIModel(async (imodel) => {
+          categoryKey = insertSpatialCategory({ imodel, fullClassNameSeparator: ":", codeValue: "My Category" });
+          modelKey = insertPhysicalModelWithPartition({ imodel, fullClassNameSeparator: ":", codeValue: "My Model" });
           elementKey = insertPhysicalElement({
-            builder,
+            imodel,
             fullClassNameSeparator: ":",
             userLabel: "My Element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           });
         });
-        using provider = createProvider({ imodel, ruleset: DEFAULT_PROPERTY_GRID_RULESET });
+        using provider = createProvider({ imodel: imodelConnection, ruleset: DEFAULT_PROPERTY_GRID_RULESET });
         provider.keys = new KeySet([{ className: "BisCore:Element", id: elementKey!.id }]);
         const properties = await provider.getData();
         expect((properties.label.value as PrimitiveValue).displayValue).toContain("My Element");
@@ -159,10 +159,10 @@ describe("PropertyDataProvider", async () => {
       it("favorites properties", async () => {
         let categoryKey: InstanceKey;
 
-        const { imodel } = await buildTestIModel(async (builder) => {
-          categoryKey = insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
+        const { imodelConnection } = await buildTestIModel(async (imodel) => {
+          categoryKey = insertSpatialCategory({ imodel, fullClassNameSeparator: ":", codeValue: "My Category" });
         });
-        using provider = createProvider({ imodel, ruleset: DEFAULT_PROPERTY_GRID_RULESET });
+        using provider = createProvider({ imodel: imodelConnection, ruleset: DEFAULT_PROPERTY_GRID_RULESET });
         vi.spyOn(provider as any, "isFieldFavorite").mockReturnValue(true);
         provider.keys = new KeySet([categoryKey!]);
         const properties = await provider.getData();
@@ -184,11 +184,11 @@ describe("PropertyDataProvider", async () => {
       it("overrides default property category", async () => {
         let categoryKey: InstanceKey;
 
-        const { imodel } = await buildTestIModel(async (builder) => {
-          categoryKey = insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
+        const { imodelConnection } = await buildTestIModel(async (imodel) => {
+          categoryKey = insertSpatialCategory({ imodel, fullClassNameSeparator: ":", codeValue: "My Category" });
         });
         using provider = createProvider({
-          imodel,
+          imodel: imodelConnection,
           ruleset: {
             ...DEFAULT_PROPERTY_GRID_RULESET,
             rules: [
@@ -218,11 +218,11 @@ describe("PropertyDataProvider", async () => {
       it("finds root property record keys", async () => {
         let categoryKey: InstanceKey;
 
-        const { imodel } = await buildTestIModel(async (builder) => {
-          categoryKey = insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
+        const { imodelConnection } = await buildTestIModel(async (imodel) => {
+          categoryKey = insertSpatialCategory({ imodel, fullClassNameSeparator: ":", codeValue: "My Category" });
         });
 
-        using provider = createProvider({ imodel, ruleset: DEFAULT_PROPERTY_GRID_RULESET });
+        using provider = createProvider({ imodel: imodelConnection, ruleset: DEFAULT_PROPERTY_GRID_RULESET });
         provider.keys = new KeySet([categoryKey!]);
         const properties = await provider.getData();
 
@@ -240,28 +240,28 @@ describe("PropertyDataProvider", async () => {
         let elementKey: InstanceKey;
         let externalsSourceAspectKey: InstanceKey;
 
-        const { imodel } = await buildTestIModel(async (builder) => {
-          const categoryKey = insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
+        const { imodelConnection } = await buildTestIModel(async (imodel) => {
+          const categoryKey = insertSpatialCategory({ imodel, fullClassNameSeparator: ":", codeValue: "My Category" });
           const modelKey = insertPhysicalModelWithPartition({
-            builder,
+            imodel,
             fullClassNameSeparator: ":",
             codeValue: "My Model",
           });
           elementKey = insertPhysicalElement({
-            builder,
+            imodel,
             fullClassNameSeparator: ":",
             userLabel: "My Element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           });
           const repositoryLinkKey = insertRepositoryLink({
-            builder,
+            imodel,
             fullClassNameSeparator: ":",
             repositoryUrl: "Repository URL",
             repositoryLabel: "Repository Label",
           });
           externalsSourceAspectKey = insertExternalSourceAspect({
-            builder,
+            imodel,
             fullClassNameSeparator: ":",
             elementId: elementKey.id,
             identifier: "My External Source Aspect",
@@ -269,7 +269,7 @@ describe("PropertyDataProvider", async () => {
           });
         });
 
-        using provider = createProvider({ imodel, ruleset: DEFAULT_PROPERTY_GRID_RULESET });
+        using provider = createProvider({ imodel: imodelConnection, ruleset: DEFAULT_PROPERTY_GRID_RULESET });
         provider.keys = new KeySet([elementKey!]);
         const properties = await provider.getData();
 
@@ -302,10 +302,10 @@ describe("PropertyDataProvider", async () => {
   runTests("with nested property categories", (provider) => (provider.isNestedPropertyCategoryGroupingEnabled = true));
 
   it("finds array item & struct member fields", async () => {
-    const { imodel, ...keys } = await buildTestIModel(async (builder, testName) => {
+    const { imodelConnection, ...keys } = await buildTestIModel(async (imodel, testName) => {
       const schema = await importSchema(
         testName,
-        builder,
+        imodel,
         `
           <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
           <ECStructClass typeName="TestStruct">
@@ -320,14 +320,10 @@ describe("PropertyDataProvider", async () => {
           </ECEntityClass>
         `,
       );
-      const categoryKey = insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
-      const modelKey = insertPhysicalModelWithPartition({
-        builder,
-        fullClassNameSeparator: ":",
-        codeValue: "My Model",
-      });
+      const categoryKey = insertSpatialCategory({ imodel, fullClassNameSeparator: ":", codeValue: "My Category" });
+      const modelKey = insertPhysicalModelWithPartition({ imodel, fullClassNameSeparator: ":", codeValue: "My Model" });
       const elementKey = insertPhysicalElement({
-        builder,
+        imodel,
         classFullName: `${schema.schemaAlias}:TestPhysicalObject` as const,
         userLabel: "Test element",
         modelId: modelKey.id,
@@ -342,7 +338,7 @@ describe("PropertyDataProvider", async () => {
       return { element: elementKey };
     });
 
-    using provider = new PresentationPropertyDataProvider({ imodel });
+    using provider = new PresentationPropertyDataProvider({ imodel: imodelConnection });
     provider.keys = new KeySet([keys.element]);
     const properties = await provider.getData();
 
@@ -491,11 +487,11 @@ describe("PropertyDataProvider", async () => {
   it("gets property data after re-initializing Presentation", async () => {
     let categoryKey: InstanceKey;
 
-    const { imodel } = await buildTestIModel(async (builder) => {
-      categoryKey = insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
+    const { imodelConnection } = await buildTestIModel(async (imodel) => {
+      categoryKey = insertSpatialCategory({ imodel, fullClassNameSeparator: ":", codeValue: "My Category" });
     });
     const checkDataProvider = async () => {
-      using provider = new PresentationPropertyDataProvider({ imodel });
+      using provider = new PresentationPropertyDataProvider({ imodel: imodelConnection });
       provider.keys = new KeySet([categoryKey]);
       const properties = await provider.getData();
       expect(properties.categories).not.toHaveLength(0);

--- a/apps/full-stack-tests/src/components/table/ErrorHandling.test.tsx
+++ b/apps/full-stack-tests/src/components/table/ErrorHandling.test.tsx
@@ -125,16 +125,16 @@ describe("Learning snippets", () => {
 
       // set up imodel for the test
       let modelKey: InstanceKey | undefined;
-      const { imodel } = await buildTestIModel(async (builder) => {
-        const categoryKey = insertSpatialCategory({ builder, codeValue: "My Category" });
-        modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "My Model" });
-        insertPhysicalElement({ builder, userLabel: "My Element 1", modelId: modelKey.id, categoryId: categoryKey.id });
-        insertPhysicalElement({ builder, userLabel: "My Element 2", modelId: modelKey.id, categoryId: categoryKey.id });
+      const { imodelConnection } = await buildTestIModel(async (imodel) => {
+        const categoryKey = insertSpatialCategory({ imodel, codeValue: "My Category" });
+        modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "My Model" });
+        insertPhysicalElement({ imodel, userLabel: "My Element 1", modelId: modelKey.id, categoryId: categoryKey.id });
+        insertPhysicalElement({ imodel, userLabel: "My Element 2", modelId: modelKey.id, categoryId: categoryKey.id });
       });
       assert(modelKey !== undefined);
 
       // render the component
-      const { container, rerender } = render(<MyTable imodel={imodel} keys={new KeySet([modelKey])} />);
+      const { container, rerender } = render(<MyTable imodel={imodelConnection} keys={new KeySet([modelKey])} />);
       await ensureTableHasRowsWithCellValues(container, "User Label", ["My Element 1", "My Element 2"]);
 
       // simulate a network error in RPC request
@@ -150,7 +150,7 @@ describe("Learning snippets", () => {
       }
 
       // re-render the component, ensure we now get an error
-      rerender(<MyTable imodel={imodel} keys={new KeySet([modelKey])} />);
+      rerender(<MyTable imodel={imodelConnection} keys={new KeySet([modelKey])} />);
       await ensureHasError(container, "Network error");
       consoleStub.mockRestore();
     });

--- a/apps/full-stack-tests/src/components/tree/ErrorHandling.test.tsx
+++ b/apps/full-stack-tests/src/components/tree/ErrorHandling.test.tsx
@@ -73,19 +73,19 @@ describe("Learning snippets", () => {
       // __PUBLISH_EXTRACT_END__
 
       // set up imodel for the test
-      const { imodel } = await buildTestIModel((builder) => {
-        const categoryKey = insertSpatialCategory({ builder, codeValue: "My Category" });
-        const modelKeyA = insertPhysicalModelWithPartition({ builder, codeValue: "My Model A" });
-        const modelKeyB = insertPhysicalModelWithPartition({ builder, codeValue: "My Model B" });
+      const { imodelConnection } = await buildTestIModel((imodel) => {
+        const categoryKey = insertSpatialCategory({ imodel, codeValue: "My Category" });
+        const modelKeyA = insertPhysicalModelWithPartition({ imodel, codeValue: "My Model A" });
+        const modelKeyB = insertPhysicalModelWithPartition({ imodel, codeValue: "My Model B" });
         for (let i = 0; i < 2; ++i) {
           insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: `A element ${i + 1}`,
             modelId: modelKeyA.id,
             categoryId: categoryKey.id,
           });
           insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: `B element ${i + 1}`,
             modelId: modelKeyB.id,
             categoryId: categoryKey.id,
@@ -94,7 +94,7 @@ describe("Learning snippets", () => {
       });
 
       // render the component
-      const { container, getByText, rerender } = render(<MyTree imodel={imodel} />);
+      const { container, getByText, rerender } = render(<MyTree imodel={imodelConnection} />);
       await waitFor(() => getByRole(container, "tree"));
 
       // find & expand model A node
@@ -128,7 +128,7 @@ describe("Learning snippets", () => {
       expect(() => getNodeByLabel(container, `B element 2`)).toThrow();
 
       // now try to force-rerender the tree to see how the error is handled at the root nodes' level
-      rerender(<MyTree key={Guid.createValue()} imodel={imodel} />);
+      rerender(<MyTree key={Guid.createValue()} imodel={imodelConnection} />);
       await waitFor(() => getByRole(container, "tree"));
       expect(() => getNodeByLabel(container, `My Model A`)).toThrow();
       expect(() => getNodeByLabel(container, `My Model B`)).toThrow();

--- a/apps/full-stack-tests/src/components/tree/HierarchyLevelFiltering.test.tsx
+++ b/apps/full-stack-tests/src/components/tree/HierarchyLevelFiltering.test.tsx
@@ -73,15 +73,15 @@ describe("Learning snippets", () => {
       // __PUBLISH_EXTRACT_END__
 
       // set up imodel for the test
-      const { imodel } = await buildTestIModel(async (builder) => {
-        const categoryKey = insertSpatialCategory({ builder, codeValue: "My Category" });
-        const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "My Model" });
-        insertPhysicalElement({ builder, userLabel: "My Element 1", modelId: modelKey.id, categoryId: categoryKey.id });
-        insertPhysicalElement({ builder, userLabel: "My Element 2", modelId: modelKey.id, categoryId: categoryKey.id });
+      const { imodelConnection } = await buildTestIModel(async (imodel) => {
+        const categoryKey = insertSpatialCategory({ imodel, codeValue: "My Category" });
+        const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "My Model" });
+        insertPhysicalElement({ imodel, userLabel: "My Element 1", modelId: modelKey.id, categoryId: categoryKey.id });
+        insertPhysicalElement({ imodel, userLabel: "My Element 2", modelId: modelKey.id, categoryId: categoryKey.id });
       });
 
       // render the component
-      const { container, baseElement, user } = render(<MyTree imodel={imodel} />, { addThemeProvider: true });
+      const { container, baseElement, user } = render(<MyTree imodel={imodelConnection} />, { addThemeProvider: true });
       await waitFor(() => getByRole(container, "tree"));
 
       // find & expand the model node

--- a/apps/full-stack-tests/src/components/tree/HierarchyLevelLimiting.test.tsx
+++ b/apps/full-stack-tests/src/components/tree/HierarchyLevelLimiting.test.tsx
@@ -82,21 +82,21 @@ describe("Learning snippets", () => {
       // __PUBLISH_EXTRACT_END__
 
       // set up imodel for the test
-      const { imodel } = await buildTestIModel(async (builder) => {
-        const categoryKey = insertSpatialCategory({ builder, codeValue: "My Category" });
-        const modelKeyA = insertPhysicalModelWithPartition({ builder, codeValue: "My Model A" });
+      const { imodelConnection } = await buildTestIModel(async (imodel) => {
+        const categoryKey = insertSpatialCategory({ imodel, codeValue: "My Category" });
+        const modelKeyA = insertPhysicalModelWithPartition({ imodel, codeValue: "My Model A" });
         for (let i = 0; i < 10; ++i) {
           insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: `A element ${i + 1}`,
             modelId: modelKeyA.id,
             categoryId: categoryKey.id,
           });
         }
-        const modelKeyB = insertPhysicalModelWithPartition({ builder, codeValue: "My Model B" });
+        const modelKeyB = insertPhysicalModelWithPartition({ imodel, codeValue: "My Model B" });
         for (let i = 0; i < 11; ++i) {
           insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: `B element ${i + 1}`,
             modelId: modelKeyB.id,
             categoryId: categoryKey.id,
@@ -105,7 +105,7 @@ describe("Learning snippets", () => {
       });
 
       // render the component
-      const { container, getByText } = render(<MyTree imodel={imodel} />, { addThemeProvider: true });
+      const { container, getByText } = render(<MyTree imodel={imodelConnection} />, { addThemeProvider: true });
       await waitFor(() => getByRole(container, "tree"));
 
       // find & expand both model nodes

--- a/apps/full-stack-tests/src/components/unified-selection/PropertyGrid.test.tsx
+++ b/apps/full-stack-tests/src/components/unified-selection/PropertyGrid.test.tsx
@@ -90,18 +90,18 @@ describe("Learning snippets", async () => {
       // set up imodel for the test
       const elementKeys: InstanceKey[] = [];
 
-      const { imodel } = await buildTestIModel((builder) => {
-        const categoryKey = insertSpatialCategory({ builder, codeValue: "My Category" });
-        const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "My Model" });
+      const { imodelConnection } = await buildTestIModel((imodel) => {
+        const categoryKey = insertSpatialCategory({ imodel, codeValue: "My Category" });
+        const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "My Model" });
         elementKeys.push(
           insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "My Element 1",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           }),
           insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "My Element 2",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
@@ -110,18 +110,26 @@ describe("Learning snippets", async () => {
       });
 
       // render the component
-      const { container } = render(<MyPropertyGrid imodel={imodel} />);
+      const { container } = render(<MyPropertyGrid imodel={imodelConnection} />);
       await waitFor(() => getByText(container, "Select an element to see its properties"));
 
       // test Unified Selection -> Property Grid content synchronization
       act(() =>
-        selectionStorage.replaceSelection({ imodelKey: imodel.key, source: "", selectables: [elementKeys[0]] }),
+        selectionStorage.replaceSelection({
+          imodelKey: imodelConnection.key,
+          source: "",
+          selectables: [elementKeys[0]],
+        }),
       );
       // cspell:disable-next-line
       await ensurePropertyGridHasPropertyRecord(container, "$élêçtèd Ítêm(s)", "User Label", "My Element 1");
 
       act(() =>
-        selectionStorage.replaceSelection({ imodelKey: imodel.key, source: "", selectables: [elementKeys[1]] }),
+        selectionStorage.replaceSelection({
+          imodelKey: imodelConnection.key,
+          source: "",
+          selectables: [elementKeys[1]],
+        }),
       );
       // cspell:disable-next-line
       await ensurePropertyGridHasPropertyRecord(container, "$élêçtèd Ítêm(s)", "User Label", "My Element 2");

--- a/apps/full-stack-tests/src/components/unified-selection/Table.test.tsx
+++ b/apps/full-stack-tests/src/components/unified-selection/Table.test.tsx
@@ -111,18 +111,18 @@ describe("Learning snippets", async () => {
       let modelKey: InstanceKey;
       const elementKeys: InstanceKey[] = [];
 
-      const { imodel } = await buildTestIModel((builder) => {
-        const categoryKey = insertSpatialCategory({ builder, codeValue: "My Category" });
-        modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "My Model" });
+      const { imodelConnection } = await buildTestIModel((imodel) => {
+        const categoryKey = insertSpatialCategory({ imodel, codeValue: "My Category" });
+        modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "My Model" });
         elementKeys.push(
           insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "My Element 1",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           }),
           insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "My Element 2",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
@@ -136,7 +136,7 @@ describe("Learning snippets", async () => {
 
       function App() {
         // pass selection storage to the component to hook into it
-        return <MyTable imodel={imodel} selectionStorage={selectionStorage} />;
+        return <MyTable imodel={imodelConnection} selectionStorage={selectionStorage} />;
       }
       // __PUBLISH_EXTRACT_END__
 
@@ -147,28 +147,38 @@ describe("Learning snippets", async () => {
 
       // test Unified Selection -> Table content synchronization
       act(() =>
-        selectionStorage.replaceSelection({ imodelKey: imodel.key, source: "", selectables: [elementKeys[0]] }),
+        selectionStorage.replaceSelection({
+          imodelKey: imodelConnection.key,
+          source: "",
+          selectables: [elementKeys[0]],
+        }),
       );
       await ensureTableHasRowsWithCellValues(container, "User Label", ["My Element 1"]);
 
       act(() =>
-        selectionStorage.replaceSelection({ imodelKey: imodel.key, source: "", selectables: [elementKeys[1]] }),
+        selectionStorage.replaceSelection({
+          imodelKey: imodelConnection.key,
+          source: "",
+          selectables: [elementKeys[1]],
+        }),
       );
       await ensureTableHasRowsWithCellValues(container, "User Label", ["My Element 2"]);
 
       act(() =>
         selectionStorage.replaceSelection({
-          imodelKey: imodel.key,
+          imodelKey: imodelConnection.key,
           source: "",
           selectables: [elementKeys[0], elementKeys[1]],
         }),
       );
       await ensureTableHasRowsWithCellValues(container, "User Label", ["My Element 1", "My Element 2"]);
 
-      act(() => selectionStorage.clearSelection({ imodelKey: imodel.key, source: "" }));
+      act(() => selectionStorage.clearSelection({ imodelKey: imodelConnection.key, source: "" }));
       await waitFor(() => getByText(container, "Select something to see properties"));
 
-      act(() => selectionStorage.replaceSelection({ imodelKey: imodel.key, source: "", selectables: [modelKey] }));
+      act(() =>
+        selectionStorage.replaceSelection({ imodelKey: imodelConnection.key, source: "", selectables: [modelKey] }),
+      );
       await ensureTableHasRowsWithCellValues(container, "User Label", ["My Element 1", "My Element 2"]);
     });
   });

--- a/apps/full-stack-tests/src/components/unified-selection/Tree.test.tsx
+++ b/apps/full-stack-tests/src/components/unified-selection/Tree.test.tsx
@@ -72,11 +72,11 @@ describe("Learning snippets", async () => {
       // set up imodel for the test
       let modelKey: InstanceKey;
       let elementKey: InstanceKey;
-      const { imodel } = await buildTestIModel(async (builder) => {
-        const categoryKey = insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
-        modelKey = insertPhysicalModelWithPartition({ builder, fullClassNameSeparator: ":", codeValue: "My Model" });
+      const { imodelConnection } = await buildTestIModel(async (imodel) => {
+        const categoryKey = insertSpatialCategory({ imodel, fullClassNameSeparator: ":", codeValue: "My Category" });
+        modelKey = insertPhysicalModelWithPartition({ imodel, fullClassNameSeparator: ":", codeValue: "My Model" });
         elementKey = insertPhysicalElement({
-          builder,
+          imodel,
           fullClassNameSeparator: ":",
           userLabel: "My Element",
           modelId: modelKey.id,
@@ -85,7 +85,7 @@ describe("Learning snippets", async () => {
       });
 
       // render the component
-      const { container, getByRole } = render(<MyTree imodel={imodel} />);
+      const { container, getByRole } = render(<MyTree imodel={imodelConnection} />);
       await waitFor(() => getByRole("tree"));
 
       // find & expand the model node
@@ -95,12 +95,12 @@ describe("Learning snippets", async () => {
       const elementNode = await waitFor(() => getNodeByLabel(container, "My Element"));
 
       // test Unified Selection -> Tree selection synchronization
-      act(() => Presentation.selection.replaceSelection("", imodel, new KeySet([modelKey!])));
+      act(() => Presentation.selection.replaceSelection("", imodelConnection, new KeySet([modelKey!])));
       await waitFor(() => {
         expect(isNodeSelectedInTree(modelNode)).toBe(true);
         expect(isNodeSelectedInTree(elementNode)).toBe(false);
       });
-      act(() => Presentation.selection.replaceSelection("", imodel, new KeySet([elementKey!])));
+      act(() => Presentation.selection.replaceSelection("", imodelConnection, new KeySet([elementKey!])));
       await waitFor(() => {
         expect(isNodeSelectedInTree(modelNode)).toBe(false);
         expect(isNodeSelectedInTree(elementNode)).toBe(true);
@@ -109,11 +109,11 @@ describe("Learning snippets", async () => {
       // test Tree selection -> Unified Selection synchronization
       fireEvent.click(modelNode);
       await waitFor(() => {
-        expect(getInstanceKeysInUnifiedSelection(imodel)).toEqual([modelKey]);
+        expect(getInstanceKeysInUnifiedSelection(imodelConnection)).toEqual([modelKey]);
       });
       fireEvent.click(elementNode);
       await waitFor(() => {
-        expect(getInstanceKeysInUnifiedSelection(imodel)).toEqual([elementKey]);
+        expect(getInstanceKeysInUnifiedSelection(imodelConnection)).toEqual([elementKey]);
       });
     });
   });

--- a/apps/full-stack-tests/src/components/unified-selection/Viewport.test.tsx
+++ b/apps/full-stack-tests/src/components/unified-selection/Viewport.test.tsx
@@ -42,23 +42,23 @@ describe("Learning snippets", async () => {
       const UnifiedSelectionViewport = viewWithUnifiedSelection(ViewportComponent);
       // besides the above line, the component may be used just like the general `ViewportComponent` from `@itwin/imodel-components-react`
       function MyViewport(props: { imodel: IModelConnection; initialViewState: ViewState }) {
-        return <UnifiedSelectionViewport imodel={imodel} viewState={props.initialViewState} />;
+        return <UnifiedSelectionViewport imodel={imodelConnection} viewState={props.initialViewState} />;
       }
       // __PUBLISH_EXTRACT_END__
 
       // set up imodel for the test
       const elementKeys: InstanceKey[] = [];
 
-      const { imodel } = await buildTestIModel(async (builder) => {
-        const categoryKey = insertSpatialCategory({ builder, fullClassNameSeparator: ":", codeValue: "My Category" });
+      const { imodelConnection } = await buildTestIModel(async (imodel) => {
+        const categoryKey = insertSpatialCategory({ imodel, fullClassNameSeparator: ":", codeValue: "My Category" });
         const modelKey = insertPhysicalModelWithPartition({
-          builder,
+          imodel,
           fullClassNameSeparator: ":",
           codeValue: "My Model",
         });
         (elementKeys.push(
           insertPhysicalElement({
-            builder,
+            imodel,
             fullClassNameSeparator: ":",
             userLabel: "My Assembly Element",
             modelId: modelKey.id,
@@ -67,7 +67,7 @@ describe("Learning snippets", async () => {
         ),
           elementKeys.push(
             insertPhysicalElement({
-              builder,
+              imodel,
               fullClassNameSeparator: ":",
               userLabel: "My Child Element 1",
               modelId: modelKey.id,
@@ -75,7 +75,7 @@ describe("Learning snippets", async () => {
               parentId: elementKeys[0].id,
             }),
             insertPhysicalElement({
-              builder,
+              imodel,
               fullClassNameSeparator: ":",
               userLabel: "My Child Element 2",
               modelId: modelKey.id,
@@ -91,42 +91,50 @@ describe("Learning snippets", async () => {
       // render the component
       const { getByTestId } = render(
         <MyViewport
-          imodel={imodel}
-          initialViewState={SpatialViewState.createBlank(imodel, Point3d.createZero(), Vector3d.create(400, 400))}
+          imodel={imodelConnection}
+          initialViewState={SpatialViewState.createBlank(
+            imodelConnection,
+            Point3d.createZero(),
+            Vector3d.create(400, 400),
+          )}
         />,
       );
       await waitFor(() => getByTestId("viewport-component"));
 
       // test Unified Selection -> Hilited elements synchronization
-      Presentation.selection.replaceSelection("", imodel, new KeySet([elementKeys[0]]));
+      Presentation.selection.replaceSelection("", imodelConnection, new KeySet([elementKeys[0]]));
       await waitFor(() => {
-        expect(imodel.hilited.models.isEmpty).toBe(true);
-        expect(imodel.hilited.subcategories.isEmpty).toBe(true);
-        expect(imodel.hilited.elements.toId64Array()).toHaveLength(3);
-        expect(imodel.hilited.elements.toId64Array()).toEqual(expect.arrayContaining(elementKeys.map((k) => k.id)));
-        expect([...imodel.selectionSet.elements]).toHaveLength(3);
-        expect([...imodel.selectionSet.elements]).toEqual(expect.arrayContaining(elementKeys.map((k) => k.id)));
+        expect(imodelConnection.hilited.models.isEmpty).toBe(true);
+        expect(imodelConnection.hilited.subcategories.isEmpty).toBe(true);
+        expect(imodelConnection.hilited.elements.toId64Array()).toHaveLength(3);
+        expect(imodelConnection.hilited.elements.toId64Array()).toEqual(
+          expect.arrayContaining(elementKeys.map((k) => k.id)),
+        );
+        expect([...imodelConnection.selectionSet.elements]).toHaveLength(3);
+        expect([...imodelConnection.selectionSet.elements]).toEqual(
+          expect.arrayContaining(elementKeys.map((k) => k.id)),
+        );
       });
 
-      Presentation.selection.clearSelection("", imodel);
+      Presentation.selection.clearSelection("", imodelConnection);
       await waitFor(() => {
-        expect(imodel.hilited.models.isEmpty).toBe(true);
-        expect(imodel.hilited.subcategories.isEmpty).toBe(true);
-        expect(imodel.hilited.elements.isEmpty).toBe(true);
-        expect(imodel.selectionSet.size).toBe(0);
+        expect(imodelConnection.hilited.models.isEmpty).toBe(true);
+        expect(imodelConnection.hilited.subcategories.isEmpty).toBe(true);
+        expect(imodelConnection.hilited.elements.isEmpty).toBe(true);
+        expect(imodelConnection.selectionSet.size).toBe(0);
       });
 
       // test Viewport elements selection => Unified Selection synchronization
-      imodel.selectionSet.replace(elementKeys[2].id);
+      imodelConnection.selectionSet.replace(elementKeys[2].id);
       await waitFor(() => {
-        const selection = Presentation.selection.getSelection(imodel);
+        const selection = Presentation.selection.getSelection(imodelConnection);
         expect(selection.size).toBe(1);
         expect(selection.has(elementKeys[2])).toBe(true);
       });
 
-      imodel.selectionSet.emptyAll();
+      imodelConnection.selectionSet.emptyAll();
       await waitFor(() => {
-        const selection = Presentation.selection.getSelection(imodel);
+        const selection = Presentation.selection.getSelection(imodelConnection);
         expect(selection.isEmpty).toBe(true);
       });
     });

--- a/apps/full-stack-tests/src/core-interop/learning-snippets/CreateECSchemaProvider.test.ts
+++ b/apps/full-stack-tests/src/core-interop/learning-snippets/CreateECSchemaProvider.test.ts
@@ -8,8 +8,8 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { IModelConnection } from "@itwin/core-frontend";
 import { createECSchemaProvider } from "@itwin/presentation-core-interop";
 // __PUBLISH_EXTRACT_END__
-import { initialize, terminate } from "../../IntegrationTests.js";
 import { buildTestIModel } from "../../IModelUtils.js";
+import { initialize, terminate } from "../../IntegrationTests.js";
 
 describe("Core interop", () => {
   describe("Learning snippets", () => {
@@ -23,7 +23,7 @@ describe("Core interop", () => {
       });
 
       it("creates provider that returns BisCore schema from iModel", async function () {
-        const { imodel: emptyIModel } = await buildTestIModel(async () => {});
+        const { imodelConnection: emptyIModel } = await buildTestIModel(async () => {});
         function getIModelConnection(): IModelConnection {
           return emptyIModel;
         }

--- a/apps/full-stack-tests/src/core-interop/learning-snippets/CreateECSqlQueryExecutor.test.ts
+++ b/apps/full-stack-tests/src/core-interop/learning-snippets/CreateECSqlQueryExecutor.test.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 /* eslint-disable no-console */
 
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 // __PUBLISH_EXTRACT_START__ Presentation.CoreInterop.CreateECSqlQueryExecutor.Imports
 import { IModelConnection } from "@itwin/core-frontend";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 // __PUBLISH_EXTRACT_END__
-import { initialize, terminate } from "../../IntegrationTests.js";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { buildTestIModel } from "../../IModelUtils.js";
+import { initialize, terminate } from "../../IntegrationTests.js";
 
 describe("Core interop", () => {
   describe("Learning snippets", () => {
@@ -24,7 +24,7 @@ describe("Core interop", () => {
       });
 
       it("creates executor that can run ECSql queries", async function () {
-        const { imodel: emptyIModel } = await buildTestIModel(async () => {});
+        const { imodelConnection: emptyIModel } = await buildTestIModel(async () => {});
         function getIModelConnection(): IModelConnection {
           return emptyIModel;
         }

--- a/apps/full-stack-tests/src/core-interop/learning-snippets/CreateValueFormatter.test.ts
+++ b/apps/full-stack-tests/src/core-interop/learning-snippets/CreateValueFormatter.test.ts
@@ -3,14 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 // __PUBLISH_EXTRACT_START__ Presentation.CoreInterop.CreateValueFormatter.Imports
-import { IModelConnection } from "@itwin/core-frontend";
+import { SchemaContext } from "@itwin/ecschema-metadata";
 import { createValueFormatter } from "@itwin/presentation-core-interop";
 // __PUBLISH_EXTRACT_END__
-import { importSchema } from "../../SchemaUtils.js";
-import { initialize, terminate } from "../../IntegrationTests.js";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildTestIModel } from "../../IModelUtils.js";
+import { initialize, terminate } from "../../IntegrationTests.js";
+import { importSchema } from "../../SchemaUtils.js";
 
 describe("Core interop", () => {
   describe("Learning snippets", () => {
@@ -24,11 +24,11 @@ describe("Core interop", () => {
       });
 
       it("creates formatter that formats values with units", async function () {
-        const { imodel: testIModel, schema } = await buildTestIModel(async (builder, testName) => {
+        const { imodelConnection, schema } = await buildTestIModel(async (imodel, testName) => {
           return {
             schema: await importSchema(
               testName,
-              builder,
+              imodel,
               `
                 <ECSchemaReference name="Formats" version="01.00.00" alias="f"/>
                 <ECSchemaReference name="Units" version="01.00.03" alias="u"/>
@@ -39,13 +39,13 @@ describe("Core interop", () => {
         });
         const KOQ_SCHEMA_NAME = schema.schemaName;
         function getIModelConnection() {
-          return testIModel;
+          return imodelConnection;
         }
 
         // __PUBLISH_EXTRACT_START__ Presentation.CoreInterop.CreateValueFormatter.Example
-        const imodel: IModelConnection = getIModelConnection();
-        const metricFormatter = createValueFormatter({ schemaContext: imodel.schemaContext, unitSystem: "metric" });
-        const imperialFormatter = createValueFormatter({ schemaContext: imodel.schemaContext, unitSystem: "imperial" });
+        const schemaContext: SchemaContext = getIModelConnection().schemaContext;
+        const metricFormatter = createValueFormatter({ schemaContext, unitSystem: "metric" });
+        const imperialFormatter = createValueFormatter({ schemaContext, unitSystem: "imperial" });
 
         // Define the raw value to be formatted
         const value = 1.234;

--- a/apps/full-stack-tests/src/hierarchies/CustomNodes.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/CustomNodes.test.ts
@@ -18,7 +18,7 @@ describe("Hierarchies", () => {
 
     test.beforeAll(async (_, suite) => {
       await initialize();
-      emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodel;
+      emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodelConnection;
     });
 
     afterAll(async () => {

--- a/apps/full-stack-tests/src/hierarchies/ECCustomAttributesHandling.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/ECCustomAttributesHandling.test.ts
@@ -7,7 +7,7 @@ import { collect } from "presentation-test-utilities";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
-import { withECDb } from "../ECDbUtils.js";
+import { buildTestECDb } from "../ECDbUtils.js";
 import { initialize, terminate } from "../IntegrationTests.js";
 import { importSchema } from "../SchemaUtils.js";
 import { NodeValidators, validateHierarchyLevel } from "./HierarchyValidation.js";
@@ -27,443 +27,425 @@ describe("Hierarchies", () => {
 
     describe("HiddenClass", () => {
       it("loads nodes for instances of hidden class", async function () {
-        await withECDb(
-          async (db, testName) => {
-            const schema = await importSchema(
-              testName,
-              db,
-              `
-                <ECEntityClass typeName="X">
-                  <ECCustomAttributes>
-                    <HiddenClass xmlns="CoreCustomAttributes.01.00.01" />
-                  </ECCustomAttributes>
-                </ECEntityClass>
-              `,
-            );
-            const x = db.insertInstance(schema.items.X.fullName);
-            return { schema, x };
-          },
-          async (imodel, { schema, x }) => {
-            const imodelAccess = createIModelAccess(imodel);
-            const selectQueryFactory = createNodesQueryClauseFactory({
-              imodelAccess,
-              instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-                classHierarchyInspector: imodelAccess,
-              }),
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECCustomAttributes>
+                  <HiddenClass xmlns="CoreCustomAttributes.01.00.01" />
+                </ECCustomAttributes>
+              </ECEntityClass>
+            `,
+          );
+          const x = builder.insertInstance(schema.items.X.fullName);
+          return { schema: s, x };
+        });
+        const { ecdb, schema, ...keys } = setup;
+        const imodelAccess = createIModelAccess(ecdb);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+            classHierarchyInspector: imodelAccess,
+          }),
+        });
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ instanceFilter }) {
+            const filterClauses = await selectQueryFactory.createFilterClauses({
+              filter: instanceFilter,
+              contentClass: { fullName: schema.items.X.fullName, alias: "this" },
             });
-            const hierarchy: HierarchyDefinition = {
-              async defineHierarchyLevel({ instanceFilter }) {
-                const filterClauses = await selectQueryFactory.createFilterClauses({
-                  filter: instanceFilter,
-                  contentClass: { fullName: schema.items.X.fullName, alias: "this" },
-                });
-                return [
-                  {
-                    fullClassName: schema.items.X.fullName,
-                    query: {
-                      ecsql: `
-                        SELECT ${await selectQueryFactory.createSelectClause({
-                          ecClassId: { selector: `this.ECClassId` },
-                          ecInstanceId: { selector: `this.ECInstanceId` },
-                          nodeLabel: "x",
-                        })}
-                        FROM ${filterClauses.from} AS this
-                        ${filterClauses.joins}
-                        ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
-                      `,
-                    },
-                  },
-                ];
+            return [
+              {
+                fullClassName: schema.items.X.fullName,
+                query: {
+                  ecsql: `
+                    SELECT ${await selectQueryFactory.createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: "x",
+                    })}
+                    FROM ${filterClauses.from} AS this
+                    ${filterClauses.joins}
+                    ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
+                  `,
+                },
               },
-            };
-            const provider = createProvider({ imodel, hierarchy });
-            validateHierarchyLevel({
-              nodes: await collect(provider.getNodes({ parentNode: undefined })),
-              expect: [NodeValidators.createForInstanceNode({ instanceKeys: [x] })],
-            });
+            ];
           },
-        );
+        };
+        const provider = createProvider({ ecdb, hierarchy });
+        validateHierarchyLevel({
+          nodes: await collect(provider.getNodes({ parentNode: undefined })),
+          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x] })],
+        });
       });
 
       it("loads nodes for instances of class with hidden base", async function () {
-        await withECDb(
-          async (db, testName) => {
-            const schema = await importSchema(
-              testName,
-              db,
-              `
-                <ECEntityClass typeName="X">
-                  <ECCustomAttributes>
-                    <HiddenClass xmlns="CoreCustomAttributes.01.00.01" />
-                  </ECCustomAttributes>
-                </ECEntityClass>
-                <ECEntityClass typeName="Y">
-                  <BaseClass>X</BaseClass>
-                </ECEntityClass>
-              `,
-            );
-            const x = db.insertInstance(schema.items.X.fullName);
-            const y = db.insertInstance(schema.items.Y.fullName);
-            return { schema, x, y };
-          },
-          async (imodel, { schema, y }) => {
-            const imodelAccess = createIModelAccess(imodel);
-            const selectQueryFactory = createNodesQueryClauseFactory({
-              imodelAccess,
-              instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-                classHierarchyInspector: imodelAccess,
-              }),
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECCustomAttributes>
+                  <HiddenClass xmlns="CoreCustomAttributes.01.00.01" />
+                </ECCustomAttributes>
+              </ECEntityClass>
+              <ECEntityClass typeName="Y">
+                <BaseClass>X</BaseClass>
+              </ECEntityClass>
+            `,
+          );
+          const x = builder.insertInstance(s.items.X.fullName);
+          const y = builder.insertInstance(s.items.Y.fullName);
+          return { schema: s, x, y };
+        });
+        const { ecdb, schema, ...keys } = setup;
+        const imodelAccess = createIModelAccess(ecdb);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+            classHierarchyInspector: imodelAccess,
+          }),
+        });
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ instanceFilter }) {
+            const filterClauses = await selectQueryFactory.createFilterClauses({
+              filter: instanceFilter,
+              contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
             });
-            const hierarchy: HierarchyDefinition = {
-              async defineHierarchyLevel({ instanceFilter }) {
-                const filterClauses = await selectQueryFactory.createFilterClauses({
-                  filter: instanceFilter,
-                  contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
-                });
-                return [
-                  {
-                    fullClassName: schema.items.Y.fullName,
-                    query: {
-                      ecsql: `
-                        SELECT ${await selectQueryFactory.createSelectClause({
-                          ecClassId: { selector: `this.ECClassId` },
-                          ecInstanceId: { selector: `this.ECInstanceId` },
-                          nodeLabel: "y",
-                        })}
-                        FROM ${filterClauses.from} AS this
-                        ${filterClauses.joins}
-                        ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
-                      `,
-                    },
-                  },
-                ];
+            return [
+              {
+                fullClassName: schema.items.Y.fullName,
+                query: {
+                  ecsql: `
+                    SELECT ${await selectQueryFactory.createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: "y",
+                    })}
+                    FROM ${filterClauses.from} AS this
+                    ${filterClauses.joins}
+                    ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
+                  `,
+                },
               },
-            };
-            const provider = createProvider({ imodel, hierarchy });
-            validateHierarchyLevel({
-              nodes: await collect(provider.getNodes({ parentNode: undefined })),
-              expect: [NodeValidators.createForInstanceNode({ instanceKeys: [y] })],
-            });
+            ];
           },
-        );
+        };
+        const provider = createProvider({ ecdb, hierarchy });
+        validateHierarchyLevel({
+          nodes: await collect(provider.getNodes({ parentNode: undefined })),
+          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.y] })],
+        });
       });
 
       it("hides instances of hidden classes", async function () {
-        await withECDb(
-          async (db, testName) => {
-            const schema = await importSchema(
-              testName,
-              db,
-              `
-                <ECEntityClass typeName="X">
-                </ECEntityClass>
-                <ECEntityClass typeName="Y">
-                  <BaseClass>X</BaseClass>
-                  <ECCustomAttributes>
-                    <HiddenClass xmlns="CoreCustomAttributes.01.00.01" />
-                  </ECCustomAttributes>
-                </ECEntityClass>
-                <ECEntityClass typeName="Z">
-                  <BaseClass>Y</BaseClass>
-                  <ECCustomAttributes>
-                    <HiddenClass xmlns="CoreCustomAttributes.01.00.01">
-                      <Show>true</Show>
-                    </HiddenClass>
-                  </ECCustomAttributes>
-                </ECEntityClass>
-                <ECEntityClass typeName="W">
-                  <BaseClass>Z</BaseClass>
-                  <ECCustomAttributes>
-                    <HiddenClass xmlns="CoreCustomAttributes.01.00.01">
-                      <Show>false</Show>
-                    </HiddenClass>
-                  </ECCustomAttributes>
-                </ECEntityClass>
-              `,
-            );
-            const x = db.insertInstance(schema.items.X.fullName);
-            const y = db.insertInstance(schema.items.Y.fullName);
-            const z = db.insertInstance(schema.items.Z.fullName);
-            const w = db.insertInstance(schema.items.W.fullName);
-            return { schema, x, y, z, w };
-          },
-          async (imodel, { schema, x, z }) => {
-            const imodelAccess = createIModelAccess(imodel);
-            const selectQueryFactory = createNodesQueryClauseFactory({
-              imodelAccess,
-              instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-                classHierarchyInspector: imodelAccess,
-              }),
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+              </ECEntityClass>
+              <ECEntityClass typeName="Y">
+                <BaseClass>X</BaseClass>
+                <ECCustomAttributes>
+                  <HiddenClass xmlns="CoreCustomAttributes.01.00.01" />
+                </ECCustomAttributes>
+              </ECEntityClass>
+              <ECEntityClass typeName="Z">
+                <BaseClass>Y</BaseClass>
+                <ECCustomAttributes>
+                  <HiddenClass xmlns="CoreCustomAttributes.01.00.01">
+                    <Show>true</Show>
+                  </HiddenClass>
+                </ECCustomAttributes>
+              </ECEntityClass>
+              <ECEntityClass typeName="W">
+                <BaseClass>Z</BaseClass>
+                <ECCustomAttributes>
+                  <HiddenClass xmlns="CoreCustomAttributes.01.00.01">
+                    <Show>false</Show>
+                  </HiddenClass>
+                </ECCustomAttributes>
+              </ECEntityClass>
+            `,
+          );
+          const x = builder.insertInstance(s.items.X.fullName);
+          const y = builder.insertInstance(s.items.Y.fullName);
+          const z = builder.insertInstance(s.items.Z.fullName);
+          const w = builder.insertInstance(s.items.W.fullName);
+          return { schema: s, x, y, z, w };
+        });
+        const { ecdb, schema, ...keys } = setup;
+        const imodelAccess = createIModelAccess(ecdb);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+            classHierarchyInspector: imodelAccess,
+          }),
+        });
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ instanceFilter }) {
+            const filterClauses = await selectQueryFactory.createFilterClauses({
+              filter: instanceFilter,
+              contentClass: { fullName: schema.items.X.fullName, alias: "this" },
             });
-            const hierarchy: HierarchyDefinition = {
-              async defineHierarchyLevel({ instanceFilter }) {
-                const filterClauses = await selectQueryFactory.createFilterClauses({
-                  filter: instanceFilter,
-                  contentClass: { fullName: schema.items.X.fullName, alias: "this" },
-                });
-                return [
-                  {
-                    fullClassName: schema.items.X.fullName,
-                    query: {
-                      ecsql: `
-                        SELECT ${await selectQueryFactory.createSelectClause({
-                          ecClassId: { selector: `this.ECClassId` },
-                          ecInstanceId: { selector: `this.ECInstanceId` },
-                          nodeLabel: { selector: `ec_classname(this.ECClassId, 'c')` },
-                        })}
-                        FROM ${filterClauses.from} AS this
-                        ${filterClauses.joins}
-                        ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
-                      `,
-                    },
-                  },
-                ];
+            return [
+              {
+                fullClassName: schema.items.X.fullName,
+                query: {
+                  ecsql: `
+                    SELECT ${await selectQueryFactory.createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: { selector: `ec_classname(this.ECClassId, 'c')` },
+                    })}
+                    FROM ${filterClauses.from} AS this
+                    ${filterClauses.joins}
+                    ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
+                  `,
+                },
               },
-            };
-            const provider = createProvider({ imodel, hierarchy });
-            validateHierarchyLevel({
-              nodes: await collect(provider.getNodes({ parentNode: undefined })),
-              expect: [
-                NodeValidators.createForInstanceNode({ instanceKeys: [x] }),
-                NodeValidators.createForInstanceNode({ instanceKeys: [z] }),
-              ],
-            });
+            ];
           },
-        );
+        };
+        const provider = createProvider({ ecdb, hierarchy });
+        validateHierarchyLevel({
+          nodes: await collect(provider.getNodes({ parentNode: undefined })),
+          expect: [
+            NodeValidators.createForInstanceNode({ instanceKeys: [keys.x] }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [keys.z] }),
+          ],
+        });
       });
     });
 
     describe("HiddenSchema", () => {
       it("loads nodes for instances of hidden schema classes", async function () {
-        await withECDb(
-          async (db, testName) => {
-            const schema = await importSchema(
-              testName,
-              db,
-              `
-                <ECCustomAttributes>
-                  <HiddenSchema xmlns="CoreCustomAttributes.01.00.01" />
-                </ECCustomAttributes>
-                <ECEntityClass typeName="X" />
-              `,
-            );
-            const x = db.insertInstance(schema.items.X.fullName);
-            return { schema, x };
-          },
-          async (imodel, { schema, x }) => {
-            const imodelAccess = createIModelAccess(imodel);
-            const selectQueryFactory = createNodesQueryClauseFactory({
-              imodelAccess,
-              instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-                classHierarchyInspector: imodelAccess,
-              }),
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECCustomAttributes>
+                <HiddenSchema xmlns="CoreCustomAttributes.01.00.01" />
+              </ECCustomAttributes>
+              <ECEntityClass typeName="X" />
+            `,
+          );
+          const x = builder.insertInstance(s.items.X.fullName);
+          return { schema: s, x };
+        });
+        const { ecdb, schema, ...keys } = setup;
+        const imodelAccess = createIModelAccess(ecdb);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+            classHierarchyInspector: imodelAccess,
+          }),
+        });
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ instanceFilter }) {
+            const filterClauses = await selectQueryFactory.createFilterClauses({
+              filter: instanceFilter,
+              contentClass: { fullName: schema.items.X.fullName, alias: "this" },
             });
-            const hierarchy: HierarchyDefinition = {
-              async defineHierarchyLevel({ instanceFilter }) {
-                const filterClauses = await selectQueryFactory.createFilterClauses({
-                  filter: instanceFilter,
-                  contentClass: { fullName: schema.items.X.fullName, alias: "this" },
-                });
-                return [
-                  {
-                    fullClassName: schema.items.X.fullName,
-                    query: {
-                      ecsql: `
-                        SELECT ${await selectQueryFactory.createSelectClause({
-                          ecClassId: { selector: `this.ECClassId` },
-                          ecInstanceId: { selector: `this.ECInstanceId` },
-                          nodeLabel: "x",
-                        })}
-                        FROM ${filterClauses.from} AS this
-                        ${filterClauses.joins}
-                        ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
-                      `,
-                    },
-                  },
-                ];
+            return [
+              {
+                fullClassName: schema.items.X.fullName,
+                query: {
+                  ecsql: `
+                    SELECT ${await selectQueryFactory.createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: "x",
+                    })}
+                    FROM ${filterClauses.from} AS this
+                    ${filterClauses.joins}
+                    ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
+                  `,
+                },
               },
-            };
-            const provider = createProvider({ imodel, hierarchy });
-            validateHierarchyLevel({
-              nodes: await collect(provider.getNodes({ parentNode: undefined })),
-              expect: [NodeValidators.createForInstanceNode({ instanceKeys: [x] })],
-            });
+            ];
           },
-        );
+        };
+        const provider = createProvider({ ecdb, hierarchy });
+        validateHierarchyLevel({
+          nodes: await collect(provider.getNodes({ parentNode: undefined })),
+          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x] })],
+        });
       });
 
       it("loads nodes for instances of class whose base is in hidden schema", async function () {
-        await withECDb(
-          async (db, testName) => {
-            const hiddenSchema = await importSchema(
-              `${testName}_HiddenSchema`,
-              db,
-              `
-                <ECCustomAttributes>
-                  <HiddenSchema xmlns="CoreCustomAttributes.01.00.01" />
-                </ECCustomAttributes>
-                <ECEntityClass typeName="X" />
-              `,
-            );
-            const schema = await importSchema(
-              testName,
-              db,
-              `
-                <ECSchemaReference name="${hiddenSchema.schemaName}" version="01.00.00" alias="hs" />
-                <ECEntityClass typeName="Y">
-                  <BaseClass>hs:X</BaseClass>
-                </ECEntityClass>
-              `,
-            );
-            const x = db.insertInstance(hiddenSchema.items.X.fullName);
-            const y = db.insertInstance(schema.items.Y.fullName);
-            return { hiddenSchema, schema, x, y };
-          },
-          async (imodel, { schema, y }) => {
-            const imodelAccess = createIModelAccess(imodel);
-            const selectQueryFactory = createNodesQueryClauseFactory({
-              imodelAccess,
-              instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-                classHierarchyInspector: imodelAccess,
-              }),
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const hiddenSchema = await importSchema(
+            `${testName}_HiddenSchema`,
+            builder,
+            `
+              <ECCustomAttributes>
+                <HiddenSchema xmlns="CoreCustomAttributes.01.00.01" />
+              </ECCustomAttributes>
+              <ECEntityClass typeName="X" />
+            `,
+          );
+          const nonHiddenSchema = await importSchema(
+            testName,
+            builder,
+            `
+              <ECSchemaReference name="${hiddenSchema.schemaName}" version="01.00.00" alias="hs" />
+              <ECEntityClass typeName="Y">
+                <BaseClass>hs:X</BaseClass>
+              </ECEntityClass>
+            `,
+          );
+          const x = builder.insertInstance(hiddenSchema.items.X.fullName);
+          const y = builder.insertInstance(nonHiddenSchema.items.Y.fullName);
+          return { hiddenSchema, nonHiddenSchema, x, y };
+        });
+        const { ecdb, nonHiddenSchema: schema, ...keys } = setup;
+        const imodelAccess = createIModelAccess(ecdb);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+            classHierarchyInspector: imodelAccess,
+          }),
+        });
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ instanceFilter }) {
+            const filterClauses = await selectQueryFactory.createFilterClauses({
+              filter: instanceFilter,
+              contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
             });
-            const hierarchy: HierarchyDefinition = {
-              async defineHierarchyLevel({ instanceFilter }) {
-                const filterClauses = await selectQueryFactory.createFilterClauses({
-                  filter: instanceFilter,
-                  contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
-                });
-                return [
-                  {
-                    fullClassName: schema.items.Y.fullName,
-                    query: {
-                      ecsql: `
-                        SELECT ${await selectQueryFactory.createSelectClause({
-                          ecClassId: { selector: `this.ECClassId` },
-                          ecInstanceId: { selector: `this.ECInstanceId` },
-                          nodeLabel: "y",
-                        })}
-                        FROM ${filterClauses.from} AS this
-                        ${filterClauses.joins}
-                        ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
-                      `,
-                    },
-                  },
-                ];
+            return [
+              {
+                fullClassName: schema.items.Y.fullName,
+                query: {
+                  ecsql: `
+                    SELECT ${await selectQueryFactory.createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: "y",
+                    })}
+                    FROM ${filterClauses.from} AS this
+                    ${filterClauses.joins}
+                    ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
+                  `,
+                },
               },
-            };
-            const provider = createProvider({ imodel, hierarchy });
-            validateHierarchyLevel({
-              nodes: await collect(provider.getNodes({ parentNode: undefined })),
-              expect: [NodeValidators.createForInstanceNode({ instanceKeys: [y] })],
-            });
+            ];
           },
-        );
+        };
+        const provider = createProvider({ ecdb, hierarchy });
+        validateHierarchyLevel({
+          nodes: await collect(provider.getNodes({ parentNode: undefined })),
+          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.y] })],
+        });
       });
 
       // https://github.com/iTwin/itwinjs-core/issues/8047
       it.skip("hides instances of hidden schema classes", async function () {
-        await withECDb(
-          async (db, testName) => {
-            const xSchema = await importSchema(
-              `${testName}_x`,
-              db,
-              `
-                <ECEntityClass typeName="X" />
-              `,
-            );
-            const ySchema = await importSchema(
-              `${testName}_y`,
-              db,
-              `
-                <ECSchemaReference name="${xSchema.schemaName}" version="01.00.00" alias="xSchema" />
-                <ECCustomAttributes>
-                  <HiddenSchema xmlns="CoreCustomAttributes.01.00.01" />
-                </ECCustomAttributes>
-                <ECEntityClass typeName="Y">
-                  <BaseClass>xSchema:X</BaseClass>
-                </ECEntityClass>
-              `,
-            );
-            const zSchema = await importSchema(
-              `${testName}_z`,
-              db,
-              `
-                <ECSchemaReference name="${ySchema.schemaName}" version="01.00.00" alias="ySchema" />
-                <ECCustomAttributes>
-                  <HiddenSchema xmlns="CoreCustomAttributes.01.00.01">
-                    <ShowClasses>true</ShowClasses>
-                  </HiddenSchema>
-                </ECCustomAttributes>
-                <ECEntityClass typeName="Z">
-                  <BaseClass>ySchema:Y</BaseClass>
-                </ECEntityClass>
-              `,
-            );
-            const wSchema = await importSchema(
-              `${testName}_w`,
-              db,
-              `
-                <ECSchemaReference name="${zSchema.schemaName}" version="01.00.00" alias="zSchema" />
-                <ECCustomAttributes>
-                  <HiddenSchema xmlns="CoreCustomAttributes.01.00.01">
-                    <ShowClasses>false</ShowClasses>
-                  </HiddenSchema>
-                </ECCustomAttributes>
-                <ECEntityClass typeName="W">
-                  <BaseClass>zSchema:Z</BaseClass>
-                </ECEntityClass>
-              `,
-            );
-            const x = db.insertInstance(xSchema.items.X.fullName);
-            const y = db.insertInstance(ySchema.items.Y.fullName);
-            const z = db.insertInstance(zSchema.items.Z.fullName);
-            const w = db.insertInstance(wSchema.items.W.fullName);
-            return { xSchema, ySchema, zSchema, wSchema, x, y, z, w };
-          },
-          async (imodel, { xSchema: schema, x, z }) => {
-            const imodelAccess = createIModelAccess(imodel);
-            const selectQueryFactory = createNodesQueryClauseFactory({
-              imodelAccess,
-              instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-                classHierarchyInspector: imodelAccess,
-              }),
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const xSchema = await importSchema(
+            `${testName}_x`,
+            builder,
+            `
+              <ECEntityClass typeName="X" />
+            `,
+          );
+          const ySchema = await importSchema(
+            `${testName}_y`,
+            builder,
+            `
+              <ECSchemaReference name="${xSchema.schemaName}" version="01.00.00" alias="xSchema" />
+              <ECCustomAttributes>
+                <HiddenSchema xmlns="CoreCustomAttributes.01.00.01" />
+              </ECCustomAttributes>
+              <ECEntityClass typeName="Y">
+                <BaseClass>xSchema:X</BaseClass>
+              </ECEntityClass>
+            `,
+          );
+          const zSchema = await importSchema(
+            `${testName}_z`,
+            builder,
+            `
+              <ECSchemaReference name="${ySchema.schemaName}" version="01.00.00" alias="ySchema" />
+              <ECCustomAttributes>
+                <HiddenSchema xmlns="CoreCustomAttributes.01.00.01">
+                  <ShowClasses>true</ShowClasses>
+                </HiddenSchema>
+              </ECCustomAttributes>
+              <ECEntityClass typeName="Z">
+                <BaseClass>ySchema:Y</BaseClass>
+              </ECEntityClass>
+            `,
+          );
+          const wSchema = await importSchema(
+            `${testName}_w`,
+            builder,
+            `
+              <ECSchemaReference name="${zSchema.schemaName}" version="01.00.00" alias="zSchema" />
+              <ECCustomAttributes>
+                <HiddenSchema xmlns="CoreCustomAttributes.01.00.01">
+                  <ShowClasses>false</ShowClasses>
+                </HiddenSchema>
+              </ECCustomAttributes>
+              <ECEntityClass typeName="W">
+                <BaseClass>zSchema:Z</BaseClass>
+              </ECEntityClass>
+            `,
+          );
+          const x = builder.insertInstance(xSchema.items.X.fullName);
+          const y = builder.insertInstance(ySchema.items.Y.fullName);
+          const z = builder.insertInstance(zSchema.items.Z.fullName);
+          const w = builder.insertInstance(wSchema.items.W.fullName);
+          return { xSchema, ySchema, zSchema, wSchema, x, y, z, w };
+        });
+        const { ecdb, xSchema: schema, ...keys } = setup;
+        const imodelAccess = createIModelAccess(ecdb);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+            classHierarchyInspector: imodelAccess,
+          }),
+        });
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ instanceFilter }) {
+            const filterClauses = await selectQueryFactory.createFilterClauses({
+              filter: instanceFilter,
+              contentClass: { fullName: schema.items.X.fullName, alias: "this" },
             });
-            const hierarchy: HierarchyDefinition = {
-              async defineHierarchyLevel({ instanceFilter }) {
-                const filterClauses = await selectQueryFactory.createFilterClauses({
-                  filter: instanceFilter,
-                  contentClass: { fullName: schema.items.X.fullName, alias: "this" },
-                });
-                return [
-                  {
-                    fullClassName: schema.items.X.fullName,
-                    query: {
-                      ecsql: `
-                        SELECT ${await selectQueryFactory.createSelectClause({
-                          ecClassId: { selector: `this.ECClassId` },
-                          ecInstanceId: { selector: `this.ECInstanceId` },
-                          nodeLabel: { selector: `ec_classname(this.ECClassId, 'c')` },
-                        })}
-                        FROM ${filterClauses.from} AS this
-                        ${filterClauses.joins}
-                        ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
-                      `,
-                    },
-                  },
-                ];
+            return [
+              {
+                fullClassName: schema.items.X.fullName,
+                query: {
+                  ecsql: `
+                    SELECT ${await selectQueryFactory.createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: { selector: `ec_classname(this.ECClassId, 'c')` },
+                    })}
+                    FROM ${filterClauses.from} AS this
+                    ${filterClauses.joins}
+                    ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
+                  `,
+                },
               },
-            };
-            const provider = createProvider({ imodel, hierarchy });
-            validateHierarchyLevel({
-              nodes: await collect(provider.getNodes({ parentNode: undefined })),
-              expect: [
-                NodeValidators.createForInstanceNode({ instanceKeys: [x] }),
-                NodeValidators.createForInstanceNode({ instanceKeys: [z] }),
-              ],
-            });
+            ];
           },
-        );
+        };
+        const provider = createProvider({ ecdb, hierarchy });
+        validateHierarchyLevel({
+          nodes: await collect(provider.getNodes({ parentNode: undefined })),
+          expect: [
+            NodeValidators.createForInstanceNode({ instanceKeys: [keys.x] }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [keys.z] }),
+          ],
+        });
       });
     });
   });

--- a/apps/full-stack-tests/src/hierarchies/ECCustomAttributesHandling.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/ECCustomAttributesHandling.test.ts
@@ -39,7 +39,7 @@ describe("Hierarchies", () => {
               </ECEntityClass>
             `,
           );
-          const x = builder.insertInstance(schema.items.X.fullName);
+          const x = builder.insertInstance(s.items.X.fullName);
           return { schema: s, x };
         });
         const { ecdb, schema, ...keys } = setup;

--- a/apps/full-stack-tests/src/hierarchies/Formatting.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/Formatting.test.ts
@@ -42,7 +42,7 @@ describe("Hierarchies", () => {
 
   test.beforeAll(async (_, suite) => {
     await initialize();
-    emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodel;
+    emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodelConnection;
     subjectClassName = normalizeFullClassName(Subject.classFullName);
   });
 
@@ -93,11 +93,11 @@ describe("Hierarchies", () => {
 
     describe("KindOfQuantity", () => {
       it("formats instance node labels", async () => {
-        const { imodel, schema } = await buildTestIModel(async (builder, testName) => {
+        const { imodelConnection, schema } = await buildTestIModel(async (imodel, testName) => {
           // eslint-disable-next-line @typescript-eslint/no-shadow
           const schema = await importSchema(
             testName,
-            builder,
+            imodel,
             `
               <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
               <ECSchemaReference name="Units" version="01.00.07" alias="u" />
@@ -109,10 +109,10 @@ describe("Hierarchies", () => {
               </ECEntityClass>
             `,
           );
-          const model = insertPhysicalModelWithPartition({ builder, codeValue: "model" });
-          const category = insertSpatialCategory({ builder, codeValue: "category" });
+          const model = insertPhysicalModelWithPartition({ imodel, codeValue: "model" });
+          const category = insertSpatialCategory({ imodel, codeValue: "category" });
           const element = insertPhysicalElement({
-            builder,
+            imodel,
             classFullName: schema.items.ClassX.fullName,
             modelId: model.id,
             categoryId: category.id,
@@ -120,7 +120,7 @@ describe("Hierarchies", () => {
           });
           return { schema, model, category, element };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
 
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
@@ -163,7 +163,7 @@ describe("Hierarchies", () => {
         };
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "metric" }),
           }),
@@ -171,7 +171,7 @@ describe("Hierarchies", () => {
         });
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "imperial" }),
           }),
@@ -179,7 +179,7 @@ describe("Hierarchies", () => {
         });
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "usCustomary" }),
           }),
@@ -187,7 +187,7 @@ describe("Hierarchies", () => {
         });
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "usSurvey" }),
           }),
@@ -367,14 +367,14 @@ describe("Hierarchies", () => {
 
     describe("Boolean", () => {
       it("formats instance node labels", async () => {
-        const { imodel, modelClassName } = await buildTestIModel(async (builder) => {
-          const p1 = insertPhysicalPartition({ builder, codeValue: "p1", parentId: IModel.rootSubjectId });
-          insertPhysicalSubModel({ builder, modeledElementId: p1.id, isPrivate: false });
-          const p2 = insertPhysicalPartition({ builder, codeValue: "p2", parentId: IModel.rootSubjectId });
-          const m2 = insertPhysicalSubModel({ builder, modeledElementId: p2.id, isPrivate: true });
+        const { imodelConnection, modelClassName } = await buildTestIModel(async (imodel) => {
+          const p1 = insertPhysicalPartition({ imodel, codeValue: "p1", parentId: IModel.rootSubjectId });
+          insertPhysicalSubModel({ imodel, modeledElementId: p1.id, isPrivate: false });
+          const p2 = insertPhysicalPartition({ imodel, codeValue: "p2", parentId: IModel.rootSubjectId });
+          const m2 = insertPhysicalSubModel({ imodel, modeledElementId: p2.id, isPrivate: true });
           return { modelClassName: m2.className };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
 
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
@@ -416,7 +416,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy }),
+          provider: createProvider({ imodel: imodelConnection, hierarchy }),
           expect: [
             { node: (node) => expect(node.label).toBe(`[false]`) },
             { node: (node) => expect(node.label).toBe(`[true]`) },
@@ -454,10 +454,10 @@ describe("Hierarchies", () => {
 
     describe("Integer", () => {
       it("formats instance node labels", async () => {
-        const { imodel, sheetIndexFolder } = await buildTestIModel(async (builder) => {
-          return { sheetIndexFolder: insertSheetIndexFolder({ builder, entryPriority: 2 }) };
+        const { imodelConnection, sheetIndexFolder } = await buildTestIModel(async (imodel) => {
+          return { sheetIndexFolder: insertSheetIndexFolder({ imodel, entryPriority: 2 }) };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
 
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
@@ -499,7 +499,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy }),
+          provider: createProvider({ imodel: imodelConnection, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`[2]`) }],
         });
       });
@@ -533,19 +533,19 @@ describe("Hierarchies", () => {
 
     describe("Double", () => {
       it("formats instance node labels", async () => {
-        const { imodel, element } = await buildTestIModel(async (builder) => {
-          const model = insertPhysicalModelWithPartition({ builder, codeValue: "model" });
-          const category = insertSpatialCategory({ builder, codeValue: "category" });
+        const { imodelConnection, element } = await buildTestIModel(async (imodel) => {
+          const model = insertPhysicalModelWithPartition({ imodel, codeValue: "model" });
+          const category = insertSpatialCategory({ imodel, codeValue: "category" });
           // eslint-disable-next-line @typescript-eslint/no-shadow
           const element = insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             placement: { origin: { x: 1.23, y: 4.56, z: 7.89 }, angles: { yaw: 90.789 } },
           });
           return { model, category, element };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
 
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
@@ -587,7 +587,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy }),
+          provider: createProvider({ imodel: imodelConnection, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`[90.79]`) }],
         });
       });
@@ -622,19 +622,19 @@ describe("Hierarchies", () => {
 
     describe("Point2d", () => {
       it("formats instance node labels", async () => {
-        const { imodel, element } = await buildTestIModel(async (builder) => {
-          const model = insertDrawingModelWithPartition({ builder, codeValue: "model" });
-          const category = insertDrawingCategory({ builder, codeValue: "category" });
+        const { imodelConnection, element } = await buildTestIModel(async (imodel) => {
+          const model = insertDrawingModelWithPartition({ imodel, codeValue: "model" });
+          const category = insertDrawingCategory({ imodel, codeValue: "category" });
           // eslint-disable-next-line @typescript-eslint/no-shadow
           const element = insertDrawingGraphic({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             placement: { origin: { x: 1.477, y: 2.588 }, angle: 0 },
           });
           return { model, category, element };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
 
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
@@ -676,7 +676,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy }),
+          provider: createProvider({ imodel: imodelConnection, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`[(1.48, 2.59)]`) }],
         });
       });
@@ -711,19 +711,19 @@ describe("Hierarchies", () => {
 
     describe("Point3d", () => {
       it("formats instance node labels", async () => {
-        const { imodel, element } = await buildTestIModel(async (builder) => {
-          const model = insertPhysicalModelWithPartition({ builder, codeValue: "model" });
-          const category = insertSpatialCategory({ builder, codeValue: "category" });
+        const { imodelConnection, element } = await buildTestIModel(async (imodel) => {
+          const model = insertPhysicalModelWithPartition({ imodel, codeValue: "model" });
+          const category = insertSpatialCategory({ imodel, codeValue: "category" });
           // eslint-disable-next-line @typescript-eslint/no-shadow
           const element = insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             placement: { origin: { x: 1.234, y: 4.567, z: 7.89 }, angles: {} },
           });
           return { model, category, element };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
 
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
@@ -765,7 +765,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy }),
+          provider: createProvider({ imodel: imodelConnection, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`[(1.23, 4.57, 7.89)]`) }],
         });
       });
@@ -801,19 +801,19 @@ describe("Hierarchies", () => {
     describe("Guid", () => {
       it("formats instance node labels", async () => {
         const guid = Guid.createValue();
-        const { imodel, element } = await buildTestIModel(async (builder) => {
-          const model = insertPhysicalModelWithPartition({ builder, codeValue: "model" });
-          const category = insertSpatialCategory({ builder, codeValue: "category" });
+        const { imodelConnection, element } = await buildTestIModel(async (imodel) => {
+          const model = insertPhysicalModelWithPartition({ imodel, codeValue: "model" });
+          const category = insertSpatialCategory({ imodel, codeValue: "category" });
           // eslint-disable-next-line @typescript-eslint/no-shadow
           const element = insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             federationGuid: guid,
           });
           return { model, category, element };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
 
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
@@ -855,7 +855,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy }),
+          provider: createProvider({ imodel: imodelConnection, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`[${guid}]`) }],
         });
       });

--- a/apps/full-stack-tests/src/hierarchies/HierarchyLevelFiltering.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchyLevelFiltering.test.ts
@@ -7,7 +7,7 @@ import { collect } from "presentation-test-utilities";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
-import { withECDb } from "../ECDbUtils.js";
+import { buildTestECDb } from "../ECDbUtils.js";
 import { initialize, terminate } from "../IntegrationTests.js";
 import { importSchema } from "../SchemaUtils.js";
 import { NodeValidators, validateHierarchyLevel } from "./HierarchyValidation.js";
@@ -26,595 +26,578 @@ describe("Hierarchies", () => {
     });
 
     it("filters root hierarchy level", async () => {
-      await withECDb(
-        async (db, testName) => {
-          const schema = await importSchema(
-            testName,
-            db,
-            `
-              <ECEntityClass typeName="X">
-                <ECProperty propertyName="Prop" typeName="string" />
-              </ECEntityClass>
-            `,
-          );
-          const x1 = db.insertInstance(schema.items.X.fullName, { prop: "one" });
-          const x2 = db.insertInstance(schema.items.X.fullName, { prop: "two" });
-          return { schema, x1, x2 };
-        },
-        async (imodel, { schema, x1, x2 }) => {
-          const imodelAccess = createIModelAccess(imodel);
-          const selectQueryFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-              classHierarchyInspector: imodelAccess,
-            }),
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="X">
+              <ECProperty propertyName="Prop" typeName="string" />
+            </ECEntityClass>
+          `,
+        );
+        const x1 = builder.insertInstance(s.items.X.fullName, { prop: "one" });
+        const x2 = builder.insertInstance(s.items.X.fullName, { prop: "two" });
+        return { schema: s, x1, x2 };
+      });
+      const { ecdb, schema, ...keys } = setup;
+      const imodelAccess = createIModelAccess(ecdb);
+      const selectQueryFactory = createNodesQueryClauseFactory({
+        imodelAccess,
+        instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+          classHierarchyInspector: imodelAccess,
+        }),
+      });
+      const hierarchy: HierarchyDefinition = {
+        async defineHierarchyLevel({ instanceFilter }) {
+          const filterClauses = await selectQueryFactory.createFilterClauses({
+            filter: instanceFilter,
+            contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
-          const hierarchy: HierarchyDefinition = {
-            async defineHierarchyLevel({ instanceFilter }) {
-              const filterClauses = await selectQueryFactory.createFilterClauses({
-                filter: instanceFilter,
-                contentClass: { fullName: schema.items.X.fullName, alias: "this" },
-              });
-              return [
-                {
-                  fullClassName: schema.items.X.fullName,
-                  query: {
-                    ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
-                        ecClassId: { selector: `this.ECClassId` },
-                        ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `this.Prop` },
-                      })}
-                      FROM ${filterClauses.from} AS this
-                      ${filterClauses.joins}
-                      ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
-                    `,
-                  },
-                },
-              ];
+          return [
+            {
+              fullClassName: schema.items.X.fullName,
+              query: {
+                ecsql: `
+                  SELECT ${await selectQueryFactory.createSelectClause({
+                    ecClassId: { selector: `this.ECClassId` },
+                    ecInstanceId: { selector: `this.ECInstanceId` },
+                    nodeLabel: { selector: `this.Prop` },
+                  })}
+                  FROM ${filterClauses.from} AS this
+                  ${filterClauses.joins}
+                  ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
+                `,
+              },
             },
-          };
-          const provider = createProvider({ imodel, hierarchy });
-          validateHierarchyLevel({
-            nodes: await collect(provider.getNodes({ parentNode: undefined })),
-            expect: [
-              NodeValidators.createForInstanceNode({ instanceKeys: [x1] }),
-              NodeValidators.createForInstanceNode({ instanceKeys: [x2] }),
-            ],
-          });
-          validateHierarchyLevel({
-            nodes: await collect(
-              provider.getNodes({
-                parentNode: undefined,
-                instanceFilter: {
-                  propertyClassNames: [schema.items.X.fullName],
-                  relatedInstances: [],
-                  rules: {
-                    sourceAlias: "this",
-                    propertyName: `Prop`,
-                    operator: "is-equal",
-                    propertyTypeName: "string",
-                    value: { rawValue: `one`, displayValue: "one" },
-                  },
-                },
-              }),
-            ),
-            expect: [NodeValidators.createForInstanceNode({ instanceKeys: [x1] })],
-          });
+          ];
         },
-      );
+      };
+      const provider = createProvider({ ecdb, hierarchy });
+      validateHierarchyLevel({
+        nodes: await collect(provider.getNodes({ parentNode: undefined })),
+        expect: [
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1] }),
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2] }),
+        ],
+      });
+      validateHierarchyLevel({
+        nodes: await collect(
+          provider.getNodes({
+            parentNode: undefined,
+            instanceFilter: {
+              propertyClassNames: [schema.items.X.fullName],
+              relatedInstances: [],
+              rules: {
+                sourceAlias: "this",
+                propertyName: `Prop`,
+                operator: "is-equal",
+                propertyTypeName: "string",
+                value: { rawValue: `one`, displayValue: "one" },
+              },
+            },
+          }),
+        ),
+        expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1] })],
+      });
     });
 
     it("filters child hierarchy level", async () => {
-      await withECDb(
-        async (db, testName) => {
-          const schema = await importSchema(
-            testName,
-            db,
-            `
-              <ECEntityClass typeName="X" />
-              <ECEntityClass typeName="Y">
-                <ECProperty propertyName="Prop" typeName="string" />
-              </ECEntityClass>
-            `,
-          );
-          const x = db.insertInstance(schema.items.X.fullName);
-          const y1 = db.insertInstance(schema.items.Y.fullName, { prop: "one" });
-          const y2 = db.insertInstance(schema.items.Y.fullName, { prop: "two" });
-          return { schema, x, y1, y2 };
-        },
-        async (imodel, { schema, x, y1, y2 }) => {
-          const imodelAccess = createIModelAccess(imodel);
-          const selectQueryFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-              classHierarchyInspector: imodelAccess,
-            }),
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="X" />
+            <ECEntityClass typeName="Y">
+              <ECProperty propertyName="Prop" typeName="string" />
+            </ECEntityClass>
+          `,
+        );
+        const x = builder.insertInstance(s.items.X.fullName);
+        const y1 = builder.insertInstance(s.items.Y.fullName, { prop: "one" });
+        const y2 = builder.insertInstance(s.items.Y.fullName, { prop: "two" });
+        return { schema: s, x, y1, y2 };
+      });
+      const { ecdb, schema, ...keys } = setup;
+      const imodelAccess = createIModelAccess(ecdb);
+      const selectQueryFactory = createNodesQueryClauseFactory({
+        imodelAccess,
+        instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+          classHierarchyInspector: imodelAccess,
+        }),
+      });
+      const hierarchy: HierarchyDefinition = {
+        async defineHierarchyLevel({ instanceFilter }) {
+          const filterClauses = await selectQueryFactory.createFilterClauses({
+            filter: instanceFilter,
+            contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
           });
-          const hierarchy: HierarchyDefinition = {
-            async defineHierarchyLevel({ instanceFilter }) {
-              const filterClauses = await selectQueryFactory.createFilterClauses({
-                filter: instanceFilter,
-                contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
-              });
-              return [
-                {
-                  fullClassName: schema.items.Y.fullName,
-                  query: {
-                    ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
-                        ecClassId: { selector: `this.ECClassId` },
-                        ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
-                      })}
-                      FROM ${filterClauses.from} AS this
-                      ${filterClauses.joins}
-                      ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
-                    `,
-                  },
-                },
-              ];
+          return [
+            {
+              fullClassName: schema.items.Y.fullName,
+              query: {
+                ecsql: `
+                  SELECT ${await selectQueryFactory.createSelectClause({
+                    ecClassId: { selector: `this.ECClassId` },
+                    ecInstanceId: { selector: `this.ECInstanceId` },
+                    nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
+                  })}
+                  FROM ${filterClauses.from} AS this
+                  ${filterClauses.joins}
+                  ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
+                `,
+              },
             },
-          };
-          const provider = createProvider({ imodel, hierarchy });
-          validateHierarchyLevel({
-            nodes: await collect(
-              provider.getNodes({
-                parentNode: { key: { type: "instances", instanceKeys: [x] }, parentKeys: [], label: "" },
-              }),
-            ),
-            expect: [
-              NodeValidators.createForInstanceNode({ instanceKeys: [y1] }),
-              NodeValidators.createForInstanceNode({ instanceKeys: [y2] }),
-            ],
-          });
-          validateHierarchyLevel({
-            nodes: await collect(
-              provider.getNodes({
-                parentNode: { key: { type: "instances", instanceKeys: [x] }, parentKeys: [], label: "" },
-                instanceFilter: {
-                  propertyClassNames: [schema.items.Y.fullName],
-                  relatedInstances: [],
-                  rules: {
-                    sourceAlias: "this",
-                    propertyName: `Prop`,
-                    operator: "is-equal",
-                    propertyTypeName: "string",
-                    value: { rawValue: `two`, displayValue: "two" },
-                  },
-                },
-              }),
-            ),
-            expect: [NodeValidators.createForInstanceNode({ instanceKeys: [y2] })],
-          });
+          ];
         },
-      );
+      };
+      const provider = createProvider({ ecdb, hierarchy });
+      validateHierarchyLevel({
+        nodes: await collect(
+          provider.getNodes({
+            parentNode: { key: { type: "instances", instanceKeys: [keys.x] }, parentKeys: [], label: "" },
+          }),
+        ),
+        expect: [
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.y1] }),
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.y2] }),
+        ],
+      });
+      validateHierarchyLevel({
+        nodes: await collect(
+          provider.getNodes({
+            parentNode: { key: { type: "instances", instanceKeys: [keys.x] }, parentKeys: [], label: "" },
+            instanceFilter: {
+              propertyClassNames: [schema.items.Y.fullName],
+              relatedInstances: [],
+              rules: {
+                sourceAlias: "this",
+                propertyName: `Prop`,
+                operator: "is-equal",
+                propertyTypeName: "string",
+                value: { rawValue: `two`, displayValue: "two" },
+              },
+            },
+          }),
+        ),
+        expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.y2] })],
+      });
     });
 
     it("filters grouped hierarchy level", async () => {
-      await withECDb(
-        async (db, testName) => {
-          const schema = await importSchema(
-            testName,
-            db,
-            `
-              <ECEntityClass typeName="X" />
-              <ECEntityClass typeName="Y">
-                <ECProperty propertyName="Prop" typeName="string" />
-              </ECEntityClass>
-            `,
-          );
-          const x = db.insertInstance(schema.items.X.fullName);
-          const y1 = db.insertInstance(schema.items.Y.fullName, { prop: "one" });
-          const y2 = db.insertInstance(schema.items.Y.fullName, { prop: "two" });
-          return { schema, x, y1, y2 };
-        },
-        async (imodel, { schema, x, y1, y2 }) => {
-          const imodelAccess = createIModelAccess(imodel);
-          const selectQueryFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-              classHierarchyInspector: imodelAccess,
-            }),
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="X" />
+            <ECEntityClass typeName="Y">
+              <ECProperty propertyName="Prop" typeName="string" />
+            </ECEntityClass>
+          `,
+        );
+        const x = builder.insertInstance(s.items.X.fullName);
+        const y1 = builder.insertInstance(s.items.Y.fullName, { prop: "one" });
+        const y2 = builder.insertInstance(s.items.Y.fullName, { prop: "two" });
+        return { schema: s, x, y1, y2 };
+      });
+      const { ecdb, schema, ...keys } = setup;
+      const imodelAccess = createIModelAccess(ecdb);
+      const selectQueryFactory = createNodesQueryClauseFactory({
+        imodelAccess,
+        instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+          classHierarchyInspector: imodelAccess,
+        }),
+      });
+      const hierarchy: HierarchyDefinition = {
+        async defineHierarchyLevel({ instanceFilter }) {
+          const filterClauses = await selectQueryFactory.createFilterClauses({
+            filter: instanceFilter,
+            contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
           });
-          const hierarchy: HierarchyDefinition = {
-            async defineHierarchyLevel({ instanceFilter }) {
-              const filterClauses = await selectQueryFactory.createFilterClauses({
-                filter: instanceFilter,
-                contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
-              });
-              return [
-                {
-                  fullClassName: schema.items.Y.fullName,
-                  query: {
-                    ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
-                        ecClassId: { selector: `this.ECClassId` },
-                        ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
-                        grouping: { byClass: true },
-                      })}
-                      FROM ${filterClauses.from} AS this
-                      ${filterClauses.joins}
-                      ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
-                    `,
-                  },
-                },
-              ];
+          return [
+            {
+              fullClassName: schema.items.Y.fullName,
+              query: {
+                ecsql: `
+                  SELECT ${await selectQueryFactory.createSelectClause({
+                    ecClassId: { selector: `this.ECClassId` },
+                    ecInstanceId: { selector: `this.ECInstanceId` },
+                    nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
+                    grouping: { byClass: true },
+                  })}
+                  FROM ${filterClauses.from} AS this
+                  ${filterClauses.joins}
+                  ${filterClauses.where ? `WHERE ${filterClauses.where}` : ""}
+                `,
+              },
             },
-          };
-          const provider = createProvider({ imodel, hierarchy });
-          const groupingNode = {
-            key: { type: "class-grouping" as const, className: schema.items.Y.fullName },
-            parentKeys: [{ type: "instances" as const, instanceKeys: [x] }],
-            nonGroupingAncestor: { key: { type: "instances" as const, instanceKeys: [x] }, parentKeys: [], label: "X" },
-            label: "Y",
-            groupedInstanceKeys: [y1, y2],
-          };
-          validateHierarchyLevel({
-            nodes: await collect(provider.getNodes({ parentNode: groupingNode })),
-            expect: [
-              NodeValidators.createForInstanceNode({ instanceKeys: [y1] }),
-              NodeValidators.createForInstanceNode({ instanceKeys: [y2] }),
-            ],
-          });
-          validateHierarchyLevel({
-            nodes: await collect(
-              provider.getNodes({
-                parentNode: groupingNode,
-                instanceFilter: {
-                  propertyClassNames: [schema.items.Y.fullName],
-                  relatedInstances: [],
-                  rules: {
-                    sourceAlias: "this",
-                    propertyName: `Prop`,
-                    operator: "is-equal",
-                    propertyTypeName: "string",
-                    value: { rawValue: `two`, displayValue: "two" },
-                  },
-                },
-              }),
-            ),
-            expect: [NodeValidators.createForInstanceNode({ instanceKeys: [y2] })],
-          });
+          ];
         },
-      );
+      };
+      const provider = createProvider({ ecdb, hierarchy });
+      const groupingNode = {
+        key: { type: "class-grouping" as const, className: schema.items.Y.fullName },
+        parentKeys: [{ type: "instances" as const, instanceKeys: [keys.x] }],
+        nonGroupingAncestor: {
+          key: { type: "instances" as const, instanceKeys: [keys.x] },
+          parentKeys: [],
+          label: "X",
+        },
+        label: "Y",
+        groupedInstanceKeys: [keys.y1, keys.y2],
+      };
+      validateHierarchyLevel({
+        nodes: await collect(provider.getNodes({ parentNode: groupingNode })),
+        expect: [
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.y1] }),
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.y2] }),
+        ],
+      });
+      validateHierarchyLevel({
+        nodes: await collect(
+          provider.getNodes({
+            parentNode: groupingNode,
+            instanceFilter: {
+              propertyClassNames: [schema.items.Y.fullName],
+              relatedInstances: [],
+              rules: {
+                sourceAlias: "this",
+                propertyName: `Prop`,
+                operator: "is-equal",
+                propertyTypeName: "string",
+                value: { rawValue: `two`, displayValue: "two" },
+              },
+            },
+          }),
+        ),
+        expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.y2] })],
+      });
     });
 
     it("filters by property class", async () => {
-      await withECDb(
-        async (db, testName) => {
-          const schema = await importSchema(
-            testName,
-            db,
-            `
-              <ECEntityClass typeName="X" />
-              <ECEntityClass typeName="Y">
-                <BaseClass>X</BaseClass>
-              </ECEntityClass>
-            `,
-          );
-          const x = db.insertInstance(schema.items.X.fullName);
-          const y = db.insertInstance(schema.items.Y.fullName);
-          return { schema, x, y };
-        },
-        async (imodel, { schema, x, y }) => {
-          const imodelAccess = createIModelAccess(imodel);
-          const selectQueryFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-              classHierarchyInspector: imodelAccess,
-            }),
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="X" />
+            <ECEntityClass typeName="Y">
+              <BaseClass>X</BaseClass>
+            </ECEntityClass>
+          `,
+        );
+        const x = builder.insertInstance(s.items.X.fullName);
+        const y = builder.insertInstance(s.items.Y.fullName);
+        return { schema: s, x, y };
+      });
+      const { ecdb, schema, ...keys } = setup;
+      const imodelAccess = createIModelAccess(ecdb);
+      const selectQueryFactory = createNodesQueryClauseFactory({
+        imodelAccess,
+        instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+          classHierarchyInspector: imodelAccess,
+        }),
+      });
+      const hierarchy: HierarchyDefinition = {
+        async defineHierarchyLevel({ instanceFilter }) {
+          const subjectFilterClauses = await selectQueryFactory.createFilterClauses({
+            filter: instanceFilter,
+            contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
-          const hierarchy: HierarchyDefinition = {
-            async defineHierarchyLevel({ instanceFilter }) {
-              const subjectFilterClauses = await selectQueryFactory.createFilterClauses({
-                filter: instanceFilter,
-                contentClass: { fullName: schema.items.X.fullName, alias: "this" },
-              });
-              return [
-                {
-                  fullClassName: schema.items.X.fullName,
-                  query: {
-                    ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
-                        ecClassId: { selector: `this.ECClassId` },
-                        ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
-                      })}
-                      FROM ${subjectFilterClauses.from} AS this
-                      ${subjectFilterClauses.joins}
-                      ${subjectFilterClauses.where ? `WHERE ${subjectFilterClauses.where}` : ""}
-                    `,
-                  },
-                },
-              ];
+          return [
+            {
+              fullClassName: schema.items.X.fullName,
+              query: {
+                ecsql: `
+                  SELECT ${await selectQueryFactory.createSelectClause({
+                    ecClassId: { selector: `this.ECClassId` },
+                    ecInstanceId: { selector: `this.ECInstanceId` },
+                    nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
+                  })}
+                  FROM ${subjectFilterClauses.from} AS this
+                  ${subjectFilterClauses.joins}
+                  ${subjectFilterClauses.where ? `WHERE ${subjectFilterClauses.where}` : ""}
+                `,
+              },
             },
-          };
-          const provider = createProvider({ imodel, hierarchy });
-          validateHierarchyLevel({
-            nodes: await collect(provider.getNodes({ parentNode: undefined })),
-            expect: [
-              NodeValidators.createForInstanceNode({ instanceKeys: [x] }),
-              NodeValidators.createForInstanceNode({ instanceKeys: [y] }),
-            ],
-          });
-          validateHierarchyLevel({
-            nodes: await collect(
-              provider.getNodes({
-                parentNode: undefined,
-                instanceFilter: {
-                  propertyClassNames: [schema.items.Y.fullName],
-                  relatedInstances: [],
-                  rules: { operator: "and", rules: [] },
-                },
-              }),
-            ),
-            expect: [NodeValidators.createForInstanceNode({ instanceKeys: [y] })],
-          });
+          ];
         },
-      );
+      };
+      const provider = createProvider({ ecdb, hierarchy });
+      validateHierarchyLevel({
+        nodes: await collect(provider.getNodes({ parentNode: undefined })),
+        expect: [
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.x] }),
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.y] }),
+        ],
+      });
+      validateHierarchyLevel({
+        nodes: await collect(
+          provider.getNodes({
+            parentNode: undefined,
+            instanceFilter: {
+              propertyClassNames: [schema.items.Y.fullName],
+              relatedInstances: [],
+              rules: { operator: "and", rules: [] },
+            },
+          }),
+        ),
+        expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.y] })],
+      });
     });
 
     it("filters by filter class", async () => {
-      await withECDb(
-        async (db, testName) => {
-          const schema = await importSchema(
-            testName,
-            db,
-            `
-              <ECEntityClass typeName="X" />
-              <ECEntityClass typeName="Y">
-                <BaseClass>X</BaseClass>
-              </ECEntityClass>
-            `,
-          );
-          const x = db.insertInstance(schema.items.X.fullName);
-          const y = db.insertInstance(schema.items.Y.fullName);
-          return { schema, x, y };
-        },
-        async (imodel, { schema, x, y }) => {
-          const imodelAccess = createIModelAccess(imodel);
-          const selectQueryFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-              classHierarchyInspector: imodelAccess,
-            }),
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="X" />
+            <ECEntityClass typeName="Y">
+              <BaseClass>X</BaseClass>
+            </ECEntityClass>
+          `,
+        );
+        const x = builder.insertInstance(s.items.X.fullName);
+        const y = builder.insertInstance(s.items.Y.fullName);
+        return { schema: s, x, y };
+      });
+      const { ecdb, schema, ...keys } = setup;
+      const imodelAccess = createIModelAccess(ecdb);
+      const selectQueryFactory = createNodesQueryClauseFactory({
+        imodelAccess,
+        instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+          classHierarchyInspector: imodelAccess,
+        }),
+      });
+      const hierarchy: HierarchyDefinition = {
+        async defineHierarchyLevel({ instanceFilter }) {
+          const subjectFilterClauses = await selectQueryFactory.createFilterClauses({
+            filter: instanceFilter,
+            contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
-          const hierarchy: HierarchyDefinition = {
-            async defineHierarchyLevel({ instanceFilter }) {
-              const subjectFilterClauses = await selectQueryFactory.createFilterClauses({
-                filter: instanceFilter,
-                contentClass: { fullName: schema.items.X.fullName, alias: "this" },
-              });
-              return [
-                {
-                  fullClassName: schema.items.X.fullName,
-                  query: {
-                    ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
-                        ecClassId: { selector: `this.ECClassId` },
-                        ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
-                      })}
-                      FROM ${subjectFilterClauses.from} AS this
-                      ${subjectFilterClauses.joins}
-                      ${subjectFilterClauses.where ? `WHERE ${subjectFilterClauses.where}` : ""}
-                    `,
-                  },
-                },
-              ];
+          return [
+            {
+              fullClassName: schema.items.X.fullName,
+              query: {
+                ecsql: `
+                  SELECT ${await selectQueryFactory.createSelectClause({
+                    ecClassId: { selector: `this.ECClassId` },
+                    ecInstanceId: { selector: `this.ECInstanceId` },
+                    nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
+                  })}
+                  FROM ${subjectFilterClauses.from} AS this
+                  ${subjectFilterClauses.joins}
+                  ${subjectFilterClauses.where ? `WHERE ${subjectFilterClauses.where}` : ""}
+                `,
+              },
             },
-          };
-          const provider = createProvider({ imodel, hierarchy });
-          validateHierarchyLevel({
-            nodes: await collect(provider.getNodes({ parentNode: undefined })),
-            expect: [
-              NodeValidators.createForInstanceNode({ instanceKeys: [x] }),
-              NodeValidators.createForInstanceNode({ instanceKeys: [y] }),
-            ],
-          });
-          validateHierarchyLevel({
-            nodes: await collect(
-              provider.getNodes({
-                parentNode: undefined,
-                instanceFilter: {
-                  propertyClassNames: [schema.items.X.fullName],
-                  filteredClassNames: [schema.items.Y.fullName],
-                  relatedInstances: [],
-                  rules: { operator: "and", rules: [] },
-                },
-              }),
-            ),
-            expect: [NodeValidators.createForInstanceNode({ instanceKeys: [y] })],
-          });
+          ];
         },
-      );
+      };
+      const provider = createProvider({ ecdb, hierarchy });
+      validateHierarchyLevel({
+        nodes: await collect(provider.getNodes({ parentNode: undefined })),
+        expect: [
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.x] }),
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.y] }),
+        ],
+      });
+      validateHierarchyLevel({
+        nodes: await collect(
+          provider.getNodes({
+            parentNode: undefined,
+            instanceFilter: {
+              propertyClassNames: [schema.items.X.fullName],
+              filteredClassNames: [schema.items.Y.fullName],
+              relatedInstances: [],
+              rules: { operator: "and", rules: [] },
+            },
+          }),
+        ),
+        expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.y] })],
+      });
     });
 
     it("filters by direct property", async () => {
-      await withECDb(
-        async (db, testName) => {
-          const schema = await importSchema(
-            testName,
-            db,
-            `
-              <ECEntityClass typeName="X">
-                <ECProperty propertyName="Prop" typeName="Int" />
-              </ECEntityClass>
-            `,
-          );
-          const x1 = db.insertInstance(schema.items.X.fullName, { prop: 123 });
-          const x2 = db.insertInstance(schema.items.X.fullName, { prop: 456 });
-          return { schema, x1, x2 };
-        },
-        async (imodel, { schema, x1, x2 }) => {
-          const imodelAccess = createIModelAccess(imodel);
-          const selectQueryFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-              classHierarchyInspector: imodelAccess,
-            }),
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="X">
+              <ECProperty propertyName="Prop" typeName="Int" />
+            </ECEntityClass>
+          `,
+        );
+        const x1 = builder.insertInstance(s.items.X.fullName, { prop: 123 });
+        const x2 = builder.insertInstance(s.items.X.fullName, { prop: 456 });
+        return { schema: s, x1, x2 };
+      });
+      const { ecdb, schema, ...keys } = setup;
+      const imodelAccess = createIModelAccess(ecdb);
+      const selectQueryFactory = createNodesQueryClauseFactory({
+        imodelAccess,
+        instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+          classHierarchyInspector: imodelAccess,
+        }),
+      });
+      const hierarchy: HierarchyDefinition = {
+        async defineHierarchyLevel({ instanceFilter }) {
+          const subjectFilterClauses = await selectQueryFactory.createFilterClauses({
+            filter: instanceFilter,
+            contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
-          const hierarchy: HierarchyDefinition = {
-            async defineHierarchyLevel({ instanceFilter }) {
-              const subjectFilterClauses = await selectQueryFactory.createFilterClauses({
-                filter: instanceFilter,
-                contentClass: { fullName: schema.items.X.fullName, alias: "this" },
-              });
-              return [
-                {
-                  fullClassName: schema.items.X.fullName,
-                  query: {
-                    ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
-                        ecClassId: { selector: `this.ECClassId` },
-                        ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
-                      })}
-                      FROM ${subjectFilterClauses.from} AS this
-                      ${subjectFilterClauses.joins}
-                      ${subjectFilterClauses.where ? `WHERE ${subjectFilterClauses.where}` : ""}
-                    `,
-                  },
-                },
-              ];
+          return [
+            {
+              fullClassName: schema.items.X.fullName,
+              query: {
+                ecsql: `
+                  SELECT ${await selectQueryFactory.createSelectClause({
+                    ecClassId: { selector: `this.ECClassId` },
+                    ecInstanceId: { selector: `this.ECInstanceId` },
+                    nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
+                  })}
+                  FROM ${subjectFilterClauses.from} AS this
+                  ${subjectFilterClauses.joins}
+                  ${subjectFilterClauses.where ? `WHERE ${subjectFilterClauses.where}` : ""}
+                `,
+              },
             },
-          };
-          const provider = createProvider({ imodel, hierarchy });
-          validateHierarchyLevel({
-            nodes: await collect(provider.getNodes({ parentNode: undefined })),
-            expect: [
-              NodeValidators.createForInstanceNode({ instanceKeys: [x1] }),
-              NodeValidators.createForInstanceNode({ instanceKeys: [x2] }),
-            ],
-          });
-          validateHierarchyLevel({
-            nodes: await collect(
-              provider.getNodes({
-                parentNode: undefined,
-                instanceFilter: {
-                  propertyClassNames: [schema.items.X.fullName],
-                  relatedInstances: [],
-                  rules: {
-                    sourceAlias: "this",
-                    propertyName: "Prop",
-                    operator: "less",
-                    propertyTypeName: "int",
-                    value: { rawValue: 200, displayValue: "200" },
-                  },
-                },
-              }),
-            ),
-            expect: [NodeValidators.createForInstanceNode({ instanceKeys: [x1] })],
-          });
+          ];
         },
-      );
+      };
+      const provider = createProvider({ ecdb, hierarchy });
+      validateHierarchyLevel({
+        nodes: await collect(provider.getNodes({ parentNode: undefined })),
+        expect: [
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1] }),
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2] }),
+        ],
+      });
+      validateHierarchyLevel({
+        nodes: await collect(
+          provider.getNodes({
+            parentNode: undefined,
+            instanceFilter: {
+              propertyClassNames: [schema.items.X.fullName],
+              relatedInstances: [],
+              rules: {
+                sourceAlias: "this",
+                propertyName: "Prop",
+                operator: "less",
+                propertyTypeName: "int",
+                value: { rawValue: 200, displayValue: "200" },
+              },
+            },
+          }),
+        ),
+        expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1] })],
+      });
     });
 
     it("filters by related property", async () => {
-      await withECDb(
-        async (db, testName) => {
-          const schema = await importSchema(
-            testName,
-            db,
-            `
-              <ECEntityClass typeName="X" />
-              <ECEntityClass typeName="Y">
-                <ECProperty propertyName="Prop" typeName="Int" />
-              </ECEntityClass>
-              <ECRelationshipClass typeName="XY"  strength="referencing" strengthDirection="forward" modifier="None">
-                  <Source multiplicity="(0..1)" roleLabel="xy" polymorphic="False">
-                      <Class class="X" />
-                  </Source>
-                  <Target multiplicity="(0..1)" roleLabel="yx" polymorphic="True">
-                      <Class class="Y" />
-                  </Target>
-              </ECRelationshipClass>
-            `,
-          );
-          const x1 = db.insertInstance(schema.items.X.fullName);
-          const x2 = db.insertInstance(schema.items.X.fullName);
-          const y1 = db.insertInstance(schema.items.Y.fullName, { prop: 123 });
-          const y2 = db.insertInstance(schema.items.Y.fullName, { prop: 456 });
-          db.insertRelationship(schema.items.XY.fullName, x1.id, y1.id);
-          db.insertRelationship(schema.items.XY.fullName, x2.id, y2.id);
-          return { schema, x1, x2 };
-        },
-        async (imodel, { schema, x1, x2 }) => {
-          const imodelAccess = createIModelAccess(imodel);
-          const selectQueryFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-              classHierarchyInspector: imodelAccess,
-            }),
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="X" />
+            <ECEntityClass typeName="Y">
+              <ECProperty propertyName="Prop" typeName="Int" />
+            </ECEntityClass>
+            <ECRelationshipClass typeName="XY"  strength="referencing" strengthDirection="forward" modifier="None">
+                <Source multiplicity="(0..1)" roleLabel="xy" polymorphic="False">
+                    <Class class="X" />
+                </Source>
+                <Target multiplicity="(0..1)" roleLabel="yx" polymorphic="True">
+                    <Class class="Y" />
+                </Target>
+            </ECRelationshipClass>
+          `,
+        );
+        const x1 = builder.insertInstance(s.items.X.fullName);
+        const x2 = builder.insertInstance(s.items.X.fullName);
+        const y1 = builder.insertInstance(s.items.Y.fullName, { prop: 123 });
+        const y2 = builder.insertInstance(s.items.Y.fullName, { prop: 456 });
+        builder.insertRelationship(s.items.XY.fullName, x1.id, y1.id);
+        builder.insertRelationship(s.items.XY.fullName, x2.id, y2.id);
+        return { schema: s, x1, x2 };
+      });
+      const { ecdb, schema, ...keys } = setup;
+      const imodelAccess = createIModelAccess(ecdb);
+      const selectQueryFactory = createNodesQueryClauseFactory({
+        imodelAccess,
+        instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+          classHierarchyInspector: imodelAccess,
+        }),
+      });
+      const hierarchy: HierarchyDefinition = {
+        async defineHierarchyLevel({ instanceFilter }) {
+          const subjectFilterClauses = await selectQueryFactory.createFilterClauses({
+            filter: instanceFilter,
+            contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
-          const hierarchy: HierarchyDefinition = {
-            async defineHierarchyLevel({ instanceFilter }) {
-              const subjectFilterClauses = await selectQueryFactory.createFilterClauses({
-                filter: instanceFilter,
-                contentClass: { fullName: schema.items.X.fullName, alias: "this" },
-              });
-              return [
-                {
-                  fullClassName: schema.items.X.fullName,
-                  query: {
-                    ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
-                        ecClassId: { selector: `this.ECClassId` },
-                        ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
-                      })}
-                      FROM ${subjectFilterClauses.from} AS this
-                      ${subjectFilterClauses.joins}
-                      ${subjectFilterClauses.where ? `WHERE ${subjectFilterClauses.where}` : ""}
-                    `,
-                  },
-                },
-              ];
+          return [
+            {
+              fullClassName: schema.items.X.fullName,
+              query: {
+                ecsql: `
+                  SELECT ${await selectQueryFactory.createSelectClause({
+                    ecClassId: { selector: `this.ECClassId` },
+                    ecInstanceId: { selector: `this.ECInstanceId` },
+                    nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
+                  })}
+                  FROM ${subjectFilterClauses.from} AS this
+                  ${subjectFilterClauses.joins}
+                  ${subjectFilterClauses.where ? `WHERE ${subjectFilterClauses.where}` : ""}
+                `,
+              },
             },
-          };
-          const provider = createProvider({ imodel, hierarchy });
-          validateHierarchyLevel({
-            nodes: await collect(provider.getNodes({ parentNode: undefined })),
-            expect: [
-              NodeValidators.createForInstanceNode({ instanceKeys: [x1] }),
-              NodeValidators.createForInstanceNode({ instanceKeys: [x2] }),
-            ],
-          });
-          validateHierarchyLevel({
-            nodes: await collect(
-              provider.getNodes({
-                parentNode: undefined,
-                instanceFilter: {
-                  propertyClassNames: [schema.items.X.fullName],
-                  relatedInstances: [
+          ];
+        },
+      };
+      const provider = createProvider({ ecdb, hierarchy });
+      validateHierarchyLevel({
+        nodes: await collect(provider.getNodes({ parentNode: undefined })),
+        expect: [
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1] }),
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2] }),
+        ],
+      });
+      validateHierarchyLevel({
+        nodes: await collect(
+          provider.getNodes({
+            parentNode: undefined,
+            instanceFilter: {
+              propertyClassNames: [schema.items.X.fullName],
+              relatedInstances: [
+                {
+                  path: [
                     {
-                      path: [
-                        {
-                          sourceClassName: schema.items.X.fullName,
-                          relationshipClassName: schema.items.XY.fullName,
-                          targetClassName: schema.items.Y.fullName,
-                          isForwardRelationship: true,
-                        },
-                      ],
-                      alias: "related-y",
+                      sourceClassName: schema.items.X.fullName,
+                      relationshipClassName: schema.items.XY.fullName,
+                      targetClassName: schema.items.Y.fullName,
+                      isForwardRelationship: true,
                     },
                   ],
-                  rules: {
-                    sourceAlias: "related-y",
-                    propertyName: "Prop",
-                    operator: "is-equal",
-                    propertyTypeName: "int",
-                    value: { rawValue: 123, displayValue: "123" },
-                  },
+                  alias: "related-y",
                 },
-              }),
-            ),
-            expect: [NodeValidators.createForInstanceNode({ instanceKeys: [x1] })],
-          });
-        },
-      );
+              ],
+              rules: {
+                sourceAlias: "related-y",
+                propertyName: "Prop",
+                operator: "is-equal",
+                propertyTypeName: "int",
+                value: { rawValue: 123, displayValue: "123" },
+              },
+            },
+          }),
+        ),
+        expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1] })],
+      });
     });
   });
 });

--- a/apps/full-stack-tests/src/hierarchies/HierarchyLevelInstanceKeys.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchyLevelInstanceKeys.test.ts
@@ -26,7 +26,7 @@ describe("Hierarchies", () => {
     test.beforeAll(async (_, suite) => {
       await initialize();
 
-      imodel = (await buildTestIModel(suite.fullTestName!)).imodel;
+      imodel = (await buildTestIModel(suite.fullTestName!)).imodelConnection;
     });
 
     afterAll(async () => {

--- a/apps/full-stack-tests/src/hierarchies/HierarchySearch.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchySearch.test.ts
@@ -24,7 +24,7 @@ import {
   mergeProviders,
 } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory, normalizeFullClassName } from "@itwin/presentation-shared";
-import { withECDb } from "../ECDbUtils.js";
+import { buildTestECDb } from "../ECDbUtils.js";
 import { buildTestIModel } from "../IModelUtils.js";
 import { initialize, terminate } from "../IntegrationTests.js";
 import { importSchema } from "../SchemaUtils.js";
@@ -58,13 +58,13 @@ describe("Hierarchies", () => {
 
     describe("generic nodes", () => {
       it("searches through generic nodes", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-          const childSubject1 = insertSubject({ builder, codeValue: "test subject 1", parentId: rootSubject.id });
-          const childSubject2 = insertSubject({ builder, codeValue: "test subject 2", parentId: rootSubject.id });
+          const childSubject1 = insertSubject({ imodel, codeValue: "test subject 1", parentId: rootSubject.id });
+          const childSubject2 = insertSubject({ imodel, codeValue: "test subject 2", parentId: rootSubject.id });
           return { rootSubject, childSubject1, childSubject2 };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
           instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -129,7 +129,7 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             search: [
               {
@@ -171,12 +171,12 @@ describe("Hierarchies", () => {
       });
 
       it("searches generic nodes", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async () => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async () => {
           const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
           return { rootSubject };
         });
 
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
           instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -214,7 +214,7 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             search: [
               {
@@ -238,7 +238,7 @@ describe("Hierarchies", () => {
       });
 
       it("searches generic nodes when targeting child and ancestor", async () => {
-        const { imodel } = await buildTestIModel();
+        const { imodelConnection } = await buildTestIModel();
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {
@@ -261,7 +261,7 @@ describe("Hierarchies", () => {
         };
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             search: [
               {
@@ -308,15 +308,15 @@ describe("Hierarchies", () => {
 
     describe("instance nodes", () => {
       it("sets auto-expand flag up to specific grouping level", async function () {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-          const childSubject1 = insertSubject({ builder, codeValue: "test subject 1", parentId: rootSubject.id });
-          const childSubject21 = insertSubject({ builder, codeValue: "test subject 2.1", parentId: rootSubject.id });
-          const childSubject22 = insertSubject({ builder, codeValue: "test subject 2.2", parentId: rootSubject.id });
-          const childSubject3 = insertSubject({ builder, codeValue: "test subject 3", parentId: rootSubject.id });
+          const childSubject1 = insertSubject({ imodel, codeValue: "test subject 1", parentId: rootSubject.id });
+          const childSubject21 = insertSubject({ imodel, codeValue: "test subject 2.1", parentId: rootSubject.id });
+          const childSubject22 = insertSubject({ imodel, codeValue: "test subject 2.2", parentId: rootSubject.id });
+          const childSubject3 = insertSubject({ imodel, codeValue: "test subject 3", parentId: rootSubject.id });
           return { rootSubject, childSubject1, childSubject21, childSubject22, childSubject3 };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
           instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -367,7 +367,7 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             search: [
               {
@@ -443,15 +443,15 @@ describe("Hierarchies", () => {
       });
 
       it("searches through instance nodes that are in multiple paths", async function () {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-          const childSubject1 = insertSubject({ builder, codeValue: "test subject 1", parentId: rootSubject.id });
-          const childSubject2 = insertSubject({ builder, codeValue: "test subject 2", parentId: rootSubject.id });
-          const childSubject3 = insertSubject({ builder, codeValue: "test subject 3", parentId: rootSubject.id });
-          const childSubject4 = insertSubject({ builder, codeValue: "test subject 4", parentId: rootSubject.id });
+          const childSubject1 = insertSubject({ imodel, codeValue: "test subject 1", parentId: rootSubject.id });
+          const childSubject2 = insertSubject({ imodel, codeValue: "test subject 2", parentId: rootSubject.id });
+          const childSubject3 = insertSubject({ imodel, codeValue: "test subject 3", parentId: rootSubject.id });
+          const childSubject4 = insertSubject({ imodel, codeValue: "test subject 4", parentId: rootSubject.id });
           return { rootSubject, childSubject1, childSubject2, childSubject3, childSubject4 };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
           instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -515,7 +515,7 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             search: [
               {
@@ -572,14 +572,14 @@ describe("Hierarchies", () => {
       });
 
       it("searches instance nodes when targeting child and ancestor", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-          const childSubject1 = insertSubject({ builder, codeValue: "test subject 1", parentId: rootSubject.id });
-          const childSubject2 = insertSubject({ builder, codeValue: "test subject 2", parentId: rootSubject.id });
-          const childSubject21 = insertSubject({ builder, codeValue: "test subject 21", parentId: rootSubject.id });
-          const childSubject22 = insertSubject({ builder, codeValue: "test subject 22", parentId: rootSubject.id });
-          const childSubject221 = insertSubject({ builder, codeValue: "test subject 221", parentId: rootSubject.id });
-          const childSubject222 = insertSubject({ builder, codeValue: "test subject 222", parentId: rootSubject.id });
+          const childSubject1 = insertSubject({ imodel, codeValue: "test subject 1", parentId: rootSubject.id });
+          const childSubject2 = insertSubject({ imodel, codeValue: "test subject 2", parentId: rootSubject.id });
+          const childSubject21 = insertSubject({ imodel, codeValue: "test subject 21", parentId: rootSubject.id });
+          const childSubject22 = insertSubject({ imodel, codeValue: "test subject 22", parentId: rootSubject.id });
+          const childSubject221 = insertSubject({ imodel, codeValue: "test subject 221", parentId: rootSubject.id });
+          const childSubject222 = insertSubject({ imodel, codeValue: "test subject 222", parentId: rootSubject.id });
           return {
             rootSubject,
             childSubject1,
@@ -590,7 +590,7 @@ describe("Hierarchies", () => {
             childSubject222,
           };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
           instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -639,7 +639,7 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             search: [
               {
@@ -696,14 +696,14 @@ describe("Hierarchies", () => {
 
     describe("when searching through hidden nodes", () => {
       it("searches through hidden generic nodes", async function () {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-          const childSubject1 = insertSubject({ builder, codeValue: "test subject 1", parentId: rootSubject.id });
-          const childSubject2 = insertSubject({ builder, codeValue: "test subject 2", parentId: rootSubject.id });
+          const childSubject1 = insertSubject({ imodel, codeValue: "test subject 1", parentId: rootSubject.id });
+          const childSubject2 = insertSubject({ imodel, codeValue: "test subject 2", parentId: rootSubject.id });
           return { rootSubject, childSubject1, childSubject2 };
         });
 
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
           instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -769,7 +769,7 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             search: [
               {
@@ -806,14 +806,14 @@ describe("Hierarchies", () => {
 
     describe("when targeting hidden nodes", () => {
       it("doesn't return matching hidden generic nodes or their children", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-          const childSubject1 = insertSubject({ builder, codeValue: "test subject 1", parentId: rootSubject.id });
-          const childSubject2 = insertSubject({ builder, codeValue: "test subject 2", parentId: rootSubject.id });
+          const childSubject1 = insertSubject({ imodel, codeValue: "test subject 1", parentId: rootSubject.id });
+          const childSubject2 = insertSubject({ imodel, codeValue: "test subject 2", parentId: rootSubject.id });
           return { rootSubject, childSubject1, childSubject2 };
         });
 
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
           instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -879,7 +879,7 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             search: [{ identifier: keys.rootSubject, children: [{ identifier: { type: "generic", id: "custom" } }] }],
           }),
@@ -894,15 +894,15 @@ describe("Hierarchies", () => {
       });
 
       it("doesn't return matching hidden instance nodes", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-          const childSubject1 = insertSubject({ builder, codeValue: "test subject 1", parentId: rootSubject.id });
-          const childSubject2 = insertSubject({ builder, codeValue: "test subject 2", parentId: childSubject1.id });
-          const childSubject3 = insertSubject({ builder, codeValue: "test subject 3", parentId: childSubject1.id });
+          const childSubject1 = insertSubject({ imodel, codeValue: "test subject 1", parentId: rootSubject.id });
+          const childSubject2 = insertSubject({ imodel, codeValue: "test subject 2", parentId: childSubject1.id });
+          const childSubject3 = insertSubject({ imodel, codeValue: "test subject 3", parentId: childSubject1.id });
           return { rootSubject, childSubject1, childSubject2, childSubject3 };
         });
 
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
           instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -973,7 +973,7 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             search: [{ identifier: keys.rootSubject, children: [{ identifier: keys.childSubject1 }] }],
           }),
@@ -988,38 +988,37 @@ describe("Hierarchies", () => {
       });
 
       it("doesn't return hidden instance node when targeting both the node and its parent, when parent has visible children from other hierarchy level definitions", async () => {
-        await withECDb(
-          async (db, testName) => {
-            const schema = await importSchema(
-              testName,
-              db,
-              `
-                <ECEntityClass typeName="X" />
-                <ECEntityClass typeName="Y" />
-                <ECEntityClass typeName="Z" />
-              `,
-            );
-            const x = db.insertInstance(schema.items.X.fullName);
-            const y = db.insertInstance(schema.items.Y.fullName);
-            const z = db.insertInstance(schema.items.Z.fullName);
-            return { schema, x, y, z };
-          },
-          async (imodel, { schema, x, y, z }) => {
-            const imodelAccess = createIModelAccess(imodel);
-            const selectQueryFactory = createNodesQueryClauseFactory({
-              imodelAccess,
-              instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-                classHierarchyInspector: imodelAccess,
-              }),
-            });
-            const hierarchy: HierarchyDefinition = {
-              async defineHierarchyLevel({ parentNode }) {
-                if (!parentNode) {
-                  return [
-                    {
-                      fullClassName: schema.items.X.fullName,
-                      query: {
-                        ecsql: `
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X" />
+              <ECEntityClass typeName="Y" />
+              <ECEntityClass typeName="Z" />
+            `,
+          );
+          const x = builder.insertInstance(s.items.X.fullName);
+          const y = builder.insertInstance(s.items.Y.fullName);
+          const z = builder.insertInstance(s.items.Z.fullName);
+          return { schema: s, x, y, z };
+        });
+        const { ecdb, schema, ...keys } = setup;
+        const imodelAccess = createIModelAccess(ecdb);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+            classHierarchyInspector: imodelAccess,
+          }),
+        });
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ parentNode }) {
+            if (!parentNode) {
+              return [
+                {
+                  fullClassName: schema.items.X.fullName,
+                  query: {
+                    ecsql: `
                           SELECT ${await selectQueryFactory.createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
@@ -1027,16 +1026,16 @@ describe("Hierarchies", () => {
                           })}
                           FROM ${schema.items.X.fullName} AS this
                         `,
-                      },
-                    },
-                  ];
-                }
-                if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "x") {
-                  return [
-                    {
-                      fullClassName: schema.items.Y.fullName,
-                      query: {
-                        ecsql: `
+                  },
+                },
+              ];
+            }
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "x") {
+              return [
+                {
+                  fullClassName: schema.items.Y.fullName,
+                  query: {
+                    ecsql: `
                           SELECT ${await selectQueryFactory.createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
@@ -1045,12 +1044,12 @@ describe("Hierarchies", () => {
                           })}
                           FROM ${schema.items.Y.fullName} AS this
                         `,
-                      },
-                    },
-                    {
-                      fullClassName: schema.items.Z.fullName,
-                      query: {
-                        ecsql: `
+                  },
+                },
+                {
+                  fullClassName: schema.items.Z.fullName,
+                  query: {
+                    ecsql: `
                           SELECT ${await selectQueryFactory.createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
@@ -1058,76 +1057,73 @@ describe("Hierarchies", () => {
                           })}
                           FROM ${schema.items.Z.fullName} AS this
                         `,
-                      },
-                    },
-                  ];
-                }
-                return [];
-              },
-            };
+                  },
+                },
+              ];
+            }
+            return [];
+          },
+        };
 
-            await validateHierarchy({
-              provider: createProvider({
-                imodel,
-                hierarchy,
-                search: [
-                  { identifier: x, isTarget: true, options: { autoExpand: true }, children: [{ identifier: y }] },
-                ],
-              }),
-              expect: [
+        await validateHierarchy({
+          provider: createProvider({
+            ecdb,
+            hierarchy,
+            search: [
+              { identifier: keys.x, isTarget: true, options: { autoExpand: true }, children: [{ identifier: keys.y }] },
+            ],
+          }),
+          expect: [
+            NodeValidators.createForInstanceNode({
+              instanceKeys: [keys.x],
+              autoExpand: true,
+              isSearchTarget: true,
+              children: [
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [x],
-                  autoExpand: true,
-                  isSearchTarget: true,
-                  children: [
-                    NodeValidators.createForInstanceNode({
-                      instanceKeys: [z],
-                      autoExpand: false,
-                      isSearchTarget: false,
-                      children: false,
-                    }),
-                  ],
+                  instanceKeys: [keys.z],
+                  autoExpand: false,
+                  isSearchTarget: false,
+                  children: false,
                 }),
               ],
-            });
-          },
-        );
+            }),
+          ],
+        });
       });
 
       it("doesn't return hidden instance node when targeting both the node and its parent, when parent has visible children from the same hierarchy level definition", async () => {
-        await withECDb(
-          async (db, testName) => {
-            const schema = await importSchema(
-              testName,
-              db,
-              `
-                <ECEntityClass typeName="X" />
-                <ECEntityClass typeName="Y">
-                  <ECProperty propertyName="IsHidden" typeName="boolean" />
-                </ECEntityClass>
-              `,
-            );
-            const x = db.insertInstance(schema.items.X.fullName);
-            const y1 = db.insertInstance(schema.items.Y.fullName, { isHidden: true });
-            const y2 = db.insertInstance(schema.items.Y.fullName, { isHidden: false });
-            return { schema, x, y1, y2 };
-          },
-          async (imodel, { schema, x, y1, y2 }) => {
-            const imodelAccess = createIModelAccess(imodel);
-            const selectQueryFactory = createNodesQueryClauseFactory({
-              imodelAccess,
-              instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-                classHierarchyInspector: imodelAccess,
-              }),
-            });
-            const hierarchy: HierarchyDefinition = {
-              async defineHierarchyLevel({ parentNode }) {
-                if (!parentNode) {
-                  return [
-                    {
-                      fullClassName: schema.items.X.fullName,
-                      query: {
-                        ecsql: `
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X" />
+              <ECEntityClass typeName="Y">
+                <ECProperty propertyName="IsHidden" typeName="boolean" />
+              </ECEntityClass>
+            `,
+          );
+          const x = builder.insertInstance(s.items.X.fullName);
+          const y1 = builder.insertInstance(s.items.Y.fullName, { isHidden: true });
+          const y2 = builder.insertInstance(s.items.Y.fullName, { isHidden: false });
+          return { schema: s, x, y1, y2 };
+        });
+        const { ecdb, schema, ...keys } = setup;
+        const imodelAccess = createIModelAccess(ecdb);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+            classHierarchyInspector: imodelAccess,
+          }),
+        });
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ parentNode }) {
+            if (!parentNode) {
+              return [
+                {
+                  fullClassName: schema.items.X.fullName,
+                  query: {
+                    ecsql: `
                           SELECT ${await selectQueryFactory.createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
@@ -1135,16 +1131,16 @@ describe("Hierarchies", () => {
                           })}
                           FROM ${schema.items.X.fullName} AS this
                         `,
-                      },
-                    },
-                  ];
-                }
-                if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "x") {
-                  return [
-                    {
-                      fullClassName: schema.items.Y.fullName,
-                      query: {
-                        ecsql: `
+                  },
+                },
+              ];
+            }
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "x") {
+              return [
+                {
+                  fullClassName: schema.items.Y.fullName,
+                  query: {
+                    ecsql: `
                           SELECT ${await selectQueryFactory.createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
@@ -1153,57 +1149,60 @@ describe("Hierarchies", () => {
                           })}
                           FROM ${schema.items.Y.fullName} AS this
                         `,
-                      },
-                    },
-                  ];
-                }
-                return [];
-              },
-            };
+                  },
+                },
+              ];
+            }
+            return [];
+          },
+        };
 
-            await validateHierarchy({
-              provider: createProvider({
-                imodel,
-                hierarchy,
-                search: [
-                  { identifier: x, isTarget: true, options: { autoExpand: true }, children: [{ identifier: y1 }] },
-                ],
-              }),
-              expect: [
+        await validateHierarchy({
+          provider: createProvider({
+            ecdb,
+            hierarchy,
+            search: [
+              {
+                identifier: keys.x,
+                isTarget: true,
+                options: { autoExpand: true },
+                children: [{ identifier: keys.y1 }],
+              },
+            ],
+          }),
+          expect: [
+            NodeValidators.createForInstanceNode({
+              instanceKeys: [keys.x],
+              autoExpand: true,
+              isSearchTarget: true,
+              children: [
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [x],
-                  autoExpand: true,
-                  isSearchTarget: true,
-                  children: [
-                    NodeValidators.createForInstanceNode({
-                      instanceKeys: [y2],
-                      autoExpand: false,
-                      isSearchTarget: false,
-                      children: false,
-                    }),
-                  ],
+                  instanceKeys: [keys.y2],
+                  autoExpand: false,
+                  isSearchTarget: false,
+                  children: false,
                 }),
               ],
-            });
-          },
-        );
+            }),
+          ],
+        });
       });
     });
 
     describe("when targeting grouped instance nodes", () => {
       it("sets auto-expand flag for parent nodes before the target grouping node", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-          const category = insertSpatialCategory({ builder, codeValue: "category" });
-          const model = insertPhysicalModelWithPartition({ builder, codeValue: "model" });
+          const category = insertSpatialCategory({ imodel, codeValue: "category" });
+          const model = insertPhysicalModelWithPartition({ imodel, codeValue: "model" });
           const elements = [
-            insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id }),
-            insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id }),
+            insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id }),
+            insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id }),
           ];
           return { rootSubject, model, category, elements };
         });
 
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
           instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -1238,7 +1237,7 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             search: [
               {
@@ -1265,19 +1264,19 @@ describe("Hierarchies", () => {
       });
 
       it("sets auto-expand flag for all deeply-nested grouping nodes before the target grouping node", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-          const category = insertSpatialCategory({ builder, codeValue: "category" });
-          const model = insertPhysicalModelWithPartition({ builder, codeValue: "model" });
-          const rootElement = insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id });
+          const category = insertSpatialCategory({ imodel, codeValue: "category" });
+          const model = insertPhysicalModelWithPartition({ imodel, codeValue: "model" });
+          const rootElement = insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id });
           const middleElement = insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             parentId: rootElement.id,
           });
           const childElement = insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             parentId: middleElement.id,
@@ -1285,7 +1284,7 @@ describe("Hierarchies", () => {
           return { rootSubject, model, category, rootElement, middleElement, childElement };
         });
 
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
           instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -1323,7 +1322,7 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
+            imodel: imodelConnection,
             hierarchy,
             search: [
               {
@@ -1387,15 +1386,15 @@ describe("Hierarchies", () => {
       describe("nested grouping nodes of different types", async function () {
         const rootNodeKey: GenericNodeKey = { type: "generic", id: "root-node" };
         let hierarchy: HierarchyDefinition;
-        let imodel: IModelConnection;
+        let imodelConnection: IModelConnection;
         let elementKey: InstanceKey;
         let circleClassName: EC.FullClassName;
 
         test.beforeAll(async (_, suite) => {
-          const result = await buildTestIModel(suite.fullTestName!, async (builder, testName) => {
+          const result = await buildTestIModel(suite.fullTestName!, async (imodel, testName) => {
             const schema = await importSchema(
               testName,
-              builder,
+              imodel,
               `
                 <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
                 <ECEntityClass typeName="Circle">
@@ -1404,20 +1403,20 @@ describe("Hierarchies", () => {
                 </ECEntityClass>
               `,
             );
-            const category = insertSpatialCategory({ builder, codeValue: "category" });
-            const model = insertPhysicalModelWithPartition({ builder, codeValue: "model" });
+            const category = insertSpatialCategory({ imodel, codeValue: "category" });
+            const model = insertPhysicalModelWithPartition({ imodel, codeValue: "model" });
             circleClassName = schema.items.Circle.fullName;
             elementKey = insertPhysicalElement({
-              builder,
+              imodel,
               modelId: model.id,
               categoryId: category.id,
               classFullName: circleClassName,
               ["Color"]: "Red",
             });
           });
-          imodel = result.imodel;
+          imodelConnection = result.imodelConnection;
 
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
           const selectQueryFactory = createNodesQueryClauseFactory({
             imodelAccess,
             instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -1460,7 +1459,7 @@ describe("Hierarchies", () => {
         it("sets auto-expand flag until the first grouping node", async () => {
           await validateHierarchy({
             provider: createProvider({
-              imodel,
+              imodel: imodelConnection,
               hierarchy,
               search: [
                 { identifier: rootNodeKey, options: { autoExpand: true }, children: [{ identifier: elementKey }] },
@@ -1502,7 +1501,7 @@ describe("Hierarchies", () => {
         it("sets auto-expand flag until the second grouping node", async () => {
           await validateHierarchy({
             provider: createProvider({
-              imodel,
+              imodel: imodelConnection,
               hierarchy,
               search: [
                 {
@@ -1549,7 +1548,7 @@ describe("Hierarchies", () => {
         it("sets auto-expand flag until the third grouping node", async () => {
           await validateHierarchy({
             provider: createProvider({
-              imodel,
+              imodel: imodelConnection,
               hierarchy,
               search: [
                 {
@@ -1596,7 +1595,7 @@ describe("Hierarchies", () => {
         it("sets auto-expand flag until the instance node", async () => {
           await validateHierarchy({
             provider: createProvider({
-              imodel,
+              imodel: imodelConnection,
               hierarchy,
               search: [
                 {
@@ -1644,17 +1643,17 @@ describe("Hierarchies", () => {
 
     describe("when searching merged hierarchy provider", () => {
       it("searches root nodes of individual provider", async function () {
-        const { imodel: imodel1, ...keys1 } = await buildTestIModel(
+        const { imodelConnection: imodel1, ...keys1 } = await buildTestIModel(
           `${expect.getState().currentTestName!} 1`,
-          async (builder) => {
-            const testSubject = insertSubject({ builder, codeValue: "A subject", parentId: IModel.rootSubjectId });
+          async (imodel) => {
+            const testSubject = insertSubject({ imodel, codeValue: "A subject", parentId: IModel.rootSubjectId });
             return { testSubject };
           },
         );
-        const { imodel: imodel2, ...keys2 } = await buildTestIModel(
+        const { imodelConnection: imodel2, ...keys2 } = await buildTestIModel(
           `${expect.getState().currentTestName!} 2`,
-          async (builder) => {
-            const testSubject = insertSubject({ builder, codeValue: "B subject", parentId: IModel.rootSubjectId });
+          async (imodel) => {
+            const testSubject = insertSubject({ imodel, codeValue: "B subject", parentId: IModel.rootSubjectId });
             return { testSubject };
           },
         );
@@ -1846,19 +1845,19 @@ describe("Hierarchies", () => {
 
       it("searches through multiple providers", async function () {
         const rootSubjectKey = { className: subjectClassName, id: IModel.rootSubjectId };
-        const { imodel: imodel1, ...keys1 } = await buildTestIModel(
+        const { imodelConnection: imodel1, ...keys1 } = await buildTestIModel(
           `${expect.getState().currentTestName!} 1`,
-          async (builder) => {
-            const subject1 = insertSubject({ builder, codeValue: "A subject 1", parentId: rootSubjectKey.id });
-            const subject2 = insertSubject({ builder, codeValue: "A subject 2", parentId: subject1.id });
+          async (imodel) => {
+            const subject1 = insertSubject({ imodel, codeValue: "A subject 1", parentId: rootSubjectKey.id });
+            const subject2 = insertSubject({ imodel, codeValue: "A subject 2", parentId: subject1.id });
             return { subject1, subject2 };
           },
         );
-        const { imodel: imodel2, ...keys2 } = await buildTestIModel(
+        const { imodelConnection: imodel2, ...keys2 } = await buildTestIModel(
           `${expect.getState().currentTestName!} 2`,
-          async (builder) => {
-            const subject1 = insertSubject({ builder, codeValue: "B subject 1", parentId: rootSubjectKey.id });
-            const subject2 = insertSubject({ builder, codeValue: "B subject 2", parentId: subject1.id });
+          async (imodel) => {
+            const subject1 = insertSubject({ imodel, codeValue: "B subject 1", parentId: rootSubjectKey.id });
+            const subject2 = insertSubject({ imodel, codeValue: "B subject 2", parentId: subject1.id });
             return { subject1, subject2 };
           },
         );

--- a/apps/full-stack-tests/src/hierarchies/Utils.ts
+++ b/apps/full-stack-tests/src/hierarchies/Utils.ts
@@ -44,10 +44,8 @@ export function createProvider(
         search?: HierarchySearchPaths;
         queryCacheSize?: number;
       }
-    | {
-        imodel: IModelConnection | IModelDb | ECDb;
-        formatterFactory?: (schemas: SchemaContext) => IPrimitiveValueFormatter;
-      }
+    | { imodel: IModelConnection | IModelDb; formatterFactory?: (schemas: SchemaContext) => IPrimitiveValueFormatter }
+    | { ecdb: ECDb; formatterFactory?: (schemas: SchemaContext) => IPrimitiveValueFormatter }
   ) & {
     imodelChanged?: Event<() => void>;
     hierarchy: HierarchyDefinition;
@@ -59,9 +57,12 @@ export function createProvider(
 ) {
   const { imodelChanged, hierarchy, localizedStrings, search, queryCacheSize } = props;
   const formatter =
-    "imodel" in props && props.formatterFactory ? props.formatterFactory(createSchemaContext(props.imodel)) : undefined;
+    "formatterFactory" in props && props.formatterFactory
+      ? props.formatterFactory(createSchemaContext("imodel" in props ? props.imodel : props.ecdb))
+      : undefined;
   return createIModelHierarchyProvider({
-    imodelAccess: "imodelAccess" in props ? props.imodelAccess : createIModelAccess(props.imodel),
+    imodelAccess:
+      "imodelAccess" in props ? props.imodelAccess : createIModelAccess("imodel" in props ? props.imodel : props.ecdb),
     imodelChanged,
     hierarchyDefinition: hierarchy,
     formatter,

--- a/apps/full-stack-tests/src/hierarchies/grouping/AutoExpand.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/AutoExpand.test.ts
@@ -28,7 +28,7 @@ describe("Hierarchies", () => {
 
     test.beforeAll(async (_, suite) => {
       await initialize();
-      emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodel;
+      emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodelConnection;
       subjectClassName = Subject.classFullName.replace(":", ".");
     });
 
@@ -127,16 +127,20 @@ describe("Hierarchies", () => {
       });
 
       it("grouping nodes' autoExpand option is undefined when none of the child nodes have autoExpand set to 'always'", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const childSubject1 = insertSubject({ builder, codeValue: "A1", parentId: IModel.rootSubjectId });
-          const childSubject2 = insertSubject({ builder, codeValue: "A2", parentId: IModel.rootSubjectId });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const childSubject1 = insertSubject({ imodel, codeValue: "A1", parentId: IModel.rootSubjectId });
+          const childSubject2 = insertSubject({ imodel, codeValue: "A2", parentId: IModel.rootSubjectId });
           return { childSubject1, childSubject2 };
         });
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, baseClassAutoExpandSingleChild, `ECInstanceId`),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(
+              imodelConnection,
+              baseClassAutoExpandSingleChild,
+              `ECInstanceId`,
+            ),
           }),
           expect: [
             NodeValidators.createForClassGroupingNode({
@@ -205,16 +209,20 @@ describe("Hierarchies", () => {
       });
 
       it("grouping nodes' autoExpand option is undefined when none of the child nodes have autoExpand set to 'always'", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const childSubject1 = insertSubject({ builder, codeValue: "A1", parentId: IModel.rootSubjectId });
-          const childSubject2 = insertSubject({ builder, codeValue: "A2", parentId: IModel.rootSubjectId });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const childSubject1 = insertSubject({ imodel, codeValue: "A1", parentId: IModel.rootSubjectId });
+          const childSubject2 = insertSubject({ imodel, codeValue: "A2", parentId: IModel.rootSubjectId });
           return { childSubject1, childSubject2 };
         });
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, classAutoExpandSingleChild, `ECInstanceId`),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(
+              imodelConnection,
+              classAutoExpandSingleChild,
+              `ECInstanceId`,
+            ),
           }),
           expect: [
             NodeValidators.createForClassGroupingNode({
@@ -281,15 +289,15 @@ describe("Hierarchies", () => {
 
       it("grouping nodes' autoExpand option is undefined when none of the child nodes have autoExpand set to 'always'", async () => {
         const groupName = "test1";
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const childSubject1 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A1",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
           });
           const childSubject2 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A2",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
@@ -299,8 +307,8 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, labelAutoExpandSingleChild, "UserLabel"),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, labelAutoExpandSingleChild, "UserLabel"),
           }),
           expect: [
             NodeValidators.createForLabelGroupingNode({
@@ -385,16 +393,20 @@ describe("Hierarchies", () => {
       });
 
       it("grouping nodes' autoExpand option is undefined when none of the child nodes have autoExpand set to 'always'", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const childSubject1 = insertSubject({ builder, codeValue: "A1", parentId: IModel.rootSubjectId });
-          const childSubject2 = insertSubject({ builder, codeValue: "A2", parentId: IModel.rootSubjectId });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const childSubject1 = insertSubject({ imodel, codeValue: "A1", parentId: IModel.rootSubjectId });
+          const childSubject2 = insertSubject({ imodel, codeValue: "A2", parentId: IModel.rootSubjectId });
           return { childSubject1, childSubject2 };
         });
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, propertiesAutoExpandSingleChild, "ECInstanceId"),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(
+              imodelConnection,
+              propertiesAutoExpandSingleChild,
+              "ECInstanceId",
+            ),
           }),
           expect: [
             NodeValidators.createForPropertyValueGroupingNode({

--- a/apps/full-stack-tests/src/hierarchies/grouping/BaseClassGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/BaseClassGrouping.test.ts
@@ -26,7 +26,7 @@ describe("Hierarchies", () => {
 
     test.beforeAll(async (_, suite) => {
       await initialize();
-      emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodel;
+      emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodelConnection;
       subjectClassName = normalizeFullClassName(Subject.classFullName);
       physicalPartitionClassName = normalizeFullClassName(PhysicalPartition.classFullName);
     });
@@ -188,12 +188,12 @@ describe("Hierarchies", () => {
       const baseClassName2 = "InformationContentElement";
       const baseClassName3 = "InformationPartitionElement";
       const baseSchemaName = "BisCore";
-      const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-        const childPartition1 = insertPhysicalPartition({ builder, codeValue: "B1", parentId: IModel.rootSubjectId });
+      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+        const childPartition1 = insertPhysicalPartition({ imodel, codeValue: "B1", parentId: IModel.rootSubjectId });
         return { childPartition1 };
       });
 
-      const imodelAccess = createIModelAccess(imodel);
+      const imodelAccess = createIModelAccess(imodelConnection);
       const selectQueryFactory = createNodesQueryClauseFactory({
         imodelAccess,
         instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -237,7 +237,7 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel, hierarchy: customHierarchy }),
+        provider: createProvider({ imodel: imodelConnection, hierarchy: customHierarchy }),
         expect: [
           NodeValidators.createForClassGroupingNode({
             label: "Element",
@@ -267,13 +267,13 @@ describe("Hierarchies", () => {
       const baseClassName2 = "InformationContentElement";
       const baseClassName3 = "InformationPartitionElement";
       const baseSchemaName = "BisCore";
-      const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-        const childPartition1 = insertPhysicalPartition({ builder, codeValue: "B1", parentId: IModel.rootSubjectId });
-        const childPartition2 = insertPhysicalPartition({ builder, codeValue: "B2", parentId: IModel.rootSubjectId });
+      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+        const childPartition1 = insertPhysicalPartition({ imodel, codeValue: "B1", parentId: IModel.rootSubjectId });
+        const childPartition2 = insertPhysicalPartition({ imodel, codeValue: "B2", parentId: IModel.rootSubjectId });
         return { childPartition1, childPartition2 };
       });
 
-      const imodelAccess = createIModelAccess(imodel);
+      const imodelAccess = createIModelAccess(imodelConnection);
       const selectQueryFactory = createNodesQueryClauseFactory({
         imodelAccess,
         instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -341,7 +341,7 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel, hierarchy: customHierarchy }),
+        provider: createProvider({ imodel: imodelConnection, hierarchy: customHierarchy }),
         expect: [
           NodeValidators.createForClassGroupingNode({
             label: "Element",
@@ -380,13 +380,13 @@ describe("Hierarchies", () => {
     });
 
     it("groups nodes of different classes if they share the same base class", async () => {
-      const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-        const childSubject1 = insertSubject({ builder, codeValue: "A1", parentId: IModel.rootSubjectId });
-        const childPartition2 = insertPhysicalPartition({ builder, codeValue: "B2", parentId: IModel.rootSubjectId });
+      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+        const childSubject1 = insertSubject({ imodel, codeValue: "A1", parentId: IModel.rootSubjectId });
+        const childPartition2 = insertPhysicalPartition({ imodel, codeValue: "B2", parentId: IModel.rootSubjectId });
         return { childSubject1, childPartition2 };
       });
 
-      const imodelAccess = createIModelAccess(imodel);
+      const imodelAccess = createIModelAccess(imodelConnection);
       const selectQueryFactory = createNodesQueryClauseFactory({
         imodelAccess,
         instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -425,7 +425,7 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel, hierarchy: customHierarchy }),
+        provider: createProvider({ imodel: imodelConnection, hierarchy: customHierarchy }),
         expect: [
           NodeValidators.createForClassGroupingNode({
             label: "Element",

--- a/apps/full-stack-tests/src/hierarchies/grouping/ClassGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/ClassGrouping.test.ts
@@ -32,15 +32,15 @@ describe("Hierarchies", () => {
     });
 
     it("creates different groups for different classes", async () => {
-      const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-        const childSubject1 = insertSubject({ builder, codeValue: "1", parentId: IModel.rootSubjectId });
-        const childPartition2 = insertPhysicalPartition({ builder, codeValue: "2", parentId: IModel.rootSubjectId });
-        const childSubject3 = insertSubject({ builder, codeValue: "3", parentId: IModel.rootSubjectId });
-        const childPartition4 = insertPhysicalPartition({ builder, codeValue: "4", parentId: IModel.rootSubjectId });
+      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+        const childSubject1 = insertSubject({ imodel, codeValue: "1", parentId: IModel.rootSubjectId });
+        const childPartition2 = insertPhysicalPartition({ imodel, codeValue: "2", parentId: IModel.rootSubjectId });
+        const childSubject3 = insertSubject({ imodel, codeValue: "3", parentId: IModel.rootSubjectId });
+        const childPartition4 = insertPhysicalPartition({ imodel, codeValue: "4", parentId: IModel.rootSubjectId });
         return { childSubject1, childPartition2, childSubject3, childPartition4 };
       });
 
-      const imodelAccess = createIModelAccess(imodel);
+      const imodelAccess = createIModelAccess(imodelConnection);
       const selectQueryFactory = createNodesQueryClauseFactory({
         imodelAccess,
         instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -79,7 +79,7 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel, hierarchy }),
+        provider: createProvider({ imodel: imodelConnection, hierarchy }),
         expect: [
           NodeValidators.createForClassGroupingNode({
             children: [

--- a/apps/full-stack-tests/src/hierarchies/grouping/GroupHiding.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/GroupHiding.test.ts
@@ -91,16 +91,16 @@ describe("Hierarchies", () => {
       };
 
       it("hides base class groups when there're no siblings", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const childSubject1 = insertSubject({ builder, codeValue: "A1", parentId: IModel.rootSubjectId });
-          const childSubject2 = insertSubject({ builder, codeValue: "A2", parentId: IModel.rootSubjectId });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const childSubject1 = insertSubject({ imodel, codeValue: "A1", parentId: IModel.rootSubjectId });
+          const childSubject2 = insertSubject({ imodel, codeValue: "A2", parentId: IModel.rootSubjectId });
           return { childSubject1, childSubject2 };
         });
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, baseClassHideIfNoSiblingsGrouping),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, baseClassHideIfNoSiblingsGrouping),
           }),
           expect: [
             NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
@@ -110,36 +110,36 @@ describe("Hierarchies", () => {
       });
 
       it("hides base class groups when there's only 1 grouped node", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const childSubject1 = insertSubject({ builder, codeValue: "A1", parentId: IModel.rootSubjectId });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const childSubject1 = insertSubject({ imodel, codeValue: "A1", parentId: IModel.rootSubjectId });
           return { childSubject1 };
         });
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, baseClassHideIfOneGroupedNodeGrouping),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, baseClassHideIfOneGroupedNodeGrouping),
           }),
           expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
         });
       });
 
       it("doesn't hide base class groups when there are siblings", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const childSubject1 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A1",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
           });
-          const childPartition2 = insertPhysicalPartition({ builder, codeValue: "B1", parentId: IModel.rootSubjectId });
+          const childPartition2 = insertPhysicalPartition({ imodel, codeValue: "B1", parentId: IModel.rootSubjectId });
           return { childSubject1, childPartition2 };
         });
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, baseClassHideIfNoSiblingsGrouping),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, baseClassHideIfNoSiblingsGrouping),
           }),
           expect: [
             NodeValidators.createForInstanceNode({ instanceKeys: [keys.childPartition2], children: false }),
@@ -153,16 +153,16 @@ describe("Hierarchies", () => {
       });
 
       it("doesn't hide base class groups when there's more than 1 grouped node", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const childSubject1 = insertSubject({ builder, codeValue: "A1", parentId: IModel.rootSubjectId });
-          const childSubject2 = insertSubject({ builder, codeValue: "A2", parentId: IModel.rootSubjectId });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const childSubject1 = insertSubject({ imodel, codeValue: "A1", parentId: IModel.rootSubjectId });
+          const childSubject2 = insertSubject({ imodel, codeValue: "A2", parentId: IModel.rootSubjectId });
           return { childSubject1, childSubject2 };
         });
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, baseClassHideIfOneGroupedNodeGrouping),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, baseClassHideIfOneGroupedNodeGrouping),
           }),
           expect: [
             NodeValidators.createForClassGroupingNode({
@@ -186,16 +186,16 @@ describe("Hierarchies", () => {
       };
 
       it("hides class groups when there're no siblings", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const childSubject1 = insertSubject({ builder, codeValue: "A1", parentId: IModel.rootSubjectId });
-          const childSubject2 = insertSubject({ builder, codeValue: "A2", parentId: IModel.rootSubjectId });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const childSubject1 = insertSubject({ imodel, codeValue: "A1", parentId: IModel.rootSubjectId });
+          const childSubject2 = insertSubject({ imodel, codeValue: "A2", parentId: IModel.rootSubjectId });
           return { childSubject1, childSubject2 };
         });
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, classHideIfNoSiblingsGrouping),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, classHideIfNoSiblingsGrouping),
           }),
           expect: [
             NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
@@ -205,31 +205,31 @@ describe("Hierarchies", () => {
       });
 
       it("hides class groups when there's only 1 grouped node", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const childSubject1 = insertSubject({ builder, codeValue: "A1", parentId: IModel.rootSubjectId });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const childSubject1 = insertSubject({ imodel, codeValue: "A1", parentId: IModel.rootSubjectId });
           return { childSubject1 };
         });
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, classHideIfOneGroupedNodeGrouping),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, classHideIfOneGroupedNodeGrouping),
           }),
           expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
         });
       });
 
       it("doesn't hide class groups when there are siblings", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const childSubject1 = insertSubject({ builder, codeValue: "A1", parentId: IModel.rootSubjectId });
-          const childPartition2 = insertPhysicalPartition({ builder, codeValue: "B1", parentId: IModel.rootSubjectId });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const childSubject1 = insertSubject({ imodel, codeValue: "A1", parentId: IModel.rootSubjectId });
+          const childPartition2 = insertPhysicalPartition({ imodel, codeValue: "B1", parentId: IModel.rootSubjectId });
           return { childSubject1, childPartition2 };
         });
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, classHideIfNoSiblingsGrouping),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, classHideIfNoSiblingsGrouping),
           }),
           expect: [
             NodeValidators.createForClassGroupingNode({
@@ -247,16 +247,16 @@ describe("Hierarchies", () => {
       });
 
       it("doesn't hide class groups when there's more than 1 grouped node", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const childSubject1 = insertSubject({ builder, codeValue: "A1", parentId: IModel.rootSubjectId });
-          const childSubject2 = insertSubject({ builder, codeValue: "A2", parentId: IModel.rootSubjectId });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const childSubject1 = insertSubject({ imodel, codeValue: "A1", parentId: IModel.rootSubjectId });
+          const childSubject2 = insertSubject({ imodel, codeValue: "A2", parentId: IModel.rootSubjectId });
           return { childSubject1, childSubject2 };
         });
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, classHideIfOneGroupedNodeGrouping),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, classHideIfOneGroupedNodeGrouping),
           }),
           expect: [
             NodeValidators.createForClassGroupingNode({
@@ -279,15 +279,15 @@ describe("Hierarchies", () => {
       const labelHideIfNoSiblingsGrouping: ECSqlSelectClauseGroupingParams = { byLabel: { hideIfNoSiblings: true } };
 
       it("hides label groups when there're no siblings", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const childSubject1 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A1",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
           });
           const childSubject2 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A2",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
@@ -297,8 +297,12 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, labelHideIfNoSiblingsGrouping, "UserLabel"),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(
+              imodelConnection,
+              labelHideIfNoSiblingsGrouping,
+              "UserLabel",
+            ),
           }),
           expect: [
             NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
@@ -308,9 +312,9 @@ describe("Hierarchies", () => {
       });
 
       it("hides label groups when there's only 1 grouped node", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const childSubject1 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A1",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
@@ -320,23 +324,27 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, labelHideIfOneGroupedNodeGrouping, "UserLabel"),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(
+              imodelConnection,
+              labelHideIfOneGroupedNodeGrouping,
+              "UserLabel",
+            ),
           }),
           expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
         });
       });
 
       it("doesn't hide label groups when there are siblings", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const childSubject1 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A1",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
           });
           const childSubject2 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A2",
             parentId: IModel.rootSubjectId,
             userLabel: "test2",
@@ -346,8 +354,12 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, labelHideIfNoSiblingsGrouping, "UserLabel"),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(
+              imodelConnection,
+              labelHideIfNoSiblingsGrouping,
+              "UserLabel",
+            ),
           }),
           expect: [
             NodeValidators.createForLabelGroupingNode({
@@ -363,15 +375,15 @@ describe("Hierarchies", () => {
       });
 
       it("doesn't hide label groups when there's more than 1 grouped node", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const childSubject1 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A1",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
           });
           const childSubject2 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A2",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
@@ -381,8 +393,12 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, labelHideIfOneGroupedNodeGrouping, "UserLabel"),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(
+              imodelConnection,
+              labelHideIfOneGroupedNodeGrouping,
+              "UserLabel",
+            ),
           }),
           expect: [
             NodeValidators.createForLabelGroupingNode({
@@ -415,15 +431,15 @@ describe("Hierarchies", () => {
       };
 
       it("hides property groups when there're no siblings", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const childSubject1 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A1",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
           });
           const childSubject2 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A2",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
@@ -433,8 +449,8 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, propertiesHideIfNoSiblingsGrouping),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, propertiesHideIfNoSiblingsGrouping),
           }),
           expect: [
             NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
@@ -444,9 +460,9 @@ describe("Hierarchies", () => {
       });
 
       it("hides property groups when there's only 1 grouped node", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const childSubject1 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A1",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
@@ -456,23 +472,23 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, propertiesHideIfOneGroupedNodeGrouping),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, propertiesHideIfOneGroupedNodeGrouping),
           }),
           expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
         });
       });
 
       it("doesn't hide property groups when there are siblings", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const childSubject1 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A1",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
           });
           const childSubject2 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A2",
             parentId: IModel.rootSubjectId,
             userLabel: `${groupName}2`,
@@ -482,8 +498,8 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, propertiesHideIfNoSiblingsGrouping),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, propertiesHideIfNoSiblingsGrouping),
           }),
           expect: [
             NodeValidators.createForPropertyValueGroupingNode({
@@ -503,15 +519,15 @@ describe("Hierarchies", () => {
       });
 
       it("doesn't hide base class groups when there's more than 1 grouped node", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const childSubject1 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A1",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
           });
           const childSubject2 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A2",
             parentId: IModel.rootSubjectId,
             userLabel: groupName,
@@ -521,8 +537,8 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, propertiesHideIfOneGroupedNodeGrouping),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, propertiesHideIfOneGroupedNodeGrouping),
           }),
           expect: [
             NodeValidators.createForPropertyValueGroupingNode({

--- a/apps/full-stack-tests/src/hierarchies/grouping/LabelGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/LabelGrouping.test.ts
@@ -33,27 +33,27 @@ describe("Hierarchies", () => {
     it("creates different groups for different labels", async () => {
       const labelGroupName1 = "test1";
       const labelGroupName2 = "test2";
-      const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
         const childSubject1 = insertSubject({
-          builder,
+          imodel,
           codeValue: "1",
           parentId: IModel.rootSubjectId,
           userLabel: labelGroupName1,
         });
         const childSubject2 = insertSubject({
-          builder,
+          imodel,
           codeValue: "2",
           parentId: IModel.rootSubjectId,
           userLabel: labelGroupName2,
         });
         const childSubject3 = insertSubject({
-          builder,
+          imodel,
           codeValue: "3",
           parentId: IModel.rootSubjectId,
           userLabel: labelGroupName1,
         });
         const childSubject4 = insertSubject({
-          builder,
+          imodel,
           codeValue: "4",
           parentId: IModel.rootSubjectId,
           userLabel: labelGroupName2,
@@ -61,7 +61,7 @@ describe("Hierarchies", () => {
         return { childSubject1, childSubject2, childSubject3, childSubject4 };
       });
 
-      const imodelAccess = createIModelAccess(imodel);
+      const imodelAccess = createIModelAccess(imodelConnection);
       const selectQueryFactory = createNodesQueryClauseFactory({
         imodelAccess,
         instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -94,7 +94,7 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel, hierarchy }),
+        provider: createProvider({ imodel: imodelConnection, hierarchy }),
         expect: [
           NodeValidators.createForLabelGroupingNode({
             label: labelGroupName1,
@@ -117,30 +117,30 @@ describe("Hierarchies", () => {
     it("creates different groups for same labels and different groupIds", async () => {
       const descriptionGroupName1 = "test1";
       const descriptionGroupName2 = "test2";
-      const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
         const childSubject1 = insertSubject({
-          builder,
+          imodel,
           codeValue: "1",
           parentId: IModel.rootSubjectId,
           userLabel: "test",
           description: descriptionGroupName1,
         });
         const childSubject2 = insertSubject({
-          builder,
+          imodel,
           codeValue: "2",
           parentId: IModel.rootSubjectId,
           userLabel: "test",
           description: descriptionGroupName2,
         });
         const childSubject3 = insertSubject({
-          builder,
+          imodel,
           codeValue: "3",
           parentId: IModel.rootSubjectId,
           userLabel: "test",
           description: descriptionGroupName1,
         });
         const childSubject4 = insertSubject({
-          builder,
+          imodel,
           codeValue: "4",
           parentId: IModel.rootSubjectId,
           userLabel: "test",
@@ -149,7 +149,7 @@ describe("Hierarchies", () => {
         return { childSubject1, childSubject2, childSubject3, childSubject4 };
       });
 
-      const imodelAccess = createIModelAccess(imodel);
+      const imodelAccess = createIModelAccess(imodelConnection);
       const selectQueryFactory = createNodesQueryClauseFactory({
         imodelAccess,
         instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -182,7 +182,7 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel, hierarchy }),
+        provider: createProvider({ imodel: imodelConnection, hierarchy }),
         expect: [
           NodeValidators.createForLabelGroupingNode({
             label: "test",
@@ -207,24 +207,24 @@ describe("Hierarchies", () => {
 
   describe("Label merging", () => {
     it("doesn't merge when different groupIds or labels are provided", async () => {
-      const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
         const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
         const childSubject1 = insertSubject({
-          builder,
+          imodel,
           codeValue: "1",
           parentId: rootSubject.id,
           userLabel: "label1",
           description: "description1",
         });
         const childSubject2 = insertSubject({
-          builder,
+          imodel,
           codeValue: "2",
           parentId: rootSubject.id,
           userLabel: "label1",
           description: "description2",
         });
         const childSubject3 = insertSubject({
-          builder,
+          imodel,
           codeValue: "3",
           parentId: rootSubject.id,
           userLabel: "label2",
@@ -233,7 +233,7 @@ describe("Hierarchies", () => {
         return { rootSubject, childSubject1, childSubject2, childSubject3 };
       });
 
-      const imodelAccess = createIModelAccess(imodel);
+      const imodelAccess = createIModelAccess(imodelConnection);
       const selectQueryFactory = createNodesQueryClauseFactory({
         imodelAccess,
         instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -266,7 +266,7 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel, hierarchy }),
+        provider: createProvider({ imodel: imodelConnection, hierarchy }),
         expect: [
           NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
           NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
@@ -276,14 +276,14 @@ describe("Hierarchies", () => {
     });
 
     it("merges instance nodes with same merge id", async () => {
-      const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
         const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-        const childSubject1 = insertSubject({ builder, codeValue: "1", parentId: rootSubject.id });
-        const childSubject2 = insertSubject({ builder, codeValue: "2", parentId: rootSubject.id });
+        const childSubject1 = insertSubject({ imodel, codeValue: "1", parentId: rootSubject.id });
+        const childSubject2 = insertSubject({ imodel, codeValue: "2", parentId: rootSubject.id });
         return { rootSubject, childSubject1, childSubject2 };
       });
 
-      const imodelAccess = createIModelAccess(imodel);
+      const imodelAccess = createIModelAccess(imodelConnection);
       const selectQueryFactory = createNodesQueryClauseFactory({
         imodelAccess,
         instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -316,7 +316,7 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel, hierarchy }),
+        provider: createProvider({ imodel: imodelConnection, hierarchy }),
         expect: [
           NodeValidators.createForInstanceNode({
             instanceKeys: [keys.childSubject1, keys.childSubject2],
@@ -328,15 +328,15 @@ describe("Hierarchies", () => {
     });
 
     it("merges instance nodes from different hidden parent hierarchy levels ", async () => {
-      const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
         const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-        const visibleSubject1 = insertSubject({ builder, codeValue: "merged", parentId: rootSubject.id });
-        const hiddenSubject = insertSubject({ builder, codeValue: "hide", parentId: rootSubject.id });
-        const visibleSubject2 = insertSubject({ builder, codeValue: "merged", parentId: hiddenSubject.id });
+        const visibleSubject1 = insertSubject({ imodel, codeValue: "merged", parentId: rootSubject.id });
+        const hiddenSubject = insertSubject({ imodel, codeValue: "hide", parentId: rootSubject.id });
+        const visibleSubject2 = insertSubject({ imodel, codeValue: "merged", parentId: hiddenSubject.id });
         return { rootSubject, visibleSubject1, visibleSubject2 };
       });
 
-      const imodelAccess = createIModelAccess(imodel);
+      const imodelAccess = createIModelAccess(imodelConnection);
       const selectQueryFactory = createNodesQueryClauseFactory({
         imodelAccess,
         instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -390,7 +390,7 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel, hierarchy }),
+        provider: createProvider({ imodel: imodelConnection, hierarchy }),
         expect: [
           NodeValidators.createForInstanceNode({
             instanceKeys: [keys.visibleSubject1, keys.visibleSubject2],

--- a/apps/full-stack-tests/src/hierarchies/grouping/MultiLevelGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/MultiLevelGrouping.test.ts
@@ -35,35 +35,35 @@ describe("Hierarchies", () => {
       const labelGroupName1 = "test1";
       const labelGroupName2 = "test2";
       const description1 = "test description1";
-      const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
         const childSubject1 = insertSubject({
-          builder,
+          imodel,
           codeValue: "A1",
           parentId: IModel.rootSubjectId,
           userLabel: labelGroupName1,
           description: description1,
         });
         const childSubject2 = insertSubject({
-          builder,
+          imodel,
           codeValue: "A2",
           parentId: IModel.rootSubjectId,
           userLabel: labelGroupName1,
           description: description1,
         });
         const childPartition3 = insertPhysicalPartition({
-          builder,
+          imodel,
           codeValue: "B3",
           parentId: IModel.rootSubjectId,
           userLabel: labelGroupName1,
         });
         const childPartition4 = insertPhysicalPartition({
-          builder,
+          imodel,
           codeValue: "B4",
           parentId: IModel.rootSubjectId,
           userLabel: labelGroupName2,
         });
         const childPartition5 = insertPhysicalPartition({
-          builder,
+          imodel,
           codeValue: "B5",
           parentId: IModel.rootSubjectId,
           userLabel: labelGroupName2,
@@ -71,7 +71,7 @@ describe("Hierarchies", () => {
         return { childSubject1, childSubject2, childPartition3, childPartition4, childPartition5 };
       });
 
-      const imodelAccess = createIModelAccess(imodel);
+      const imodelAccess = createIModelAccess(imodelConnection);
       const selectQueryFactory = createNodesQueryClauseFactory({
         imodelAccess,
         instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -138,7 +138,7 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel, hierarchy: customHierarchy }),
+        provider: createProvider({ imodel: imodelConnection, hierarchy: customHierarchy }),
         expect: [
           NodeValidators.createForClassGroupingNode({
             label: "Information Content Element",

--- a/apps/full-stack-tests/src/hierarchies/grouping/PropertiesGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/PropertiesGrouping.test.ts
@@ -14,7 +14,7 @@ import { Subject } from "@itwin/core-backend";
 import { IModel } from "@itwin/core-common";
 import { createIModelHierarchyProvider, createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
-import { withECDb } from "../../ECDbUtils.js";
+import { buildTestECDb } from "../../ECDbUtils.js";
 import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { importSchema } from "../../SchemaUtils.js";
@@ -36,7 +36,7 @@ describe("Hierarchies", () => {
     test.beforeAll(async (_, suite) => {
       await initialize();
       subjectClassName = Subject.classFullName.replace(":", ".");
-      emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodel;
+      emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodelConnection;
     });
 
     afterAll(async () => {
@@ -81,9 +81,9 @@ describe("Hierarchies", () => {
     }
 
     it("doesn't group if provided properties class isn't base of nodes class", async () => {
-      const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
         const childSubject1 = insertSubject({
-          builder,
+          imodel,
           codeValue: "A1",
           parentId: IModel.rootSubjectId,
           description: "TestDescription",
@@ -97,15 +97,18 @@ describe("Hierarchies", () => {
         createGroupForUnspecifiedValues: true,
       };
       await validateHierarchy({
-        provider: createProvider({ imodel, hierarchy: createHierarchyWithSpecifiedGrouping(imodel, groupingParams) }),
+        provider: createProvider({
+          imodel: imodelConnection,
+          hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, groupingParams),
+        }),
         expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
       });
     });
 
     describe("unspecified values grouping", () => {
       it("doesn't create grouping nodes if provided property values are not defined and `createGroupForUnspecifiedValues` isn't set", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const childSubject1 = insertSubject({ builder, codeValue: "A1", parentId: IModel.rootSubjectId });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const childSubject1 = insertSubject({ imodel, codeValue: "A1", parentId: IModel.rootSubjectId });
           return { childSubject1 };
         });
 
@@ -115,14 +118,17 @@ describe("Hierarchies", () => {
         };
 
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy: createHierarchyWithSpecifiedGrouping(imodel, groupingParams) }),
+          provider: createProvider({
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, groupingParams),
+          }),
           expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
         });
       });
 
       it("creates property value grouping node if provided property values are not defined and `createGroupForOutOfRangeValues` is `true`", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const childSubject1 = insertSubject({ builder, codeValue: "A1", parentId: IModel.rootSubjectId });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const childSubject1 = insertSubject({ imodel, codeValue: "A1", parentId: IModel.rootSubjectId });
           return { childSubject1 };
         });
 
@@ -134,8 +140,8 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodel, groupingParams),
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, groupingParams),
             localizedStrings: { other: "", unspecified: "NOT SPECIFIED" },
           }),
           expect: [
@@ -205,9 +211,9 @@ describe("Hierarchies", () => {
 
     describe("value grouping", () => {
       it("creates property value grouping nodes", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const childSubject1 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A1",
             parentId: IModel.rootSubjectId,
             description: "TestDescription",
@@ -221,7 +227,10 @@ describe("Hierarchies", () => {
         };
 
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy: createHierarchyWithSpecifiedGrouping(imodel, groupingParams) }),
+          provider: createProvider({
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, groupingParams),
+          }),
           expect: [
             NodeValidators.createForPropertyValueGroupingNode({
               label: "TestDescription",
@@ -235,15 +244,15 @@ describe("Hierarchies", () => {
       });
 
       it("creates multiple grouping nodes if nodes have different property values", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const childSubject1 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A1",
             parentId: IModel.rootSubjectId,
             userLabel: "Test1",
           });
           const childSubject2 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A2",
             parentId: IModel.rootSubjectId,
             userLabel: "Test2",
@@ -251,7 +260,7 @@ describe("Hierarchies", () => {
           return { childSubject1, childSubject2 };
         });
 
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const selectQueryFactory = createNodesQueryClauseFactory({
           imodelAccess,
           instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -289,7 +298,7 @@ describe("Hierarchies", () => {
         };
 
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy: customHierarchy }),
+          provider: createProvider({ imodel: imodelConnection, hierarchy: customHierarchy }),
           expect: [
             NodeValidators.createForPropertyValueGroupingNode({
               label: "Test1",
@@ -310,9 +319,9 @@ describe("Hierarchies", () => {
       });
 
       it("creates multiple levels of grouping if node has multiple property groupings", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
           const childSubject1 = insertSubject({
-            builder,
+            imodel,
             codeValue: "A1",
             parentId: IModel.rootSubjectId,
             userLabel: "TestLabel",
@@ -329,7 +338,10 @@ describe("Hierarchies", () => {
         };
 
         await validateHierarchy({
-          provider: createProvider({ imodel, hierarchy: createHierarchyWithSpecifiedGrouping(imodel, groupingParams) }),
+          provider: createProvider({
+            imodel: imodelConnection,
+            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, groupingParams),
+          }),
           expect: [
             NodeValidators.createForPropertyValueGroupingNode({
               label: "TestLabel",
@@ -354,11 +366,11 @@ describe("Hierarchies", () => {
 
       describe("navigation property", () => {
         it("groups by navigation property with forward direction", async () => {
-          const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-            const model = insertPhysicalModelWithPartition({ builder, codeValue: "Physical model" });
-            const category = insertSpatialCategory({ builder, codeValue: "Spatial category" });
+          const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+            const model = insertPhysicalModelWithPartition({ imodel, codeValue: "Physical model" });
+            const category = insertSpatialCategory({ imodel, codeValue: "Spatial category" });
             const physicalElement = insertPhysicalElement({
-              builder,
+              imodel,
               modelId: model.id,
               categoryId: category.id,
               codeValue: "Physical element",
@@ -366,7 +378,7 @@ describe("Hierarchies", () => {
             return { physicalElement };
           });
 
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
           const selectQueryFactory = createNodesQueryClauseFactory({
             imodelAccess,
             instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -374,7 +386,7 @@ describe("Hierarchies", () => {
             }),
           });
           const provider = createIModelHierarchyProvider({
-            imodelAccess: createIModelAccess(imodel),
+            imodelAccess: createIModelAccess(imodelConnection),
             hierarchyDefinition: {
               defineHierarchyLevel: async ({ parentNode }) =>
                 parentNode
@@ -419,18 +431,18 @@ describe("Hierarchies", () => {
         });
 
         it("groups by navigation property with backward direction", async () => {
-          const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+          const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
             const childSubject1 = insertSubject({
-              builder,
+              imodel,
               codeValue: "A1",
               parentId: IModel.rootSubjectId,
               userLabel: "custom label",
             });
-            const childSubject2 = insertSubject({ builder, codeValue: "A2", parentId: childSubject1.id });
+            const childSubject2 = insertSubject({ imodel, codeValue: "A2", parentId: childSubject1.id });
             return { childSubject1, childSubject2 };
           });
 
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
           const selectQueryFactory = createNodesQueryClauseFactory({
             imodelAccess,
             instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -438,7 +450,7 @@ describe("Hierarchies", () => {
             }),
           });
           const provider = createIModelHierarchyProvider({
-            imodelAccess: createIModelAccess(imodel),
+            imodelAccess: createIModelAccess(imodelConnection),
             hierarchyDefinition: {
               defineHierarchyLevel: async ({ parentNode }) =>
                 parentNode
@@ -484,36 +496,36 @@ describe("Hierarchies", () => {
         });
 
         it("creates one grouping node when navigation properties point to different nodes with same labels", async () => {
-          const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+          const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
             const childSubject1 = insertSubject({
-              builder,
+              imodel,
               codeValue: "A1",
               parentId: IModel.rootSubjectId,
               description: "TestDescription",
               userLabel: "sameLabel",
             });
             const childSubject2 = insertSubject({
-              builder,
+              imodel,
               codeValue: "A2",
               parentId: childSubject1.id,
               description: "TestDescription",
             });
             const childSubject3 = insertSubject({
-              builder,
+              imodel,
               codeValue: "A3",
               parentId: IModel.rootSubjectId,
               description: "TestDescription",
               userLabel: "sameLabel",
             });
             const childSubject4 = insertSubject({
-              builder,
+              imodel,
               codeValue: "A4",
               parentId: childSubject3.id,
               description: "TestDescription",
             });
             return { childSubject1, childSubject2, childSubject3, childSubject4 };
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
           const selectQueryFactory = createNodesQueryClauseFactory({
             imodelAccess,
             instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -521,7 +533,7 @@ describe("Hierarchies", () => {
             }),
           });
           const provider = createIModelHierarchyProvider({
-            imodelAccess: createIModelAccess(imodel),
+            imodelAccess: createIModelAccess(imodelConnection),
             hierarchyDefinition: {
               defineHierarchyLevel: async ({ parentNode }) =>
                 parentNode
@@ -568,29 +580,29 @@ describe("Hierarchies", () => {
         });
 
         it("creates different grouping nodes when navigation properties point to different nodes with different labels", async () => {
-          const { imodel, ...keys } = await buildTestIModel(async (builder) => {
+          const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
             const childSubject1 = insertSubject({
-              builder,
+              imodel,
               codeValue: "A1",
               parentId: IModel.rootSubjectId,
               description: "TestDescription",
               userLabel: "differentLabel1",
             });
             const childSubject2 = insertSubject({
-              builder,
+              imodel,
               codeValue: "A2",
               parentId: childSubject1.id,
               description: "TestDescription",
             });
             const childSubject3 = insertSubject({
-              builder,
+              imodel,
               codeValue: "A3",
               parentId: IModel.rootSubjectId,
               description: "TestDescription",
               userLabel: "differentLabel2",
             });
             const childSubject4 = insertSubject({
-              builder,
+              imodel,
               codeValue: "A4",
               parentId: childSubject3.id,
               description: "TestDescription",
@@ -598,7 +610,7 @@ describe("Hierarchies", () => {
             return { childSubject1, childSubject2, childSubject3, childSubject4 };
           });
 
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
           const selectQueryFactory = createNodesQueryClauseFactory({
             imodelAccess,
             instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -606,7 +618,7 @@ describe("Hierarchies", () => {
             }),
           });
           const provider = createIModelHierarchyProvider({
-            imodelAccess: createIModelAccess(imodel),
+            imodelAccess: createIModelAccess(imodelConnection),
             hierarchyDefinition: {
               defineHierarchyLevel: async ({ parentNode }) =>
                 parentNode
@@ -663,117 +675,113 @@ describe("Hierarchies", () => {
 
     describe("range grouping", () => {
       it("creates property value range grouping nodes", async () => {
-        await withECDb(
-          async (db, testName) => {
-            const schema = await importSchema(
-              testName,
-              db,
-              `
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
                 <ECEntityClass typeName="X">
                   <ECProperty propertyName="Label" typeName="string" />
                   <ECProperty propertyName="Prop" typeName="int" />
                 </ECEntityClass>
               `,
-            );
-            const x1 = db.insertInstance(schema.items.X.fullName, { label: "one", prop: 1.5 });
-            const x2 = db.insertInstance(schema.items.X.fullName, { label: "two", prop: 3 });
-            return { schema, x1, x2 };
-          },
-          async (imodel, { schema, x1, x2 }) => {
-            const imodelAccess = createIModelAccess(imodel);
-            const selectQueryFactory = createNodesQueryClauseFactory({
-              imodelAccess,
-              instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-                classHierarchyInspector: imodelAccess,
-              }),
-            });
-            const hierarchy: HierarchyDefinition = {
-              async defineHierarchyLevel({ parentNode }) {
-                if (!parentNode) {
-                  return [
-                    {
-                      fullClassName: schema.items.X.fullName,
-                      query: {
-                        ecsql: `
-                        SELECT ${await selectQueryFactory.createSelectClause({
-                          ecClassId: { selector: `this.ECClassId` },
-                          ecInstanceId: { selector: `this.ECInstanceId` },
-                          nodeLabel: { selector: `this.Label` },
-                          grouping: {
-                            byProperties: {
-                              propertiesClassName: schema.items.X.fullName,
-                              propertyGroups: [
-                                {
-                                  propertyName: "Prop",
-                                  propertyClassAlias: "this",
-                                  ranges: [{ fromValue: 1, toValue: 5 }],
-                                },
-                              ],
-                            },
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { label: "one", prop: 1.5 });
+          const x2 = builder.insertInstance(s.items.X.fullName, { label: "two", prop: 3 });
+          return { schema: s, x1, x2 };
+        });
+        const { ecdb, schema, ...keys } = setup;
+        const imodelAccess = createIModelAccess(ecdb);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+            classHierarchyInspector: imodelAccess,
+          }),
+        });
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ parentNode }) {
+            if (!parentNode) {
+              return [
+                {
+                  fullClassName: schema.items.X.fullName,
+                  query: {
+                    ecsql: `
+                      SELECT ${await selectQueryFactory.createSelectClause({
+                        ecClassId: { selector: `this.ECClassId` },
+                        ecInstanceId: { selector: `this.ECInstanceId` },
+                        nodeLabel: { selector: `this.Label` },
+                        grouping: {
+                          byProperties: {
+                            propertiesClassName: schema.items.X.fullName,
+                            propertyGroups: [
+                              {
+                                propertyName: "Prop",
+                                propertyClassAlias: "this",
+                                ranges: [{ fromValue: 1, toValue: 5 }],
+                              },
+                            ],
                           },
-                        })}
-                        FROM ${schema.items.X.fullName} AS this
-                      `,
-                      },
-                    },
-                  ];
-                }
-                return [];
-              },
-            };
-            const provider = createProvider({ imodel, hierarchy });
-            await validateHierarchy({
-              provider,
-              expect: [
-                NodeValidators.createForPropertyValueRangeGroupingNode({
-                  label: "1 - 5",
-                  propertyClassName: schema.items.X.fullName,
-                  propertyName: "Prop",
-                  fromValue: 1,
-                  toValue: 5,
-                  children: [
-                    NodeValidators.createForInstanceNode({ instanceKeys: [x1] }),
-                    NodeValidators.createForInstanceNode({ instanceKeys: [x2] }),
-                  ],
-                }),
-              ],
-            });
+                        },
+                      })}
+                      FROM ${schema.items.X.fullName} AS this
+                    `,
+                  },
+                },
+              ];
+            }
+            return [];
           },
-        );
+        };
+        const provider = createProvider({ ecdb, hierarchy });
+        await validateHierarchy({
+          provider,
+          expect: [
+            NodeValidators.createForPropertyValueRangeGroupingNode({
+              label: "1 - 5",
+              propertyClassName: schema.items.X.fullName,
+              propertyName: "Prop",
+              fromValue: 1,
+              toValue: 5,
+              children: [
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1] }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2] }),
+              ],
+            }),
+          ],
+        });
       });
 
       it("creates property value range grouping nodes with custom range label", async () => {
-        await withECDb(
-          async (db, testName) => {
-            const schema = await importSchema(
-              testName,
-              db,
-              `
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
               <ECEntityClass typeName="X">
                 <ECProperty propertyName="Label" typeName="string" />
                 <ECProperty propertyName="Prop" typeName="int" />
               </ECEntityClass>
             `,
-            );
-            const x1 = db.insertInstance(schema.items.X.fullName, { label: "one", prop: 1.5 });
-            return { schema, x1 };
-          },
-          async (imodel, { schema, x1 }) => {
-            const imodelAccess = createIModelAccess(imodel);
-            const selectQueryFactory = createNodesQueryClauseFactory({
-              imodelAccess,
-              instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-                classHierarchyInspector: imodelAccess,
-              }),
-            });
-            const hierarchy: HierarchyDefinition = {
-              async defineHierarchyLevel({ parentNode }) {
-                if (!parentNode) {
-                  return [
-                    {
-                      fullClassName: schema.items.X.fullName,
-                      query: {
-                        ecsql: `
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { label: "one", prop: 1.5 });
+          return { schema: s, x1 };
+        });
+        const { ecdb, schema, ...keys } = setup;
+        const imodelAccess = createIModelAccess(ecdb);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+            classHierarchyInspector: imodelAccess,
+          }),
+        });
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ parentNode }) {
+            if (!parentNode) {
+              return [
+                {
+                  fullClassName: schema.items.X.fullName,
+                  query: {
+                    ecsql: `
                       SELECT ${await selectQueryFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
@@ -793,64 +801,61 @@ describe("Hierarchies", () => {
                       })}
                       FROM ${schema.items.X.fullName} AS this
                     `,
-                      },
-                    },
-                  ];
-                }
-                return [];
-              },
-            };
-            const provider = createProvider({ imodel, hierarchy });
-            await validateHierarchy({
-              provider,
-              expect: [
-                NodeValidators.createForPropertyValueRangeGroupingNode({
-                  label: "TestLabel",
-                  propertyClassName: schema.items.X.fullName,
-                  propertyName: "Prop",
-                  fromValue: 1,
-                  toValue: 2,
-                  children: [NodeValidators.createForInstanceNode({ instanceKeys: [x1] })],
-                }),
-              ],
-            });
+                  },
+                },
+              ];
+            }
+            return [];
           },
-        );
+        };
+        const provider = createProvider({ ecdb, hierarchy });
+        await validateHierarchy({
+          provider,
+          expect: [
+            NodeValidators.createForPropertyValueRangeGroupingNode({
+              label: "TestLabel",
+              propertyClassName: schema.items.X.fullName,
+              propertyName: "Prop",
+              fromValue: 1,
+              toValue: 2,
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1] })],
+            }),
+          ],
+        });
       });
 
       it("creates multiple grouping nodes when nodes' property values fit in different ranges", async () => {
-        await withECDb(
-          async (db, testName) => {
-            const schema = await importSchema(
-              testName,
-              db,
-              `
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
               <ECEntityClass typeName="X">
                 <ECProperty propertyName="Label" typeName="string" />
                 <ECProperty propertyName="Prop" typeName="int" />
               </ECEntityClass>
             `,
-            );
-            const x1 = db.insertInstance(schema.items.X.fullName, { label: "one", prop: 1 });
-            const x2 = db.insertInstance(schema.items.X.fullName, { label: "two", prop: 4 });
-            return { schema, x1, x2 };
-          },
-          async (imodel, { schema, x1, x2 }) => {
-            const imodelAccess = createIModelAccess(imodel);
-            const selectQueryFactory = createNodesQueryClauseFactory({
-              imodelAccess,
-              instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-                classHierarchyInspector: imodelAccess,
-              }),
-            });
-            const hierarchy: HierarchyDefinition = {
-              async defineHierarchyLevel({ parentNode }) {
-                if (!parentNode) {
-                  return [
-                    {
-                      fullClassName: schema.items.X.fullName,
-                      query: {
-                        ecsql: `
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { label: "one", prop: 1 });
+          const x2 = builder.insertInstance(s.items.X.fullName, { label: "two", prop: 4 });
+          return { schema: s, x1, x2 };
+        });
+        const { ecdb, schema, ...keys } = setup;
+        const imodelAccess = createIModelAccess(ecdb);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+            classHierarchyInspector: imodelAccess,
+          }),
+        });
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ parentNode }) {
+            if (!parentNode) {
+              return [
+                {
+                  fullClassName: schema.items.X.fullName,
+                  query: {
+                    ecsql: `
                       SELECT ${await selectQueryFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
@@ -874,71 +879,68 @@ describe("Hierarchies", () => {
                       })}
                       FROM ${schema.items.X.fullName} AS this
                     `,
-                      },
-                    },
-                  ];
-                }
-                return [];
-              },
-            };
-            const provider = createProvider({ imodel, hierarchy });
-            await validateHierarchy({
-              provider,
-              expect: [
-                NodeValidators.createForPropertyValueRangeGroupingNode({
-                  label: "0 - 2",
-                  propertyClassName: schema.items.X.fullName,
-                  propertyName: "Prop",
-                  fromValue: 0,
-                  toValue: 2,
-                  children: [NodeValidators.createForInstanceNode({ instanceKeys: [x1] })],
-                }),
-                NodeValidators.createForPropertyValueRangeGroupingNode({
-                  label: "3 - 5",
-                  propertyClassName: schema.items.X.fullName,
-                  propertyName: "Prop",
-                  fromValue: 3,
-                  toValue: 5,
-                  children: [NodeValidators.createForInstanceNode({ instanceKeys: [x2] })],
-                }),
-              ],
-            });
+                  },
+                },
+              ];
+            }
+            return [];
           },
-        );
+        };
+        const provider = createProvider({ ecdb, hierarchy });
+        await validateHierarchy({
+          provider,
+          expect: [
+            NodeValidators.createForPropertyValueRangeGroupingNode({
+              label: "0 - 2",
+              propertyClassName: schema.items.X.fullName,
+              propertyName: "Prop",
+              fromValue: 0,
+              toValue: 2,
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1] })],
+            }),
+            NodeValidators.createForPropertyValueRangeGroupingNode({
+              label: "3 - 5",
+              propertyClassName: schema.items.X.fullName,
+              propertyName: "Prop",
+              fromValue: 3,
+              toValue: 5,
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2] })],
+            }),
+          ],
+        });
       });
 
       it("doesn't create grouping nodes if provided properties don't fit in the range and `createGroupForOutOfRangeValues` isn't set", async () => {
-        await withECDb(
-          async (db, testName) => {
-            const schema = await importSchema(
-              testName,
-              db,
-              `
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
               <ECEntityClass typeName="X">
                 <ECProperty propertyName="Label" typeName="string" />
                 <ECProperty propertyName="Prop" typeName="int" />
               </ECEntityClass>
             `,
-            );
-            const x1 = db.insertInstance(schema.items.X.fullName, { label: "one", prop: 3 });
-            return { schema, x1 };
-          },
-          async (imodel, { schema, x1 }) => {
-            const imodelAccess = createIModelAccess(imodel);
-            const selectQueryFactory = createNodesQueryClauseFactory({
-              imodelAccess,
-              instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-                classHierarchyInspector: imodelAccess,
-              }),
-            });
-            const hierarchy: HierarchyDefinition = {
-              async defineHierarchyLevel({ parentNode }) {
-                if (!parentNode) {
-                  return [
-                    {
-                      fullClassName: schema.items.X.fullName,
-                      query: {
-                        ecsql: `
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { label: "one", prop: 3 });
+          return { schema: s, x1 };
+        });
+        const { ecdb, schema, ...keys } = setup;
+        const imodelAccess = createIModelAccess(ecdb);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+            classHierarchyInspector: imodelAccess,
+          }),
+        });
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ parentNode }) {
+            if (!parentNode) {
+              return [
+                {
+                  fullClassName: schema.items.X.fullName,
+                  query: {
+                    ecsql: `
                       SELECT ${await selectQueryFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
@@ -958,55 +960,52 @@ describe("Hierarchies", () => {
                       })}
                       FROM ${schema.items.X.fullName} AS this
                     `,
-                      },
-                    },
-                  ];
-                }
-                return [];
-              },
-            };
-            const provider = createProvider({ imodel, hierarchy });
-            await validateHierarchy({
-              provider,
-              expect: [NodeValidators.createForInstanceNode({ instanceKeys: [x1] })],
-            });
+                  },
+                },
+              ];
+            }
+            return [];
           },
-        );
+        };
+        const provider = createProvider({ ecdb, hierarchy });
+        await validateHierarchy({
+          provider,
+          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1] })],
+        });
       });
 
       it("creates 'other' property value grouping node if provided properties don't fit in the range and `createGroupForOutOfRangeValues` is `true`", async () => {
-        await withECDb(
-          async (db, testName) => {
-            const schema = await importSchema(
-              testName,
-              db,
-              `
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
               <ECEntityClass typeName="X">
                 <ECProperty propertyName="Label" typeName="string" />
                 <ECProperty propertyName="Prop" typeName="int" />
               </ECEntityClass>
             `,
-            );
-            const x1 = db.insertInstance(schema.items.X.fullName, { label: "one", prop: 3 });
-            const x2 = db.insertInstance(schema.items.X.fullName, { label: "two", prop: 10 });
-            return { schema, x1, x2 };
-          },
-          async (imodel, { schema, x1, x2 }) => {
-            const imodelAccess = createIModelAccess(imodel);
-            const selectQueryFactory = createNodesQueryClauseFactory({
-              imodelAccess,
-              instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-                classHierarchyInspector: imodelAccess,
-              }),
-            });
-            const hierarchy: HierarchyDefinition = {
-              async defineHierarchyLevel({ parentNode }) {
-                if (!parentNode) {
-                  return [
-                    {
-                      fullClassName: schema.items.X.fullName,
-                      query: {
-                        ecsql: `
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { label: "one", prop: 3 });
+          const x2 = builder.insertInstance(s.items.X.fullName, { label: "two", prop: 10 });
+          return { schema: s, x1, x2 };
+        });
+        const { ecdb, schema, ...keys } = setup;
+        const imodelAccess = createIModelAccess(ecdb);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+            classHierarchyInspector: imodelAccess,
+          }),
+        });
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ parentNode }) {
+            if (!parentNode) {
+              return [
+                {
+                  fullClassName: schema.items.X.fullName,
+                  query: {
+                    ecsql: `
                       SELECT ${await selectQueryFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
@@ -1027,41 +1026,34 @@ describe("Hierarchies", () => {
                       })}
                       FROM ${schema.items.X.fullName} AS this
                     `,
-                      },
-                    },
-                  ];
-                }
-                return [];
-              },
-            };
-            const provider = createProvider({
-              imodel,
-              hierarchy,
-              localizedStrings: { other: "OTHER", unspecified: "" },
-            });
-            await validateHierarchy({
-              provider,
-              expect: [
-                NodeValidators.createForPropertyOtherValuesGroupingNode({
-                  label: "OTHER",
-                  children: [
-                    NodeValidators.createForInstanceNode({ instanceKeys: [x1] }),
-                    NodeValidators.createForInstanceNode({ instanceKeys: [x2] }),
-                  ],
-                }),
-              ],
-            });
+                  },
+                },
+              ];
+            }
+            return [];
           },
-        );
+        };
+        const provider = createProvider({ ecdb, hierarchy, localizedStrings: { other: "OTHER", unspecified: "" } });
+        await validateHierarchy({
+          provider,
+          expect: [
+            NodeValidators.createForPropertyOtherValuesGroupingNode({
+              label: "OTHER",
+              children: [
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1] }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2] }),
+              ],
+            }),
+          ],
+        });
       });
 
       it("creates a single 'other' property value grouping node for different properties", async () => {
-        await withECDb(
-          async (db, testName) => {
-            const schema = await importSchema(
-              testName,
-              db,
-              `
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
               <ECEntityClass typeName="X">
                 <ECProperty propertyName="Label" typeName="string" />
                 <ECProperty propertyName="PropX" typeName="int" />
@@ -1071,99 +1063,93 @@ describe("Hierarchies", () => {
                 <ECProperty propertyName="PropY" typeName="int" />
               </ECEntityClass>
             `,
-            );
-            const x = db.insertInstance(schema.items.X.fullName, { label: "one", propX: 123 });
-            const y = db.insertInstance(schema.items.Y.fullName, { label: "two", propY: 456 });
-            return { schema, x, y };
+          );
+          const x = builder.insertInstance(s.items.X.fullName, { label: "one", propX: 123 });
+          const y = builder.insertInstance(s.items.Y.fullName, { label: "two", propY: 456 });
+          return { schema: s, x, y };
+        });
+        const { ecdb, schema, ...keys } = setup;
+        const imodelAccess = createIModelAccess(ecdb);
+        const selectQueryFactory = createNodesQueryClauseFactory({
+          imodelAccess,
+          instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+            classHierarchyInspector: imodelAccess,
+          }),
+        });
+        const hierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ parentNode }) {
+            if (!parentNode) {
+              return [
+                {
+                  fullClassName: schema.items.X.fullName,
+                  query: {
+                    ecsql: `
+                      SELECT ${await selectQueryFactory.createSelectClause({
+                        ecClassId: { selector: `this.ECClassId` },
+                        ecInstanceId: { selector: `this.ECInstanceId` },
+                        nodeLabel: { selector: `this.Label` },
+                        grouping: {
+                          byProperties: {
+                            propertiesClassName: schema.items.X.fullName,
+                            createGroupForOutOfRangeValues: true,
+                            propertyGroups: [
+                              {
+                                propertyName: "PropX",
+                                propertyClassAlias: "this",
+                                ranges: [{ fromValue: 1, toValue: 2 }],
+                              },
+                            ],
+                          },
+                        },
+                      })}
+                      FROM ${schema.items.X.fullName} AS this
+                    `,
+                  },
+                },
+                {
+                  fullClassName: schema.items.Y.fullName,
+                  query: {
+                    ecsql: `
+                      SELECT ${await selectQueryFactory.createSelectClause({
+                        ecClassId: { selector: `this.ECClassId` },
+                        ecInstanceId: { selector: `this.ECInstanceId` },
+                        nodeLabel: { selector: `this.Label` },
+                        grouping: {
+                          byProperties: {
+                            propertiesClassName: schema.items.Y.fullName,
+                            createGroupForOutOfRangeValues: true,
+                            propertyGroups: [
+                              {
+                                propertyName: "PropY",
+                                propertyClassAlias: "this",
+                                ranges: [{ fromValue: 1, toValue: 2 }],
+                              },
+                            ],
+                          },
+                        },
+                      })}
+                      FROM ${schema.items.Y.fullName} AS this
+                    `,
+                  },
+                },
+              ];
+            }
+            return [];
           },
-          async (imodel, { schema, x, y }) => {
-            const imodelAccess = createIModelAccess(imodel);
-            const selectQueryFactory = createNodesQueryClauseFactory({
-              imodelAccess,
-              instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-                classHierarchyInspector: imodelAccess,
-              }),
-            });
-            const hierarchy: HierarchyDefinition = {
-              async defineHierarchyLevel({ parentNode }) {
-                if (!parentNode) {
-                  return [
-                    {
-                      fullClassName: schema.items.X.fullName,
-                      query: {
-                        ecsql: `
-                          SELECT ${await selectQueryFactory.createSelectClause({
-                            ecClassId: { selector: `this.ECClassId` },
-                            ecInstanceId: { selector: `this.ECInstanceId` },
-                            nodeLabel: { selector: `this.Label` },
-                            grouping: {
-                              byProperties: {
-                                propertiesClassName: schema.items.X.fullName,
-                                createGroupForOutOfRangeValues: true,
-                                propertyGroups: [
-                                  {
-                                    propertyName: "PropX",
-                                    propertyClassAlias: "this",
-                                    ranges: [{ fromValue: 1, toValue: 2 }],
-                                  },
-                                ],
-                              },
-                            },
-                          })}
-                          FROM ${schema.items.X.fullName} AS this
-                        `,
-                      },
-                    },
-                    {
-                      fullClassName: schema.items.Y.fullName,
-                      query: {
-                        ecsql: `
-                          SELECT ${await selectQueryFactory.createSelectClause({
-                            ecClassId: { selector: `this.ECClassId` },
-                            ecInstanceId: { selector: `this.ECInstanceId` },
-                            nodeLabel: { selector: `this.Label` },
-                            grouping: {
-                              byProperties: {
-                                propertiesClassName: schema.items.Y.fullName,
-                                createGroupForOutOfRangeValues: true,
-                                propertyGroups: [
-                                  {
-                                    propertyName: "PropY",
-                                    propertyClassAlias: "this",
-                                    ranges: [{ fromValue: 1, toValue: 2 }],
-                                  },
-                                ],
-                              },
-                            },
-                          })}
-                          FROM ${schema.items.Y.fullName} AS this
-                        `,
-                      },
-                    },
-                  ];
-                }
-                return [];
-              },
-            };
-            const provider = createProvider({
-              imodel,
-              hierarchy,
-              localizedStrings: { other: "OTHER", unspecified: "" },
-            });
-            await validateHierarchy({
-              provider,
-              expect: [
-                NodeValidators.createForPropertyOtherValuesGroupingNode({
-                  label: "OTHER",
-                  children: [
-                    NodeValidators.createForInstanceNode({ instanceKeys: [x] }),
-                    NodeValidators.createForInstanceNode({ instanceKeys: [y] }),
-                  ],
-                }),
+        };
+        const provider = createProvider({ ecdb, hierarchy, localizedStrings: { other: "OTHER", unspecified: "" } });
+        await validateHierarchy({
+          provider,
+          expect: [
+            NodeValidators.createForPropertyOtherValuesGroupingNode({
+              label: "OTHER",
+              children: [
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x] }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.y] }),
               ],
-            });
-          },
-        );
+            }),
+          ],
+        });
       });
     });
   });

--- a/apps/full-stack-tests/src/hierarchies/grouping/SpecialCases.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/SpecialCases.test.ts
@@ -6,7 +6,7 @@
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { createNodesQueryClauseFactory, HierarchyNode } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
-import { withECDb } from "../../ECDbUtils.js";
+import { buildTestECDb } from "../../ECDbUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { importSchema } from "../../SchemaUtils.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
@@ -25,12 +25,11 @@ describe("Hierarchies", () => {
     });
 
     it("groups children of hidden hierarchy levels", async () => {
-      await withECDb(
-        async (db, testName) => {
-          const schema = await importSchema(
-            testName,
-            db,
-            `
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
             <ECEntityClass typeName="B" />
             <ECEntityClass typeName="X">
               <BaseClass>B</BaseClass>
@@ -39,80 +38,78 @@ describe("Hierarchies", () => {
               <BaseClass>B</BaseClass>
             </ECEntityClass>
           `,
-          );
-          const x1 = db.insertInstance(schema.items.X.fullName);
-          const x2 = db.insertInstance(schema.items.X.fullName);
-          const y1 = db.insertInstance(schema.items.Y.fullName);
-          const y2 = db.insertInstance(schema.items.Y.fullName);
-          return { schema, x1, x2, y1, y2 };
+        );
+        const x1 = builder.insertInstance(s.items.X.fullName);
+        const x2 = builder.insertInstance(s.items.X.fullName);
+        const y1 = builder.insertInstance(s.items.Y.fullName);
+        const y2 = builder.insertInstance(s.items.Y.fullName);
+        return { schema: s, x1, x2, y1, y2 };
+      });
+      const { ecdb: db, schema, ...keys } = setup;
+      const imodelAccess = createIModelAccess(db);
+      const selectQueryFactory = createNodesQueryClauseFactory({
+        imodelAccess,
+        instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
+          classHierarchyInspector: imodelAccess,
+        }),
+      });
+      const hierarchy: HierarchyDefinition = {
+        async defineHierarchyLevel({ parentNode }) {
+          if (!parentNode) {
+            return [
+              {
+                fullClassName: schema.items.X.fullName,
+                query: {
+                  ecsql: `
+                    SELECT ${await selectQueryFactory.createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: "x",
+                      hideNodeInHierarchy: true,
+                    })}
+                    FROM ${schema.items.X.fullName} AS this
+                  `,
+                },
+              },
+            ];
+          }
+          if (
+            HierarchyNode.isInstancesNode(parentNode) &&
+            parentNode.key.instanceKeys.some((k) => k.className === schema.items.X.fullName)
+          ) {
+            return [
+              {
+                fullClassName: schema.items.Y.fullName,
+                query: {
+                  ecsql: `
+                    SELECT ${await selectQueryFactory.createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: { selector: `'y: ' || CAST(this.ECInstanceId AS TEXT)` },
+                      grouping: { byClass: true },
+                    })}
+                    FROM ${schema.items.Y.fullName} AS this
+                  `,
+                },
+              },
+            ];
+          }
+          return [];
         },
-        async (db, { schema, y1, y2 }) => {
-          const imodelAccess = createIModelAccess(db);
-          const selectQueryFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
-              classHierarchyInspector: imodelAccess,
-            }),
-          });
-          const hierarchy: HierarchyDefinition = {
-            async defineHierarchyLevel({ parentNode }) {
-              if (!parentNode) {
-                return [
-                  {
-                    fullClassName: schema.items.X.fullName,
-                    query: {
-                      ecsql: `
-                        SELECT ${await selectQueryFactory.createSelectClause({
-                          ecClassId: { selector: `this.ECClassId` },
-                          ecInstanceId: { selector: `this.ECInstanceId` },
-                          nodeLabel: "x",
-                          hideNodeInHierarchy: true,
-                        })}
-                        FROM ${schema.items.X.fullName} AS this
-                      `,
-                    },
-                  },
-                ];
-              }
-              if (
-                HierarchyNode.isInstancesNode(parentNode) &&
-                parentNode.key.instanceKeys.some((k) => k.className === schema.items.X.fullName)
-              ) {
-                return [
-                  {
-                    fullClassName: schema.items.Y.fullName,
-                    query: {
-                      ecsql: `
-                        SELECT ${await selectQueryFactory.createSelectClause({
-                          ecClassId: { selector: `this.ECClassId` },
-                          ecInstanceId: { selector: `this.ECInstanceId` },
-                          nodeLabel: { selector: `'y: ' || CAST(this.ECInstanceId AS TEXT)` },
-                          grouping: { byClass: true },
-                        })}
-                        FROM ${schema.items.Y.fullName} AS this
-                      `,
-                    },
-                  },
-                ];
-              }
-              return [];
-            },
-          };
-          await validateHierarchy({
-            provider: createProvider({ imodel: db, hierarchy }),
-            expect: [
-              NodeValidators.createForClassGroupingNode({
-                label: "Y",
-                className: schema.items.Y.fullName,
-                children: [
-                  NodeValidators.createForInstanceNode({ instanceKeys: [y1], children: false }),
-                  NodeValidators.createForInstanceNode({ instanceKeys: [y2], children: false }),
-                ],
-              }),
+      };
+      await validateHierarchy({
+        provider: createProvider({ ecdb: db, hierarchy }),
+        expect: [
+          NodeValidators.createForClassGroupingNode({
+            label: "Y",
+            className: schema.items.Y.fullName,
+            children: [
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.y1], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.y2], children: false }),
             ],
-          });
-        },
-      );
+          }),
+        ],
+      });
     });
   });
 });

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/CustomHierarchyProvider.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/CustomHierarchyProvider.test.ts
@@ -5,8 +5,8 @@
 /* eslint-disable no-console */
 /* eslint-disable no-duplicate-imports */
 
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { collect } from "presentation-test-utilities";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.Imports
 import { createHierarchyProvider, HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";
 import { Props } from "@itwin/presentation-shared";
@@ -35,8 +35,8 @@ import {
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.HierarchyLevelFilteringProviderImports
 import { GenericInstanceFilter, GenericInstanceFilterRule, GenericInstanceFilterRuleGroup } from "@itwin/core-common";
 // __PUBLISH_EXTRACT_END__
-import { initialize, terminate } from "../../IntegrationTests.js";
 import { buildTestIModel } from "../../IModelUtils.js";
+import { initialize, terminate } from "../../IntegrationTests.js";
 
 describe("Hierarchies", () => {
   describe("Learning snippets", () => {
@@ -79,7 +79,7 @@ describe("Hierarchies", () => {
       });
 
       it("creates iModel provider", async () => {
-        const { imodel } = await buildTestIModel();
+        const { imodelConnection } = await buildTestIModel();
         const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.CustomHierarchyProviders.CustomIModelProviderExample
@@ -90,8 +90,8 @@ describe("Hierarchies", () => {
           // and raise `hierarchyChanged` event when the hierarchy should be refreshed. `BriefcaseTxns` has a number
           // of events that we should listen to - here we're using `registerTxnListeners` helper to simplify subscription.
           const disposeTxnListeners =
-            imodel instanceof BriefcaseConnection
-              ? registerTxnListeners(imodel.txns, () => hierarchyChanged.raiseEvent({}))
+            imodelConnection instanceof BriefcaseConnection
+              ? registerTxnListeners(imodelConnection.txns, () => hierarchyChanged.raiseEvent({}))
               : undefined;
           return {
             // Make this provider disposable. Owners of the provider should make sure `Symbol.dispose` is called when the
@@ -106,7 +106,7 @@ describe("Hierarchies", () => {
             }: Props<HierarchyProvider["getNodes"]>): AsyncIterableIterator<HierarchyNode> {
               if (!parentNode) {
                 // Query and return root bis.Subject node
-                for await (const row of imodel.createQueryReader(
+                for await (const row of imodelConnection.createQueryReader(
                   `
                     SELECT
                       COALESCE(s.UserLabel, s.CodeValue, ec_classname(s.ECClassId, 'c')) label,
@@ -118,7 +118,7 @@ describe("Hierarchies", () => {
                   yield {
                     key: {
                       type: "instances",
-                      instanceKeys: [{ className: "BisCore.Subject", id: "0x1", imodelKey: imodel.key }],
+                      instanceKeys: [{ className: "BisCore.Subject", id: "0x1", imodelKey: imodelConnection.key }],
                     },
                     label: row.label,
                     children: !!row.hasChildren,
@@ -131,9 +131,9 @@ describe("Hierarchies", () => {
               if (
                 HierarchyNode.isInstancesNode(parentNode) &&
                 parentNode.key.instanceKeys.length > 0 &&
-                parentNode.key.instanceKeys.every((k) => k.imodelKey === imodel.key)
+                parentNode.key.instanceKeys.every((k) => k.imodelKey === imodelConnection.key)
               ) {
-                for await (const row of imodel.createQueryReader(
+                for await (const row of imodelConnection.createQueryReader(
                   `
                     SELECT
                       ec_classname(e.ECClassId, 's.c') className,
@@ -147,7 +147,7 @@ describe("Hierarchies", () => {
                   yield {
                     key: {
                       type: "instances",
-                      instanceKeys: [{ className: row.className, id: row.id, imodelKey: imodel.key }],
+                      instanceKeys: [{ className: row.className, id: row.id, imodelKey: imodelConnection.key }],
                     },
                     label: row.label,
                     children: !!row.hasChildren,
@@ -162,23 +162,23 @@ describe("Hierarchies", () => {
             async *getNodeInstanceKeys({ parentNode }: Props<HierarchyProvider["getNodeInstanceKeys"]>) {
               if (!parentNode) {
                 // Don't need to run a query here - we know all iModels have one root Subject with `0x1` id
-                yield { className: "BisCore.Subject", id: "0x1", imodelKey: imodel.key };
+                yield { className: "BisCore.Subject", id: "0x1", imodelKey: imodelConnection.key };
                 return;
               }
               // Query and return children instance keys for the given parent node
               if (
                 HierarchyNode.isInstancesNode(parentNode) &&
                 parentNode.key.instanceKeys.length > 0 &&
-                parentNode.key.instanceKeys.every((k) => k.imodelKey === imodel.key)
+                parentNode.key.instanceKeys.every((k) => k.imodelKey === imodelConnection.key)
               ) {
-                for await (const row of imodel.createQueryReader(
+                for await (const row of imodelConnection.createQueryReader(
                   `
                     SELECT ec_classname(e.ECClassId, 's.c') className, e.ECInstanceId id
                     FROM bis.Element e
                     WHERE e.Parent.Id IN (${parentNode.key.instanceKeys.map((key) => key.id).join(",")})
                   `,
                 )) {
-                  yield { className: row.className, id: row.id, imodelKey: imodel.key };
+                  yield { className: row.className, id: row.id, imodelKey: imodelConnection.key };
                 }
               }
             },
@@ -191,7 +191,7 @@ describe("Hierarchies", () => {
         // __PUBLISH_EXTRACT_END__
 
         expect(consoleLogSpy.mock.calls).toHaveLength(3);
-        expect(consoleLogSpy.mock.calls[0][0]).toBe(imodel.rootSubject.name);
+        expect(consoleLogSpy.mock.calls[0][0]).toBe(imodelConnection.rootSubject.name);
         expect(consoleLogSpy.mock.calls[1][0]).toBe("  BisCore.RealityDataSources");
         expect(consoleLogSpy.mock.calls[2][0]).toBe("  BisCore.DictionaryModel");
       });

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/Grouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/Grouping.test.ts
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   insertDrawingCategory,
   insertPhysicalElement,
@@ -12,15 +11,16 @@ import {
   insertRepositoryLink,
   insertSpatialCategory,
 } from "presentation-test-utilities";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Grouping.Imports
 import { createIModelHierarchyProvider, createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
+import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
 import { createIModelAccess } from "../Utils.js";
 import { collectHierarchy } from "./Utils.js";
-import { buildTestIModel } from "../../IModelUtils.js";
 
 describe("Hierarchies", () => {
   describe("Learning snippets", () => {
@@ -35,23 +35,13 @@ describe("Hierarchies", () => {
 
       describe("By label", () => {
         it("groups by label", async () => {
-          const { imodel } = await buildTestIModel(async (builder) => {
-            const category = insertSpatialCategory({ builder, codeValue: "Category" });
-            const model = insertPhysicalModelWithPartition({ builder, codeValue: "Model" });
-            insertPhysicalElement({
-              builder,
-              modelId: model.id,
-              categoryId: category.id,
-              userLabel: "Example element",
-            });
-            insertPhysicalElement({
-              builder,
-              modelId: model.id,
-              categoryId: category.id,
-              userLabel: "Example element",
-            });
+          const { imodelConnection } = await buildTestIModel(async (imodel) => {
+            const category = insertSpatialCategory({ imodel, codeValue: "Category" });
+            const model = insertPhysicalModelWithPartition({ imodel, codeValue: "Model" });
+            insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id, userLabel: "Example element" });
+            insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id, userLabel: "Example element" });
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
 
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Grouping.LabelGroupingExample
           const hierarchyProvider = createIModelHierarchyProvider({
@@ -112,24 +102,24 @@ describe("Hierarchies", () => {
         });
 
         it("merges by label", async () => {
-          const { imodel } = await buildTestIModel(async (builder) => {
-            const category = insertSpatialCategory({ builder, codeValue: "Category" });
-            const model = insertPhysicalModelWithPartition({ builder, codeValue: "Model" });
+          const { imodelConnection } = await buildTestIModel(async (imodel) => {
+            const category = insertSpatialCategory({ imodel, codeValue: "Category" });
+            const model = insertPhysicalModelWithPartition({ imodel, codeValue: "Model" });
             const element1 = insertPhysicalElement({
-              builder,
+              imodel,
               modelId: model.id,
               categoryId: category.id,
               userLabel: "Example element",
             });
             const element2 = insertPhysicalElement({
-              builder,
+              imodel,
               modelId: model.id,
               categoryId: category.id,
               userLabel: "Example element",
             });
             return { element1, element2 };
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
 
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Grouping.LabelMergingExample
           const hierarchyProvider = createIModelHierarchyProvider({
@@ -180,12 +170,12 @@ describe("Hierarchies", () => {
 
       describe("By class", () => {
         it("groups by node's class", async () => {
-          const { imodel } = await buildTestIModel(async (builder) => {
-            const drawingCategory = insertDrawingCategory({ builder, codeValue: "Example drawing category" });
-            const spatialCategory = insertSpatialCategory({ builder, codeValue: "Example spatial category" });
+          const { imodelConnection } = await buildTestIModel(async (imodel) => {
+            const drawingCategory = insertDrawingCategory({ imodel, codeValue: "Example drawing category" });
+            const spatialCategory = insertSpatialCategory({ imodel, codeValue: "Example spatial category" });
             return { spatialCategory, drawingCategory };
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
 
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Grouping.ClassGroupingExample
           const hierarchyProvider = createIModelHierarchyProvider({
@@ -252,12 +242,12 @@ describe("Hierarchies", () => {
         });
 
         it("groups by base classes", async () => {
-          const { imodel } = await buildTestIModel(async (builder) => {
-            const drawingCategory = insertDrawingCategory({ builder, codeValue: "Example drawing category" });
-            const spatialCategory = insertSpatialCategory({ builder, codeValue: "Example spatial category" });
+          const { imodelConnection } = await buildTestIModel(async (imodel) => {
+            const drawingCategory = insertDrawingCategory({ imodel, codeValue: "Example drawing category" });
+            const spatialCategory = insertSpatialCategory({ imodel, codeValue: "Example spatial category" });
             return { spatialCategory, drawingCategory };
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
 
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Grouping.BaseClassGroupingExample
           const hierarchyProvider = createIModelHierarchyProvider({
@@ -327,13 +317,13 @@ describe("Hierarchies", () => {
 
       describe("By properties", () => {
         it("groups by property value", async () => {
-          const { imodel } = await buildTestIModel(async (builder) => {
-            insertRepositoryLink({ builder, repositoryLabel: "Example iModel link 1", format: "iModel" });
-            insertRepositoryLink({ builder, repositoryLabel: "Example iModel link 2", format: "iModel" });
-            insertRepositoryLink({ builder, repositoryLabel: "Example DGN link", format: "DGN" });
-            insertRepositoryLink({ builder, repositoryLabel: "Example link with no format" });
+          const { imodelConnection } = await buildTestIModel(async (imodel) => {
+            insertRepositoryLink({ imodel, repositoryLabel: "Example iModel link 1", format: "iModel" });
+            insertRepositoryLink({ imodel, repositoryLabel: "Example iModel link 2", format: "iModel" });
+            insertRepositoryLink({ imodel, repositoryLabel: "Example DGN link", format: "DGN" });
+            insertRepositoryLink({ imodel, repositoryLabel: "Example link with no format" });
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
 
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Grouping.PropertyValueGroupingExample
           const hierarchyProvider = createIModelHierarchyProvider({
@@ -415,13 +405,13 @@ describe("Hierarchies", () => {
         });
 
         it("groups by property value ranges", async () => {
-          const { imodel } = await buildTestIModel(async (builder) => {
-            insertPhysicalMaterial({ builder, userLabel: "Material 1", density: 4 });
-            insertPhysicalMaterial({ builder, userLabel: "Material 2", density: 7 });
-            insertPhysicalMaterial({ builder, userLabel: "Material 3", density: 11 });
-            insertPhysicalMaterial({ builder, userLabel: "Material 4", density: 200 });
+          const { imodelConnection } = await buildTestIModel(async (imodel) => {
+            insertPhysicalMaterial({ imodel, userLabel: "Material 1", density: 4 });
+            insertPhysicalMaterial({ imodel, userLabel: "Material 2", density: 7 });
+            insertPhysicalMaterial({ imodel, userLabel: "Material 3", density: 11 });
+            insertPhysicalMaterial({ imodel, userLabel: "Material 4", density: 200 });
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
 
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Grouping.PropertyValueRangesGroupingExample
           const hierarchyProvider = createIModelHierarchyProvider({
@@ -507,13 +497,13 @@ describe("Hierarchies", () => {
       });
 
       it("creates multi-level grouping hierarchy", async () => {
-        const { imodel } = await buildTestIModel(async (builder) => {
-          insertRepositoryLink({ builder, repositoryLabel: "Example iModel link", format: "iModel" });
-          insertRepositoryLink({ builder, repositoryLabel: "Example iModel link", format: "iModel" });
-          insertRepositoryLink({ builder, repositoryLabel: "Example DGN link 1", format: "DGN" });
-          insertRepositoryLink({ builder, repositoryLabel: "Example DGN link 2", format: "DGN" });
+        const { imodelConnection } = await buildTestIModel(async (imodel) => {
+          insertRepositoryLink({ imodel, repositoryLabel: "Example iModel link", format: "iModel" });
+          insertRepositoryLink({ imodel, repositoryLabel: "Example iModel link", format: "iModel" });
+          insertRepositoryLink({ imodel, repositoryLabel: "Example DGN link 1", format: "DGN" });
+          insertRepositoryLink({ imodel, repositoryLabel: "Example DGN link 2", format: "DGN" });
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
 
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Grouping.MultiLevelGroupingExample
         const hierarchyProvider = createIModelHierarchyProvider({
@@ -634,12 +624,12 @@ describe("Hierarchies", () => {
 
       describe("Customization options", () => {
         it("doesn't return grouping node if there's only one grouped instance and `hideIfOneGroupedNode = true`", async () => {
-          const { imodel } = await buildTestIModel(async (builder) => {
-            insertRepositoryLink({ builder, repositoryLabel: "Example link 1" });
-            insertRepositoryLink({ builder, repositoryLabel: "Example link 2" });
-            insertRepositoryLink({ builder, repositoryLabel: "Example link 2" });
+          const { imodelConnection } = await buildTestIModel(async (imodel) => {
+            insertRepositoryLink({ imodel, repositoryLabel: "Example link 1" });
+            insertRepositoryLink({ imodel, repositoryLabel: "Example link 2" });
+            insertRepositoryLink({ imodel, repositoryLabel: "Example link 2" });
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
 
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Grouping.HideIfOneGroupedNodeExample
           const hierarchyProvider = createIModelHierarchyProvider({
@@ -693,11 +683,11 @@ describe("Hierarchies", () => {
         });
 
         it("doesn't return grouping node if it has no siblings and `hideIfNoSiblings = true`", async () => {
-          const { imodel } = await buildTestIModel(async (builder) => {
-            insertRepositoryLink({ builder, repositoryLabel: "Example link 1" });
-            insertRepositoryLink({ builder, repositoryLabel: "Example link 2" });
+          const { imodelConnection } = await buildTestIModel(async (imodel) => {
+            insertRepositoryLink({ imodel, repositoryLabel: "Example link 1" });
+            insertRepositoryLink({ imodel, repositoryLabel: "Example link 2" });
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
 
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Grouping.HideIfNoSiblingsExample
           const hierarchyProvider = createIModelHierarchyProvider({
@@ -752,11 +742,11 @@ describe("Hierarchies", () => {
         });
 
         it("sets auto-expand flag on grouping nodes when `autoExpand = true`", async () => {
-          const { imodel } = await buildTestIModel(async (builder) => {
-            insertRepositoryLink({ builder, repositoryLabel: "Example link 1" });
-            insertRepositoryLink({ builder, repositoryLabel: "Example link 2" });
+          const { imodelConnection } = await buildTestIModel(async (imodel) => {
+            insertRepositoryLink({ imodel, repositoryLabel: "Example link 1" });
+            insertRepositoryLink({ imodel, repositoryLabel: "Example link 2" });
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
 
           const hierarchyProvider = createIModelHierarchyProvider({
             imodelAccess,

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyDefinitions.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyDefinitions.test.ts
@@ -9,8 +9,8 @@ import {
   insertPhysicalModelWithPartition,
   insertSpatialCategory,
 } from "presentation-test-utilities";
-import { IModelConnection } from "@itwin/core-frontend";
 import { afterAll, describe, it, test } from "vitest";
+import { IModelConnection } from "@itwin/core-frontend";
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyDefinitions.Imports
 import {
   createNodesQueryClauseFactory,
@@ -22,27 +22,27 @@ import {
 // __PUBLISH_EXTRACT_END__
 import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
+import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
 import { createIModelAccess } from "../Utils.js";
-import { buildTestIModel } from "../../IModelUtils.js";
 
 describe("Hierarchies", () => {
   describe("Learning snippets", () => {
     describe("Hierarchy definitions", () => {
-      let imodel: IModelConnection;
+      let imodelConnection: IModelConnection;
 
       test.beforeAll(async (_, suite) => {
         await initialize();
 
-        const res = await buildTestIModel(suite.fullTestName!, async (builder) => {
-          const model = insertPhysicalModelWithPartition({ builder, codeValue: "model" });
-          const category = insertSpatialCategory({ builder, codeValue: "category" });
-          const a = insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id, userLabel: "A" });
-          const b = insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id, userLabel: "B" });
+        const res = await buildTestIModel(suite.fullTestName!, async (imodel) => {
+          const model = insertPhysicalModelWithPartition({ imodel, codeValue: "model" });
+          const category = insertSpatialCategory({ imodel, codeValue: "category" });
+          const a = insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id, userLabel: "A" });
+          const b = insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id, userLabel: "B" });
           return { a, b };
         });
-        imodel = res.imodel;
+        imodelConnection = res.imodelConnection;
       });
 
       afterAll(async () => {
@@ -50,7 +50,7 @@ describe("Hierarchies", () => {
       });
 
       it("creates a hierarchy using simple hierarchy definition", async () => {
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyDefinitions.Simple
         const hierarchyDefinition: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode }) {
@@ -103,7 +103,7 @@ describe("Hierarchies", () => {
       });
 
       it("uses hierarchy definition's parseNode callback", async () => {
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyDefinitions.ParseNode
         const hierarchyDefinition: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode }) {
@@ -149,7 +149,7 @@ describe("Hierarchies", () => {
       });
 
       it("uses hierarchy definition's preProcessNode callback", async () => {
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const externalService = {
           getExternalId: async <TNode extends { label: string }>(node: TNode) => {
             if (node.label === "A") {
@@ -209,7 +209,7 @@ describe("Hierarchies", () => {
       });
 
       it("uses hierarchy definition's postProcessNode callback", async () => {
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyDefinitions.PostProcessNode
         const hierarchyDefinition: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode }) {
@@ -270,7 +270,7 @@ describe("Hierarchies", () => {
       });
 
       it("creates hierarchy using predicate based hierarchy definition", async () => {
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyDefinitions.PredicateBasedHierarchyDefinition
         const queryClauseFactory = createNodesQueryClauseFactory({
           imodelAccess,

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyLevelFiltering.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyLevelFiltering.test.ts
@@ -10,39 +10,39 @@ import {
   insertPhysicalModelWithPartition,
   insertSpatialCategory,
 } from "presentation-test-utilities";
-import { IModelConnection } from "@itwin/core-frontend";
 import { afterAll, describe, it, test } from "vitest";
+import { IModelConnection } from "@itwin/core-frontend";
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyLevelFiltering.Imports
 import { createNodesQueryClauseFactory, HierarchyDefinition } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
 import { createIModelHierarchyProvider, GenericInstanceFilter } from "@itwin/presentation-hierarchies";
+import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { NodeValidators, validateHierarchy, validateHierarchyLevel } from "../HierarchyValidation.js";
 import { createIModelAccess } from "../Utils.js";
-import { buildTestIModel } from "../../IModelUtils.js";
 
 describe("Hierarchies", () => {
   describe("Learning snippets", () => {
     describe("Hierarchy level filtering", () => {
-      let imodel: IModelConnection;
+      let imodelConnection: IModelConnection;
 
       test.beforeAll(async (_, suite) => {
         await initialize();
 
-        const res = await buildTestIModel(suite.fullTestName!, async (builder) => {
-          const model = insertPhysicalModelWithPartition({ builder, codeValue: "model" });
-          const category = insertSpatialCategory({ builder, codeValue: "category" });
-          const a = insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id, userLabel: "A" });
+        const res = await buildTestIModel(suite.fullTestName!, async (imodel) => {
+          const model = insertPhysicalModelWithPartition({ imodel, codeValue: "model" });
+          const category = insertSpatialCategory({ imodel, codeValue: "category" });
+          const a = insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id, userLabel: "A" });
           const b = insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             userLabel: "B",
             parentId: a.id,
           });
           const c = insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             userLabel: "C",
@@ -50,7 +50,7 @@ describe("Hierarchies", () => {
           });
           return { a, b, c };
         });
-        imodel = res.imodel;
+        imodelConnection = res.imodelConnection;
       });
 
       afterAll(async () => {
@@ -69,7 +69,10 @@ describe("Hierarchies", () => {
         };
         // __PUBLISH_EXTRACT_END__
         await validateHierarchy({
-          provider: createIModelHierarchyProvider({ imodelAccess: createIModelAccess(imodel), hierarchyDefinition }),
+          provider: createIModelHierarchyProvider({
+            imodelAccess: createIModelAccess(imodelConnection),
+            hierarchyDefinition,
+          }),
           expect: [
             NodeValidators.createForGenericNode({ key: "custom node", label: "Custom Node", supportsFiltering: true }),
           ],
@@ -77,7 +80,7 @@ describe("Hierarchies", () => {
       });
 
       it("creates filterable instances node", async () => {
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyLevelFiltering.InstanceNodesQueryDefinition
         const queryClauseFactory = createNodesQueryClauseFactory({
           imodelAccess,
@@ -111,13 +114,16 @@ describe("Hierarchies", () => {
         };
         // __PUBLISH_EXTRACT_END__
         await validateHierarchy({
-          provider: createIModelHierarchyProvider({ imodelAccess: createIModelAccess(imodel), hierarchyDefinition }),
+          provider: createIModelHierarchyProvider({
+            imodelAccess: createIModelAccess(imodelConnection),
+            hierarchyDefinition,
+          }),
           expect: [NodeValidators.createForInstanceNode({ label: "A", supportsFiltering: true })],
         });
       });
 
       it("applies filter", async () => {
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyLevelFiltering.ApplyFilter
         const queryClauseFactory = createNodesQueryClauseFactory({
           imodelAccess,
@@ -157,7 +163,7 @@ describe("Hierarchies", () => {
         };
         // __PUBLISH_EXTRACT_END__
         const provider = createIModelHierarchyProvider({
-          imodelAccess: createIModelAccess(imodel),
+          imodelAccess: createIModelAccess(imodelConnection),
           hierarchyDefinition,
         });
         const instanceFilter: GenericInstanceFilter = {

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyNodeLabels.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyNodeLabels.test.ts
@@ -3,12 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   insertPhysicalElement,
   insertPhysicalModelWithPartition,
   insertSpatialCategory,
 } from "presentation-test-utilities";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.NodeLabels.Imports
 import {
   createIModelHierarchyProvider,
@@ -17,11 +17,11 @@ import {
 } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory, ECSql } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
+import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
+import { importSchema } from "../../SchemaUtils.js";
 import { createIModelAccess } from "../Utils.js";
 import { collectHierarchy } from "./Utils.js";
-import { buildTestIModel } from "../../IModelUtils.js";
-import { importSchema } from "../../SchemaUtils.js";
 
 describe("Hierarchies", () => {
   describe("Learning snippets", () => {
@@ -35,8 +35,8 @@ describe("Hierarchies", () => {
       });
 
       it("formats generic node's concatenated value label", async () => {
-        const { imodel } = await buildTestIModel();
-        const imodelAccess = createIModelAccess(imodel);
+        const { imodelConnection } = await buildTestIModel();
+        const imodelAccess = createIModelAccess(imodelConnection);
 
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.NodeLabels.GenericHierarchyNodeDefinitionLabelFormattingExample
         const hierarchyProvider = createIModelHierarchyProvider({
@@ -70,15 +70,15 @@ describe("Hierarchies", () => {
       });
 
       it("creates a hierarchy using labels from `createBisInstanceLabelSelectClauseFactory`", async () => {
-        const { imodel } = await buildTestIModel(async (builder) => {
-          const model = insertPhysicalModelWithPartition({ builder, codeValue: "model" });
-          const category = insertSpatialCategory({ builder, codeValue: "category" });
-          const a = insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id, codeValue: "A" });
-          const b = insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id, userLabel: "B" });
-          const c = insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id });
+        const { imodelConnection } = await buildTestIModel(async (imodel) => {
+          const model = insertPhysicalModelWithPartition({ imodel, codeValue: "model" });
+          const category = insertSpatialCategory({ imodel, codeValue: "category" });
+          const a = insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id, codeValue: "A" });
+          const b = insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id, userLabel: "B" });
+          const c = insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id });
           return { a, b, c };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
 
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.NodeLabels.BisInstanceLabelSelectClauseFactory
         const hierarchyDefinition: HierarchyDefinition = {
@@ -133,15 +133,15 @@ describe("Hierarchies", () => {
       });
 
       it("creates a hierarchy using labels from custom selector", async () => {
-        const { imodel } = await buildTestIModel(async (builder) => {
-          const model = insertPhysicalModelWithPartition({ builder, codeValue: "model" });
-          const category = insertSpatialCategory({ builder, codeValue: "category" });
-          const a = insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id, codeValue: "A" });
-          const b = insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id, codeValue: "B" });
-          const c = insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id, codeValue: "C" });
+        const { imodelConnection } = await buildTestIModel(async (imodel) => {
+          const model = insertPhysicalModelWithPartition({ imodel, codeValue: "model" });
+          const category = insertSpatialCategory({ imodel, codeValue: "category" });
+          const a = insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id, codeValue: "A" });
+          const b = insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id, codeValue: "B" });
+          const c = insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id, codeValue: "C" });
           return { a, b, c };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
 
         const hierarchyProvider = createIModelHierarchyProvider({
           imodelAccess,
@@ -201,10 +201,10 @@ describe("Hierarchies", () => {
       });
 
       it("formats property grouping node's label", async () => {
-        const { imodel, myPhysicalObjectClassName } = await buildTestIModel(async (builder, testName) => {
+        const { imodelConnection, myPhysicalObjectClassName } = await buildTestIModel(async (imodel, testName) => {
           const schema = await importSchema(
             testName,
-            builder,
+            imodel,
             `
               <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
               <ECEntityClass typeName="MyPhysicalObject">
@@ -213,10 +213,10 @@ describe("Hierarchies", () => {
               </ECEntityClass>
             `,
           );
-          const category = insertSpatialCategory({ builder, codeValue: "Category" });
-          const model = insertPhysicalModelWithPartition({ builder, codeValue: "Model" });
+          const category = insertSpatialCategory({ imodel, codeValue: "Category" });
+          const model = insertPhysicalModelWithPartition({ imodel, codeValue: "Model" });
           insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             classFullName: schema.items.MyPhysicalObject.fullName,
@@ -224,7 +224,7 @@ describe("Hierarchies", () => {
             doubleProperty: 123.45,
           });
           insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             classFullName: schema.items.MyPhysicalObject.fullName,
@@ -233,7 +233,7 @@ describe("Hierarchies", () => {
           });
           return { myPhysicalObjectClassName: schema.items.MyPhysicalObject.fullName };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
 
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.NodeLabels.PropertyGroupsFormattingExample
         const hierarchyProvider = createIModelHierarchyProvider({

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchySearch.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchySearch.test.ts
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 /* eslint-disable no-duplicate-imports */
 
-import { afterAll, describe, expect, it, test } from "vitest";
 import {
   insertPhysicalElement,
   insertPhysicalModelWithPartition,
   insertSpatialCategory,
 } from "presentation-test-utilities";
+import { afterAll, describe, expect, it, test } from "vitest";
 import { assert, Id64String } from "@itwin/core-bentley";
 import { IModelConnection } from "@itwin/core-frontend";
 import { createBisInstanceLabelSelectClauseFactory, InstanceKey } from "@itwin/presentation-shared";
@@ -34,63 +34,63 @@ import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchySearch.HierarchySearchPathImport
 import { HierarchySearchPath } from "@itwin/presentation-hierarchies";
 // __PUBLISH_EXTRACT_END__
+import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { createIModelAccess } from "../Utils.js";
 import { collectHierarchy } from "./Utils.js";
-import { buildTestIModel } from "../../IModelUtils.js";
 
 describe("Hierarchies", () => {
   describe("Learning snippets", () => {
     describe("Hierarchy search", () => {
       type IModelAccess = ReturnType<typeof createIModelAccess>;
-      let imodel: IModelConnection;
+      let imodelConnection: IModelConnection;
       let elementIds: { [name: string]: Id64String };
       let elementKeys: { [name: string]: InstanceKey };
 
       test.beforeAll(async (_context, suite) => {
         await initialize();
 
-        const res = await buildTestIModel(suite.fullTestName!, async (builder) => {
-          const model = insertPhysicalModelWithPartition({ builder, codeValue: "model" });
-          const category = insertSpatialCategory({ builder, codeValue: "category" });
-          const a = insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id, userLabel: "A" });
+        const res = await buildTestIModel(suite.fullTestName!, async (imodel) => {
+          const model = insertPhysicalModelWithPartition({ imodel, codeValue: "model" });
+          const category = insertSpatialCategory({ imodel, codeValue: "category" });
+          const a = insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id, userLabel: "A" });
           const b = insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             userLabel: "B",
             parentId: a.id,
           });
           const c = insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             userLabel: "C",
             parentId: b.id,
           });
           const d = insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             userLabel: "D",
             parentId: b.id,
           });
           const e = insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             userLabel: "E",
             parentId: a.id,
           });
           const f = insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             userLabel: "F",
             parentId: e.id,
           });
           const g = insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             userLabel: "G",
@@ -98,10 +98,13 @@ describe("Hierarchies", () => {
           });
           return { a, b, c, d, e, f, g };
         });
-        const { imodel: _, ...elements } = res;
-        imodel = res.imodel;
+        const { imodelConnection: _, ...elements } = res;
+        imodelConnection = res.imodelConnection;
         elementKeys = Object.entries(elements).reduce(
-          (acc, [name, instanceKey]) => ({ ...acc, [name]: { ...instanceKey, imodelKey: createIModelKey(imodel) } }),
+          (acc, [name, instanceKey]) => ({
+            ...acc,
+            [name]: { ...instanceKey, imodelKey: createIModelKey(imodelConnection) },
+          }),
           {} as { [name: string]: InstanceKey },
         );
         elementIds = Object.entries(elements).reduce(
@@ -165,7 +168,7 @@ describe("Hierarchies", () => {
       // __PUBLISH_EXTRACT_END__
 
       it("creates expected default hierarchy", async () => {
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const hierarchyProvider = createIModelHierarchyProvider({
           imodelAccess,
           hierarchyDefinition: createHierarchyDefinition(imodelAccess),
@@ -184,7 +187,7 @@ describe("Hierarchies", () => {
       });
 
       it("creates hierarchy searched by label", async () => {
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchySearch.FindPathsByLabel
         // Define a function that returns `HierarchySearchTree[]` based on given search string. In this case, we run
         // a query to find matching elements by their `UserLabel` property. Then, we construct paths to the root element using recursive
@@ -217,7 +220,7 @@ describe("Hierarchies", () => {
             searchTreeBuilder.accept({
               path: (JSON.parse(row.Path) as InstanceKey[])
                 .reverse()
-                .map((key) => ({ ...key, imodelKey: createIModelKey(imodel) })),
+                .map((key) => ({ ...key, imodelKey: createIModelKey(imodelConnection) })),
             });
           }
           return searchTreeBuilder.getTree();
@@ -259,7 +262,7 @@ describe("Hierarchies", () => {
       });
 
       it("creates hierarchy searched by target instance ids", async () => {
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchySearch.FindPathsByTargetElementId
         // Define a function that returns `HierarchyNodeIdentifiersPath[]` based on given target element IDs. In this case, we run
         // a query to find matching elements by their `ECInstanceId` property. Then, we construct paths to the root element using recursive
@@ -294,7 +297,7 @@ describe("Hierarchies", () => {
             result.push(
               (JSON.parse(row.Path) as InstanceKey[])
                 .reverse()
-                .map((key) => ({ ...key, imodelKey: createIModelKey(imodel) })),
+                .map((key) => ({ ...key, imodelKey: createIModelKey(imodelConnection) })),
             );
           }
           return result;
@@ -329,7 +332,7 @@ describe("Hierarchies", () => {
       });
 
       it("sets auto-expand flag to parent nodes of the revealed search target", async () => {
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
 
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchySearch.Reveal.SearchPath
         const searchPath: HierarchySearchPath = {
@@ -358,7 +361,7 @@ describe("Hierarchies", () => {
       });
 
       it("sets auto-expand flag to parent nodes of the search target until specified groupingLevel", async () => {
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const queryClauseFactory = createNodesQueryClauseFactory({
           imodelAccess,
           instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -484,7 +487,7 @@ describe("Hierarchies", () => {
       });
 
       it("sets auto-expand flag to parent nodes of the search target until specified depthInPath", async () => {
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const queryClauseFactory = createNodesQueryClauseFactory({
           imodelAccess,
           instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({
@@ -591,7 +594,7 @@ describe("Hierarchies", () => {
       });
 
       it("sets auto-expand flag on search target when `HierarchySearchPathOptions.autoExpand` flag is set", async function () {
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
         const queryClauseFactory = createNodesQueryClauseFactory({
           imodelAccess,
           instanceLabelSelectClauseFactory: createBisInstanceLabelSelectClauseFactory({

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/Localization.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/Localization.test.ts
@@ -3,21 +3,21 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   insertPhysicalElement,
   insertPhysicalModelWithPartition,
   insertSpatialCategory,
 } from "presentation-test-utilities";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Localization.Imports
 import { createIModelHierarchyProvider, createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
+import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
+import { importSchema } from "../../SchemaUtils.js";
 import { createIModelAccess } from "../Utils.js";
 import { collectHierarchy } from "./Utils.js";
-import { buildTestIModel } from "../../IModelUtils.js";
-import { importSchema } from "../../SchemaUtils.js";
 
 describe("Hierarchies", () => {
   describe("Learning snippets", () => {
@@ -31,10 +31,10 @@ describe("Hierarchies", () => {
       });
 
       it("localizes property grouping node labels", async () => {
-        const { imodel, myPhysicalObjectClassName } = await buildTestIModel(async (builder, testName) => {
+        const { imodelConnection, myPhysicalObjectClassName } = await buildTestIModel(async (imodel, testName) => {
           const schema = await importSchema(
             testName,
-            builder,
+            imodel,
             `
               <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
               <ECEntityClass typeName="MyPhysicalObject">
@@ -43,10 +43,10 @@ describe("Hierarchies", () => {
               </ECEntityClass>
             `,
           );
-          const category = insertSpatialCategory({ builder, codeValue: "Category" });
-          const model = insertPhysicalModelWithPartition({ builder, codeValue: "Model" });
+          const category = insertSpatialCategory({ imodel, codeValue: "Category" });
+          const model = insertPhysicalModelWithPartition({ imodel, codeValue: "Model" });
           insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             classFullName: schema.items.MyPhysicalObject.fullName,
@@ -54,7 +54,7 @@ describe("Hierarchies", () => {
             intProperty: 2,
           });
           insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             classFullName: schema.items.MyPhysicalObject.fullName,
@@ -62,7 +62,7 @@ describe("Hierarchies", () => {
             intProperty: 4,
           });
           insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             classFullName: schema.items.MyPhysicalObject.fullName,
@@ -70,7 +70,7 @@ describe("Hierarchies", () => {
             intProperty: 6,
           });
           insertPhysicalElement({
-            builder,
+            imodel,
             modelId: model.id,
             categoryId: category.id,
             classFullName: schema.items.MyPhysicalObject.fullName,
@@ -78,7 +78,7 @@ describe("Hierarchies", () => {
           });
           return { myPhysicalObjectClassName: schema.items.MyPhysicalObject.fullName };
         });
-        const imodelAccess = createIModelAccess(imodel);
+        const imodelAccess = createIModelAccess(imodelConnection);
 
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Localization.PropertyGroupsLocalizationExample
         const hierarchyProvider = createIModelHierarchyProvider({

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/MergedIModelHierarchies.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/MergedIModelHierarchies.test.ts
@@ -3,6 +3,13 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import {
+  insertPhysicalElement,
+  insertPhysicalModelWithPartition,
+  insertSpatialCategory,
+} from "presentation-test-utilities";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { BisCodeSpec, Code } from "@itwin/core-common";
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.MergedIModelHierarchies.Imports
 import {
   createIModelHierarchyProvider,
@@ -13,17 +20,10 @@ import {
 } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory, EC } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
-import { BisCodeSpec } from "@itwin/core-common";
-import {
-  insertPhysicalElement,
-  insertPhysicalModelWithPartition,
-  insertSpatialCategory,
-} from "presentation-test-utilities";
 import { createChangedIModels } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { createIModelAccess } from "../Utils.js";
 import { collectHierarchy } from "./Utils.js";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 describe("Hierarchies", () => {
   describe("Learning snippets", () => {
@@ -38,45 +38,49 @@ describe("Hierarchies", () => {
 
       it("creates merged iModel hierarchy", async function () {
         await using changesets = await createChangedIModels(
-          async (builder) => {
-            const model1 = insertPhysicalModelWithPartition({ builder, codeValue: "Model 1" });
-            const category = insertSpatialCategory({ builder, codeValue: "Category" });
+          async (imodel) => {
+            const model1 = insertPhysicalModelWithPartition({ imodel, codeValue: "Model 1" });
+            const category = insertSpatialCategory({ imodel, codeValue: "Category" });
             const element1 = insertPhysicalElement({
-              builder,
+              imodel,
               modelId: model1.id,
               categoryId: category.id,
               codeValue: "Element 1",
             });
             const element2 = insertPhysicalElement({
-              builder,
+              imodel,
               modelId: model1.id,
               categoryId: category.id,
               codeValue: "Element 2",
             });
             const element3 = insertPhysicalElement({
-              builder,
+              imodel,
               modelId: model1.id,
               categoryId: category.id,
               codeValue: "Element 3",
             });
             return { model1, category, element1, element2, element3 };
           },
-          async (builder, base) => {
+          async (imodel, base) => {
             const { element2, ...restKeys } = base;
-            builder.deleteElement(element2.id);
-            builder.updateElement({
+            imodel.elements.deleteElement(element2.id);
+            imodel.elements.updateElement({
               id: base.element3.id,
-              code: builder.createCode(base.model1.id, BisCodeSpec.nullCodeSpec, "Updated element 3"),
+              code: new Code({
+                spec: imodel.codeSpecs.getByName(BisCodeSpec.nullCodeSpec).id,
+                scope: base.model1.id,
+                value: "Updated element 3",
+              }),
             });
             const element4 = insertPhysicalElement({
-              builder,
+              imodel,
               modelId: base.model1.id,
               categoryId: base.category.id,
               codeValue: "Element 4",
             });
-            const model2 = insertPhysicalModelWithPartition({ builder, codeValue: "Model 2" });
+            const model2 = insertPhysicalModelWithPartition({ imodel, codeValue: "Model 2" });
             const element5 = insertPhysicalElement({
-              builder,
+              imodel,
               modelId: model2.id,
               categoryId: base.category.id,
               codeValue: "Element 5",
@@ -90,8 +94,8 @@ describe("Hierarchies", () => {
         // both versions - `base` and `changeset1`. The order is important - we want the changesets to be from oldest to
         // newest.
         const imodels = [
-          { imodelAccess: createIModelAccess(changesets.base.imodel) },
-          { imodelAccess: createIModelAccess(changesets.changeset1.imodel) },
+          { imodelAccess: createIModelAccess(changesets.base.imodelConnection) },
+          { imodelAccess: createIModelAccess(changesets.changeset1.imodelConnection) },
         ];
 
         // Define an utility for creating instance nodes query definitions, that we'll use in our hierarchy definition.

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/Migration.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/Migration.test.ts
@@ -16,9 +16,9 @@ import {
   insertRepositoryLink,
   insertSpatialCategory,
 } from "presentation-test-utilities";
+import { afterAll, describe, it, test } from "vitest";
 import { IModel } from "@itwin/core-common";
 import { IModelConnection } from "@itwin/core-frontend";
-import { afterAll, describe, it, test } from "vitest";
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.HierarchyProviderImports
 import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 // __PUBLISH_EXTRACT_END__
@@ -40,11 +40,11 @@ import {
 } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
+import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
+import { importSchema } from "../../SchemaUtils.js";
 import { NodeValidators, validateHierarchy, validateHierarchyLevel } from "../HierarchyValidation.js";
 import { createIModelAccess } from "../Utils.js";
-import { buildTestIModel } from "../../IModelUtils.js";
-import { importSchema } from "../../SchemaUtils.js";
 
 describe("Hierarchies", () => {
   describe("Learning snippets", () => {
@@ -53,7 +53,7 @@ describe("Hierarchies", () => {
 
       test.beforeAll(async (_, suite) => {
         await initialize();
-        emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodel;
+        emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodelConnection;
       });
 
       afterAll(async () => {
@@ -175,20 +175,20 @@ describe("Hierarchies", () => {
         });
 
         it("creates instance nodes of specific classes definition", async () => {
-          const { imodel } = await buildTestIModel(async (builder) => {
-            insertPhysicalModelWithPartition({ builder, codeValue: "Non-private physical model" });
+          const { imodelConnection } = await buildTestIModel(async (imodel) => {
+            insertPhysicalModelWithPartition({ imodel, codeValue: "Non-private physical model" });
             insertPhysicalSubModel({
-              builder,
+              imodel,
               modeledElementId: insertPhysicalPartition({
-                builder,
+                imodel,
                 codeValue: "Private physical model",
                 parentId: IModel.rootSubjectId,
               }).id,
               isPrivate: true,
             });
-            insertDrawingModelWithPartition({ builder, codeValue: "Drawing model" });
+            insertDrawingModelWithPartition({ imodel, codeValue: "Drawing model" });
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.InstanceNodesOfSpecificClassesDefinition
           const labelsFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
           const selectClauseFactory = createNodesQueryClauseFactory({
@@ -237,19 +237,19 @@ describe("Hierarchies", () => {
         });
 
         it("creates related instance nodes definition", async () => {
-          const { imodel } = await buildTestIModel(async (builder) => {
-            const model = insertPhysicalModelWithPartition({ builder, codeValue: "Physical model" });
-            const category = insertSpatialCategory({ builder, codeValue: "Spatial category" });
-            const type = insertPhysicalType({ builder, codeValue: "Physical type" });
+          const { imodelConnection } = await buildTestIModel(async (imodel) => {
+            const model = insertPhysicalModelWithPartition({ imodel, codeValue: "Physical model" });
+            const category = insertSpatialCategory({ imodel, codeValue: "Spatial category" });
+            const type = insertPhysicalType({ imodel, codeValue: "Physical type" });
             insertPhysicalElement({
-              builder,
+              imodel,
               modelId: model.id,
               categoryId: category.id,
               typeDefinitionId: type.id,
               codeValue: "Physical element",
             });
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.RelatedInstanceNodesDefinition
           const labelsFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
           const selectClauseFactory = createNodesQueryClauseFactory({
@@ -324,10 +324,10 @@ describe("Hierarchies", () => {
         });
 
         it("creates custom query instance nodes definition", async () => {
-          const { imodel, schema } = await buildTestIModel(async (builder, testName) => {
+          const { imodelConnection, schema } = await buildTestIModel(async (imodel, testName) => {
             const importedSchema = await importSchema(
               testName,
-              builder,
+              imodel,
               `
                 <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
                 <ECEntityClass typeName="MyParentElement">
@@ -339,10 +339,10 @@ describe("Hierarchies", () => {
                 </ECEntityClass>
               `,
             );
-            const model = insertPhysicalModelWithPartition({ builder, codeValue: "Physical model" });
-            const category = insertSpatialCategory({ builder, codeValue: "Spatial category" });
+            const model = insertPhysicalModelWithPartition({ imodel, codeValue: "Physical model" });
+            const category = insertSpatialCategory({ imodel, codeValue: "Spatial category" });
             insertPhysicalElement({
-              builder,
+              imodel,
               classFullName: importedSchema.items.MyParentElement.fullName,
               modelId: model.id,
               categoryId: category.id,
@@ -350,7 +350,7 @@ describe("Hierarchies", () => {
               ["ChildrenQuery"]: `SELECT ECClassId, ECInstanceId FROM ${importedSchema.items.MyChildElement.fullName}`,
             });
             insertPhysicalElement({
-              builder,
+              imodel,
               classFullName: importedSchema.items.MyChildElement.fullName,
               modelId: model.id,
               categoryId: category.id,
@@ -358,7 +358,7 @@ describe("Hierarchies", () => {
             });
             return { schema: importedSchema };
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.CustomQueryInstanceNodesDefinition
           const labelsFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
           const selectClauseFactory = createNodesQueryClauseFactory({
@@ -460,17 +460,17 @@ describe("Hierarchies", () => {
 
       describe("Migrating grouping specifications", () => {
         it("groups by base class", async () => {
-          const { imodel } = await buildTestIModel(async (builder) => {
-            const model = insertPhysicalModelWithPartition({ builder, codeValue: "Physical model" });
-            const category = insertSpatialCategory({ builder, codeValue: "Spatial category" });
+          const { imodelConnection } = await buildTestIModel(async (imodel) => {
+            const model = insertPhysicalModelWithPartition({ imodel, codeValue: "Physical model" });
+            const category = insertSpatialCategory({ imodel, codeValue: "Spatial category" });
             insertPhysicalElement({
-              builder,
+              imodel,
               modelId: model.id,
               categoryId: category.id,
               codeValue: "Physical element",
             });
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.BaseClassGrouping
           const labelsFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
           const selectClauseFactory = createNodesQueryClauseFactory({
@@ -575,18 +575,18 @@ describe("Hierarchies", () => {
         });
 
         it("groups by properties", async () => {
-          const { imodel } = await buildTestIModel(async (builder) => {
-            const model = insertPhysicalModelWithPartition({ builder, codeValue: "Physical model" });
-            const category = insertSpatialCategory({ builder, codeValue: "Spatial category" });
+          const { imodelConnection } = await buildTestIModel(async (imodel) => {
+            const model = insertPhysicalModelWithPartition({ imodel, codeValue: "Physical model" });
+            const category = insertSpatialCategory({ imodel, codeValue: "Spatial category" });
             insertPhysicalElement({
-              builder,
+              imodel,
               modelId: model.id,
               categoryId: category.id,
               codeValue: "Physical element",
               placement: { origin: { x: 0, y: 0, z: 0 }, angles: { yaw: 180 } },
             });
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.PropertyGrouping
           const labelsFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
           const selectClauseFactory = createNodesQueryClauseFactory({
@@ -649,11 +649,11 @@ describe("Hierarchies", () => {
         });
 
         it("groups by label", async () => {
-          const { imodel } = await buildTestIModel(async (builder) => {
-            insertRepositoryLink({ builder, repositoryLabel: "Test repository link" });
-            insertRepositoryLink({ builder, repositoryLabel: "Test repository link" });
+          const { imodelConnection } = await buildTestIModel(async (imodel) => {
+            insertRepositoryLink({ imodel, repositoryLabel: "Test repository link" });
+            insertRepositoryLink({ imodel, repositoryLabel: "Test repository link" });
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.LabelGrouping
           const labelsFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
           const selectClauseFactory = createNodesQueryClauseFactory({
@@ -690,7 +690,7 @@ describe("Hierarchies", () => {
               NodeValidators.createForInstanceNode({ label: "BisCore.DictionaryModel" }),
               NodeValidators.createForInstanceNode({ label: "BisCore.RealityDataSources" }),
               NodeValidators.createForInstanceNode({
-                label: imodel.name,
+                label: imodelConnection.name,
                 instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
               }),
               NodeValidators.createForLabelGroupingNode({
@@ -705,15 +705,15 @@ describe("Hierarchies", () => {
         });
 
         it("merges by label", async () => {
-          const { imodel, repoLinkKeys } = await buildTestIModel(async (builder) => {
+          const { imodelConnection, repoLinkKeys } = await buildTestIModel(async (imodel) => {
             return {
               repoLinkKeys: [
-                insertRepositoryLink({ builder, repositoryLabel: "Test repository link" }),
-                insertRepositoryLink({ builder, repositoryLabel: "Test repository link" }),
+                insertRepositoryLink({ imodel, repositoryLabel: "Test repository link" }),
+                insertRepositoryLink({ imodel, repositoryLabel: "Test repository link" }),
               ],
             };
           });
-          const imodelAccess = createIModelAccess(imodel);
+          const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.SameLabelGrouping
           const labelsFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
           const selectClauseFactory = createNodesQueryClauseFactory({
@@ -750,7 +750,7 @@ describe("Hierarchies", () => {
               NodeValidators.createForInstanceNode({ label: "BisCore.DictionaryModel" }),
               NodeValidators.createForInstanceNode({ label: "BisCore.RealityDataSources" }),
               NodeValidators.createForInstanceNode({
-                label: imodel.name,
+                label: imodelConnection.name,
                 instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
               }),
               NodeValidators.createForInstanceNode({ label: "Test repository link", instanceKeys: repoLinkKeys }),

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/ReadmeExample.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/ReadmeExample.test.ts
@@ -5,13 +5,12 @@
 /* eslint-disable no-console */
 /* eslint-disable no-duplicate-imports */
 
-// Test-specific imports should be kept out of extracted code
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   insertPhysicalElement,
   insertPhysicalModelWithPartition,
   insertSpatialCategory,
 } from "presentation-test-utilities";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Logger } from "@itwin/core-bentley";
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.IModelAccessImports
 import { IModelConnection } from "@itwin/core-frontend";
@@ -19,7 +18,6 @@ import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } fro
 import { createLimitingECSqlQueryExecutor, HierarchyLevelDefinition } from "@itwin/presentation-hierarchies";
 import { createCachingECClassHierarchyInspector, Props } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
-
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.ReadmeExampleImports
 import {
   createIModelHierarchyProvider,
@@ -31,9 +29,8 @@ import {
 } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory, ECSqlBinding } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
-
-import { initialize, terminate } from "../../IntegrationTests.js";
 import { buildTestIModel } from "../../IModelUtils.js";
+import { initialize, terminate } from "../../IntegrationTests.js";
 
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.IModelAccess
 function createIModelAccess(imodel: IModelConnection) {
@@ -141,13 +138,13 @@ async function main() {
 // __PUBLISH_EXTRACT_END__
 
 async function getIModelConnection(): Promise<IModelConnection> {
-  const { imodel } = await buildTestIModel(async (builder) => {
-    const category = insertSpatialCategory({ builder, codeValue: "Test category" });
-    const model = insertPhysicalModelWithPartition({ builder, codeValue: "Test model" });
-    insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id, userLabel: "Test element 1" });
-    insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id, userLabel: "Test element 2" });
+  const { imodelConnection } = await buildTestIModel(async (imodel) => {
+    const category = insertSpatialCategory({ imodel, codeValue: "Test category" });
+    const model = insertPhysicalModelWithPartition({ imodel, codeValue: "Test model" });
+    insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id, userLabel: "Test element 1" });
+    insertPhysicalElement({ imodel, modelId: model.id, categoryId: category.id, userLabel: "Test element 2" });
   });
-  return imodel;
+  return imodelConnection;
 }
 
 describe("Hierarchies", () => {

--- a/apps/full-stack-tests/src/unified-selection/HiliteSet.test.ts
+++ b/apps/full-stack-tests/src/unified-selection/HiliteSet.test.ts
@@ -29,7 +29,7 @@ import type { IModelConnection } from "@itwin/core-frontend";
 import type { SelectableInstanceKey } from "@itwin/unified-selection";
 
 describe("HiliteSet", () => {
-  let iModel: IModelConnection;
+  let imodelConnection: IModelConnection;
 
   beforeAll(async () => {
     await initialize();
@@ -40,7 +40,7 @@ describe("HiliteSet", () => {
   });
 
   async function loadHiliteSet(selectables: Selectables) {
-    const provider = createHiliteSetProvider({ imodelAccess: createIModelAccess(iModel) });
+    const provider = createHiliteSetProvider({ imodelAccess: createIModelAccess(imodelConnection) });
     const iterator = provider.getHiliteSet({ selectables });
 
     const models: string[] = [];
@@ -62,15 +62,15 @@ describe("HiliteSet", () => {
         let subjectKey: SelectableInstanceKey;
         let modelKeys: SelectableInstanceKey[];
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
-            subjectKey = insertSubject({ builder, codeValue: "test subject" });
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
+            subjectKey = insertSubject({ imodel, codeValue: "test subject" });
             modelKeys = [
-              insertPhysicalModelWithPartition({ builder, codeValue: "model 1", partitionParentId: subjectKey.id }),
-              insertPhysicalModelWithPartition({ builder, codeValue: "model 2", partitionParentId: subjectKey.id }),
+              insertPhysicalModelWithPartition({ imodel, codeValue: "model 1", partitionParentId: subjectKey.id }),
+              insertPhysicalModelWithPartition({ imodel, codeValue: "model 2", partitionParentId: subjectKey.id }),
             ];
           })
-        ).imodel;
+        ).imodelConnection;
 
         const hiliteSet = await loadHiliteSet(Selectables.create([subjectKey!]));
 
@@ -78,25 +78,25 @@ describe("HiliteSet", () => {
         expect(hiliteSet.models).toEqual(expect.arrayContaining(modelKeys!.map((k) => k.id)));
         expect(hiliteSet.subCategories).toHaveLength(0);
         expect(hiliteSet.elements).toHaveLength(0);
-        expect(iModel.selectionSet.size).toBe(0);
+        expect(imodelConnection.selectionSet.size).toBe(0);
       });
 
       it("hilites models nested deeply under subject", async () => {
         let subjectKey: SelectableInstanceKey;
         let modelKeys: SelectableInstanceKey[];
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
-            subjectKey = insertSubject({ builder, codeValue: "test subject" });
-            const subject2 = insertSubject({ builder, codeValue: "subject 2", parentId: subjectKey.id });
-            const subject3 = insertSubject({ builder, codeValue: "subject 3", parentId: subjectKey.id });
-            const subject4 = insertSubject({ builder, codeValue: "subject 4", parentId: subject3.id });
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
+            subjectKey = insertSubject({ imodel, codeValue: "test subject" });
+            const subject2 = insertSubject({ imodel, codeValue: "subject 2", parentId: subjectKey.id });
+            const subject3 = insertSubject({ imodel, codeValue: "subject 3", parentId: subjectKey.id });
+            const subject4 = insertSubject({ imodel, codeValue: "subject 4", parentId: subject3.id });
             modelKeys = [
-              insertPhysicalModelWithPartition({ builder, codeValue: "model 1", partitionParentId: subject2.id }),
-              insertPhysicalModelWithPartition({ builder, codeValue: "model 2", partitionParentId: subject4.id }),
+              insertPhysicalModelWithPartition({ imodel, codeValue: "model 1", partitionParentId: subject2.id }),
+              insertPhysicalModelWithPartition({ imodel, codeValue: "model 2", partitionParentId: subject4.id }),
             ];
           })
-        ).imodel;
+        ).imodelConnection;
         const hiliteSet = await loadHiliteSet(Selectables.create([subjectKey!]));
 
         expect(hiliteSet.models).toHaveLength(modelKeys!.length);
@@ -110,11 +110,11 @@ describe("HiliteSet", () => {
       it("hilites model", async () => {
         let modelKey: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
-            modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
+            modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const hiliteSet = await loadHiliteSet(Selectables.create([modelKey!]));
 
@@ -122,7 +122,7 @@ describe("HiliteSet", () => {
         expect(hiliteSet.models).toContain(modelKey!.id);
         expect(hiliteSet.subCategories).toHaveLength(0);
         expect(hiliteSet.elements).toHaveLength(0);
-        expect(iModel.selectionSet.size).toBe(0);
+        expect(imodelConnection.selectionSet.size).toBe(0);
       });
     });
 
@@ -131,16 +131,16 @@ describe("HiliteSet", () => {
         let categoryKey: SelectableInstanceKey;
         let subCategoryKeys: SelectableInstanceKey[];
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
-            categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
+            categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             subCategoryKeys = [
               getDefaultSubcategoryKey(categoryKey.id),
-              insertSubCategory({ builder, codeValue: "sub 1", parentCategoryId: categoryKey.id }),
-              insertSubCategory({ builder, codeValue: "sub 2", parentCategoryId: categoryKey.id }),
+              insertSubCategory({ imodel, codeValue: "sub 1", parentCategoryId: categoryKey.id }),
+              insertSubCategory({ imodel, codeValue: "sub 2", parentCategoryId: categoryKey.id }),
             ];
           })
-        ).imodel;
+        ).imodelConnection;
 
         const hiliteSet = await loadHiliteSet(Selectables.create([categoryKey!]));
 
@@ -153,11 +153,11 @@ describe("HiliteSet", () => {
       it("hilites subcategory", async () => {
         let categoryKey: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
-            categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
+            categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const subCategoryKey = getDefaultSubcategoryKey(categoryKey!.id);
         const hiliteSet = await loadHiliteSet(Selectables.create([subCategoryKey]));
@@ -172,16 +172,16 @@ describe("HiliteSet", () => {
         let categoryKey: SelectableInstanceKey;
         let subCategoryKeys: SelectableInstanceKey[];
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
-            categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
+            categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             subCategoryKeys = [
               getDefaultSubcategoryKey(categoryKey.id),
-              insertSubCategory({ builder, codeValue: "sub 1", parentCategoryId: categoryKey.id }),
-              insertSubCategory({ builder, codeValue: "sub 2", parentCategoryId: categoryKey.id }),
+              insertSubCategory({ imodel, codeValue: "sub 1", parentCategoryId: categoryKey.id }),
+              insertSubCategory({ imodel, codeValue: "sub 2", parentCategoryId: categoryKey.id }),
             ];
           })
-        ).imodel;
+        ).imodelConnection;
 
         const hiliteSet = await loadHiliteSet(Selectables.create([categoryKey!, subCategoryKeys![0]]));
 
@@ -197,41 +197,41 @@ describe("HiliteSet", () => {
         let assemblyKey: SelectableInstanceKey;
         let expectedHighlightedElementKeys: SelectableInstanceKey[];
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
-            const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
+            const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            await imodel.importSchemaStrings([schema]);
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             assemblyKey = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element 1",
               modelId: modelKey.id,
               categoryId: categoryKey.id,
             });
             const element2 = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element 2",
               modelId: modelKey.id,
               categoryId: categoryKey.id,
               parentId: assemblyKey.id,
             });
             const element3 = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element 3",
               modelId: modelKey.id,
               categoryId: categoryKey.id,
               parentId: assemblyKey.id,
             });
             const element4 = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element 4",
               modelId: modelKey.id,
               categoryId: categoryKey.id,
               parentId: element3.id,
             });
             const element5 = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element 5",
               modelId: modelKey.id,
               categoryId: categoryKey.id,
@@ -239,7 +239,7 @@ describe("HiliteSet", () => {
             });
             expectedHighlightedElementKeys = [assemblyKey, element2, element3, element4, element5];
           })
-        ).imodel;
+        ).imodelConnection;
 
         const hiliteSet = await loadHiliteSet(Selectables.create([assemblyKey!]));
 
@@ -252,20 +252,20 @@ describe("HiliteSet", () => {
       it("hilites leaf element", async () => {
         let elementKey: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
-            const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
+            const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            await imodel.importSchemaStrings([schema]);
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             elementKey = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: modelKey.id,
               categoryId: categoryKey.id,
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const hiliteSet = await loadHiliteSet(Selectables.create([elementKey!]));
 
@@ -278,34 +278,19 @@ describe("HiliteSet", () => {
       it("hilites all selected elements", async () => {
         let elementKeys: SelectableInstanceKey[];
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
-            const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
+            const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            await imodel.importSchemaStrings([schema]);
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             elementKeys = [
-              insertPhysicalElement({
-                builder,
-                userLabel: "element",
-                modelId: modelKey.id,
-                categoryId: categoryKey.id,
-              }),
-              insertPhysicalElement({
-                builder,
-                userLabel: "element",
-                modelId: modelKey.id,
-                categoryId: categoryKey.id,
-              }),
-              insertPhysicalElement({
-                builder,
-                userLabel: "element",
-                modelId: modelKey.id,
-                categoryId: categoryKey.id,
-              }),
+              insertPhysicalElement({ imodel, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
+              insertPhysicalElement({ imodel, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
+              insertPhysicalElement({ imodel, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
             ];
           })
-        ).imodel;
+        ).imodelConnection;
 
         const hiliteSet = await loadHiliteSet(Selectables.create(elementKeys!));
 
@@ -322,45 +307,45 @@ describe("HiliteSet", () => {
         let physicalElement: SelectableInstanceKey;
         let expectedElements: SelectableInstanceKey[];
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             physicalElement = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
             const physicalElementChild = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "child element 1",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: physicalElement.id,
             });
             const physicalElementChild2 = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "child element 2",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: physicalElement.id,
             });
             const physicalElementChildChild = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "child 1 child element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: physicalElementChild.id,
             });
             functionalElement = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: physicalElement.id,
               relationshipName: "PhysicalElementFulfillsFunction",
@@ -372,7 +357,7 @@ describe("HiliteSet", () => {
               physicalElementChildChild,
             ];
           })
-        ).imodel;
+        ).imodelConnection;
 
         const hiliteSet = await loadHiliteSet(Selectables.create([functionalElement!]));
 
@@ -387,41 +372,37 @@ describe("HiliteSet", () => {
         let graphicsElement: SelectableInstanceKey;
         let expectedElements: SelectableInstanceKey[];
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
-            graphicsElement = insertDrawingGraphic({
-              builder,
-              modelId: drawingModelKey.id,
-              categoryId: categoryKey.id,
-            });
+            const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
+            graphicsElement = insertDrawingGraphic({ imodel, modelId: drawingModelKey.id, categoryId: categoryKey.id });
             const graphicsElementChild = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElement.id,
             });
             const graphicsElementChild2 = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementChild.id,
             });
             const graphicsElementChildChild = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementChild.id,
             });
             functionalElement = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: graphicsElement.id,
               relationshipName: "DrawingGraphicRepresentsFunctionalElement",
@@ -433,7 +414,7 @@ describe("HiliteSet", () => {
               graphicsElementChildChild,
             ];
           })
-        ).imodel;
+        ).imodelConnection;
 
         const hiliteSet = await loadHiliteSet(Selectables.create([functionalElement!]));
 
@@ -449,41 +430,41 @@ describe("HiliteSet", () => {
         let groupInformationElement: SelectableInstanceKey;
         let expectedElements: SelectableInstanceKey[];
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const groupModel = insertGroupInformationModelWithPartition({
-              builder,
+              imodel,
               codeValue: "group information model",
             });
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
-            groupInformationElement = insertGroupInformationElement({ builder, modelId: groupModel.id });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
+            groupInformationElement = insertGroupInformationElement({ imodel, modelId: groupModel.id });
             const physicalElementGroupMember = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "child element 1",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
-            builder.insertRelationship({
+            imodel.relationships.insertInstance({
               sourceId: groupInformationElement.id,
               targetId: physicalElementGroupMember.id,
               classFullName: "BisCore.ElementGroupsMembers",
             });
             const physicalElementGroupMember2 = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "child element 2",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
-            builder.insertRelationship({
+            imodel.relationships.insertInstance({
               sourceId: groupInformationElement.id,
               targetId: physicalElementGroupMember2.id,
               classFullName: "BisCore.ElementGroupsMembers",
             });
             const physicalElementGroupMemberChild = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "child 1 child element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
@@ -495,7 +476,7 @@ describe("HiliteSet", () => {
               physicalElementGroupMemberChild,
             ];
           })
-        ).imodel;
+        ).imodelConnection;
 
         const hiliteSet = await loadHiliteSet(Selectables.create([groupInformationElement!]));
 

--- a/apps/full-stack-tests/src/unified-selection/SelectionScope.test.ts
+++ b/apps/full-stack-tests/src/unified-selection/SelectionScope.test.ts
@@ -25,7 +25,7 @@ import type { Props } from "@itwin/presentation-shared";
 import type { SelectableInstanceKey } from "@itwin/unified-selection";
 
 describe("SelectionScope", () => {
-  let iModel: IModelConnection;
+  let imodelConnection: IModelConnection;
 
   beforeAll(async () => {
     await initialize();
@@ -41,7 +41,7 @@ describe("SelectionScope", () => {
   ): Promise<SelectableInstanceKey[]> {
     const selectables: SelectableInstanceKey[] = [];
     for await (const selectable of computeSelection({
-      queryExecutor: createECSqlQueryExecutor(iModel),
+      queryExecutor: createECSqlQueryExecutor(imodelConnection),
       elementIds: keys,
       scope,
     })) {
@@ -54,25 +54,25 @@ describe("SelectionScope", () => {
     it("returns element", async () => {
       let elementKey1: SelectableInstanceKey;
 
-      iModel = (
-        await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           const assemblyKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "root element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           }).id;
           elementKey1 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 1",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: assemblyKey,
           });
         })
-      ).imodel;
+      ).imodelConnection;
 
       const actual = await getSelection([elementKey1!.id], { id: "element" });
       expect(actual).toEqual(expect.arrayContaining([elementKey1!]));
@@ -81,25 +81,25 @@ describe("SelectionScope", () => {
     it("skips invalid ID's", async () => {
       let elementKey1: SelectableInstanceKey;
 
-      iModel = (
-        await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           const assemblyKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "root element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           }).id;
           elementKey1 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 1",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: assemblyKey,
           });
         })
-      ).imodel;
+      ).imodelConnection;
 
       const actual = await getSelection([elementKey1!.id, "invalid"], { id: "element" });
       expect(actual).toEqual(expect.arrayContaining([elementKey1!]));
@@ -110,32 +110,32 @@ describe("SelectionScope", () => {
       let elementKey1: SelectableInstanceKey;
       let elementKey2: SelectableInstanceKey;
 
-      iModel = (
-        await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           parentKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "root element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           });
           elementKey1 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 1",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: parentKey.id,
           });
           elementKey2 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 2",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: parentKey.id,
           });
         })
-      ).imodel;
+      ).imodelConnection;
       const actual = await getSelection([elementKey1!.id, elementKey2!.id], { id: "element", ancestorLevel: 1 });
       expect(actual).toEqual(expect.arrayContaining([parentKey!]));
     });
@@ -143,18 +143,18 @@ describe("SelectionScope", () => {
     it("returns element when it has no parent", async () => {
       let elementKey: SelectableInstanceKey;
 
-      iModel = (
-        await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           elementKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "root element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           });
         })
-      ).imodel;
+      ).imodelConnection;
 
       const actual = await getSelection([elementKey!.id], { id: "element", ancestorLevel: 1 });
       expect(actual).toEqual(expect.arrayContaining([elementKey!]));
@@ -164,32 +164,32 @@ describe("SelectionScope", () => {
       let grandParentKey: SelectableInstanceKey;
       let elementKey: SelectableInstanceKey;
 
-      iModel = (
-        await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           grandParentKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "root element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           });
           const parentKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 1",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: grandParentKey.id,
           });
           elementKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 2",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: parentKey.id,
           });
         })
-      ).imodel;
+      ).imodelConnection;
 
       const actual = await getSelection([elementKey!.id], { id: "element", ancestorLevel: 2 });
       expect(actual).toEqual(expect.arrayContaining([grandParentKey!]));
@@ -199,25 +199,25 @@ describe("SelectionScope", () => {
       let parentKey: SelectableInstanceKey;
       let elementKey: SelectableInstanceKey;
 
-      iModel = (
-        await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           parentKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "root element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           });
           elementKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 1",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: parentKey.id,
           });
         })
-      ).imodel;
+      ).imodelConnection;
 
       const actual = await getSelection([elementKey!.id], { id: "element", ancestorLevel: 2 });
       expect(actual).toEqual(expect.arrayContaining([parentKey!]));
@@ -226,17 +226,17 @@ describe("SelectionScope", () => {
     it("returns all selected elements", async () => {
       let elementKeys: SelectableInstanceKey[];
 
-      iModel = (
-        await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           elementKeys = [
-            insertPhysicalElement({ builder, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
-            insertPhysicalElement({ builder, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
-            insertPhysicalElement({ builder, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
+            insertPhysicalElement({ imodel, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
+            insertPhysicalElement({ imodel, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
+            insertPhysicalElement({ imodel, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
           ];
         })
-      ).imodel;
+      ).imodelConnection;
 
       const actual = await getSelection(
         elementKeys!.map((key) => key.id),
@@ -249,39 +249,39 @@ describe("SelectionScope", () => {
       let rootElementKey: SelectableInstanceKey;
       let elementKey3: SelectableInstanceKey;
 
-      iModel = (
-        await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           rootElementKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "root element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           });
           const elementKey1 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 1",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: rootElementKey.id,
           });
           const elementKey2 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 2",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: elementKey1.id,
           });
           elementKey3 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 3",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: elementKey2.id,
           });
         })
-      ).imodel;
+      ).imodelConnection;
 
       const actual = await getSelection([elementKey3!.id], { id: "element", ancestorLevel: -1 });
       expect(actual).toEqual(expect.arrayContaining([rootElementKey!]));
@@ -294,34 +294,34 @@ describe("SelectionScope", () => {
       let categoryKey2: SelectableInstanceKey;
       let elementIds: string[];
 
-      iModel = (
-        await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          categoryKey1 = insertSpatialCategory({ builder, codeValue: "test category 1" });
-          categoryKey2 = insertSpatialCategory({ builder, codeValue: "test category 2" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          categoryKey1 = insertSpatialCategory({ imodel, codeValue: "test category 1" });
+          categoryKey2 = insertSpatialCategory({ imodel, codeValue: "test category 2" });
           const assemblyKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "root element",
             modelId: modelKey.id,
             categoryId: categoryKey1.id,
           });
           elementIds = [
             insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element 1",
               modelId: modelKey.id,
               categoryId: categoryKey1.id,
               parentId: assemblyKey.id,
             }).id,
             insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element 2",
               modelId: modelKey.id,
               categoryId: categoryKey1.id,
               parentId: assemblyKey.id,
             }).id,
             insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element 2",
               modelId: modelKey.id,
               categoryId: categoryKey2.id,
@@ -329,7 +329,7 @@ describe("SelectionScope", () => {
             }).id,
           ];
         })
-      ).imodel;
+      ).imodelConnection;
 
       const actual = await getSelection(elementIds!, { id: "category" });
       expect(actual).toEqual(expect.arrayContaining([categoryKey1!, categoryKey2!]));
@@ -341,26 +341,26 @@ describe("SelectionScope", () => {
       let modelKey: SelectableInstanceKey;
       let elementIds: string[];
 
-      iModel = (
-        await buildTestIModel(async (builder) => {
-          modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           const assemblyKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "root element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           });
           elementIds = [
             insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element 1",
               modelId: modelKey.id,
               categoryId: categoryKey.id,
               parentId: assemblyKey.id,
             }).id,
             insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element 2",
               modelId: modelKey.id,
               categoryId: categoryKey.id,
@@ -368,7 +368,7 @@ describe("SelectionScope", () => {
             }).id,
           ];
         })
-      ).imodel;
+      ).imodelConnection;
 
       const actual = await getSelection(elementIds!, { id: "model" });
       expect(actual).toEqual(expect.arrayContaining([modelKey!]));
@@ -381,30 +381,30 @@ describe("SelectionScope", () => {
         let physicalElement: SelectableInstanceKey;
         let functionalElement: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             physicalElement = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
             functionalElement = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: physicalElement.id,
               relationshipName: "PhysicalElementFulfillsFunction",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([physicalElement!.id], { id: "functional" });
         expect(actual).toEqual(expect.arrayContaining([functionalElement!]));
@@ -413,20 +413,20 @@ describe("SelectionScope", () => {
       it("returns `GeometricElement3d` when no related functional element exists", async () => {
         let physicalElement: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             physicalElement = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([physicalElement!.id], { id: "functional" });
         expect(actual).toEqual(expect.arrayContaining([physicalElement!]));
@@ -435,37 +435,37 @@ describe("SelectionScope", () => {
       it("returns `GeometricElement3d` when parent has related functional element", async () => {
         let physicalElement: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             const physicalElementParent = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
             physicalElement = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: physicalElementParent.id,
             });
             insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: physicalElementParent.id,
               relationshipName: "PhysicalElementFulfillsFunction",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([physicalElement!.id], { id: "functional" });
         expect(actual).toEqual(expect.arrayContaining([physicalElement!]));
@@ -476,37 +476,37 @@ describe("SelectionScope", () => {
         let physicalElement2: SelectableInstanceKey;
         let functionalElement: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             physicalElement1 = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
             physicalElement2 = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: physicalElement1.id,
             });
             functionalElement = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: physicalElement1.id,
               relationshipName: "PhysicalElementFulfillsFunction",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([physicalElement1!.id, physicalElement2!.id], { id: "functional" });
         expect(actual).toEqual(expect.arrayContaining([functionalElement!, physicalElement2!]));
@@ -516,37 +516,37 @@ describe("SelectionScope", () => {
         let physicalElement: SelectableInstanceKey;
         let functionalElementKey: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             const physicalElementParent = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
             physicalElement = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: physicalElementParent.id,
             });
             functionalElementKey = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: physicalElementParent.id,
               relationshipName: "PhysicalElementFulfillsFunction",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([physicalElement!.id], { id: "functional", ancestorLevel: 1 });
         expect(actual).toEqual(expect.arrayContaining([functionalElementKey!]));
@@ -556,27 +556,27 @@ describe("SelectionScope", () => {
         let parentKey: SelectableInstanceKey;
         let physicalElement: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             parentKey = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
             physicalElement = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: parentKey.id,
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([physicalElement!.id], { id: "functional", ancestorLevel: 1 });
         expect(actual).toEqual(expect.arrayContaining([parentKey!]));
@@ -586,30 +586,30 @@ describe("SelectionScope", () => {
         let physicalElement: SelectableInstanceKey;
         let functionalElementKey: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             physicalElement = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
             functionalElementKey = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: physicalElement.id,
               relationshipName: "PhysicalElementFulfillsFunction",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([physicalElement!.id], { id: "functional", ancestorLevel: 1 });
         expect(actual).toEqual(expect.arrayContaining([functionalElementKey!]));
@@ -618,20 +618,20 @@ describe("SelectionScope", () => {
       it("returns parentless `GeometricElement3d` when functional element does not exist", async () => {
         let physicalElement: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             physicalElement = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([physicalElement!.id], { id: "functional", ancestorLevel: 1 });
         expect(actual).toEqual(expect.arrayContaining([physicalElement!]));
@@ -641,44 +641,44 @@ describe("SelectionScope", () => {
         let physicalElement: SelectableInstanceKey;
         let functionalElementKey: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             const physicalElementGrandParent = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
             const physicalElementParent = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: physicalElementGrandParent.id,
             });
             physicalElement = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: physicalElementParent.id,
             });
             functionalElementKey = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: physicalElementGrandParent.id,
               relationshipName: "PhysicalElementFulfillsFunction",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([physicalElement!.id], { id: "functional", ancestorLevel: 2 });
         expect(actual).toEqual(expect.arrayContaining([functionalElementKey!]));
@@ -688,34 +688,34 @@ describe("SelectionScope", () => {
         let physicalElementGrandParent: SelectableInstanceKey;
         let physicalElement: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             physicalElementGrandParent = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
             const physicalElementParent = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: physicalElementGrandParent.id,
             });
             physicalElement = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: physicalElementParent.id,
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([physicalElement!.id], { id: "functional", ancestorLevel: 2 });
         expect(actual).toEqual(expect.arrayContaining([physicalElementGrandParent!]));
@@ -725,37 +725,37 @@ describe("SelectionScope", () => {
         let physicalElement: SelectableInstanceKey;
         let functionalElementKey: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             const physicalElementParent = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
             physicalElement = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: physicalElementParent.id,
             });
             functionalElementKey = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: physicalElementParent.id,
               relationshipName: "PhysicalElementFulfillsFunction",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([physicalElement!.id], { id: "functional", ancestorLevel: 2 });
         expect(actual).toEqual(expect.arrayContaining([functionalElementKey!]));
@@ -765,27 +765,27 @@ describe("SelectionScope", () => {
         let physicalElementParent: SelectableInstanceKey;
         let physicalElement: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             physicalElementParent = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
             physicalElement = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: physicalElementParent.id,
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([physicalElement!.id], { id: "functional", ancestorLevel: 2 });
         expect(actual).toEqual(expect.arrayContaining([physicalElementParent!]));
@@ -795,44 +795,44 @@ describe("SelectionScope", () => {
         let physicalElement: SelectableInstanceKey;
         let functionalElementKey: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+            await imodel.importSchemaStrings([schema]);
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             const physicalElementGrandparent = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
             });
             const physicalElementParent = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: physicalElementGrandparent.id,
             });
             physicalElement = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: categoryKey.id,
               parentId: physicalElementParent.id,
             });
             functionalElementKey = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: physicalElementGrandparent.id,
               relationshipName: "PhysicalElementFulfillsFunction",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([physicalElement!.id], { id: "functional", ancestorLevel: -1 });
         expect(actual).toEqual(expect.arrayContaining([functionalElementKey!]));
@@ -844,41 +844,41 @@ describe("SelectionScope", () => {
         let graphicsElement: SelectableInstanceKey;
         let functionalElement: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+            const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
             const graphicsElementGrandParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
             });
             const graphicsElementParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementGrandParent.id,
             });
             graphicsElement = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementParent.id,
             });
             functionalElement = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: graphicsElement.id,
               relationshipName: "DrawingGraphicRepresentsFunctionalElement",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([graphicsElement!.id], { id: "functional" });
         expect(actual).toEqual(expect.arrayContaining([functionalElement!]));
@@ -887,31 +887,31 @@ describe("SelectionScope", () => {
       it("returns `GeometricElement2d` when no related functional element exists", async () => {
         let graphicsElement: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
-            const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
+            const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
             const graphicsElementGrandParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
             });
             const graphicsElementParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementGrandParent.id,
             });
             graphicsElement = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementParent.id,
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([graphicsElement!.id], { id: "functional" });
         expect(actual).toEqual(expect.arrayContaining([graphicsElement!]));
@@ -923,53 +923,53 @@ describe("SelectionScope", () => {
         let functionalElement1: SelectableInstanceKey;
         let functionalElement2: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+            const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
             const graphicsElementGrandParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
             });
             const graphicsElementParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementGrandParent.id,
             });
             graphicsElement1 = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementParent.id,
             });
             graphicsElement2 = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementParent.id,
             });
             functionalElement1 = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: graphicsElement2.id,
               relationshipName: "DrawingGraphicRepresentsFunctionalElement",
             });
             functionalElement2 = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: graphicsElementGrandParent.id,
               relationshipName: "DrawingGraphicRepresentsFunctionalElement",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([graphicsElement1!.id, graphicsElement2!.id], { id: "functional" });
         expect(actual).toEqual(expect.arrayContaining([functionalElement1!, functionalElement2!]));
@@ -980,59 +980,59 @@ describe("SelectionScope", () => {
         let graphicsElement2: SelectableInstanceKey;
         let functionalElement1: SelectableInstanceKey;
         let functionalElement2: SelectableInstanceKey;
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+            const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
             const graphicsElementGrandParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
             });
             const graphicsElementParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementGrandParent.id,
             });
             graphicsElement1 = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementParent.id,
             });
             graphicsElement2 = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementParent.id,
             });
             functionalElement1 = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: graphicsElement2.id,
               relationshipName: "DrawingGraphicRepresentsFunctionalElement",
             });
             functionalElement2 = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: graphicsElementParent.id,
               relationshipName: "DrawingGraphicRepresentsFunctionalElement",
             });
             insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: graphicsElementGrandParent.id,
               relationshipName: "DrawingGraphicRepresentsFunctionalElement",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([graphicsElement1!.id, graphicsElement2!.id], { id: "functional" });
         expect(actual).toMatchObject([functionalElement1!, functionalElement2!]);
@@ -1042,41 +1042,41 @@ describe("SelectionScope", () => {
         let graphicsElement: SelectableInstanceKey;
         let functionalElementKey: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+            const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
             const graphicsElementGrandParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
             });
             const graphicsElementParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementGrandParent.id,
             });
             graphicsElement = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementParent.id,
             });
             functionalElementKey = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: graphicsElement.id,
               relationshipName: "DrawingGraphicRepresentsFunctionalElement",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([graphicsElement!.id], { id: "functional", ancestorLevel: 1 });
         expect(actual).toMatchObject([functionalElementKey!]);
@@ -1086,41 +1086,41 @@ describe("SelectionScope", () => {
         let graphicsElement: SelectableInstanceKey;
         let functionalElementKey: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+            const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
             const graphicsElementGrandParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
             });
             const graphicsElementParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementGrandParent.id,
             });
             graphicsElement = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementParent.id,
             });
             functionalElementKey = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: graphicsElementParent.id,
               relationshipName: "DrawingGraphicRepresentsFunctionalElement",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([graphicsElement!.id], { id: "functional", ancestorLevel: 1 });
         expect(actual).toMatchObject([functionalElementKey!]);
@@ -1130,41 +1130,41 @@ describe("SelectionScope", () => {
         let graphicsElement: SelectableInstanceKey;
         let functionalElementKey: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+            const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
             const graphicsElementGrandParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
             });
             const graphicsElementParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementGrandParent.id,
             });
             graphicsElement = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementParent.id,
             });
             functionalElementKey = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: graphicsElementGrandParent.id,
               relationshipName: "DrawingGraphicRepresentsFunctionalElement",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([graphicsElement!.id], { id: "functional", ancestorLevel: 1 });
         expect(actual).toMatchObject([functionalElementKey!]);
@@ -1175,55 +1175,55 @@ describe("SelectionScope", () => {
         let graphicsElement2: SelectableInstanceKey;
         let functionalElementKeys: SelectableInstanceKey[];
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+            const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
             const graphicsElementGrandParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
             });
             const graphicsElementParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementGrandParent.id,
             });
             graphicsElement1 = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementParent.id,
             });
             graphicsElement2 = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementParent.id,
             });
             functionalElementKeys = [
               insertFunctionalElement({
-                builder,
+                imodel,
                 modelId: functionalModelKey.id,
                 representedElementId: graphicsElementGrandParent.id,
                 relationshipName: "DrawingGraphicRepresentsFunctionalElement",
               }),
               insertFunctionalElement({
-                builder,
+                imodel,
                 modelId: functionalModelKey.id,
                 representedElementId: graphicsElement1.id,
                 relationshipName: "DrawingGraphicRepresentsFunctionalElement",
               }),
             ];
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([graphicsElement1!.id, graphicsElement2!.id], {
           id: "functional",
@@ -1236,29 +1236,25 @@ describe("SelectionScope", () => {
         let graphicsElement: SelectableInstanceKey;
         let functionalElementKey: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
-            graphicsElement = insertDrawingGraphic({
-              builder,
-              modelId: drawingModelKey.id,
-              categoryId: categoryKey.id,
-            });
+            const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
+            graphicsElement = insertDrawingGraphic({ imodel, modelId: drawingModelKey.id, categoryId: categoryKey.id });
             functionalElementKey = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: graphicsElement.id,
               relationshipName: "DrawingGraphicRepresentsFunctionalElement",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([graphicsElement!.id], { id: "functional", ancestorLevel: 1 });
         expect(actual).toMatchObject([functionalElementKey!]);
@@ -1267,19 +1263,15 @@ describe("SelectionScope", () => {
       it("returns parentless `GeometricElement2d` without related functional element", async function () {
         let graphicsElement: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
-            const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
-            graphicsElement = insertDrawingGraphic({
-              builder,
-              modelId: drawingModelKey.id,
-              categoryId: categoryKey.id,
-            });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
+            const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
+            graphicsElement = insertDrawingGraphic({ imodel, modelId: drawingModelKey.id, categoryId: categoryKey.id });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([graphicsElement!.id], { id: "functional", ancestorLevel: 1 });
         expect(actual).toMatchObject([graphicsElement!]);
@@ -1289,31 +1281,31 @@ describe("SelectionScope", () => {
         let graphicsElementGrandParent: SelectableInstanceKey;
         let graphicsElement: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
-            const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
+            const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
             graphicsElementGrandParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
             });
             const graphicsElementParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementGrandParent.id,
             });
             graphicsElement = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementParent.id,
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([graphicsElement!.id], { id: "functional", ancestorLevel: 2 });
         expect(actual).toMatchObject([graphicsElementGrandParent!]);
@@ -1323,25 +1315,25 @@ describe("SelectionScope", () => {
         let graphicsElementParent: SelectableInstanceKey;
         let graphicsElement: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
-            const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
+            const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
             graphicsElementParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
             });
             graphicsElement = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementParent.id,
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([graphicsElement!.id], { id: "functional", ancestorLevel: 2 });
         expect(actual).toMatchObject([graphicsElementParent!]);
@@ -1351,41 +1343,41 @@ describe("SelectionScope", () => {
         let graphicsElement: SelectableInstanceKey;
         let functionalElementKey: SelectableInstanceKey;
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+            const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
             const graphicsElementGrandParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
             });
             const graphicsElementParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementGrandParent.id,
             });
             graphicsElement = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: categoryKey.id,
               parentId: graphicsElementParent.id,
             });
             functionalElementKey = insertFunctionalElement({
-              builder,
+              imodel,
               modelId: functionalModelKey.id,
               representedElementId: graphicsElementGrandParent.id,
               relationshipName: "DrawingGraphicRepresentsFunctionalElement",
             });
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection([graphicsElement!.id], { id: "functional", ancestorLevel: -1 });
         expect(actual).toMatchObject([functionalElementKey!]);
@@ -1398,50 +1390,50 @@ describe("SelectionScope", () => {
         let physicalElement2: SelectableInstanceKey;
         let functionalElementKeys: SelectableInstanceKey[];
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const spatialCategoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
-            const drawingCategoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+            const spatialCategoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
+            const drawingCategoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
 
             const graphicsElementGrandParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: drawingCategoryKey.id,
             });
             const graphicsElementParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: drawingCategoryKey.id,
               parentId: graphicsElementGrandParent.id,
             });
             const graphicsElement1 = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: drawingCategoryKey.id,
               parentId: graphicsElementParent.id,
             });
             const graphicsElement2 = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: drawingCategoryKey.id,
               parentId: graphicsElementParent.id,
             });
             const physicalElement1 = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: spatialCategoryKey.id,
             });
             physicalElement2 = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: spatialCategoryKey.id,
@@ -1450,26 +1442,26 @@ describe("SelectionScope", () => {
             elementIds = [graphicsElement1.id, graphicsElement2.id, physicalElement1.id, physicalElement2.id];
             functionalElementKeys = [
               insertFunctionalElement({
-                builder,
+                imodel,
                 modelId: functionalModelKey.id,
                 representedElementId: graphicsElement2.id,
                 relationshipName: "DrawingGraphicRepresentsFunctionalElement",
               }),
               insertFunctionalElement({
-                builder,
+                imodel,
                 modelId: functionalModelKey.id,
                 representedElementId: graphicsElementGrandParent.id,
                 relationshipName: "DrawingGraphicRepresentsFunctionalElement",
               }),
               insertFunctionalElement({
-                builder,
+                imodel,
                 modelId: functionalModelKey.id,
                 representedElementId: physicalElement1.id,
                 relationshipName: "PhysicalElementFulfillsFunction",
               }),
             ];
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection(elementIds!, { id: "functional" });
         expect(actual).toMatchObject([physicalElement2!, ...functionalElementKeys!]);
@@ -1479,50 +1471,50 @@ describe("SelectionScope", () => {
         let elementIds: string[];
         let functionalElementKeys: SelectableInstanceKey[];
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const spatialCategoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
-            const drawingCategoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+            const spatialCategoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
+            const drawingCategoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
 
             const graphicsElementGrandParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: drawingCategoryKey.id,
             });
             const graphicsElementParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: drawingCategoryKey.id,
               parentId: graphicsElementGrandParent.id,
             });
             const graphicsElement1 = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: drawingCategoryKey.id,
               parentId: graphicsElementParent.id,
             });
             const graphicsElement2 = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: drawingCategoryKey.id,
               parentId: graphicsElementParent.id,
             });
             const physicalElement1 = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: spatialCategoryKey.id,
             });
             const physicalElement2 = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: spatialCategoryKey.id,
@@ -1531,26 +1523,26 @@ describe("SelectionScope", () => {
             elementIds = [graphicsElement1.id, graphicsElement2.id, physicalElement1.id, physicalElement2.id];
             functionalElementKeys = [
               insertFunctionalElement({
-                builder,
+                imodel,
                 modelId: functionalModelKey.id,
                 representedElementId: graphicsElement2.id,
                 relationshipName: "DrawingGraphicRepresentsFunctionalElement",
               }),
               insertFunctionalElement({
-                builder,
+                imodel,
                 modelId: functionalModelKey.id,
                 representedElementId: graphicsElementParent.id,
                 relationshipName: "DrawingGraphicRepresentsFunctionalElement",
               }),
               insertFunctionalElement({
-                builder,
+                imodel,
                 modelId: functionalModelKey.id,
                 representedElementId: physicalElement1.id,
                 relationshipName: "PhysicalElementFulfillsFunction",
               }),
             ];
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection(elementIds!, { id: "functional", ancestorLevel: 1 });
         expect(actual).toMatchObject(functionalElementKeys!);
@@ -1561,50 +1553,50 @@ describe("SelectionScope", () => {
         let physicalElement2: SelectableInstanceKey;
         let functionalElementKeys: SelectableInstanceKey[];
 
-        iModel = (
-          await buildTestIModel(async (builder) => {
+        imodelConnection = (
+          await buildTestIModel(async (imodel) => {
             const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-            await builder.importSchema(schema);
-            const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
-            const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+            await imodel.importSchemaStrings([schema]);
+            const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
+            const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
             const functionalModelKey = insertFunctionalModelWithPartition({
-              builder,
+              imodel,
               codeValue: "test functional model",
             });
-            const spatialCategoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
-            const drawingCategoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+            const spatialCategoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
+            const drawingCategoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
 
             const graphicsElementGrandParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: drawingCategoryKey.id,
             });
             const graphicsElementParent = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: drawingCategoryKey.id,
               parentId: graphicsElementGrandParent.id,
             });
             const graphicsElement1 = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: drawingCategoryKey.id,
               parentId: graphicsElementParent.id,
             });
             const graphicsElement2 = insertDrawingGraphic({
-              builder,
+              imodel,
               modelId: drawingModelKey.id,
               categoryId: drawingCategoryKey.id,
               parentId: graphicsElementParent.id,
             });
             const physicalElement1 = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: spatialCategoryKey.id,
             });
             physicalElement2 = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "element",
               modelId: physicalModelKey.id,
               categoryId: spatialCategoryKey.id,
@@ -1613,26 +1605,26 @@ describe("SelectionScope", () => {
             elementIds = [graphicsElement1.id, graphicsElement2.id, physicalElement1.id, physicalElement2.id];
             functionalElementKeys = [
               insertFunctionalElement({
-                builder,
+                imodel,
                 modelId: functionalModelKey.id,
                 representedElementId: graphicsElement2.id,
                 relationshipName: "DrawingGraphicRepresentsFunctionalElement",
               }),
               insertFunctionalElement({
-                builder,
+                imodel,
                 modelId: functionalModelKey.id,
                 representedElementId: graphicsElementGrandParent.id,
                 relationshipName: "DrawingGraphicRepresentsFunctionalElement",
               }),
               insertFunctionalElement({
-                builder,
+                imodel,
                 modelId: functionalModelKey.id,
                 representedElementId: physicalElement1.id,
                 relationshipName: "PhysicalElementFulfillsFunction",
               }),
             ];
           })
-        ).imodel;
+        ).imodelConnection;
 
         const actual = await getSelection(elementIds!, { id: "functional", ancestorLevel: -1 });
         expect(actual).toEqual(expect.arrayContaining(functionalElementKeys!));

--- a/apps/full-stack-tests/src/unified-selection/SelectionSync.test.ts
+++ b/apps/full-stack-tests/src/unified-selection/SelectionSync.test.ts
@@ -34,7 +34,7 @@ import type { Props } from "@itwin/presentation-shared";
 import type { HiliteSet, SelectableInstanceKey, SelectionScope, SelectionStorage } from "@itwin/unified-selection";
 
 describe("Unified selection sync with iModel", () => {
-  let imodel: IModelConnection;
+  let imodelConnection: IModelConnection;
   let selectionStorage: SelectionStorage;
 
   beforeAll(async () => {
@@ -51,28 +51,28 @@ describe("Unified selection sync with iModel", () => {
 
   afterEach(async () => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (imodel) {
-      selectionStorage.clearStorage({ imodelKey: createIModelKey(imodel) });
-      await imodel.close();
+    if (imodelConnection) {
+      selectionStorage.clearStorage({ imodelKey: createIModelKey(imodelConnection) });
+      await imodelConnection.close();
     }
   });
 
   function getStorageSelection(): Selectables {
-    return selectionStorage.getSelection({ imodelKey: createIModelKey(imodel) });
+    return selectionStorage.getSelection({ imodelKey: createIModelKey(imodelConnection) });
   }
 
   function enableSync(props?: { selectionScope?: SelectionScope }): Disposable {
-    const schemaProvider = createECSchemaProvider(createSchemaContext(imodel));
+    const schemaProvider = createECSchemaProvider(createSchemaContext(imodelConnection));
     const classHierarchyInspector = createCachingECClassHierarchyInspector({ schemaProvider });
-    const queryExecutor = createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 123);
+    const queryExecutor = createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodelConnection), 123);
     const dispose = enableUnifiedSelectionSyncWithIModel({
       imodelAccess: {
-        key: createIModelKey(imodel),
+        key: createIModelKey(imodelConnection),
         ...schemaProvider,
         ...classHierarchyInspector,
         ...queryExecutor,
-        selectionSet: imodel.selectionSet,
-        hiliteSet: imodel.hilited,
+        selectionSet: imodelConnection.selectionSet,
+        hiliteSet: imodelConnection.hilited,
       },
       selectionStorage,
       activeScopeProvider: () => props?.selectionScope ?? "element",
@@ -85,44 +85,46 @@ describe("Unified selection sync with iModel", () => {
       let subjectKey: SelectableInstanceKey;
       let modelKeys: SelectableInstanceKey[];
 
-      imodel = (
-        await buildTestIModel(async (builder) => {
-          subjectKey = insertSubject({ builder, codeValue: "test subject" });
-          const subject2 = insertSubject({ builder, codeValue: "subject 2", parentId: subjectKey.id });
-          const subject3 = insertSubject({ builder, codeValue: "subject 3", parentId: subjectKey.id });
-          const subject4 = insertSubject({ builder, codeValue: "subject 4", parentId: subject3.id });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          subjectKey = insertSubject({ imodel, codeValue: "test subject" });
+          const subject2 = insertSubject({ imodel, codeValue: "subject 2", parentId: subjectKey.id });
+          const subject3 = insertSubject({ imodel, codeValue: "subject 3", parentId: subjectKey.id });
+          const subject4 = insertSubject({ imodel, codeValue: "subject 4", parentId: subject3.id });
           modelKeys = [
-            insertPhysicalModelWithPartition({ builder, codeValue: "model 1", partitionParentId: subject2.id }),
-            insertPhysicalModelWithPartition({ builder, codeValue: "model 2", partitionParentId: subject4.id }),
+            insertPhysicalModelWithPartition({ imodel, codeValue: "model 1", partitionParentId: subject2.id }),
+            insertPhysicalModelWithPartition({ imodel, codeValue: "model 2", partitionParentId: subject4.id }),
           ];
         })
-      ).imodel;
+      ).imodelConnection;
       using _ = enableSync();
 
       selectionStorage.addToSelection({
-        imodelKey: createIModelKey(imodel),
+        imodelKey: createIModelKey(imodelConnection),
         source: "test",
         selectables: [subjectKey!],
       });
 
       await waitFor(() => {
-        expect(getHiliteSet(imodel)).toEqual({
+        expect(getHiliteSet(imodelConnection)).toEqual({
           models: modelKeys.map(({ id }) => id),
           subCategories: [],
           elements: [],
         });
-        expect(getSelectionSet(imodel)).toEqual(
-          is5xSelectionSet(imodel.selectionSet)
+        expect(getSelectionSet(imodelConnection)).toEqual(
+          is5xSelectionSet(imodelConnection.selectionSet)
             ? { models: modelKeys.map(({ id }) => id), subCategories: [], elements: [] }
             : { elements: [] },
         );
       });
 
-      if (is5xSelectionSet(imodel.selectionSet)) {
-        imodel.selectionSet.emptyAll();
+      if (is5xSelectionSet(imodelConnection.selectionSet)) {
+        imodelConnection.selectionSet.emptyAll();
         await waitFor(() => {
-          expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodel) }))).toBe(true);
-          expect(imodel.hilited.isEmpty).toBe(true);
+          expect(
+            Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodelConnection) })),
+          ).toBe(true);
+          expect(imodelConnection.hilited.isEmpty).toBe(true);
         });
       }
     });
@@ -132,29 +134,35 @@ describe("Unified selection sync with iModel", () => {
     it("syncs model selection", async () => {
       let modelKey: SelectableInstanceKey;
 
-      imodel = (
-        await buildTestIModel(async (builder) => {
-          modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
         })
-      ).imodel;
+      ).imodelConnection;
       using _ = enableSync();
 
-      selectionStorage.addToSelection({ imodelKey: createIModelKey(imodel), source: "test", selectables: [modelKey!] });
+      selectionStorage.addToSelection({
+        imodelKey: createIModelKey(imodelConnection),
+        source: "test",
+        selectables: [modelKey!],
+      });
 
       await waitFor(() => {
-        expect(getHiliteSet(imodel)).toEqual({ models: [modelKey!.id], subCategories: [], elements: [] });
-        expect(getSelectionSet(imodel)).toEqual(
-          is5xSelectionSet(imodel.selectionSet)
+        expect(getHiliteSet(imodelConnection)).toEqual({ models: [modelKey!.id], subCategories: [], elements: [] });
+        expect(getSelectionSet(imodelConnection)).toEqual(
+          is5xSelectionSet(imodelConnection.selectionSet)
             ? { models: [modelKey!.id], subCategories: [], elements: [] }
             : { elements: [] },
         );
       });
 
-      if (is5xSelectionSet(imodel.selectionSet)) {
-        imodel.selectionSet.emptyAll();
+      if (is5xSelectionSet(imodelConnection.selectionSet)) {
+        imodelConnection.selectionSet.emptyAll();
         await waitFor(() => {
-          expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodel) }))).toBe(true);
-          expect(imodel.hilited.isEmpty).toBe(true);
+          expect(
+            Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodelConnection) })),
+          ).toBe(true);
+          expect(imodelConnection.hilited.isEmpty).toBe(true);
         });
       }
     });
@@ -165,42 +173,44 @@ describe("Unified selection sync with iModel", () => {
       let categoryKey: SelectableInstanceKey;
       let subCategoryKeys: SelectableInstanceKey[];
 
-      imodel = (
-        await buildTestIModel(async (builder) => {
-          categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           subCategoryKeys = [
             getDefaultSubcategoryKey(categoryKey.id),
-            insertSubCategory({ builder, codeValue: "sub 1", parentCategoryId: categoryKey.id }),
-            insertSubCategory({ builder, codeValue: "sub 2", parentCategoryId: categoryKey.id }),
+            insertSubCategory({ imodel, codeValue: "sub 1", parentCategoryId: categoryKey.id }),
+            insertSubCategory({ imodel, codeValue: "sub 2", parentCategoryId: categoryKey.id }),
           ];
         })
-      ).imodel;
+      ).imodelConnection;
       using _ = enableSync();
 
       selectionStorage.addToSelection({
-        imodelKey: createIModelKey(imodel),
+        imodelKey: createIModelKey(imodelConnection),
         source: "test",
         selectables: [categoryKey!],
       });
 
       await waitFor(() => {
-        expect(getHiliteSet(imodel)).toEqual({
+        expect(getHiliteSet(imodelConnection)).toEqual({
           models: [],
           subCategories: subCategoryKeys.map(({ id }) => id),
           elements: [],
         });
-        expect(getSelectionSet(imodel)).toEqual(
-          is5xSelectionSet(imodel.selectionSet)
+        expect(getSelectionSet(imodelConnection)).toEqual(
+          is5xSelectionSet(imodelConnection.selectionSet)
             ? { models: [], subCategories: subCategoryKeys.map(({ id }) => id), elements: [] }
             : { elements: [] },
         );
       });
 
-      if (is5xSelectionSet(imodel.selectionSet)) {
-        imodel.selectionSet.emptyAll();
+      if (is5xSelectionSet(imodelConnection.selectionSet)) {
+        imodelConnection.selectionSet.emptyAll();
         await waitFor(() => {
-          expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodel) }))).toBe(true);
-          expect(imodel.hilited.isEmpty).toBe(true);
+          expect(
+            Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodelConnection) })),
+          ).toBe(true);
+          expect(imodelConnection.hilited.isEmpty).toBe(true);
         });
       }
     });
@@ -208,35 +218,41 @@ describe("Unified selection sync with iModel", () => {
     it("syncs subcategory selection", async () => {
       let categoryKey: SelectableInstanceKey;
 
-      imodel = (
-        await buildTestIModel(async (builder) => {
-          categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
         })
-      ).imodel;
+      ).imodelConnection;
       const subCategoryKey = getDefaultSubcategoryKey(categoryKey!.id);
 
       using _ = enableSync();
 
       selectionStorage.addToSelection({
-        imodelKey: createIModelKey(imodel),
+        imodelKey: createIModelKey(imodelConnection),
         source: "test",
         selectables: [subCategoryKey],
       });
 
       await waitFor(() => {
-        expect(getHiliteSet(imodel)).toEqual({ models: [], subCategories: [subCategoryKey.id], elements: [] });
-        expect(getSelectionSet(imodel)).toEqual(
-          is5xSelectionSet(imodel.selectionSet)
+        expect(getHiliteSet(imodelConnection)).toEqual({
+          models: [],
+          subCategories: [subCategoryKey.id],
+          elements: [],
+        });
+        expect(getSelectionSet(imodelConnection)).toEqual(
+          is5xSelectionSet(imodelConnection.selectionSet)
             ? { models: [], subCategories: [subCategoryKey.id], elements: [] }
             : { elements: [] },
         );
       });
 
-      if (is5xSelectionSet(imodel.selectionSet)) {
-        imodel.selectionSet.emptyAll();
+      if (is5xSelectionSet(imodelConnection.selectionSet)) {
+        imodelConnection.selectionSet.emptyAll();
         await waitFor(() => {
-          expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodel) }))).toBe(true);
-          expect(imodel.hilited.isEmpty).toBe(true);
+          expect(
+            Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodelConnection) })),
+          ).toBe(true);
+          expect(imodelConnection.hilited.isEmpty).toBe(true);
         });
       }
     });
@@ -245,42 +261,44 @@ describe("Unified selection sync with iModel", () => {
       let categoryKey: SelectableInstanceKey;
       let subCategoryKeys: SelectableInstanceKey[];
 
-      imodel = (
-        await buildTestIModel(async (builder) => {
-          categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           subCategoryKeys = [
             getDefaultSubcategoryKey(categoryKey.id),
-            insertSubCategory({ builder, codeValue: "sub 1", parentCategoryId: categoryKey.id }),
-            insertSubCategory({ builder, codeValue: "sub 2", parentCategoryId: categoryKey.id }),
+            insertSubCategory({ imodel, codeValue: "sub 1", parentCategoryId: categoryKey.id }),
+            insertSubCategory({ imodel, codeValue: "sub 2", parentCategoryId: categoryKey.id }),
           ];
         })
-      ).imodel;
+      ).imodelConnection;
       using _ = enableSync();
 
       selectionStorage.addToSelection({
-        imodelKey: createIModelKey(imodel),
+        imodelKey: createIModelKey(imodelConnection),
         source: "test",
         selectables: [categoryKey!, subCategoryKeys![0]],
       });
 
       await waitFor(() => {
-        expect(getHiliteSet(imodel)).toEqual({
+        expect(getHiliteSet(imodelConnection)).toEqual({
           models: [],
           subCategories: subCategoryKeys.map(({ id }) => id),
           elements: [],
         });
-        expect(getSelectionSet(imodel)).toEqual(
-          is5xSelectionSet(imodel.selectionSet)
+        expect(getSelectionSet(imodelConnection)).toEqual(
+          is5xSelectionSet(imodelConnection.selectionSet)
             ? { models: [], subCategories: subCategoryKeys.map(({ id }) => id), elements: [] }
             : { elements: [] },
         );
       });
 
-      if (is5xSelectionSet(imodel.selectionSet)) {
-        imodel.selectionSet.emptyAll();
+      if (is5xSelectionSet(imodelConnection.selectionSet)) {
+        imodelConnection.selectionSet.emptyAll();
         await waitFor(() => {
-          expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodel) }))).toBe(true);
-          expect(imodel.hilited.isEmpty).toBe(true);
+          expect(
+            Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodelConnection) })),
+          ).toBe(true);
+          expect(imodelConnection.hilited.isEmpty).toBe(true);
         });
       }
     });
@@ -291,39 +309,39 @@ describe("Unified selection sync with iModel", () => {
       let assemblyKey: SelectableInstanceKey;
       let childElementKeys: SelectableInstanceKey[];
 
-      imodel = (
-        await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           assemblyKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 1",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           });
           const element2 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 2",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: assemblyKey.id,
           });
           const element3 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 3",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: assemblyKey.id,
           });
           const element4 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 4",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: element3.id,
           });
           const element5 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 5",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
@@ -331,76 +349,80 @@ describe("Unified selection sync with iModel", () => {
           });
           childElementKeys = [element2, element3, element4, element5];
         })
-      ).imodel;
+      ).imodelConnection;
       using _ = enableSync();
 
       selectionStorage.addToSelection({
-        imodelKey: createIModelKey(imodel),
+        imodelKey: createIModelKey(imodelConnection),
         source: "test",
         selectables: [assemblyKey!],
       });
 
       await waitFor(() => {
-        expect(getHiliteSet(imodel)).toEqual({
+        expect(getHiliteSet(imodelConnection)).toEqual({
           models: [],
           subCategories: [],
           elements: [assemblyKey.id, ...childElementKeys.map(({ id }) => id)],
         });
-        expect(getSelectionSet(imodel)).toEqual(
-          is5xSelectionSet(imodel.selectionSet)
+        expect(getSelectionSet(imodelConnection)).toEqual(
+          is5xSelectionSet(imodelConnection.selectionSet)
             ? { models: [], subCategories: [], elements: [assemblyKey.id, ...childElementKeys.map(({ id }) => id)] }
             : { elements: [assemblyKey.id, ...childElementKeys.map(({ id }) => id)] },
         );
       });
 
-      imodel.selectionSet.emptyAll();
+      imodelConnection.selectionSet.emptyAll();
       await waitFor(() => {
-        expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodel) }))).toBe(true);
-        expect(imodel.hilited.isEmpty).toBe(true);
+        expect(
+          Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodelConnection) })),
+        ).toBe(true);
+        expect(imodelConnection.hilited.isEmpty).toBe(true);
       });
     });
 
     it("multiple elements selection", async () => {
       let elementKeys: SelectableInstanceKey[];
 
-      imodel = (
-        await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
           const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-          await builder.importSchema(schema);
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+          await imodel.importSchemaStrings([schema]);
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           elementKeys = [
-            insertPhysicalElement({ builder, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
-            insertPhysicalElement({ builder, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
-            insertPhysicalElement({ builder, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
+            insertPhysicalElement({ imodel, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
+            insertPhysicalElement({ imodel, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
+            insertPhysicalElement({ imodel, userLabel: "element", modelId: modelKey.id, categoryId: categoryKey.id }),
           ];
         })
-      ).imodel;
+      ).imodelConnection;
       using _ = enableSync();
 
       selectionStorage.addToSelection({
-        imodelKey: createIModelKey(imodel),
+        imodelKey: createIModelKey(imodelConnection),
         source: "test",
         selectables: elementKeys!,
       });
 
       await waitFor(() => {
-        expect(getHiliteSet(imodel)).toEqual({
+        expect(getHiliteSet(imodelConnection)).toEqual({
           models: [],
           subCategories: [],
           elements: elementKeys.map(({ id }) => id),
         });
-        expect(getSelectionSet(imodel)).toEqual(
-          is5xSelectionSet(imodel.selectionSet)
+        expect(getSelectionSet(imodelConnection)).toEqual(
+          is5xSelectionSet(imodelConnection.selectionSet)
             ? { models: [], subCategories: [], elements: elementKeys.map(({ id }) => id) }
             : { elements: elementKeys.map(({ id }) => id) },
         );
       });
 
-      imodel.selectionSet.emptyAll();
+      imodelConnection.selectionSet.emptyAll();
       await waitFor(() => {
-        expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodel) }))).toBe(true);
-        expect(imodel.hilited.isEmpty).toBe(true);
+        expect(
+          Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodelConnection) })),
+        ).toBe(true);
+        expect(imodelConnection.hilited.isEmpty).toBe(true);
       });
     });
 
@@ -408,39 +430,39 @@ describe("Unified selection sync with iModel", () => {
       let assemblyKey: SelectableInstanceKey;
       let childElementKeys: SelectableInstanceKey[];
 
-      imodel = (
-        await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           assemblyKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 1",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           });
           const element2 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 2",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: assemblyKey.id,
           });
           const element3 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 3",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: assemblyKey.id,
           });
           const element4 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 4",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
             parentId: element3.id,
           });
           const element5 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element 5",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
@@ -448,33 +470,33 @@ describe("Unified selection sync with iModel", () => {
           });
           childElementKeys = [element2, element3, element4, element5];
         })
-      ).imodel;
+      ).imodelConnection;
       using _ = enableSync({ selectionScope: { id: "element", ancestorLevel: -1 } });
 
-      imodel.selectionSet.replace(childElementKeys![0].id);
+      imodelConnection.selectionSet.replace(childElementKeys![0].id);
       await waitFor(() => {
-        expect(getHiliteSet(imodel)).toEqual({
+        expect(getHiliteSet(imodelConnection)).toEqual({
           models: [],
           subCategories: [],
           elements: [assemblyKey.id, ...childElementKeys.map(({ id }) => id)],
         });
-        expect(getSelectionSet(imodel)).toEqual(
-          is5xSelectionSet(imodel.selectionSet)
+        expect(getSelectionSet(imodelConnection)).toEqual(
+          is5xSelectionSet(imodelConnection.selectionSet)
             ? { models: [], subCategories: [], elements: [assemblyKey.id, ...childElementKeys.map(({ id }) => id)] }
             : { elements: [assemblyKey.id, ...childElementKeys.map(({ id }) => id)] },
         );
         expect(getStorageSelection()).toEqual(Selectables.create([assemblyKey!]));
       });
 
-      imodel.selectionSet.replace(childElementKeys![1].id);
+      imodelConnection.selectionSet.replace(childElementKeys![1].id);
       await waitFor(() => {
-        expect(getHiliteSet(imodel)).toEqual({
+        expect(getHiliteSet(imodelConnection)).toEqual({
           models: [],
           subCategories: [],
           elements: [assemblyKey.id, ...childElementKeys.map(({ id }) => id)],
         });
-        expect(getSelectionSet(imodel)).toEqual(
-          is5xSelectionSet(imodel.selectionSet)
+        expect(getSelectionSet(imodelConnection)).toEqual(
+          is5xSelectionSet(imodelConnection.selectionSet)
             ? { models: [], subCategories: [], elements: [assemblyKey.id, ...childElementKeys.map(({ id }) => id)] }
             : { elements: [assemblyKey.id, ...childElementKeys.map(({ id }) => id)] },
         );
@@ -489,77 +511,76 @@ describe("Unified selection sync with iModel", () => {
       let physicalElement: SelectableInstanceKey;
       let expectedElements: SelectableInstanceKey[];
 
-      imodel = (
-        await buildTestIModel(async (builder) => {
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
           const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-          await builder.importSchema(schema);
-          const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
-          const functionalModelKey = insertFunctionalModelWithPartition({
-            builder,
-            codeValue: "test functional model",
-          });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+          await imodel.importSchemaStrings([schema]);
+          const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
+          const functionalModelKey = insertFunctionalModelWithPartition({ imodel, codeValue: "test functional model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           physicalElement = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "element",
             modelId: physicalModelKey.id,
             categoryId: categoryKey.id,
           });
           const physicalElementChild = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "child element 1",
             modelId: physicalModelKey.id,
             categoryId: categoryKey.id,
             parentId: physicalElement.id,
           });
           const physicalElementChild2 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "child element 2",
             modelId: physicalModelKey.id,
             categoryId: categoryKey.id,
             parentId: physicalElement.id,
           });
           const physicalElementChildChild = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "child 1 child element",
             modelId: physicalModelKey.id,
             categoryId: categoryKey.id,
             parentId: physicalElementChild.id,
           });
           functionalElement = insertFunctionalElement({
-            builder,
+            imodel,
             modelId: functionalModelKey.id,
             representedElementId: physicalElement.id,
             relationshipName: "PhysicalElementFulfillsFunction",
           });
           expectedElements = [physicalElement, physicalElementChild, physicalElementChild2, physicalElementChildChild];
         })
-      ).imodel;
+      ).imodelConnection;
       using _ = enableSync();
 
       selectionStorage.addToSelection({
-        imodelKey: createIModelKey(imodel),
+        imodelKey: createIModelKey(imodelConnection),
         source: "test",
         selectables: [functionalElement!],
       });
 
       await waitFor(() => {
-        expect(getHiliteSet(imodel)).toEqual({
+        expect(getHiliteSet(imodelConnection)).toEqual({
           models: [],
           subCategories: [],
           elements: expectedElements.map(({ id }) => id),
         });
-        expect(getSelectionSet(imodel)).toEqual(
-          is5xSelectionSet(imodel.selectionSet)
+        expect(getSelectionSet(imodelConnection)).toEqual(
+          is5xSelectionSet(imodelConnection.selectionSet)
             ? { models: [], subCategories: [], elements: expectedElements.map(({ id }) => id) }
             : { elements: expectedElements.map(({ id }) => id) },
         );
       });
 
-      imodel.selectionSet.emptyAll();
+      imodelConnection.selectionSet.emptyAll();
       await waitFor(() => {
-        expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodel) }))).toBe(true);
-        expect(imodel.hilited.isEmpty).toBe(true);
+        expect(
+          Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodelConnection) })),
+        ).toBe(true);
+        expect(imodelConnection.hilited.isEmpty).toBe(true);
       });
     });
 
@@ -568,69 +589,68 @@ describe("Unified selection sync with iModel", () => {
       let graphicsElement: SelectableInstanceKey;
       let expectedElements: SelectableInstanceKey[];
 
-      imodel = (
-        await buildTestIModel(async (builder) => {
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
           const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-          await builder.importSchema(schema);
-          const drawingModelKey = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
-          const functionalModelKey = insertFunctionalModelWithPartition({
-            builder,
-            codeValue: "test functional model",
-          });
-          const categoryKey = insertDrawingCategory({ builder, codeValue: "test drawing category" });
-          graphicsElement = insertDrawingGraphic({ builder, modelId: drawingModelKey.id, categoryId: categoryKey.id });
+          await imodel.importSchemaStrings([schema]);
+          const drawingModelKey = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
+          const functionalModelKey = insertFunctionalModelWithPartition({ imodel, codeValue: "test functional model" });
+          const categoryKey = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
+          graphicsElement = insertDrawingGraphic({ imodel, modelId: drawingModelKey.id, categoryId: categoryKey.id });
           const graphicsElementChild = insertDrawingGraphic({
-            builder,
+            imodel,
             modelId: drawingModelKey.id,
             categoryId: categoryKey.id,
             parentId: graphicsElement.id,
           });
           const graphicsElementChild2 = insertDrawingGraphic({
-            builder,
+            imodel,
             modelId: drawingModelKey.id,
             categoryId: categoryKey.id,
             parentId: graphicsElementChild.id,
           });
           const graphicsElementChildChild = insertDrawingGraphic({
-            builder,
+            imodel,
             modelId: drawingModelKey.id,
             categoryId: categoryKey.id,
             parentId: graphicsElementChild.id,
           });
           functionalElement = insertFunctionalElement({
-            builder,
+            imodel,
             modelId: functionalModelKey.id,
             representedElementId: graphicsElement.id,
             relationshipName: "DrawingGraphicRepresentsFunctionalElement",
           });
           expectedElements = [graphicsElement, graphicsElementChild, graphicsElementChild2, graphicsElementChildChild];
         })
-      ).imodel;
+      ).imodelConnection;
       using _ = enableSync();
 
       selectionStorage.addToSelection({
-        imodelKey: createIModelKey(imodel),
+        imodelKey: createIModelKey(imodelConnection),
         source: "test",
         selectables: [functionalElement!],
       });
 
       await waitFor(() => {
-        expect(getHiliteSet(imodel)).toEqual({
+        expect(getHiliteSet(imodelConnection)).toEqual({
           models: [],
           subCategories: [],
           elements: expectedElements.map(({ id }) => id),
         });
-        expect(getSelectionSet(imodel)).toEqual(
-          is5xSelectionSet(imodel.selectionSet)
+        expect(getSelectionSet(imodelConnection)).toEqual(
+          is5xSelectionSet(imodelConnection.selectionSet)
             ? { models: [], subCategories: [], elements: expectedElements.map(({ id }) => id) }
             : { elements: expectedElements.map(({ id }) => id) },
         );
       });
 
-      imodel.selectionSet.emptyAll();
+      imodelConnection.selectionSet.emptyAll();
       await waitFor(() => {
-        expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodel) }))).toBe(true);
-        expect(imodel.hilited.isEmpty).toBe(true);
+        expect(
+          Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodelConnection) })),
+        ).toBe(true);
+        expect(imodelConnection.hilited.isEmpty).toBe(true);
       });
     });
   });
@@ -640,41 +660,38 @@ describe("Unified selection sync with iModel", () => {
       let groupInformationElement: SelectableInstanceKey;
       let expectedElements: SelectableInstanceKey[];
 
-      imodel = (
-        await buildTestIModel(async (builder) => {
-          const groupModel = insertGroupInformationModelWithPartition({
-            builder,
-            codeValue: "group information model",
-          });
+      imodelConnection = (
+        await buildTestIModel(async (imodel) => {
+          const groupModel = insertGroupInformationModelWithPartition({ imodel, codeValue: "group information model" });
           const schema = await getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
-          await builder.importSchema(schema);
-          const physicalModelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
-          groupInformationElement = insertGroupInformationElement({ builder, modelId: groupModel.id });
+          await imodel.importSchemaStrings([schema]);
+          const physicalModelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
+          groupInformationElement = insertGroupInformationElement({ imodel, modelId: groupModel.id });
           const physicalElementGroupMember = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "child element 1",
             modelId: physicalModelKey.id,
             categoryId: categoryKey.id,
           });
-          builder.insertRelationship({
+          imodel.relationships.insertInstance({
             sourceId: groupInformationElement.id,
             targetId: physicalElementGroupMember.id,
             classFullName: "BisCore.ElementGroupsMembers",
           });
           const physicalElementGroupMember2 = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "child element 2",
             modelId: physicalModelKey.id,
             categoryId: categoryKey.id,
           });
-          builder.insertRelationship({
+          imodel.relationships.insertInstance({
             sourceId: groupInformationElement.id,
             targetId: physicalElementGroupMember2.id,
             classFullName: "BisCore.ElementGroupsMembers",
           });
           const physicalElementGroupMemberChild = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "child 1 child element",
             modelId: physicalModelKey.id,
             categoryId: categoryKey.id,
@@ -682,32 +699,34 @@ describe("Unified selection sync with iModel", () => {
           });
           expectedElements = [physicalElementGroupMember, physicalElementGroupMember2, physicalElementGroupMemberChild];
         })
-      ).imodel;
+      ).imodelConnection;
       using _ = enableSync();
 
       selectionStorage.addToSelection({
-        imodelKey: createIModelKey(imodel),
+        imodelKey: createIModelKey(imodelConnection),
         source: "test",
         selectables: [groupInformationElement!],
       });
 
       await waitFor(() => {
-        expect(getHiliteSet(imodel)).toEqual({
+        expect(getHiliteSet(imodelConnection)).toEqual({
           models: [],
           subCategories: [],
           elements: expectedElements.map(({ id }) => id),
         });
-        expect(getSelectionSet(imodel)).toEqual(
-          is5xSelectionSet(imodel.selectionSet)
+        expect(getSelectionSet(imodelConnection)).toEqual(
+          is5xSelectionSet(imodelConnection.selectionSet)
             ? { models: [], subCategories: [], elements: expectedElements.map(({ id }) => id) }
             : { elements: expectedElements.map(({ id }) => id) },
         );
       });
 
-      imodel.selectionSet.emptyAll();
+      imodelConnection.selectionSet.emptyAll();
       await waitFor(() => {
-        expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodel) }))).toBe(true);
-        expect(imodel.hilited.isEmpty).toBe(true);
+        expect(
+          Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: createIModelKey(imodelConnection) })),
+        ).toBe(true);
+        expect(imodelConnection.hilited.isEmpty).toBe(true);
       });
     });
   });

--- a/apps/full-stack-tests/src/unified-selection/learning-snippets/HiliteSets.test.ts
+++ b/apps/full-stack-tests/src/unified-selection/learning-snippets/HiliteSets.test.ts
@@ -21,8 +21,8 @@ import { createIModelHiliteSetProvider } from "@itwin/unified-selection";
 import { createIModelKey } from "@itwin/presentation-core-interop";
 // __PUBLISH_EXTRACT_END__
 import { createStorage, Selectables } from "@itwin/unified-selection";
-import { initialize, terminate } from "../../IntegrationTests.js";
 import { buildTestIModel } from "../../IModelUtils.js";
+import { initialize, terminate } from "../../IntegrationTests.js";
 
 describe("Unified selection", () => {
   describe("Learning snippets", () => {
@@ -36,11 +36,11 @@ describe("Unified selection", () => {
       });
 
       it("Basic hilite set provider", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           const elementKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "test element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
@@ -48,7 +48,7 @@ describe("Unified selection", () => {
           return { modelKey, categoryKey, elementKey };
         });
 
-        const getIModelConnection = () => imodel;
+        const getIModelConnection = () => imodelConnection;
         const selectables = Selectables.create([keys.elementKey]);
 
         // __PUBLISH_EXTRACT_START__ Presentation.UnifiedSelection.HiliteSets.BasicProvider
@@ -57,7 +57,7 @@ describe("Unified selection", () => {
           imodelAccess: {
             ...schemaProvider,
             ...createCachingECClassHierarchyInspector({ schemaProvider }),
-            ...createECSqlQueryExecutor(imodel),
+            ...createECSqlQueryExecutor(getIModelConnection()),
           },
         });
         const hiliteSetIterator = hiliteProvider.getHiliteSet({ selectables });
@@ -68,11 +68,11 @@ describe("Unified selection", () => {
       });
 
       it("iModel hilite set provider", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           const elementKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "test element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
@@ -82,17 +82,17 @@ describe("Unified selection", () => {
 
         const selectionStorage = createStorage();
         selectionStorage.addToSelection({
-          imodelKey: createIModelKey(imodel),
+          imodelKey: createIModelKey(imodelConnection),
           source: "test",
           selectables: [keys.elementKey],
         });
 
         function getIModelByKey(imodelKey: string) {
-          if (imodelKey === createIModelKey(imodel)) {
+          if (imodelKey === createIModelKey(imodelConnection)) {
             return {
-              ...createECSqlQueryExecutor(imodel),
+              ...createECSqlQueryExecutor(imodelConnection),
               ...createCachingECClassHierarchyInspector({
-                schemaProvider: createECSchemaProvider(imodel.schemaContext),
+                schemaProvider: createECSchemaProvider(imodelConnection.schemaContext),
               }),
               key: imodelKey,
             };
@@ -109,7 +109,9 @@ describe("Unified selection", () => {
           // this is called to get iModel accessor based on the iModel key
           imodelProvider: (imodelKey) => getIModelByKey(imodelKey),
         });
-        const hiliteSetIterator = selectionHiliteProvider.getCurrentHiliteSet({ imodelKey: createIModelKey(imodel) });
+        const hiliteSetIterator = selectionHiliteProvider.getCurrentHiliteSet({
+          imodelKey: createIModelKey(imodelConnection),
+        });
         // __PUBLISH_EXTRACT_END__
 
         const hiliteSet = await collect(hiliteSetIterator);

--- a/apps/full-stack-tests/src/unified-selection/learning-snippets/ReadmeExample.test.tsx
+++ b/apps/full-stack-tests/src/unified-selection/learning-snippets/ReadmeExample.test.tsx
@@ -26,10 +26,10 @@ import { enableUnifiedSelectionSyncWithIModel, SelectionStorage } from "@itwin/u
 // __PUBLISH_EXTRACT_START__ Presentation.UnifiedSelection.LegacySelectionManagerSelectionSync.Imports
 import { Presentation } from "@itwin/presentation-frontend";
 // __PUBLISH_EXTRACT_END__
+import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { render, waitFor } from "../../RenderUtils.js";
 import { isSelectionStorageSupported, stubVirtualization } from "../../Utils.js";
-import { buildTestIModel } from "../../IModelUtils.js";
 
 describe("Unified selection", () => {
   describe("Learning snippets", () => {
@@ -45,7 +45,7 @@ describe("Unified selection", () => {
       stubVirtualization();
 
       it("Basic usage example", async () => {
-        const { imodel } = await buildTestIModel();
+        const { imodelConnection } = await buildTestIModel();
 
         // __PUBLISH_EXTRACT_START__ Presentation.UnifiedSelection.Example.CreateStorage
         // Create a global selection store (generally, somewhere in main.ts or similar). This store
@@ -83,32 +83,36 @@ describe("Unified selection", () => {
         // __PUBLISH_EXTRACT_END__
 
         // Verify selection is initially empty
-        expect(Selectables.isEmpty(unifiedSelection.getSelection({ imodelKey: createIModelKey(imodel) }))).toBe(true);
+        expect(
+          Selectables.isEmpty(unifiedSelection.getSelection({ imodelKey: createIModelKey(imodelConnection) })),
+        ).toBe(true);
 
         // __PUBLISH_EXTRACT_START__ Presentation.UnifiedSelection.Example.InteractiveComponent
         // An interactive component that allows selecting elements, representing something in an iModel, may want to
         // add that something to unified selection. For example:
         const elementKey = { className: "BisCore.PhysicalElement", id: "0x1" };
         unifiedSelection.addToSelection({
-          imodelKey: createIModelKey(imodel),
+          imodelKey: createIModelKey(imodelConnection),
           source: "MyComponent",
           selectables: [elementKey],
         });
         // __PUBLISH_EXTRACT_END__
 
         // Verify selection was added
-        expect(Selectables.size(unifiedSelection.getSelection({ imodelKey: createIModelKey(imodel) }))).toBe(1);
+        expect(Selectables.size(unifiedSelection.getSelection({ imodelKey: createIModelKey(imodelConnection) }))).toBe(
+          1,
+        );
       });
 
       it("Unified selection sync with iModel selection", async () => {
         const {
-          imodel,
+          imodelConnection,
           elementKey: { id: geometricElementId },
-        } = await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+        } = await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           const elementKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "root element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
@@ -116,7 +120,7 @@ describe("Unified selection", () => {
           return { modelKey, categoryKey, elementKey };
         });
         function useActiveIModelConnection() {
-          return imodel;
+          return imodelConnection;
         }
 
         /**
@@ -172,7 +176,7 @@ describe("Unified selection", () => {
         /** A simple component that listens to selection changes and prints selected items count */
         function SelectedItemsWidget({ selectionStorage }: { selectionStorage: SelectionStorage }) {
           function getSelectedElementsCount(storage: SelectionStorage) {
-            return Selectables.size(storage.getSelection({ imodelKey: createIModelKey(imodel) }));
+            return Selectables.size(storage.getSelection({ imodelKey: createIModelKey(imodelConnection) }));
           }
 
           const [selectedElementsCount, setSelectedElementsCount] = useState(() =>
@@ -197,11 +201,11 @@ describe("Unified selection", () => {
         it("Unified selection sync with legacy SelectionManager", async () => {
           Presentation.terminate();
 
-          const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-            const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-            const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+          const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+            const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+            const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
             const elementKey = insertPhysicalElement({
-              builder,
+              imodel,
               userLabel: "root element",
               modelId: modelKey.id,
               categoryId: categoryKey.id,
@@ -217,12 +221,12 @@ describe("Unified selection", () => {
           await Presentation.initialize({ selection: { selectionStorage } });
           // __PUBLISH_EXTRACT_END__
 
-          expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: imodel.key }))).toBe(true);
+          expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: imodelConnection.key }))).toBe(true);
 
           // eslint-disable-next-line @typescript-eslint/no-deprecated
-          Presentation.selection.addToSelection("test", imodel, new KeySet([keys.elementKey]));
+          Presentation.selection.addToSelection("test", imodelConnection, new KeySet([keys.elementKey]));
           await waitFor(() => {
-            expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key }))).toBe(1);
+            expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodelConnection.key }))).toBe(1);
           });
         });
       }

--- a/apps/full-stack-tests/src/unified-selection/learning-snippets/SelectionScopes.test.ts
+++ b/apps/full-stack-tests/src/unified-selection/learning-snippets/SelectionScopes.test.ts
@@ -3,19 +3,19 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   collect,
   insertPhysicalElement,
   insertPhysicalModelWithPartition,
   insertSpatialCategory,
 } from "presentation-test-utilities";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 // __PUBLISH_EXTRACT_START__ Presentation.UnifiedSelection.SelectionScopes.Imports
 import { computeSelection } from "@itwin/unified-selection";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 // __PUBLISH_EXTRACT_END__
-import { initialize, terminate } from "../../IntegrationTests.js";
 import { buildTestIModel } from "../../IModelUtils.js";
+import { initialize, terminate } from "../../IntegrationTests.js";
 
 describe("Unified selection", () => {
   describe("Learning snippets", () => {
@@ -29,11 +29,11 @@ describe("Unified selection", () => {
       });
 
       it("Basic selection scope", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           const elementKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "test element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
@@ -44,7 +44,7 @@ describe("Unified selection", () => {
         const elementIds = [keys.elementKey.id];
 
         // __PUBLISH_EXTRACT_START__ Presentation.UnifiedSelection.SelectionScopes.BasicExample
-        const queryExecutor = createECSqlQueryExecutor(imodel);
+        const queryExecutor = createECSqlQueryExecutor(imodelConnection);
         const selection = computeSelection({ queryExecutor, elementIds, scope: "element" });
         // __PUBLISH_EXTRACT_END__
 
@@ -53,17 +53,17 @@ describe("Unified selection", () => {
       });
 
       it("Selection scope with ancestor level", async () => {
-        const { imodel, ...keys } = await buildTestIModel(async (builder) => {
-          const modelKey = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
-          const categoryKey = insertSpatialCategory({ builder, codeValue: "test category" });
+        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
+          const modelKey = insertPhysicalModelWithPartition({ imodel, codeValue: "test model" });
+          const categoryKey = insertSpatialCategory({ imodel, codeValue: "test category" });
           const parentElementKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "test element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
           });
           const elementKey = insertPhysicalElement({
-            builder,
+            imodel,
             userLabel: "test element",
             modelId: modelKey.id,
             categoryId: categoryKey.id,
@@ -75,7 +75,7 @@ describe("Unified selection", () => {
         const elementIds = [keys.elementKey.id];
 
         // __PUBLISH_EXTRACT_START__ Presentation.UnifiedSelection.SelectionScopes.AncestorLevelExample
-        const queryExecutor = createECSqlQueryExecutor(imodel);
+        const queryExecutor = createECSqlQueryExecutor(imodelConnection);
 
         // Returns the parent element, or the element itself if it does not have a parent, for each element specified in `elementIds` argument.
         const selection = computeSelection({ queryExecutor, elementIds, scope: { id: "element", ancestorLevel: 1 } });

--- a/apps/performance-tests/src/util/Datasets.ts
+++ b/apps/performance-tests/src/util/Datasets.ts
@@ -6,6 +6,7 @@
 import fs from "fs";
 import path from "path";
 import {
+  getFullSchemaXml,
   insertDrawingCategory,
   insertDrawingGraphic,
   insertDrawingModelWithPartition,
@@ -162,22 +163,22 @@ export class Datasets {
       `).join("")}
     `;
 
-    await createIModel(name, localPath, async (builder) => {
-      await builder.importSchema(schemaName, schema);
+    await createIModel(name, localPath, async (imodel) => {
+      await imodel.importSchemaStrings([getFullSchemaXml({ schemaName, schemaContentXml: schema })]);
       const { id: categoryId } = insertSpatialCategory({
-        builder,
+        imodel,
         fullClassNameSeparator: ":",
         codeValue: "My Category",
       });
       const { id: modelId } = insertPhysicalModelWithPartition({
-        builder,
+        imodel,
         fullClassNameSeparator: ":",
         codeValue: "My Model",
       });
       for (let groupIdx = 0; groupIdx < numGroups; ++groupIdx) {
         for (let j = 0; j < elementsPerGroup; ++j) {
           insertPhysicalElement({
-            builder,
+            imodel,
             classFullName: `${schemaName}:${defaultClassName}_${groupIdx}` satisfies EC.FullClassName,
             fullClassNameSeparator: ":",
             userLabel: `${defaultUserLabel}_${groupIdx}`,
@@ -200,19 +201,19 @@ export class Datasets {
   private static async createElementIModel(name: string, localPath: string, numElements: number) {
     console.log(`${numElements} elements: Creating...`);
 
-    await createIModel(name, localPath, async (builder) => {
+    await createIModel(name, localPath, async (imodel) => {
       const { id: spatialCategoryId } = insertSpatialCategory({
-        builder,
+        imodel,
         fullClassNameSeparator: ":",
         codeValue: "My Category",
       });
       const { id: physicalModelId } = insertPhysicalModelWithPartition({
-        builder,
+        imodel,
         fullClassNameSeparator: ":",
         codeValue: "My Model",
       });
-      const { id: drawingModelId } = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
-      const { id: drawingCategoryId } = insertDrawingCategory({ builder, codeValue: "test drawing category" });
+      const { id: drawingModelId } = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
+      const { id: drawingCategoryId } = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
 
       const numberOfGroups = 1000;
       const elementsPerGroup = numElements / numberOfGroups;
@@ -223,14 +224,14 @@ export class Datasets {
 
         for (let j = 0; j < elementsPerGroup / 2; ++j) {
           physicalParentId = insertPhysicalElement({
-            builder,
+            imodel,
             parentId: physicalParentId,
             modelId: physicalModelId,
             categoryId: spatialCategoryId,
             userLabel: `test_element`,
           }).id;
           drawingParentId = insertDrawingGraphic({
-            builder,
+            imodel,
             parentId: drawingParentId,
             modelId: drawingModelId,
             categoryId: drawingCategoryId,
@@ -250,7 +251,7 @@ export class Datasets {
   private static async createSubjectIModel(name: string, localPath: string, numElements: number) {
     console.log(`${numElements} elements: Creating...`);
 
-    await createIModel(name, localPath, async (builder) => {
+    await createIModel(name, localPath, async (imodel) => {
       const numberOfGroups = 20;
       const elementsPerGroup = numElements / numberOfGroups;
 
@@ -258,10 +259,10 @@ export class Datasets {
         let parentId: string | undefined;
 
         for (let j = 0; j < elementsPerGroup; ++j) {
-          parentId = insertSubject({ parentId, builder, codeValue: `subject_${i}_${j}`, userLabel: "test_subject" }).id;
+          parentId = insertSubject({ parentId, imodel, codeValue: `subject_${i}_${j}`, userLabel: "test_subject" }).id;
         }
 
-        insertPhysicalModelWithPartition({ builder, codeValue: `model_${i}`, partitionParentId: parentId });
+        insertPhysicalModelWithPartition({ imodel, codeValue: `model_${i}`, partitionParentId: parentId });
       }
     });
 
@@ -273,9 +274,9 @@ export class Datasets {
    */
   private static async createCategoryIModel(name: string, localPath: string, numElements: number) {
     console.log(`${numElements} elements: Creating...`);
-    await createIModel(name, localPath, async (builder) => {
+    await createIModel(name, localPath, async (imodel) => {
       const { id: categoryId } = insertSpatialCategory({
-        builder,
+        imodel,
         fullClassNameSeparator: ":",
         codeValue: "My Category",
         userLabel: "test_category",
@@ -283,7 +284,7 @@ export class Datasets {
 
       // Insert `numElements` - 1 subcategories as `insertSpatialCategory` provides one additional subcategory
       for (let i = 0; i < numElements - 1; ++i) {
-        insertSubCategory({ parentCategoryId: categoryId, builder, codeValue: `${i}` });
+        insertSubCategory({ parentCategoryId: categoryId, imodel, codeValue: `${i}` });
       }
     });
 
@@ -302,21 +303,21 @@ export class Datasets {
     const membersPerGroup = 1000;
     const elementsPerMember = numElements / (numGroups * membersPerGroup);
 
-    await createIModel(name, localPath, async (builder) => {
+    await createIModel(name, localPath, async (imodel) => {
       const { id: groupModelId } = insertGroupInformationModelWithPartition({
-        builder,
+        imodel,
         codeValue: "group information model",
       });
-      const { id: modelId } = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+      const { id: modelId } = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
       const { id: categoryId } = insertSpatialCategory({
-        builder,
+        imodel,
         fullClassNameSeparator: ":",
         codeValue: "My Category",
       });
 
       for (let groupIdx = 0; groupIdx < numGroups; ++groupIdx) {
         const { id: groupId } = insertGroupInformationElement({
-          builder,
+          imodel,
           modelId: groupModelId,
           userLabel: "test_group",
         });
@@ -325,9 +326,9 @@ export class Datasets {
           let parentId: string | undefined;
 
           for (let j = 0; j < elementsPerMember; ++j) {
-            parentId = insertPhysicalElement({ builder, parentId, modelId, categoryId }).id;
+            parentId = insertPhysicalElement({ imodel, parentId, modelId, categoryId }).id;
             if (j === 0) {
-              builder.insertRelationship({
+              imodel.relationships.insertInstance({
                 sourceId: groupId,
                 targetId: parentId,
                 classFullName: "BisCore.ElementGroupsMembers",
@@ -350,14 +351,14 @@ export class Datasets {
     console.log(`${numElements} elements: Creating...`);
     const schema = await this.getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
 
-    await createIModel(name, localPath, async (builder) => {
-      await builder.importFullSchema(schema);
-      const { id: physicalModelId } = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+    await createIModel(name, localPath, async (imodel) => {
+      await imodel.importSchemaStrings([schema]);
+      const { id: physicalModelId } = insertPhysicalModelWithPartition({ imodel, codeValue: "test physical model" });
       const { id: functionalModelId } = insertFunctionalModelWithPartition({
-        builder,
+        imodel,
         codeValue: "test functional model",
       });
-      const { id: categoryId } = insertSpatialCategory({ builder, codeValue: "test category" });
+      const { id: categoryId } = insertSpatialCategory({ imodel, codeValue: "test category" });
 
       const numberOfGroups = 1000;
       const elementsPerGroup = numElements / numberOfGroups;
@@ -368,14 +369,14 @@ export class Datasets {
 
         for (let j = 0; j < elementsPerGroup; ++j) {
           physicalElementParentId = insertPhysicalElement({
-            builder,
+            imodel,
             parentId: physicalElementParentId,
             modelId: physicalModelId,
             categoryId,
             userLabel: "test_element",
           }).id;
           functionalElementParentId = insertFunctionalElement({
-            builder,
+            imodel,
             parentId: functionalElementParentId,
             modelId: functionalModelId,
             representedElementId: physicalElementParentId,
@@ -401,16 +402,16 @@ export class Datasets {
     console.log(`${numElements} elements: Creating...`);
     const schema = await this.getSchemaFromPackage("functional-schema", "Functional.ecschema.xml");
 
-    await createIModel(name, localPath, async (builder) => {
-      await builder.importFullSchema(schema);
+    await createIModel(name, localPath, async (imodel) => {
+      await imodel.importSchemaStrings([schema]);
 
-      const { id: drawingModelId } = insertDrawingModelWithPartition({ builder, codeValue: "test drawing model" });
+      const { id: drawingModelId } = insertDrawingModelWithPartition({ imodel, codeValue: "test drawing model" });
       const { id: functionalModelId } = insertFunctionalModelWithPartition({
-        builder,
+        imodel,
         codeValue: "test functional model",
       });
-      const { id: categoryId } = insertDrawingCategory({ builder, codeValue: "test drawing category" });
-      const { id: graphicsElementId } = insertDrawingGraphic({ builder, modelId: drawingModelId, categoryId });
+      const { id: categoryId } = insertDrawingCategory({ imodel, codeValue: "test drawing category" });
+      const { id: graphicsElementId } = insertDrawingGraphic({ imodel, modelId: drawingModelId, categoryId });
 
       const numberOfGroups = 1000;
       const elementsPerGroup = numElements / numberOfGroups;
@@ -423,7 +424,7 @@ export class Datasets {
         for (let j = 0; j < elementsPerGroup; ++j) {
           graphicsElementParentId = insertDrawingGraphic({
             parentId: graphicsElementParentId,
-            builder,
+            imodel,
             categoryId,
             modelId: drawingModelId,
             userLabel: "test_element",
@@ -435,7 +436,7 @@ export class Datasets {
 
           functionalElementParentId = insertFunctionalElement({
             parentId: functionalElementParentId,
-            builder,
+            imodel,
             modelId: functionalModelId,
             // Last functional element in the chain represents the first graphics element, others represent an element outside the chain.
             representedElementId: j === elementsPerGroup - 1 ? firstGraphicsElementId! : graphicsElementId,

--- a/apps/performance-tests/src/util/IModelUtilities.ts
+++ b/apps/performance-tests/src/util/IModelUtilities.ts
@@ -4,60 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import fs from "fs";
-import { getFullSchemaXml } from "presentation-test-utilities";
 import { SnapshotDb } from "@itwin/core-backend";
-import { Code } from "@itwin/core-common";
 
-import type { TestIModelBuilder } from "presentation-test-utilities";
 import type { IModelDb } from "@itwin/core-backend";
-import type { BisCodeSpec, ElementAspectProps, ElementProps, ModelProps, RelationshipProps } from "@itwin/core-common";
 
-export async function createIModel(
-  name: string,
-  localPath: string,
-  cb: (builder: BackendTestIModelBuilder) => void | Promise<void>,
-) {
+export async function createIModel(name: string, localPath: string, cb: (imodel: IModelDb) => void | Promise<void>) {
   fs.rmSync(localPath, { force: true });
   const iModel = SnapshotDb.createEmpty(localPath, { rootSubject: { name } });
-  const builder = new BackendTestIModelBuilder(iModel);
   try {
-    await cb(builder);
+    await cb(iModel);
   } finally {
     iModel.saveChanges("Initial commit");
     iModel.close();
-  }
-}
-
-class BackendTestIModelBuilder implements TestIModelBuilder {
-  constructor(private readonly _iModel: IModelDb) {}
-
-  public insertModel(props: ModelProps): string {
-    return this._iModel.models.insertModel(props);
-  }
-
-  public insertElement(props: ElementProps): string {
-    return this._iModel.elements.insertElement(props);
-  }
-
-  public insertAspect(props: ElementAspectProps): string {
-    return this._iModel.elements.insertAspect(props);
-  }
-
-  public insertRelationship(props: RelationshipProps): string {
-    return this._iModel.relationships.insertInstance(props);
-  }
-
-  public createCode(scopeModelId: string, codeSpecName: BisCodeSpec, codeValue: string): Code {
-    const spec = this._iModel.codeSpecs.getByName(codeSpecName).id;
-    return new Code({ scope: scopeModelId, spec, value: codeValue });
-  }
-
-  public async importSchema(schemaName: string, schemaContentXml: string): Promise<void> {
-    const fullXml = getFullSchemaXml({ schemaName, schemaContentXml });
-    await this._iModel.importSchemaStrings([fullXml]);
-  }
-
-  public async importFullSchema(schema: string): Promise<void> {
-    await this._iModel.importSchemaStrings([schema]);
   }
 }

--- a/packages/core-interop/README.md
+++ b/packages/core-interop/README.md
@@ -84,12 +84,12 @@ Example:
 <!-- BEGIN EXTRACTION -->
 
 ```ts
-import { IModelConnection } from "@itwin/core-frontend";
+import { SchemaContext } from "@itwin/ecschema-metadata";
 import { createValueFormatter } from "@itwin/presentation-core-interop";
 
-const imodel: IModelConnection = getIModelConnection();
-const metricFormatter = createValueFormatter({ schemaContext: imodel.schemaContext, unitSystem: "metric" });
-const imperialFormatter = createValueFormatter({ schemaContext: imodel.schemaContext, unitSystem: "imperial" });
+const schemaContext: SchemaContext = getIModelConnection().schemaContext;
+const metricFormatter = createValueFormatter({ schemaContext, unitSystem: "metric" });
+const imperialFormatter = createValueFormatter({ schemaContext, unitSystem: "imperial" });
 
 // Define the raw value to be formatted
 const value = 1.234;

--- a/packages/hierarchies/learning/CustomHierarchyProviders.md
+++ b/packages/hierarchies/learning/CustomHierarchyProviders.md
@@ -53,8 +53,8 @@ using provider = createHierarchyProvider(({ hierarchyChanged }) => {
   // and raise `hierarchyChanged` event when the hierarchy should be refreshed. `BriefcaseTxns` has a number
   // of events that we should listen to - here we're using `registerTxnListeners` helper to simplify subscription.
   const disposeTxnListeners =
-    imodel instanceof BriefcaseConnection
-      ? registerTxnListeners(imodel.txns, () => hierarchyChanged.raiseEvent({}))
+    imodelConnection instanceof BriefcaseConnection
+      ? registerTxnListeners(imodelConnection.txns, () => hierarchyChanged.raiseEvent({}))
       : undefined;
   return {
     // Make this provider disposable. Owners of the provider should make sure `Symbol.dispose` is called when the
@@ -67,7 +67,7 @@ using provider = createHierarchyProvider(({ hierarchyChanged }) => {
     async *getNodes({ parentNode }: Props<HierarchyProvider["getNodes"]>): AsyncIterableIterator<HierarchyNode> {
       if (!parentNode) {
         // Query and return root bis.Subject node
-        for await (const row of imodel.createQueryReader(
+        for await (const row of imodelConnection.createQueryReader(
           `
             SELECT
               COALESCE(s.UserLabel, s.CodeValue, ec_classname(s.ECClassId, 'c')) label,
@@ -79,7 +79,7 @@ using provider = createHierarchyProvider(({ hierarchyChanged }) => {
           yield {
             key: {
               type: "instances",
-              instanceKeys: [{ className: "BisCore.Subject", id: "0x1", imodelKey: imodel.key }],
+              instanceKeys: [{ className: "BisCore.Subject", id: "0x1", imodelKey: imodelConnection.key }],
             },
             label: row.label,
             children: !!row.hasChildren,
@@ -92,9 +92,9 @@ using provider = createHierarchyProvider(({ hierarchyChanged }) => {
       if (
         HierarchyNode.isInstancesNode(parentNode) &&
         parentNode.key.instanceKeys.length > 0 &&
-        parentNode.key.instanceKeys.every((k) => k.imodelKey === imodel.key)
+        parentNode.key.instanceKeys.every((k) => k.imodelKey === imodelConnection.key)
       ) {
-        for await (const row of imodel.createQueryReader(
+        for await (const row of imodelConnection.createQueryReader(
           `
             SELECT
               ec_classname(e.ECClassId, 's.c') className,
@@ -108,7 +108,7 @@ using provider = createHierarchyProvider(({ hierarchyChanged }) => {
           yield {
             key: {
               type: "instances",
-              instanceKeys: [{ className: row.className, id: row.id, imodelKey: imodel.key }],
+              instanceKeys: [{ className: row.className, id: row.id, imodelKey: imodelConnection.key }],
             },
             label: row.label,
             children: !!row.hasChildren,
@@ -123,23 +123,23 @@ using provider = createHierarchyProvider(({ hierarchyChanged }) => {
     async *getNodeInstanceKeys({ parentNode }: Props<HierarchyProvider["getNodeInstanceKeys"]>) {
       if (!parentNode) {
         // Don't need to run a query here - we know all iModels have one root Subject with `0x1` id
-        yield { className: "BisCore.Subject", id: "0x1", imodelKey: imodel.key };
+        yield { className: "BisCore.Subject", id: "0x1", imodelKey: imodelConnection.key };
         return;
       }
       // Query and return children instance keys for the given parent node
       if (
         HierarchyNode.isInstancesNode(parentNode) &&
         parentNode.key.instanceKeys.length > 0 &&
-        parentNode.key.instanceKeys.every((k) => k.imodelKey === imodel.key)
+        parentNode.key.instanceKeys.every((k) => k.imodelKey === imodelConnection.key)
       ) {
-        for await (const row of imodel.createQueryReader(
+        for await (const row of imodelConnection.createQueryReader(
           `
             SELECT ec_classname(e.ECClassId, 's.c') className, e.ECInstanceId id
             FROM bis.Element e
             WHERE e.Parent.Id IN (${parentNode.key.instanceKeys.map((key) => key.id).join(",")})
           `,
         )) {
-          yield { className: row.className, id: row.id, imodelKey: imodel.key };
+          yield { className: row.className, id: row.id, imodelKey: imodelConnection.key };
         }
       }
     },

--- a/packages/hierarchies/learning/Formatting.md
+++ b/packages/hierarchies/learning/Formatting.md
@@ -37,12 +37,12 @@ In the above example, the formatter customizes boolean values' formatting and re
 <!-- BEGIN EXTRACTION -->
 
 ```ts
-import { IModelConnection } from "@itwin/core-frontend";
+import { SchemaContext } from "@itwin/ecschema-metadata";
 import { createValueFormatter } from "@itwin/presentation-core-interop";
 
-const imodel: IModelConnection = getIModelConnection();
-const metricFormatter = createValueFormatter({ schemaContext: imodel.schemaContext, unitSystem: "metric" });
-const imperialFormatter = createValueFormatter({ schemaContext: imodel.schemaContext, unitSystem: "imperial" });
+const schemaContext: SchemaContext = getIModelConnection().schemaContext;
+const metricFormatter = createValueFormatter({ schemaContext, unitSystem: "metric" });
+const imperialFormatter = createValueFormatter({ schemaContext, unitSystem: "imperial" });
 
 // Define the raw value to be formatted
 const value = 1.234;

--- a/packages/hierarchies/learning/imodel/HierarchySearch.md
+++ b/packages/hierarchies/learning/imodel/HierarchySearch.md
@@ -129,7 +129,7 @@ Let's consider two cases - searching by label and by target element ID:
       searchTreeBuilder.accept({
         path: (JSON.parse(row.Path) as InstanceKey[])
           .reverse()
-          .map((key) => ({ ...key, imodelKey: createIModelKey(imodel) })),
+          .map((key) => ({ ...key, imodelKey: createIModelKey(imodelConnection) })),
       });
     }
     return searchTreeBuilder.getTree();
@@ -191,7 +191,7 @@ Let's consider two cases - searching by label and by target element ID:
       result.push(
         (JSON.parse(row.Path) as InstanceKey[])
           .reverse()
-          .map((key) => ({ ...key, imodelKey: createIModelKey(imodel) })),
+          .map((key) => ({ ...key, imodelKey: createIModelKey(imodelConnection) })),
       );
     }
     return result;

--- a/packages/hierarchies/learning/imodel/MergedIModelHierarchies.md
+++ b/packages/hierarchies/learning/imodel/MergedIModelHierarchies.md
@@ -30,8 +30,8 @@ import { createBisInstanceLabelSelectClauseFactory, EC } from "@itwin/presentati
 // both versions - `base` and `changeset1`. The order is important - we want the changesets to be from oldest to
 // newest.
 const imodels = [
-  { imodelAccess: createIModelAccess(changesets.base.imodel) },
-  { imodelAccess: createIModelAccess(changesets.changeset1.imodel) },
+  { imodelAccess: createIModelAccess(changesets.base.imodelConnection) },
+  { imodelAccess: createIModelAccess(changesets.changeset1.imodelConnection) },
 ];
 
 // Define an utility for creating instance nodes query definitions, that we'll use in our hierarchy definition.

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -22,6 +22,7 @@
     "./node-hooks/ignore-styles": "./node-hooks/ignore-styles.cjs"
   },
   "devDependencies": {
+    "@itwin/core-backend": "catalog:itwinjs-core-dev",
     "@itwin/core-bentley": "catalog:itwinjs-core-dev",
     "@itwin/core-common": "catalog:itwinjs-core-dev",
     "@itwin/core-geometry": "catalog:itwinjs-core-dev",

--- a/packages/test-utilities/src/test-utilities/IModelUtils.ts
+++ b/packages/test-utilities/src/test-utilities/IModelUtils.ts
@@ -6,10 +6,10 @@
 import { Id64 } from "@itwin/core-bentley";
 import { BisCodeSpec, Code, IModel } from "@itwin/core-common";
 
+import type { IModelDb } from "@itwin/core-backend";
 import type { Id64String } from "@itwin/core-bentley";
 import type {
   CategoryProps,
-  CodeScopeProps,
   DefinitionElementProps,
   ElementAspectProps,
   ElementProps,
@@ -20,9 +20,7 @@ import type {
   GeometricModel2dProps,
   GeometricModel3dProps,
   InformationPartitionElementProps,
-  ModelProps,
   PhysicalElementProps,
-  RelationshipProps,
   RepositoryLinkProps,
   SheetIndexFolderProps,
   SubCategoryProps,
@@ -31,19 +29,11 @@ import type {
 
 // cspell:words ecdbmap
 
-export interface TestIModelBuilder {
-  insertModel<TModelProps extends ModelProps>(props: TModelProps): Id64String;
-  insertElement<TElementProps extends ElementProps>(props: TElementProps): Id64String;
-  insertAspect<TAspectProps extends ElementAspectProps>(props: TAspectProps): Id64String;
-  insertRelationship<TRelationshipProps extends RelationshipProps>(props: TRelationshipProps): Id64String;
-  createCode(scopeModelId: CodeScopeProps, codeSpecName: BisCodeSpec, codeValue: string): Code;
-}
-
 type FullClassNameSeparator = "." | ":";
 type FullClassName = `${string}${FullClassNameSeparator}${string}`;
 
 export interface BaseInstanceInsertProps {
-  builder: TestIModelBuilder;
+  imodel: IModelDb;
   classFullName?: FullClassName;
   fullClassNameSeparator?: FullClassNameSeparator;
 }
@@ -53,13 +43,17 @@ export function insertSubject(
       Omit<SubjectProps, "id" | "parent" | "code" | "model">
     >,
 ) {
-  const { builder, classFullName, codeValue, parentId, ...subjectProps } = props;
+  const { imodel, classFullName, codeValue, parentId, ...subjectProps } = props;
   const defaultClassName: FullClassName = `BisCore${props.fullClassNameSeparator ?? "."}Subject`;
   const className = classFullName ?? defaultClassName;
-  const id = builder.insertElement({
+  const id = imodel.elements.insertElement({
     classFullName: className,
     model: IModel.repositoryModelId,
-    code: builder.createCode(parentId ?? IModel.rootSubjectId, BisCodeSpec.subject, codeValue),
+    code: new Code({
+      spec: imodel.codeSpecs.getByName(BisCodeSpec.subject).id,
+      scope: parentId ?? IModel.rootSubjectId,
+      value: codeValue,
+    }),
     parent: { id: parentId ?? IModel.rootSubjectId, relClassName: "BisCore.SubjectOwnsSubjects" },
     ...subjectProps,
   });
@@ -83,13 +77,17 @@ export function insertPhysicalPartition(
       Omit<InformationPartitionElementProps, "id" | "parent" | "code">
     >,
 ) {
-  const { builder, classFullName, codeValue, parentId, ...partitionProps } = props;
+  const { imodel, classFullName, codeValue, parentId, ...partitionProps } = props;
   const defaultModelClassName: FullClassName = `BisCore${props.fullClassNameSeparator ?? "."}PhysicalPartition`;
   const className = classFullName ?? defaultModelClassName;
-  const partitionId = builder.insertElement({
+  const partitionId = imodel.elements.insertElement({
     classFullName: className,
     model: IModel.repositoryModelId,
-    code: builder.createCode(parentId, BisCodeSpec.informationPartitionElement, codeValue),
+    code: new Code({
+      spec: imodel.codeSpecs.getByName(BisCodeSpec.informationPartitionElement).id,
+      scope: parentId,
+      value: codeValue,
+    }),
     parent: { id: parentId, relClassName: `BisCore${props.fullClassNameSeparator ?? "."}SubjectOwnsPartitionElements` },
     ...partitionProps,
   });
@@ -101,10 +99,10 @@ export function insertPhysicalSubModel(
       Omit<GeometricModel3dProps, "id" | "modeledElement" | "parentModel">
     >,
 ) {
-  const { builder, classFullName, modeledElementId, ...modelProps } = props;
+  const { imodel, classFullName, modeledElementId, ...modelProps } = props;
   const defaultModelClassName: FullClassName = `BisCore${props.fullClassNameSeparator ?? "."}PhysicalModel`;
   const className = classFullName ?? defaultModelClassName;
-  const modelId = builder.insertModel({
+  const modelId = imodel.models.insertModel({
     classFullName: className,
     modeledElement: { id: modeledElementId },
     ...modelProps,
@@ -129,13 +127,17 @@ export function insertDrawingPartition(
       Omit<InformationPartitionElementProps, "id" | "parent" | "code" | "userLabel">
     >,
 ) {
-  const { builder, classFullName, codeValue, parentId, ...partitionProps } = props;
+  const { imodel, classFullName, codeValue, parentId, ...partitionProps } = props;
   const defaultModelClassName: FullClassName = `BisCore${props.fullClassNameSeparator ?? "."}Drawing`;
   const className = classFullName ?? defaultModelClassName;
-  const partitionId = builder.insertElement({
+  const partitionId = imodel.elements.insertElement({
     classFullName: className,
     model: IModel.repositoryModelId,
-    code: builder.createCode(parentId, BisCodeSpec.informationPartitionElement, codeValue),
+    code: new Code({
+      spec: imodel.codeSpecs.getByName(BisCodeSpec.informationPartitionElement).id,
+      scope: parentId,
+      value: codeValue,
+    }),
     parent: { id: parentId, relClassName: `BisCore${props.fullClassNameSeparator ?? "."}SubjectOwnsPartitionElements` },
     ...partitionProps,
   });
@@ -147,10 +149,10 @@ export function insertDrawingSubModel(
       Omit<GeometricModel2dProps, "id" | "modeledElement" | "parentModel">
     >,
 ) {
-  const { builder, classFullName, modeledElementId, ...modelProps } = props;
+  const { imodel, classFullName, modeledElementId, ...modelProps } = props;
   const defaultModelClassName: FullClassName = `BisCore${props.fullClassNameSeparator ?? "."}DrawingModel`;
   const className = classFullName ?? defaultModelClassName;
-  const modelId = builder.insertModel({
+  const modelId = imodel.models.insertModel({
     classFullName: className,
     modeledElement: { id: modeledElementId },
     ...modelProps,
@@ -163,14 +165,18 @@ export function insertSpatialCategory(
       Omit<CategoryProps, "id" | "model" | "parent" | "code">
     >,
 ) {
-  const { builder, classFullName, modelId, codeValue, ...categoryProps } = props;
+  const { imodel, classFullName, modelId, codeValue, ...categoryProps } = props;
   const defaultClassName: FullClassName = `BisCore${props.fullClassNameSeparator ?? "."}SpatialCategory`;
   const className = classFullName ?? defaultClassName;
   const model = modelId ?? IModel.dictionaryId;
-  const id = builder.insertElement({
+  const id = imodel.elements.insertElement({
     classFullName: className,
     model,
-    code: builder.createCode(model, BisCodeSpec.spatialCategory, codeValue),
+    code: new Code({
+      spec: imodel.codeSpecs.getByName(BisCodeSpec.spatialCategory).id,
+      scope: model,
+      value: codeValue,
+    }),
     ...categoryProps,
   });
   return { className, id };
@@ -181,14 +187,18 @@ export function insertDrawingCategory(
       Omit<CategoryProps, "id" | "model" | "parent" | "code">
     >,
 ) {
-  const { builder, classFullName, modelId, codeValue, ...categoryProps } = props;
+  const { imodel, classFullName, modelId, codeValue, ...categoryProps } = props;
   const defaultClassName: FullClassName = `BisCore${props.fullClassNameSeparator ?? "."}DrawingCategory`;
   const className = classFullName ?? defaultClassName;
   const model = modelId ?? IModel.dictionaryId;
-  const id = builder.insertElement({
+  const id = imodel.elements.insertElement({
     classFullName: className,
     model,
-    code: builder.createCode(model, BisCodeSpec.drawingCategory, codeValue),
+    code: new Code({
+      spec: imodel.codeSpecs.getByName(BisCodeSpec.drawingCategory).id,
+      scope: model,
+      value: codeValue,
+    }),
     ...categoryProps,
   });
   return { className, id };
@@ -205,14 +215,14 @@ export function insertSubCategory(
       Omit<SubCategoryProps, "id" | "model" | "parent" | "code">
     >,
 ) {
-  const { builder, classFullName, modelId, codeValue, parentCategoryId, ...subCategoryProps } = props;
+  const { imodel, classFullName, modelId, codeValue, parentCategoryId, ...subCategoryProps } = props;
   const defaultClassName: FullClassName = `BisCore${props.fullClassNameSeparator ?? "."}SubCategory`;
   const className = classFullName ?? defaultClassName;
   const model = modelId ?? IModel.dictionaryId;
-  const id = builder.insertElement({
+  const id = imodel.elements.insertElement({
     classFullName: className,
     model,
-    code: builder.createCode(model, BisCodeSpec.subCategory, codeValue),
+    code: new Code({ spec: imodel.codeSpecs.getByName(BisCodeSpec.subCategory).id, scope: model, value: codeValue }),
     parent: {
       id: parentCategoryId,
       relClassName: `BisCore${props.fullClassNameSeparator ?? "."}CategoryOwnsSubCategories`,
@@ -232,14 +242,20 @@ export function insertPhysicalElement<TAdditionalProps extends {}>(
   } & Partial<Omit<PhysicalElementProps, "id" | "model" | "category" | "parent" | "typeDefinition" | "code">> &
     TAdditionalProps,
 ) {
-  const { builder, classFullName, modelId, categoryId, parentId, typeDefinitionId, codeValue, ...elementProps } = props;
+  const { imodel, classFullName, modelId, categoryId, parentId, typeDefinitionId, codeValue, ...elementProps } = props;
   const defaultClassName: FullClassName = `Generic${props.fullClassNameSeparator ?? "."}PhysicalObject`;
   const className = classFullName ?? defaultClassName;
-  const id = builder.insertElement({
+  const id = imodel.elements.insertElement({
     classFullName: className,
     model: modelId,
     category: categoryId,
-    code: codeValue ? builder.createCode(parentId ?? modelId, BisCodeSpec.nullCodeSpec, codeValue) : Code.createEmpty(),
+    code: codeValue
+      ? new Code({
+          spec: imodel.codeSpecs.getByName(BisCodeSpec.nullCodeSpec).id,
+          scope: parentId ?? modelId,
+          value: codeValue,
+        })
+      : Code.createEmpty(),
     ...(parentId
       ? {
           parent: {
@@ -265,10 +281,10 @@ export function insertPhysicalType<TAdditionalProps extends {}>(
   props: BaseInstanceInsertProps & { modelId?: Id64String } & Partial<Omit<DefinitionElementProps, "id" | "model">> &
     TAdditionalProps,
 ) {
-  const { builder, classFullName, modelId, ...elementProps } = props;
+  const { imodel, classFullName, modelId, ...elementProps } = props;
   const defaultClassName: FullClassName = `Generic${props.fullClassNameSeparator ?? "."}PhysicalType`;
   const className = classFullName ?? defaultClassName;
-  const id = builder.insertElement({
+  const id = imodel.elements.insertElement({
     classFullName: className,
     model: modelId ?? IModel.dictionaryId,
     code: Code.createEmpty(),
@@ -281,10 +297,10 @@ export function insertPhysicalMaterial<TAdditionalProps extends {}>(
   props: BaseInstanceInsertProps & { modelId?: Id64String } & Partial<Omit<DefinitionElementProps, "id" | "model">> &
     TAdditionalProps,
 ) {
-  const { builder, classFullName, modelId, ...elementProps } = props;
+  const { imodel, classFullName, modelId, ...elementProps } = props;
   const defaultClassName: FullClassName = `Generic${props.fullClassNameSeparator ?? "."}PhysicalMaterial`;
   const className = classFullName ?? defaultClassName;
-  const id = builder.insertElement({
+  const id = imodel.elements.insertElement({
     classFullName: className,
     model: modelId ?? IModel.dictionaryId,
     code: Code.createEmpty(),
@@ -299,10 +315,10 @@ export function insertDrawingGraphic<TAdditionalProps extends {}>(
     > &
     TAdditionalProps,
 ) {
-  const { builder, classFullName, modelId, categoryId, parentId, ...elementProps } = props;
+  const { imodel, classFullName, modelId, categoryId, parentId, ...elementProps } = props;
   const defaultClassName: FullClassName = `BisCore${props.fullClassNameSeparator ?? "."}DrawingGraphic`;
   const className = classFullName ?? defaultClassName;
-  const id = builder.insertElement({
+  const id = imodel.elements.insertElement({
     classFullName: className,
     model: modelId,
     category: categoryId,
@@ -325,17 +341,17 @@ export function insertRepositoryLink(
       Omit<RepositoryLinkProps, "id" | "model" | "url" | "userLabel">
     >,
 ) {
-  const { builder, classFullName, repositoryUrl, repositoryLabel, ...repoLinkProps } = props;
+  const { imodel, classFullName, repositoryUrl, repositoryLabel, ...repoLinkProps } = props;
   const defaultClassName: FullClassName = `BisCore${props.fullClassNameSeparator ?? "."}RepositoryLink`;
   const className = classFullName ?? defaultClassName;
-  const id = builder.insertElement({
+  const id = imodel.elements.insertElement({
     classFullName: className,
     model: IModel.repositoryModelId,
     url: repositoryUrl,
     userLabel: repositoryLabel,
     code: Code.createEmpty(),
     ...repoLinkProps,
-  } satisfies RepositoryLinkProps);
+  } satisfies RepositoryLinkProps as ElementProps);
   return { className, id };
 }
 
@@ -344,16 +360,16 @@ export function insertExternalSourceAspect(
       Omit<ExternalSourceAspectProps, "id" | "classFullName" | "element" | "source">
     >,
 ) {
-  const { builder, repositoryId, elementId, identifier, ...externalSourceAspectProps } = props;
-  const externalSourceId = builder.insertElement({
+  const { imodel, repositoryId, elementId, identifier, ...externalSourceAspectProps } = props;
+  const externalSourceId = imodel.elements.insertElement({
     classFullName: `BisCore${props.fullClassNameSeparator ?? "."}ExternalSource`,
     model: IModel.repositoryModelId,
     code: Code.createEmpty(),
     repository: repositoryId ? { id: repositoryId } : undefined,
-  } satisfies ExternalSourceProps);
+  } satisfies ExternalSourceProps as ElementProps);
 
   const className = `BisCore${props.fullClassNameSeparator ?? "."}ExternalSourceAspect`;
-  const id = builder.insertAspect({
+  const id = imodel.elements.insertAspect({
     classFullName: className,
     kind: "ExternalSource",
     element: { id: elementId },
@@ -361,7 +377,7 @@ export function insertExternalSourceAspect(
     scope: { id: elementId },
     identifier,
     ...externalSourceAspectProps,
-  } satisfies ExternalSourceAspectProps);
+  } satisfies ExternalSourceAspectProps as ElementAspectProps);
 
   return { className, id };
 }
@@ -383,13 +399,17 @@ export function insertFunctionalPartition(
       Omit<InformationPartitionElementProps, "id" | "parent" | "code">
     >,
 ) {
-  const { builder, classFullName, codeValue, parentId, ...partitionProps } = props;
+  const { imodel, classFullName, codeValue, parentId, ...partitionProps } = props;
   const defaultModelClassName: FullClassName = `Functional${props.fullClassNameSeparator ?? "."}FunctionalPartition`;
   const className = classFullName ?? defaultModelClassName;
-  const partitionId = builder.insertElement({
+  const partitionId = imodel.elements.insertElement({
     classFullName: className,
     model: IModel.repositoryModelId,
-    code: builder.createCode(parentId, BisCodeSpec.informationPartitionElement, codeValue),
+    code: new Code({
+      spec: imodel.codeSpecs.getByName(BisCodeSpec.informationPartitionElement).id,
+      scope: parentId,
+      value: codeValue,
+    }),
     parent: { id: parentId, relClassName: `BisCore${props.fullClassNameSeparator ?? "."}SubjectOwnsPartitionElements` },
     ...partitionProps,
   });
@@ -401,10 +421,10 @@ export function insertFunctionalSubModel(
       Omit<GeometricModel3dProps, "id" | "modeledElement" | "parentModel">
     >,
 ) {
-  const { builder, classFullName, modeledElementId, ...modelProps } = props;
+  const { imodel, classFullName, modeledElementId, ...modelProps } = props;
   const defaultModelClassName: FullClassName = `Functional${props.fullClassNameSeparator ?? "."}FunctionalModel`;
   const className = classFullName ?? defaultModelClassName;
-  const modelId = builder.insertModel({
+  const modelId = imodel.models.insertModel({
     classFullName: className,
     modeledElement: { id: modeledElementId },
     ...modelProps,
@@ -420,9 +440,9 @@ export function insertFunctionalElement(
     parentId?: string;
   } & Partial<Omit<FunctionalElementProps, "id" | "parent" | "code" | "model">>,
 ) {
-  const { builder, modelId, representedElementId, relationshipName, parentId, ...elementProps } = props;
+  const { imodel, modelId, representedElementId, relationshipName, parentId, ...elementProps } = props;
   const className = `Functional${props.fullClassNameSeparator ?? "."}FunctionalComposite`;
-  const id = builder.insertElement({
+  const id = imodel.elements.insertElement({
     classFullName: className,
     model: modelId,
     code: Code.createEmpty(),
@@ -431,7 +451,7 @@ export function insertFunctionalElement(
       : undefined,
     ...elementProps,
   } satisfies FunctionalElementProps);
-  builder.insertRelationship({
+  imodel.relationships.insertInstance({
     sourceId: representedElementId,
     targetId: id,
     classFullName: `Functional.${relationshipName}`,
@@ -456,13 +476,17 @@ export function insertGroupInformationPartition(
       Omit<InformationPartitionElementProps, "id" | "parent" | "code">
     >,
 ) {
-  const { builder, classFullName, codeValue, parentId, ...partitionProps } = props;
+  const { imodel, classFullName, codeValue, parentId, ...partitionProps } = props;
   const defaultModelClassName: FullClassName = `BisCore${props.fullClassNameSeparator ?? "."}GroupInformationPartition`;
   const className = classFullName ?? defaultModelClassName;
-  const partitionId = builder.insertElement({
+  const partitionId = imodel.elements.insertElement({
     classFullName: className,
     model: IModel.repositoryModelId,
-    code: builder.createCode(parentId, BisCodeSpec.informationPartitionElement, codeValue),
+    code: new Code({
+      spec: imodel.codeSpecs.getByName(BisCodeSpec.informationPartitionElement).id,
+      scope: parentId,
+      value: codeValue,
+    }),
     parent: { id: parentId, relClassName: `BisCore${props.fullClassNameSeparator ?? "."}SubjectOwnsPartitionElements` },
     ...partitionProps,
   });
@@ -474,10 +498,10 @@ export function insertGroupInformationSubModel(
       Omit<GeometricModel3dProps, "id" | "modeledElement" | "parentModel">
     >,
 ) {
-  const { builder, classFullName, modeledElementId, ...modelProps } = props;
+  const { imodel, classFullName, modeledElementId, ...modelProps } = props;
   const defaultModelClassName: FullClassName = `Generic${props.fullClassNameSeparator ?? "."}GroupModel`;
   const className = classFullName ?? defaultModelClassName;
-  const modelId = builder.insertModel({
+  const modelId = imodel.models.insertModel({
     classFullName: className,
     modeledElement: { id: modeledElementId },
     ...modelProps,
@@ -490,9 +514,9 @@ export function insertGroupInformationElement(
       Omit<FunctionalElementProps, "id" | "parent" | "code" | "model">
     >,
 ) {
-  const { builder, modelId, ...elementProps } = props;
+  const { imodel, modelId, ...elementProps } = props;
   const className = `Generic${props.fullClassNameSeparator ?? "."}Group`;
-  const id = builder.insertElement({
+  const id = imodel.elements.insertElement({
     classFullName: className,
     model: modelId,
     code: Code.createEmpty(),
@@ -504,9 +528,9 @@ export function insertGroupInformationElement(
 export function insertSheetIndexFolder(
   props: BaseInstanceInsertProps & Partial<Omit<SheetIndexFolderProps, "id" | "parent" | "code" | "model">>,
 ) {
-  const { builder, ...elementProps } = props;
+  const { imodel, ...elementProps } = props;
   const className: FullClassName = `BisCore${props.fullClassNameSeparator ?? "."}SheetIndexFolder`;
-  const id = builder.insertElement({
+  const id = imodel.elements.insertElement({
     classFullName: className,
     model: IModel.repositoryModelId,
     code: Code.createEmpty(),

--- a/packages/unified-selection/README.md
+++ b/packages/unified-selection/README.md
@@ -64,7 +64,7 @@ unifiedSelection.selectionChangeEvent.addListener(({ imodelKey, source, changeTy
 // add that something to unified selection. For example:
 const elementKey = { className: "BisCore.PhysicalElement", id: "0x1" };
 unifiedSelection.addToSelection({
-  imodelKey: createIModelKey(imodel),
+  imodelKey: createIModelKey(imodelConnection),
   source: "MyComponent",
   selectables: [elementKey],
 });

--- a/packages/unified-selection/learning/HiliteSets.md
+++ b/packages/unified-selection/learning/HiliteSets.md
@@ -30,7 +30,7 @@ The `@itwin/unified-selection` package delivers APIs for creating a `HiliteSet` 
     imodelAccess: {
       ...schemaProvider,
       ...createCachingECClassHierarchyInspector({ schemaProvider }),
-      ...createECSqlQueryExecutor(imodel),
+      ...createECSqlQueryExecutor(getIModelConnection()),
     },
   });
   const hiliteSetIterator = hiliteProvider.getHiliteSet({ selectables });
@@ -55,7 +55,9 @@ The `@itwin/unified-selection` package delivers APIs for creating a `HiliteSet` 
     // this is called to get iModel accessor based on the iModel key
     imodelProvider: (imodelKey) => getIModelByKey(imodelKey),
   });
-  const hiliteSetIterator = selectionHiliteProvider.getCurrentHiliteSet({ imodelKey: createIModelKey(imodel) });
+  const hiliteSetIterator = selectionHiliteProvider.getCurrentHiliteSet({
+    imodelKey: createIModelKey(imodelConnection),
+  });
   ```
 
    <!-- END EXTRACTION -->

--- a/packages/unified-selection/learning/SelectionScopes.md
+++ b/packages/unified-selection/learning/SelectionScopes.md
@@ -18,7 +18,7 @@ The `@itwin/unified-selection` package delivers a `computeSelection` function fo
 import { computeSelection } from "@itwin/unified-selection";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 
-const queryExecutor = createECSqlQueryExecutor(imodel);
+const queryExecutor = createECSqlQueryExecutor(imodelConnection);
 const selection = computeSelection({ queryExecutor, elementIds, scope: "element" });
 ```
 
@@ -35,7 +35,7 @@ For the `functional` scope, the `ancestorLevel` property is used as follows: if 
 import { computeSelection } from "@itwin/unified-selection";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 
-const queryExecutor = createECSqlQueryExecutor(imodel);
+const queryExecutor = createECSqlQueryExecutor(imodelConnection);
 
 // Returns the parent element, or the element itself if it does not have a parent, for each element specified in `elementIds` argument.
 const selection = computeSelection({ queryExecutor, elementIds, scope: { id: "element", ancestorLevel: 1 } });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1345,6 +1345,9 @@ importers:
 
   packages/test-utilities:
     devDependencies:
+      '@itwin/core-backend':
+        specifier: catalog:itwinjs-core-dev
+        version: 5.8.0(@itwin/core-bentley@5.8.0)(@itwin/core-common@5.8.0(@itwin/core-bentley@5.8.0)(@itwin/core-geometry@5.8.0))(@itwin/core-geometry@5.8.0)(@itwin/ecschema-metadata@5.8.0(@itwin/core-bentley@5.8.0)(@itwin/core-quantity@5.8.0(@itwin/core-bentley@5.8.0)))(@opentelemetry/api@1.9.1)
       '@itwin/core-bentley':
         specifier: catalog:itwinjs-core-dev
         version: 5.8.0
@@ -11036,7 +11039,7 @@ snapshots:
       rimraf: 6.1.3
       tree-kill: 1.2.2
       typedoc: 0.26.11(typescript@5.6.3)
-      typedoc-plugin-merge-modules: 6.1.0(typedoc@0.26.11(typescript@5.7.3))
+      typedoc-plugin-merge-modules: 6.1.0(typedoc@0.26.11(typescript@5.6.3))
       typescript: 5.6.3
       wtfnode: 0.9.4
       yargs: 17.7.2
@@ -17757,7 +17760,7 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typedoc-plugin-merge-modules@6.1.0(typedoc@0.26.11(typescript@5.7.3)):
+  typedoc-plugin-merge-modules@6.1.0(typedoc@0.26.11(typescript@5.6.3)):
     dependencies:
       typedoc: 0.26.11(typescript@5.6.3)
 


### PR DESCRIPTION
Another one in preparation for https://github.com/iTwin/presentation/issues/805. For its full stack tests we'll need to use the `RulesetEmbedder` utility to import the ruleset into test imodels, meaning we'll need access to `IModelDb` rather than some abstraction. The `IModelBuilder` abstraction was a leftover from `@itwin/presentation-testing`, which we don't use anymore anyway, so I removed it and changed `buildTestIModel` to just use `IModelDb` directly. Adjusted all tests.

Also, got rid of the `withECDb` util and replaced it with `buildTestECDb` to be consistent with `buildTestIModel`.