### PR TITLE
[Hierarchies]: adjust `createMergedIModelHierarchyProvider`

### DIFF
--- a/.changeset/purple-dots-knock.md
+++ b/.changeset/purple-dots-knock.md
@@ -2,4 +2,4 @@
 "@itwin/presentation-hierarchies": patch
 ---
 
-Adjust provider created by `createMergedIModelHierarchyProvider` to be more performant when dealing with single imodel.
+Adjust provider created by `createMergedIModelHierarchyProvider` to be more performant when dealing with a single iModel.

--- a/.changeset/purple-dots-knock.md
+++ b/.changeset/purple-dots-knock.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies": patch
+---
+
+Adjust provider created by `createMergedIModelHierarchyProvider` to be more performant when dealing with single imodel.

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
@@ -451,7 +451,7 @@ class IModelHierarchyProviderImpl implements HierarchyProvider {
       targetInstanceKeys?: InstanceKey[];
     } & RequestContextProp,
   ): SourceNodesObservable {
-    const createSourceNodeObservable = (
+    const createSourceNodesFromDefinition = (
       imodelAccess: IModelAccess,
       def: GenericHierarchyNodeDefinition | InstanceNodesQueryDefinition,
     ): Observable<SourceHierarchyNode> => {
@@ -489,13 +489,13 @@ class IModelHierarchyProviderImpl implements HierarchyProvider {
     if (this._imodels.length === 1) {
       sourceNodes = definitions.pipe(
         mergeMap(({ imodelAccess, hierarchyNodesDefinition: def }) =>
-          defer(() => createSourceNodeObservable(imodelAccess, def)),
+          createSourceNodesFromDefinition(imodelAccess, def),
         ),
       );
     } else {
       sourceNodes = definitions.pipe(
         mergeMap(({ imodelAccess, imodelAccessIndex, hierarchyNodesDefinition: def }) =>
-          defer(() => createSourceNodeObservable(imodelAccess, def)).pipe(
+          createSourceNodesFromDefinition(imodelAccess, def).pipe(
             map((node: SourceHierarchyNode) => ({ imodelAccess, imodelAccessIndex, node })),
           ),
         ),

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
@@ -451,44 +451,60 @@ class IModelHierarchyProviderImpl implements HierarchyProvider {
       targetInstanceKeys?: InstanceKey[];
     } & RequestContextProp,
   ): SourceNodesObservable {
-    // pipe definitions to nodes and put "share replay" on it
-    return this.createHierarchyLevelDefinitionsObservable(props).pipe(
-      mergeMap(({ imodelAccess, imodelAccessIndex, hierarchyNodesDefinition: def }) =>
-        defer((): Observable<SourceHierarchyNode> => {
-          if (HierarchyNodesDefinition.isGenericNode(def)) {
-            return of({ ...def.node, key: { type: "generic" as const, id: def.node.key, source: this.#sourceName } });
-          }
-          return this.getQueryScheduler(imodelAccess.imodelKey).scheduleSubscription(
-            of(def.query).pipe(
-              map((query) => createInstanceKeysFilteredQuery(query, props.targetInstanceKeys)),
-              mergeMap((query) =>
-                readNodes({
-                  queryExecutor: imodelAccess,
-                  query,
-                  limit: props.hierarchyLevelSizeLimit,
-                  parser: this._activeHierarchyDefinition.parseNode
-                    ? ({ row }) =>
-                        this._activeHierarchyDefinition.parseNode!({
-                          row,
-                          parentNode: props.parentNode,
-                          imodelKey: imodelAccess.imodelKey,
-                        })
-                    : undefined,
-                }),
-              ),
-              map((node) => ({
-                ...node,
-                key: {
-                  ...node.key,
-                  instanceKeys: node.key.instanceKeys.map((key) => ({ ...key, imodelKey: imodelAccess.imodelKey })),
-                },
-              })),
-            ),
-          );
-        }).pipe(map((node: SourceHierarchyNode) => ({ imodelAccess, imodelAccessIndex, node }))),
-      ),
-      mergeNodes,
-      map(({ node }) => node),
+    const createSourceNodeObservable = (
+      imodelAccess: IModelAccess,
+      def: GenericHierarchyNodeDefinition | InstanceNodesQueryDefinition,
+    ): Observable<SourceHierarchyNode> => {
+      if (HierarchyNodesDefinition.isGenericNode(def)) {
+        return of({ ...def.node, key: { type: "generic" as const, id: def.node.key, source: this.#sourceName } });
+      }
+      const query = createInstanceKeysFilteredQuery(def.query, props.targetInstanceKeys);
+      return this.getQueryScheduler(imodelAccess.imodelKey).scheduleSubscription(
+        readNodes({
+          queryExecutor: imodelAccess,
+          query,
+          limit: props.hierarchyLevelSizeLimit,
+          parser: this._activeHierarchyDefinition.parseNode
+            ? ({ row }) =>
+                this._activeHierarchyDefinition.parseNode!({
+                  row,
+                  parentNode: props.parentNode,
+                  imodelKey: imodelAccess.imodelKey,
+                })
+            : undefined,
+        }).pipe(
+          map((node) => ({
+            ...node,
+            key: {
+              ...node.key,
+              instanceKeys: node.key.instanceKeys.map((key) => ({ ...key, imodelKey: imodelAccess.imodelKey })),
+            },
+          })),
+        ),
+      );
+    };
+
+    const definitions = this.createHierarchyLevelDefinitionsObservable(props);
+    let sourceNodes: Observable<SourceHierarchyNode>;
+    if (this._imodels.length === 1) {
+      sourceNodes = definitions.pipe(
+        mergeMap(({ imodelAccess, hierarchyNodesDefinition: def }) =>
+          defer(() => createSourceNodeObservable(imodelAccess, def)),
+        ),
+      );
+    } else {
+      sourceNodes = definitions.pipe(
+        mergeMap(({ imodelAccess, imodelAccessIndex, hierarchyNodesDefinition: def }) =>
+          defer(() => createSourceNodeObservable(imodelAccess, def)).pipe(
+            map((node: SourceHierarchyNode) => ({ imodelAccess, imodelAccessIndex, node })),
+          ),
+        ),
+        mergeNodes,
+        map(({ node }) => node),
+      );
+    }
+
+    return sourceNodes.pipe(
       finalize(() => {
         /* v8 ignore next -- @preserve */
         doLog({

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
@@ -9,7 +9,6 @@ import {
   catchError,
   concat,
   defaultIfEmpty,
-  defer,
   EMPTY,
   filter,
   finalize,


### PR DESCRIPTION
`createIModelHierarchyProvider` uses `createMergedIModelHierarchyProvider` under the hood. And merged provider does some things that are not needed when there is a single imodel present. 
Adjusted one such place: when getting nodes from hierarchy definition, merged provider merges them in such way:
```ts
readNodes(...),
map((node) => { node, ...propsNeededForMerging}),
reduce((acc, { node, ...propsNeededForMerging}) => {
// merge nodes if they are from different imodels
// and add merged nodes to acc;
//.....
return acc;
}, ...),
mergeAll(), // reduce was there to merge the nodes, mergeAll removes the acc,
map(({ node } ) => node),
finalize(...)
```

The above became this with single imodel:
```ts
readNodes(...),
finalize(...)
```

This is the only place which I've reviewed, might be other places where this can be optimized.