### PR TITLE
`hierarchies-react`: Remove `@stratakit/icons`, `@stratakit/bricks` and `@stratakit/structures` from peer dependencies list

### DIFF
--- a/.changeset/honest-parents-agree.md
+++ b/.changeset/honest-parents-agree.md
@@ -1,0 +1,7 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+Remove `@stratakit/icons`, `@stratakit/bricks` and `@stratakit/structures` from peer dependencies list.
+
+Only `@stratakit/foundations` is required as a peer dependency, the rest of Stratakit packages can be used as direct dependencies.

--- a/.changeset/honest-parents-agree.md
+++ b/.changeset/honest-parents-agree.md
@@ -4,4 +4,4 @@
 
 Remove `@stratakit/icons`, `@stratakit/bricks` and `@stratakit/structures` from peer dependencies list.
 
-Only `@stratakit/foundations` is required as a peer dependency, the rest of Stratakit packages can be used as direct dependencies.
+Only `@stratakit/foundations` is required as a peer dependency when using StrataKit components, the rest of `@stratakit` packages can be used as direct dependencies.

--- a/.changeset/honest-parents-agree.md
+++ b/.changeset/honest-parents-agree.md
@@ -2,6 +2,6 @@
 "@itwin/presentation-hierarchies-react": patch
 ---
 
-Remove `@stratakit/icons`, `@stratakit/bricks` and `@stratakit/structures` from peer dependencies list.
+Remove `@stratakit/bricks` and `@stratakit/structures` from peer dependencies list.
 
-Only `@stratakit/foundations` is required as a peer dependency when using StrataKit components, the rest of `@stratakit` packages can be used as direct dependencies.
+Only `@stratakit/foundations` and `@stratakit/icons` are required as peer dependencies when using StrataKit components, the rest of `@stratakit` packages can be used as direct dependencies.

--- a/apps/test-app/frontend/package.json
+++ b/apps/test-app/frontend/package.json
@@ -40,7 +40,6 @@
     "@itwin/presentation-shared": "workspace:*",
     "@itwin/unified-selection": "workspace:*",
     "@itwin/unified-selection-react": "workspace:*",
-    "@stratakit/bricks": "catalog:stratakit",
     "@stratakit/foundations": "catalog:stratakit",
     "@stratakit/icons": "catalog:stratakit",
     "@stratakit/structures": "catalog:stratakit",

--- a/packages/hierarchies-react/package.json
+++ b/packages/hierarchies-react/package.json
@@ -63,6 +63,9 @@
     "@itwin/presentation-hierarchies": "workspace:*",
     "@itwin/presentation-shared": "workspace:*",
     "@itwin/unified-selection": "workspace:^",
+    "@stratakit/bricks": "catalog:stratakit",
+    "@stratakit/icons": "catalog:stratakit",
+    "@stratakit/structures": "catalog:stratakit",
     "@tanstack/react-virtual": "^3.13.13",
     "classnames": "catalog:react",
     "immer": "^10.2.0",
@@ -71,24 +74,12 @@
     "rxjs": "catalog:rxjs"
   },
   "peerDependencies": {
-    "@stratakit/bricks": "^0.5.4",
     "@stratakit/foundations": "^0.4.7",
-    "@stratakit/icons": "^0.3.1",
-    "@stratakit/structures": "^0.5.6",
     "react": "^17.0 || ^18.0",
     "react-dom": "^17.0 || ^18.0"
   },
   "peerDependenciesMeta": {
-    "@stratakit/bricks": {
-      "optional": true
-    },
     "@stratakit/foundations": {
-      "optional": true
-    },
-    "@stratakit/structures": {
-      "optional": true
-    },
-    "@stratakit/icons": {
       "optional": true
     }
   },
@@ -96,10 +87,7 @@
     "@itwin/build-tools": "catalog:build-tools",
     "@itwin/eslint-plugin": "catalog:build-tools",
     "@rolldown/plugin-babel": "catalog:build-tools",
-    "@stratakit/bricks": "catalog:stratakit",
     "@stratakit/foundations": "catalog:stratakit",
-    "@stratakit/icons": "catalog:stratakit",
-    "@stratakit/structures": "catalog:stratakit",
     "@testing-library/dom": "catalog:test-tools",
     "@testing-library/react": "catalog:test-tools",
     "@testing-library/user-event": "catalog:test-tools",

--- a/packages/hierarchies-react/package.json
+++ b/packages/hierarchies-react/package.json
@@ -64,7 +64,6 @@
     "@itwin/presentation-shared": "workspace:*",
     "@itwin/unified-selection": "workspace:^",
     "@stratakit/bricks": "catalog:stratakit",
-    "@stratakit/icons": "catalog:stratakit",
     "@stratakit/structures": "catalog:stratakit",
     "@tanstack/react-virtual": "^3.13.13",
     "classnames": "catalog:react",
@@ -75,11 +74,15 @@
   },
   "peerDependencies": {
     "@stratakit/foundations": "^0.4.7",
+    "@stratakit/icons": "^0.3.1",
     "react": "^17.0 || ^18.0",
     "react-dom": "^17.0 || ^18.0"
   },
   "peerDependenciesMeta": {
     "@stratakit/foundations": {
+      "optional": true
+    },
+    "@stratakit/icons": {
       "optional": true
     }
   },
@@ -88,6 +91,7 @@
     "@itwin/eslint-plugin": "catalog:build-tools",
     "@rolldown/plugin-babel": "catalog:build-tools",
     "@stratakit/foundations": "catalog:stratakit",
+    "@stratakit/icons": "catalog:stratakit",
     "@testing-library/dom": "catalog:test-tools",
     "@testing-library/react": "catalog:test-tools",
     "@testing-library/user-event": "catalog:test-tools",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -799,9 +799,6 @@ importers:
       '@rolldown/plugin-babel':
         specifier: catalog:build-tools
         version: 0.2.2(@babel/core@7.29.0)(@babel/runtime@7.28.6)(rolldown@1.0.0-rc.13)(vite@8.0.7(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
-      '@stratakit/bricks':
-        specifier: catalog:stratakit
-        version: 0.5.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@stratakit/foundations':
         specifier: catalog:stratakit
         version: 0.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1135,6 +1132,15 @@ importers:
       '@itwin/unified-selection':
         specifier: workspace:^
         version: link:../unified-selection
+      '@stratakit/bricks':
+        specifier: catalog:stratakit
+        version: 0.5.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@stratakit/icons':
+        specifier: catalog:stratakit
+        version: 0.3.1
+      '@stratakit/structures':
+        specifier: catalog:stratakit
+        version: 0.5.6(@types/react@18.3.28)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
       '@tanstack/react-virtual':
         specifier: ^3.13.13
         version: 3.13.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1163,18 +1169,9 @@ importers:
       '@rolldown/plugin-babel':
         specifier: catalog:build-tools
         version: 0.2.2(@babel/core@7.29.0)(@babel/runtime@7.28.6)(rolldown@1.0.0-rc.13)(vite@8.0.7(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
-      '@stratakit/bricks':
-        specifier: catalog:stratakit
-        version: 0.5.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@stratakit/foundations':
         specifier: catalog:stratakit
         version: 0.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@stratakit/icons':
-        specifier: catalog:stratakit
-        version: 0.3.1
-      '@stratakit/structures':
-        specifier: catalog:stratakit
-        version: 0.5.6(@types/react@18.3.28)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
       '@testing-library/dom':
         specifier: catalog:test-tools
         version: 10.4.1
@@ -11039,7 +11036,7 @@ snapshots:
       rimraf: 6.1.3
       tree-kill: 1.2.2
       typedoc: 0.26.11(typescript@5.6.3)
-      typedoc-plugin-merge-modules: 6.1.0(typedoc@0.26.11(typescript@5.6.3))
+      typedoc-plugin-merge-modules: 6.1.0(typedoc@0.26.11(typescript@5.7.3))
       typescript: 5.6.3
       wtfnode: 0.9.4
       yargs: 17.7.2
@@ -17760,7 +17757,7 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typedoc-plugin-merge-modules@6.1.0(typedoc@0.26.11(typescript@5.6.3)):
+  typedoc-plugin-merge-modules@6.1.0(typedoc@0.26.11(typescript@5.7.3)):
     dependencies:
       typedoc: 0.26.11(typescript@5.6.3)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1135,9 +1135,6 @@ importers:
       '@stratakit/bricks':
         specifier: catalog:stratakit
         version: 0.5.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@stratakit/icons':
-        specifier: catalog:stratakit
-        version: 0.3.1
       '@stratakit/structures':
         specifier: catalog:stratakit
         version: 0.5.6(@types/react@18.3.28)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -1172,6 +1169,9 @@ importers:
       '@stratakit/foundations':
         specifier: catalog:stratakit
         version: 0.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@stratakit/icons':
+        specifier: catalog:stratakit
+        version: 0.3.1
       '@testing-library/dom':
         specifier: catalog:test-tools
         version: 10.4.1
@@ -11036,7 +11036,7 @@ snapshots:
       rimraf: 6.1.3
       tree-kill: 1.2.2
       typedoc: 0.26.11(typescript@5.6.3)
-      typedoc-plugin-merge-modules: 6.1.0(typedoc@0.26.11(typescript@5.7.3))
+      typedoc-plugin-merge-modules: 6.1.0(typedoc@0.26.11(typescript@5.6.3))
       typescript: 5.6.3
       wtfnode: 0.9.4
       yargs: 17.7.2
@@ -17757,7 +17757,7 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typedoc-plugin-merge-modules@6.1.0(typedoc@0.26.11(typescript@5.7.3)):
+  typedoc-plugin-merge-modules@6.1.0(typedoc@0.26.11(typescript@5.6.3)):
     dependencies:
       typedoc: 0.26.11(typescript@5.6.3)
 


### PR DESCRIPTION
Only `@stratakit/foundations` is required as a peer dependency, the rest of Stratakit packages can be used as direct dependencies.

We do expose some `Tree` APIs from `@stratakit/structures`, but I think it's okay - they're merely component props. We just have to be careful with transitive breaking changes.