### PR TITLE
`hierarchies`: Remove `createNodesQueryClauseFactory` from public API

### DIFF
--- a/.changeset/define-hierarchy-level-factories.md
+++ b/.changeset/define-hierarchy-level-factories.md
@@ -2,11 +2,13 @@
 "@itwin/presentation-hierarchies": major
 ---
 
-`HierarchyDefinition.defineHierarchyLevel` props (`DefineHierarchyLevelProps`) now includes two new properties: `instanceLabelSelectClauseFactory` and `nodeSelectClauseFactory`.
+**Breaking:** `createNodesQueryClauseFactory` and `NodeSelectClauseColumnNames` are no longer part of the public API.
 
-These factories are automatically created and cached per-iModel by `createIModelHierarchyProvider` and passed to `HierarchyDefinition.defineHierarchyLevel` calls. Consumers may use these factories from props instead of creating their own, unless some custom behavior is required - consumers who need custom behavior can ignore the provided factories and create their own inside `defineHierarchyLevel`.
+The `NodesQueryClauseFactory` is now created internally by `createIModelHierarchyProvider` and passed to `HierarchyDefinition.defineHierarchyLevel` as the `nodeSelectClauseFactory` prop.
 
-While this change can be considered **breaking** as it adds two new required parameters to `defineHierarchyLevel`, it would only affect anyone calling `defineHierarchyLevel` directly, which is not a common scenario as this method is usually called by the presentation hierarchies framework. For typical consumers who are implementing `HierarchyDefinition` and defining `defineHierarchyLevel`, it should not cause any compile-time errors, as the new parameters are passed as a single object and can be easily ignored by using rest/spread operator.
+- Added `instanceLabelSelectClauseFactory` option to `createIModelHierarchyProvider` and `createMergedIModelHierarchyProvider` props, allowing consumers to override the default instance label select clause factory. Defaults to the result of `createIModelInstanceLabelSelectClauseFactory`.
+
+- Added `{ of: ... }` variant to `NodeSelectClauseProps.nodeLabel`, which delegates label select clause creation to the `IInstanceLabelSelectClauseFactory` held by the `NodesQueryClauseFactory`. This replaces the previous pattern of manually calling `instanceLabelSelectClauseFactory.createSelectClause()` and wrapping the result in a selector.
 
 Before:
 
@@ -19,7 +21,6 @@ const hierarchyDefinition: HierarchyDefinition = {
       {
         fullClassName: "SomeClass",
         query: {
-          // use `labelSelectClauseFactory` and `nodeSelectClauseFactory` from the outer scope
           ecsql: `
             SELECT ${await nodeSelectClauseFactory.createSelectClause({
               ecClassId: { selector: "this.ECClassId" },
@@ -38,18 +39,20 @@ const hierarchyDefinition: HierarchyDefinition = {
 After:
 
 ```ts
+// Note: if a custom `IInstanceLabelSelectClauseFactory` is needed, it should be supplied to `createIModelHierarchyProvider`
+// and will be used by `nodeSelectClauseFactory` that is provided to `defineHierarchyLevel`.
 const hierarchyDefinition: HierarchyDefinition = {
-  async defineHierarchyLevel({ instanceLabelSelectClauseFactory, nodeSelectClauseFactory }) {
+  async defineHierarchyLevel({ nodeSelectClauseFactory }) {
     return [
       {
         fullClassName: "SomeClass",
         query: {
-          // use `instanceLabelSelectClauseFactory` and `nodeSelectClauseFactory` from props
           ecsql: `
             SELECT ${await nodeSelectClauseFactory.createSelectClause({
               ecClassId: { selector: "this.ECClassId" },
               ecInstanceId: { selector: "this.ECInstanceId" },
-              nodeLabel: { selector: await instanceLabelSelectClauseFactory.createSelectClause({ classAlias: "this", className: "SomeClass" }) },
+              // Use `{ of: ... }` to delegate label creation to the instance label select clause factory used by `nodeSelectClauseFactory`
+              nodeLabel: { of: { classAlias: "this", className: "SomeClass" } },
             })}
             FROM SomeClass this
           `,

--- a/.changeset/define-hierarchy-level-factories.md
+++ b/.changeset/define-hierarchy-level-factories.md
@@ -4,11 +4,11 @@
 
 **Breaking:** `createNodesQueryClauseFactory` and `NodeSelectClauseColumnNames` are no longer part of the public API.
 
-The `NodesQueryClauseFactory` is now created internally by `createIModelHierarchyProvider` and passed to `HierarchyDefinition.defineHierarchyLevel` as the `nodeSelectClauseFactory` prop.
+The `NodesQueryClauseFactory` is now created internally by `createIModelHierarchyProvider` and its methods (`createSelectClause`, `createFilterClauses`) are passed directly as props to `HierarchyDefinition.defineHierarchyLevel`.
 
 - Added `instanceLabelSelectClauseFactory` option to `createIModelHierarchyProvider` and `createMergedIModelHierarchyProvider` props, allowing consumers to override the default instance label select clause factory. Defaults to the result of `createIModelInstanceLabelSelectClauseFactory`.
 
-- Added `{ of: ... }` variant to `NodeSelectClauseProps.nodeLabel`, which delegates label select clause creation to the `IInstanceLabelSelectClauseFactory` held by the `NodesQueryClauseFactory`. This replaces the previous pattern of manually calling `instanceLabelSelectClauseFactory.createSelectClause()` and wrapping the result in a selector.
+- Added `{ of: ... }` variant to `NodeSelectClauseProps.nodeLabel`, which delegates label select clause creation to the `IInstanceLabelSelectClauseFactory` used by the provided `createSelectClause` function. This replaces the previous pattern of manually calling `instanceLabelSelectClauseFactory.createSelectClause()` and wrapping the result in a selector.
 
 Before:
 
@@ -40,18 +40,18 @@ After:
 
 ```ts
 // Note: if a custom `IInstanceLabelSelectClauseFactory` is needed, it should be supplied to `createIModelHierarchyProvider`
-// and will be used by `nodeSelectClauseFactory` that is provided to `defineHierarchyLevel`.
+// and will be used by the `createSelectClause` function provided to `defineHierarchyLevel`.
 const hierarchyDefinition: HierarchyDefinition = {
-  async defineHierarchyLevel({ nodeSelectClauseFactory }) {
+  async defineHierarchyLevel({ createSelectClause }) {
     return [
       {
         fullClassName: "SomeClass",
         query: {
           ecsql: `
-            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+            SELECT ${await createSelectClause({
               ecClassId: { selector: "this.ECClassId" },
               ecInstanceId: { selector: "this.ECInstanceId" },
-              // Use `{ of: ... }` to delegate label creation to the instance label select clause factory used by `nodeSelectClauseFactory`
+              // Use `{ of: ... }` to delegate label creation to the instance label select clause factory
               nodeLabel: { of: { classAlias: "this", className: "SomeClass" } },
             })}
             FROM SomeClass this

--- a/apps/full-stack-tests/src/hierarchies-react/learning-snippets/Localization.test.tsx
+++ b/apps/full-stack-tests/src/hierarchies-react/learning-snippets/Localization.test.tsx
@@ -70,7 +70,7 @@
 //           ...createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 1000),
 //         };
 //         getHierarchyDefinition = () => ({
-//           defineHierarchyLevel: async ({ instanceLabelSelectClauseFactory, createSelectClause }) => [
+//           defineHierarchyLevel: async ({ createSelectClause }) => [
 //             {
 //               fullClassName: "BisCore.PhysicalModel",
 //               query: {
@@ -80,7 +80,7 @@
 //                       ecClassId: { selector: "this.ECClassId" },
 //                       ecInstanceId: { selector: "this.ECInstanceId" },
 //                       nodeLabel: {
-//                         selector: await instanceLabelSelectClauseFactory.createSelectClause({ classAlias: "this", className: "BisCore.PhysicalModel" }),
+//                         of: { classAlias: "this", className: "BisCore.PhysicalModel" },
 //                       },
 //                       hasChildren: true,
 //                       hideIfNoChildren: false,

--- a/apps/full-stack-tests/src/hierarchies-react/learning-snippets/Localization.test.tsx
+++ b/apps/full-stack-tests/src/hierarchies-react/learning-snippets/Localization.test.tsx
@@ -70,13 +70,13 @@
 //           ...createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 1000),
 //         };
 //         getHierarchyDefinition = () => ({
-//           defineHierarchyLevel: async ({ instanceLabelSelectClauseFactory, nodeSelectClauseFactory }) => [
+//           defineHierarchyLevel: async ({ instanceLabelSelectClauseFactory, createSelectClause }) => [
 //             {
 //               fullClassName: "BisCore.PhysicalModel",
 //               query: {
 //                 ecsql: `
 //                   SELECT
-//                     ${await nodeSelectClauseFactory.createSelectClause({
+//                     ${await createSelectClause({
 //                       ecClassId: { selector: "this.ECClassId" },
 //                       ecInstanceId: { selector: "this.ECInstanceId" },
 //                       nodeLabel: {

--- a/apps/full-stack-tests/src/hierarchies-react/learning-snippets/ReadmeExample.test.tsx
+++ b/apps/full-stack-tests/src/hierarchies-react/learning-snippets/ReadmeExample.test.tsx
@@ -86,13 +86,13 @@
 //         // The hierarchy definition describes the hierarchy using ECSQL queries; here it just returns all `BisCore.PhysicalModel` instances
 //         function getHierarchyDefinition(): HierarchyDefinition {
 //           return {
-//             defineHierarchyLevel: async ({ instanceLabelSelectClauseFactory, nodeSelectClauseFactory }) => [
+//             defineHierarchyLevel: async ({ instanceLabelSelectClauseFactory, createSelectClause }) => [
 //               {
 //                 fullClassName: "BisCore.PhysicalModel",
 //                 query: {
 //                   ecsql: `
 //                     SELECT
-//                       ${await nodeSelectClauseFactory.createSelectClause({
+//                       ${await createSelectClause({
 //                         ecClassId: { selector: "this.ECClassId" },
 //                         ecInstanceId: { selector: "this.ECInstanceId" },
 //                         nodeLabel: {

--- a/apps/full-stack-tests/src/hierarchies-react/learning-snippets/ReadmeExample.test.tsx
+++ b/apps/full-stack-tests/src/hierarchies-react/learning-snippets/ReadmeExample.test.tsx
@@ -86,7 +86,7 @@
 //         // The hierarchy definition describes the hierarchy using ECSQL queries; here it just returns all `BisCore.PhysicalModel` instances
 //         function getHierarchyDefinition(): HierarchyDefinition {
 //           return {
-//             defineHierarchyLevel: async ({ instanceLabelSelectClauseFactory, createSelectClause }) => [
+//             defineHierarchyLevel: async ({ createSelectClause }) => [
 //               {
 //                 fullClassName: "BisCore.PhysicalModel",
 //                 query: {
@@ -96,7 +96,7 @@
 //                         ecClassId: { selector: "this.ECClassId" },
 //                         ecInstanceId: { selector: "this.ECInstanceId" },
 //                         nodeLabel: {
-//                           selector: await instanceLabelSelectClauseFactory.createSelectClause({ classAlias: "this", className: "BisCore.PhysicalModel" }),
+//                           of: { classAlias: "this", className: "BisCore.PhysicalModel" },
 //                         },
 //                         hasChildren: false,
 //                       })}

--- a/apps/full-stack-tests/src/hierarchies/ECCustomAttributesHandling.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/ECCustomAttributesHandling.test.ts
@@ -5,13 +5,11 @@
 
 import { collect } from "presentation-test-utilities";
 import { afterAll, beforeAll, describe, it } from "vitest";
-import { createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 import { buildTestECDb } from "../ECDbUtils.js";
 import { initialize, terminate } from "../IntegrationTests.js";
 import { importSchema } from "../SchemaUtils.js";
 import { NodeValidators, validateHierarchyLevel } from "./HierarchyValidation.js";
-import { createIModelAccess, createProvider } from "./Utils.js";
+import { createProvider } from "./Utils.js";
 
 import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
 
@@ -43,14 +41,9 @@ describe("Hierarchies", () => {
           return { schema: s, x };
         });
         const { ecdb, schema, ...keys } = setup;
-        const imodelAccess = createIModelAccess(ecdb);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ instanceFilter }) {
-            const filterClauses = await selectQueryFactory.createFilterClauses({
+          async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
+            const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
               filter: instanceFilter,
               contentClass: { fullName: schema.items.X.fullName, alias: "this" },
             });
@@ -59,7 +52,7 @@ describe("Hierarchies", () => {
                 fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: "x",
@@ -101,14 +94,9 @@ describe("Hierarchies", () => {
           return { schema: s, x, y };
         });
         const { ecdb, schema, ...keys } = setup;
-        const imodelAccess = createIModelAccess(ecdb);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ instanceFilter }) {
-            const filterClauses = await selectQueryFactory.createFilterClauses({
+          async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
+            const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
               filter: instanceFilter,
               contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
             });
@@ -117,7 +105,7 @@ describe("Hierarchies", () => {
                 fullClassName: schema.items.Y.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: "y",
@@ -177,14 +165,9 @@ describe("Hierarchies", () => {
           return { schema: s, x, y, z, w };
         });
         const { ecdb, schema, ...keys } = setup;
-        const imodelAccess = createIModelAccess(ecdb);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ instanceFilter }) {
-            const filterClauses = await selectQueryFactory.createFilterClauses({
+          async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
+            const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
               filter: instanceFilter,
               contentClass: { fullName: schema.items.X.fullName, alias: "this" },
             });
@@ -193,7 +176,7 @@ describe("Hierarchies", () => {
                 fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `ec_classname(this.ECClassId, 'c')` },
@@ -235,14 +218,9 @@ describe("Hierarchies", () => {
           return { schema: s, x };
         });
         const { ecdb, schema, ...keys } = setup;
-        const imodelAccess = createIModelAccess(ecdb);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ instanceFilter }) {
-            const filterClauses = await selectQueryFactory.createFilterClauses({
+          async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
+            const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
               filter: instanceFilter,
               contentClass: { fullName: schema.items.X.fullName, alias: "this" },
             });
@@ -251,7 +229,7 @@ describe("Hierarchies", () => {
                 fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: "x",
@@ -299,14 +277,9 @@ describe("Hierarchies", () => {
           return { hiddenSchema, nonHiddenSchema, x, y };
         });
         const { ecdb, nonHiddenSchema: schema, ...keys } = setup;
-        const imodelAccess = createIModelAccess(ecdb);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ instanceFilter }) {
-            const filterClauses = await selectQueryFactory.createFilterClauses({
+          async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
+            const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
               filter: instanceFilter,
               contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
             });
@@ -315,7 +288,7 @@ describe("Hierarchies", () => {
                 fullClassName: schema.items.Y.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: "y",
@@ -396,14 +369,9 @@ describe("Hierarchies", () => {
           return { xSchema, ySchema, zSchema, wSchema, x, y, z, w };
         });
         const { ecdb, xSchema: schema, ...keys } = setup;
-        const imodelAccess = createIModelAccess(ecdb);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ instanceFilter }) {
-            const filterClauses = await selectQueryFactory.createFilterClauses({
+          async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
+            const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
               filter: instanceFilter,
               contentClass: { fullName: schema.items.X.fullName, alias: "this" },
             });
@@ -412,7 +380,7 @@ describe("Hierarchies", () => {
                 fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `ec_classname(this.ECClassId, 'c')` },

--- a/apps/full-stack-tests/src/hierarchies/ECCustomAttributesHandling.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/ECCustomAttributesHandling.test.ts
@@ -42,8 +42,8 @@ describe("Hierarchies", () => {
         });
         const { ecdb, schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
-            const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
+          async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
+            const filterClauses = await createFilterClauses({
               filter: instanceFilter,
               contentClass: { fullName: schema.items.X.fullName, alias: "this" },
             });
@@ -52,7 +52,7 @@ describe("Hierarchies", () => {
                 fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: "x",
@@ -95,8 +95,8 @@ describe("Hierarchies", () => {
         });
         const { ecdb, schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
-            const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
+          async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
+            const filterClauses = await createFilterClauses({
               filter: instanceFilter,
               contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
             });
@@ -105,7 +105,7 @@ describe("Hierarchies", () => {
                 fullClassName: schema.items.Y.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: "y",
@@ -166,8 +166,8 @@ describe("Hierarchies", () => {
         });
         const { ecdb, schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
-            const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
+          async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
+            const filterClauses = await createFilterClauses({
               filter: instanceFilter,
               contentClass: { fullName: schema.items.X.fullName, alias: "this" },
             });
@@ -176,7 +176,7 @@ describe("Hierarchies", () => {
                 fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `ec_classname(this.ECClassId, 'c')` },
@@ -219,8 +219,8 @@ describe("Hierarchies", () => {
         });
         const { ecdb, schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
-            const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
+          async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
+            const filterClauses = await createFilterClauses({
               filter: instanceFilter,
               contentClass: { fullName: schema.items.X.fullName, alias: "this" },
             });
@@ -229,7 +229,7 @@ describe("Hierarchies", () => {
                 fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: "x",
@@ -278,8 +278,8 @@ describe("Hierarchies", () => {
         });
         const { ecdb, nonHiddenSchema: schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
-            const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
+          async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
+            const filterClauses = await createFilterClauses({
               filter: instanceFilter,
               contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
             });
@@ -288,7 +288,7 @@ describe("Hierarchies", () => {
                 fullClassName: schema.items.Y.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: "y",
@@ -370,8 +370,8 @@ describe("Hierarchies", () => {
         });
         const { ecdb, xSchema: schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
-            const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
+          async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
+            const filterClauses = await createFilterClauses({
               filter: instanceFilter,
               contentClass: { fullName: schema.items.X.fullName, alias: "this" },
             });
@@ -380,7 +380,7 @@ describe("Hierarchies", () => {
                 fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `ec_classname(this.ECClassId, 'c')` },

--- a/apps/full-stack-tests/src/hierarchies/Formatting.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/Formatting.test.ts
@@ -19,13 +19,7 @@ import { Subject } from "@itwin/core-backend";
 import { Guid, Id64 } from "@itwin/core-bentley";
 import { IModel } from "@itwin/core-common";
 import { createValueFormatter } from "@itwin/presentation-core-interop";
-import { createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
-import {
-  createIModelInstanceLabelSelectClauseFactory,
-  ECSql,
-  julianToDateTime,
-  normalizeFullClassName,
-} from "@itwin/presentation-shared";
+import { ECSql, julianToDateTime, normalizeFullClassName } from "@itwin/presentation-shared";
 import { buildTestIModel } from "../IModelUtils.js";
 import { initialize, terminate } from "../IntegrationTests.js";
 import { importSchema } from "../SchemaUtils.js";
@@ -121,20 +115,15 @@ describe("Hierarchies", () => {
           return { schema, model, category, element };
         });
         const imodelAccess = createIModelAccess(imodelConnection);
-
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.ClassX.fullName,
                   query: {
                     ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -235,19 +224,15 @@ describe("Hierarchies", () => {
     describe("DateTime", () => {
       it("formats instance node labels", async () => {
         const imodelAccess = createIModelAccess(emptyIModel);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -371,20 +356,15 @@ describe("Hierarchies", () => {
           return { modelClassName: m2.className };
         });
         const imodelAccess = createIModelAccess(imodelConnection);
-
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: modelClassName,
                   query: {
                     ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -452,20 +432,15 @@ describe("Hierarchies", () => {
           return { sheetIndexFolder: insertSheetIndexFolder({ imodel, entryPriority: 2 }) };
         });
         const imodelAccess = createIModelAccess(imodelConnection);
-
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: sheetIndexFolder.className,
                   query: {
                     ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -538,20 +513,15 @@ describe("Hierarchies", () => {
           return { model, category, element };
         });
         const imodelAccess = createIModelAccess(imodelConnection);
-
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: element.className,
                   query: {
                     ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -625,20 +595,15 @@ describe("Hierarchies", () => {
           return { model, category, element };
         });
         const imodelAccess = createIModelAccess(imodelConnection);
-
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: element.className,
                   query: {
                     ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -712,20 +677,15 @@ describe("Hierarchies", () => {
           return { model, category, element };
         });
         const imodelAccess = createIModelAccess(imodelConnection);
-
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: element.className,
                   query: {
                     ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -800,20 +760,15 @@ describe("Hierarchies", () => {
           return { model, category, element };
         });
         const imodelAccess = createIModelAccess(imodelConnection);
-
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: element.className,
                   query: {
                     ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -852,20 +807,15 @@ describe("Hierarchies", () => {
     });
 
     it("reacts to changed formatter without running queries", async () => {
-      const imodelAccess = createIModelAccess(emptyIModel);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: subjectClassName,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.UserLabel` },

--- a/apps/full-stack-tests/src/hierarchies/Formatting.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/Formatting.test.ts
@@ -116,14 +116,14 @@ describe("Hierarchies", () => {
         });
         const imodelAccess = createIModelAccess(imodelConnection);
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.ClassX.fullName,
                   query: {
                     ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -225,14 +225,14 @@ describe("Hierarchies", () => {
       it("formats instance node labels", async () => {
         const imodelAccess = createIModelAccess(emptyIModel);
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -357,14 +357,14 @@ describe("Hierarchies", () => {
         });
         const imodelAccess = createIModelAccess(imodelConnection);
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: modelClassName,
                   query: {
                     ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -433,14 +433,14 @@ describe("Hierarchies", () => {
         });
         const imodelAccess = createIModelAccess(imodelConnection);
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: sheetIndexFolder.className,
                   query: {
                     ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -514,14 +514,14 @@ describe("Hierarchies", () => {
         });
         const imodelAccess = createIModelAccess(imodelConnection);
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: element.className,
                   query: {
                     ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -596,14 +596,14 @@ describe("Hierarchies", () => {
         });
         const imodelAccess = createIModelAccess(imodelConnection);
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: element.className,
                   query: {
                     ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -678,14 +678,14 @@ describe("Hierarchies", () => {
         });
         const imodelAccess = createIModelAccess(imodelConnection);
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: element.className,
                   query: {
                     ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -761,14 +761,14 @@ describe("Hierarchies", () => {
         });
         const imodelAccess = createIModelAccess(imodelConnection);
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: element.className,
                   query: {
                     ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: {
@@ -808,14 +808,14 @@ describe("Hierarchies", () => {
 
     it("reacts to changed formatter without running queries", async () => {
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: subjectClassName,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.UserLabel` },

--- a/apps/full-stack-tests/src/hierarchies/HierarchyLevelFiltering.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchyLevelFiltering.test.ts
@@ -40,8 +40,8 @@ describe("Hierarchies", () => {
       });
       const { ecdb, schema, ...keys } = setup;
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
-          const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
+        async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
+          const filterClauses = await createFilterClauses({
             filter: instanceFilter,
             contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
@@ -50,7 +50,7 @@ describe("Hierarchies", () => {
               fullClassName: schema.items.X.fullName,
               query: {
                 ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.Prop` },
@@ -112,8 +112,8 @@ describe("Hierarchies", () => {
       });
       const { ecdb, schema, ...keys } = setup;
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
-          const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
+        async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
+          const filterClauses = await createFilterClauses({
             filter: instanceFilter,
             contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
           });
@@ -122,7 +122,7 @@ describe("Hierarchies", () => {
               fullClassName: schema.items.Y.fullName,
               query: {
                 ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
@@ -188,8 +188,8 @@ describe("Hierarchies", () => {
       });
       const { ecdb, schema, ...keys } = setup;
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
-          const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
+        async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
+          const filterClauses = await createFilterClauses({
             filter: instanceFilter,
             contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
           });
@@ -198,7 +198,7 @@ describe("Hierarchies", () => {
               fullClassName: schema.items.Y.fullName,
               query: {
                 ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
@@ -271,8 +271,8 @@ describe("Hierarchies", () => {
       });
       const { ecdb, schema, ...keys } = setup;
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
-          const subjectFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
+        async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
+          const subjectFilterClauses = await createFilterClauses({
             filter: instanceFilter,
             contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
@@ -281,7 +281,7 @@ describe("Hierarchies", () => {
               fullClassName: schema.items.X.fullName,
               query: {
                 ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
@@ -336,8 +336,8 @@ describe("Hierarchies", () => {
       });
       const { ecdb, schema, ...keys } = setup;
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
-          const subjectFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
+        async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
+          const subjectFilterClauses = await createFilterClauses({
             filter: instanceFilter,
             contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
@@ -346,7 +346,7 @@ describe("Hierarchies", () => {
               fullClassName: schema.items.X.fullName,
               query: {
                 ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
@@ -401,8 +401,8 @@ describe("Hierarchies", () => {
       });
       const { ecdb, schema, ...keys } = setup;
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
-          const subjectFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
+        async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
+          const subjectFilterClauses = await createFilterClauses({
             filter: instanceFilter,
             contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
@@ -411,7 +411,7 @@ describe("Hierarchies", () => {
               fullClassName: schema.items.X.fullName,
               query: {
                 ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
@@ -484,8 +484,8 @@ describe("Hierarchies", () => {
       });
       const { ecdb, schema, ...keys } = setup;
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
-          const subjectFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
+        async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
+          const subjectFilterClauses = await createFilterClauses({
             filter: instanceFilter,
             contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
@@ -494,7 +494,7 @@ describe("Hierarchies", () => {
               fullClassName: schema.items.X.fullName,
               query: {
                 ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },

--- a/apps/full-stack-tests/src/hierarchies/HierarchyLevelFiltering.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchyLevelFiltering.test.ts
@@ -5,13 +5,11 @@
 
 import { collect } from "presentation-test-utilities";
 import { afterAll, beforeAll, describe, it } from "vitest";
-import { createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 import { buildTestECDb } from "../ECDbUtils.js";
 import { initialize, terminate } from "../IntegrationTests.js";
 import { importSchema } from "../SchemaUtils.js";
 import { NodeValidators, validateHierarchyLevel } from "./HierarchyValidation.js";
-import { createIModelAccess, createProvider } from "./Utils.js";
+import { createProvider } from "./Utils.js";
 
 import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
 
@@ -41,14 +39,9 @@ describe("Hierarchies", () => {
         return { schema: s, x1, x2 };
       });
       const { ecdb, schema, ...keys } = setup;
-      const imodelAccess = createIModelAccess(ecdb);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ instanceFilter }) {
-          const filterClauses = await selectQueryFactory.createFilterClauses({
+        async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
+          const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
             filter: instanceFilter,
             contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
@@ -57,7 +50,7 @@ describe("Hierarchies", () => {
               fullClassName: schema.items.X.fullName,
               query: {
                 ecsql: `
-                  SELECT ${await selectQueryFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.Prop` },
@@ -118,14 +111,9 @@ describe("Hierarchies", () => {
         return { schema: s, x, y1, y2 };
       });
       const { ecdb, schema, ...keys } = setup;
-      const imodelAccess = createIModelAccess(ecdb);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ instanceFilter }) {
-          const filterClauses = await selectQueryFactory.createFilterClauses({
+        async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
+          const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
             filter: instanceFilter,
             contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
           });
@@ -134,7 +122,7 @@ describe("Hierarchies", () => {
               fullClassName: schema.items.Y.fullName,
               query: {
                 ecsql: `
-                  SELECT ${await selectQueryFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
@@ -199,14 +187,9 @@ describe("Hierarchies", () => {
         return { schema: s, x, y1, y2 };
       });
       const { ecdb, schema, ...keys } = setup;
-      const imodelAccess = createIModelAccess(ecdb);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ instanceFilter }) {
-          const filterClauses = await selectQueryFactory.createFilterClauses({
+        async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
+          const filterClauses = await nodeSelectClauseFactory.createFilterClauses({
             filter: instanceFilter,
             contentClass: { fullName: schema.items.Y.fullName, alias: "this" },
           });
@@ -215,7 +198,7 @@ describe("Hierarchies", () => {
               fullClassName: schema.items.Y.fullName,
               query: {
                 ecsql: `
-                  SELECT ${await selectQueryFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
@@ -287,14 +270,9 @@ describe("Hierarchies", () => {
         return { schema: s, x, y };
       });
       const { ecdb, schema, ...keys } = setup;
-      const imodelAccess = createIModelAccess(ecdb);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ instanceFilter }) {
-          const subjectFilterClauses = await selectQueryFactory.createFilterClauses({
+        async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
+          const subjectFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
             filter: instanceFilter,
             contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
@@ -303,7 +281,7 @@ describe("Hierarchies", () => {
               fullClassName: schema.items.X.fullName,
               query: {
                 ecsql: `
-                  SELECT ${await selectQueryFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
@@ -357,14 +335,9 @@ describe("Hierarchies", () => {
         return { schema: s, x, y };
       });
       const { ecdb, schema, ...keys } = setup;
-      const imodelAccess = createIModelAccess(ecdb);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ instanceFilter }) {
-          const subjectFilterClauses = await selectQueryFactory.createFilterClauses({
+        async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
+          const subjectFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
             filter: instanceFilter,
             contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
@@ -373,7 +346,7 @@ describe("Hierarchies", () => {
               fullClassName: schema.items.X.fullName,
               query: {
                 ecsql: `
-                  SELECT ${await selectQueryFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
@@ -427,14 +400,9 @@ describe("Hierarchies", () => {
         return { schema: s, x1, x2 };
       });
       const { ecdb, schema, ...keys } = setup;
-      const imodelAccess = createIModelAccess(ecdb);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ instanceFilter }) {
-          const subjectFilterClauses = await selectQueryFactory.createFilterClauses({
+        async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
+          const subjectFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
             filter: instanceFilter,
             contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
@@ -443,7 +411,7 @@ describe("Hierarchies", () => {
               fullClassName: schema.items.X.fullName,
               query: {
                 ecsql: `
-                  SELECT ${await selectQueryFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },
@@ -515,14 +483,9 @@ describe("Hierarchies", () => {
         return { schema: s, x1, x2 };
       });
       const { ecdb, schema, ...keys } = setup;
-      const imodelAccess = createIModelAccess(ecdb);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ instanceFilter }) {
-          const subjectFilterClauses = await selectQueryFactory.createFilterClauses({
+        async defineHierarchyLevel({ instanceFilter, nodeSelectClauseFactory }) {
+          const subjectFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
             filter: instanceFilter,
             contentClass: { fullName: schema.items.X.fullName, alias: "this" },
           });
@@ -531,7 +494,7 @@ describe("Hierarchies", () => {
               fullClassName: schema.items.X.fullName,
               query: {
                 ecsql: `
-                  SELECT ${await selectQueryFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `CAST(this.ECInstanceId AS TEXT)` },

--- a/apps/full-stack-tests/src/hierarchies/HierarchyLevelInstanceKeys.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchyLevelInstanceKeys.test.ts
@@ -32,13 +32,13 @@ describe("Hierarchies", () => {
 
     it("gets instance keys for root hierarchy level", async () => {
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ createSelectClause }) {
           return [
             {
               fullClassName: normalizeFullClassName(Subject.classFullName),
               query: {
                 ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.CodeValue` },
@@ -58,7 +58,7 @@ describe("Hierarchies", () => {
     it("gets instance keys for instance node's child hierarchy level", async () => {
       const rootSubjectKey: InstanceKey = { className: normalizeFullClassName(Subject.classFullName), id: "0x1" };
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (
             parentNode &&
             HierarchyNode.isInstancesNode(parentNode) &&
@@ -69,7 +69,7 @@ describe("Hierarchies", () => {
                 fullClassName: normalizeFullClassName(Subject.classFullName),
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `p.CodeValue` },
@@ -102,14 +102,14 @@ describe("Hierarchies", () => {
 
     it("gets instance keys for generic node's child hierarchy level", async () => {
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (parentNode && HierarchyNode.isGeneric(parentNode) && parentNode.key.id === "test") {
             return [
               {
                 fullClassName: normalizeFullClassName(Subject.classFullName),
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.CodeValue` },
@@ -137,14 +137,14 @@ describe("Hierarchies", () => {
     it("gets instance keys for hidden instance node's child hierarchy level", async () => {
       const rootSubjectKey: InstanceKey = { className: normalizeFullClassName(Subject.classFullName), id: "0x1" };
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: normalizeFullClassName(Subject.classFullName),
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.CodeValue` },
@@ -165,7 +165,7 @@ describe("Hierarchies", () => {
                 fullClassName: normalizeFullClassName(Subject.classFullName),
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `p.CodeValue` },
@@ -192,7 +192,7 @@ describe("Hierarchies", () => {
 
     it("gets instance keys for hidden generic node's child hierarchy level", async () => {
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               { node: { key: "test", label: "hidden custom node", processingParams: { hideInHierarchy: true } } },
@@ -204,7 +204,7 @@ describe("Hierarchies", () => {
                 fullClassName: normalizeFullClassName(Subject.classFullName),
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.CodeValue` },

--- a/apps/full-stack-tests/src/hierarchies/HierarchyLevelInstanceKeys.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchyLevelInstanceKeys.test.ts
@@ -6,15 +6,11 @@
 import { collect } from "presentation-test-utilities";
 import { afterAll, describe, expect, it, test } from "vitest";
 import { DictionaryModel, InformationPartitionElement, LinkModel, Model, Subject } from "@itwin/core-backend";
-import { createNodesQueryClauseFactory, HierarchyNode } from "@itwin/presentation-hierarchies";
-import {
-  createIModelInstanceLabelSelectClauseFactory,
-  InstanceKey,
-  normalizeFullClassName,
-} from "@itwin/presentation-shared";
+import { HierarchyNode } from "@itwin/presentation-hierarchies";
+import { InstanceKey, normalizeFullClassName } from "@itwin/presentation-shared";
 import { buildTestIModel } from "../IModelUtils.js";
 import { initialize, terminate } from "../IntegrationTests.js";
-import { createClassECSqlSelector, createIModelAccess, createProvider } from "./Utils.js";
+import { createClassECSqlSelector, createProvider } from "./Utils.js";
 
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
@@ -35,19 +31,14 @@ describe("Hierarchies", () => {
     });
 
     it("gets instance keys for root hierarchy level", async () => {
-      const imodelAccess = createIModelAccess(imodel);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel() {
+        async defineHierarchyLevel({ nodeSelectClauseFactory }) {
           return [
             {
               fullClassName: normalizeFullClassName(Subject.classFullName),
               query: {
                 ecsql: `
-                  SELECT ${await selectQueryFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.CodeValue` },
@@ -66,13 +57,8 @@ describe("Hierarchies", () => {
 
     it("gets instance keys for instance node's child hierarchy level", async () => {
       const rootSubjectKey: InstanceKey = { className: normalizeFullClassName(Subject.classFullName), id: "0x1" };
-      const imodelAccess = createIModelAccess(imodel);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (
             parentNode &&
             HierarchyNode.isInstancesNode(parentNode) &&
@@ -83,7 +69,7 @@ describe("Hierarchies", () => {
                 fullClassName: normalizeFullClassName(Subject.classFullName),
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `p.CodeValue` },
@@ -115,20 +101,15 @@ describe("Hierarchies", () => {
     });
 
     it("gets instance keys for generic node's child hierarchy level", async () => {
-      const imodelAccess = createIModelAccess(imodel);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (parentNode && HierarchyNode.isGeneric(parentNode) && parentNode.key.id === "test") {
             return [
               {
                 fullClassName: normalizeFullClassName(Subject.classFullName),
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.CodeValue` },
@@ -155,20 +136,15 @@ describe("Hierarchies", () => {
 
     it("gets instance keys for hidden instance node's child hierarchy level", async () => {
       const rootSubjectKey: InstanceKey = { className: normalizeFullClassName(Subject.classFullName), id: "0x1" };
-      const imodelAccess = createIModelAccess(imodel);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: normalizeFullClassName(Subject.classFullName),
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.CodeValue` },
@@ -189,7 +165,7 @@ describe("Hierarchies", () => {
                 fullClassName: normalizeFullClassName(Subject.classFullName),
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `p.CodeValue` },
@@ -215,13 +191,8 @@ describe("Hierarchies", () => {
     });
 
     it("gets instance keys for hidden generic node's child hierarchy level", async () => {
-      const imodelAccess = createIModelAccess(imodel);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               { node: { key: "test", label: "hidden custom node", processingParams: { hideInHierarchy: true } } },
@@ -233,7 +204,7 @@ describe("Hierarchies", () => {
                 fullClassName: normalizeFullClassName(Subject.classFullName),
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.CodeValue` },

--- a/apps/full-stack-tests/src/hierarchies/HierarchySearch.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchySearch.test.ts
@@ -65,14 +65,14 @@ describe("Hierarchies", () => {
           return { rootSubject, childSubject1, childSubject2 };
         });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: "root subject",
@@ -101,7 +101,7 @@ describe("Hierarchies", () => {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.CodeValue` },
@@ -170,14 +170,14 @@ describe("Hierarchies", () => {
         });
 
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: "root subject",
@@ -303,7 +303,7 @@ describe("Hierarchies", () => {
           return { rootSubject, childSubject1, childSubject21, childSubject22, childSubject3 };
         });
         const createHierarchyLevelDefinition = async (
-          nodeSelectClauseFactory: DefineHierarchyLevelProps["nodeSelectClauseFactory"],
+          createSelectClause: DefineHierarchyLevelProps["createSelectClause"],
           whereClause: (alias: string) => string,
         ) => {
           return [
@@ -311,7 +311,7 @@ describe("Hierarchies", () => {
               fullClassName: subjectClassName,
               query: {
                 ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.CodeValue` },
@@ -326,23 +326,23 @@ describe("Hierarchies", () => {
         };
 
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return createHierarchyLevelDefinition(
-                nodeSelectClauseFactory,
+                createSelectClause,
                 (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.childSubject1.id}`,
               );
             }
             if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 1") {
               return createHierarchyLevelDefinition(
-                nodeSelectClauseFactory,
+                createSelectClause,
                 (alias: string) =>
                   `WHERE ${alias}.ECInstanceId IN (${keys.childSubject21.id}, ${keys.childSubject22.id})`,
               );
             }
             if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 2.1") {
               return createHierarchyLevelDefinition(
-                nodeSelectClauseFactory,
+                createSelectClause,
                 (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.childSubject3.id}`,
               );
             }
@@ -437,7 +437,7 @@ describe("Hierarchies", () => {
           return { rootSubject, childSubject1, childSubject2, childSubject3, childSubject4 };
         });
         const createHierarchyLevelDefinition = async (
-          nodeSelectClauseFactory: DefineHierarchyLevelProps["nodeSelectClauseFactory"],
+          createSelectClause: DefineHierarchyLevelProps["createSelectClause"],
           whereClause: (alias: string) => string,
         ) => {
           return [
@@ -445,7 +445,7 @@ describe("Hierarchies", () => {
               fullClassName: subjectClassName,
               query: {
                 ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.CodeValue` },
@@ -459,10 +459,10 @@ describe("Hierarchies", () => {
         };
 
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return createHierarchyLevelDefinition(
-                nodeSelectClauseFactory,
+                createSelectClause,
                 (alias: string) =>
                   `WHERE ${alias}.ECInstanceId IN (${keys.childSubject1.id}, ${keys.childSubject4.id})`,
               );
@@ -473,14 +473,14 @@ describe("Hierarchies", () => {
               parentNode.parentKeys.length === 0
             ) {
               return createHierarchyLevelDefinition(
-                nodeSelectClauseFactory,
+                createSelectClause,
                 (alias: string) =>
                   `WHERE ${alias}.ECInstanceId IN (${keys.childSubject2.id}, ${keys.childSubject3.id})`,
               );
             }
             if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 4") {
               return createHierarchyLevelDefinition(
-                nodeSelectClauseFactory,
+                createSelectClause,
                 (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.childSubject1.id}`,
               );
             }
@@ -490,7 +490,7 @@ describe("Hierarchies", () => {
               parentNode.parentKeys.length === 1
             ) {
               return createHierarchyLevelDefinition(
-                nodeSelectClauseFactory,
+                createSelectClause,
                 (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.childSubject2.id}`,
               );
             }
@@ -576,14 +576,14 @@ describe("Hierarchies", () => {
           };
         });
         const createHierarchyLevelDefinition = async (
-          nodeSelectClauseFactory: DefineHierarchyLevelProps["nodeSelectClauseFactory"],
+          createSelectClause: DefineHierarchyLevelProps["createSelectClause"],
           whereClause: (alias: string) => string,
         ) => [
           {
             fullClassName: subjectClassName,
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: `this.ECClassId` },
                   ecInstanceId: { selector: `this.ECInstanceId` },
                   nodeLabel: { selector: `this.CodeValue` },
@@ -595,24 +595,24 @@ describe("Hierarchies", () => {
           },
         ];
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return createHierarchyLevelDefinition(
-                nodeSelectClauseFactory,
+                createSelectClause,
                 (alias: string) =>
                   `WHERE ${alias}.ECInstanceId IN (${keys.childSubject1.id}, ${keys.childSubject2.id})`,
               );
             }
             if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 2") {
               return createHierarchyLevelDefinition(
-                nodeSelectClauseFactory,
+                createSelectClause,
                 (alias: string) =>
                   `WHERE ${alias}.ECInstanceId IN (${keys.childSubject21.id}, ${keys.childSubject22.id})`,
               );
             }
             if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 22") {
               return createHierarchyLevelDefinition(
-                nodeSelectClauseFactory,
+                createSelectClause,
                 (alias: string) =>
                   `WHERE ${alias}.ECInstanceId IN (${keys.childSubject221.id}, ${keys.childSubject222.id})`,
               );
@@ -688,14 +688,14 @@ describe("Hierarchies", () => {
         });
 
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: "root subject",
@@ -725,7 +725,7 @@ describe("Hierarchies", () => {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.CodeValue` },
@@ -791,14 +791,14 @@ describe("Hierarchies", () => {
         });
 
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: "root subject",
@@ -828,7 +828,7 @@ describe("Hierarchies", () => {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.CodeValue` },
@@ -873,14 +873,14 @@ describe("Hierarchies", () => {
         });
 
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: "root subject",
@@ -897,7 +897,7 @@ describe("Hierarchies", () => {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.CodeValue` },
@@ -917,7 +917,7 @@ describe("Hierarchies", () => {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.CodeValue` },
@@ -968,14 +968,14 @@ describe("Hierarchies", () => {
         });
         const { ecdb, schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
                             nodeLabel: "x",
@@ -992,7 +992,7 @@ describe("Hierarchies", () => {
                   fullClassName: schema.items.Y.fullName,
                   query: {
                     ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
                             nodeLabel: "y",
@@ -1006,7 +1006,7 @@ describe("Hierarchies", () => {
                   fullClassName: schema.items.Z.fullName,
                   query: {
                     ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
                             nodeLabel: "z",
@@ -1066,14 +1066,14 @@ describe("Hierarchies", () => {
         });
         const { ecdb, schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
                             nodeLabel: "x",
@@ -1090,7 +1090,7 @@ describe("Hierarchies", () => {
                   fullClassName: schema.items.Y.fullName,
                   query: {
                     ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
                             nodeLabel: "y",
@@ -1153,7 +1153,7 @@ describe("Hierarchies", () => {
 
         const rootNodeKey: GenericNodeKey = { type: "generic", id: "root-node" };
         const hierarchy: HierarchyDefinition = {
-          defineHierarchyLevel: async ({ nodeSelectClauseFactory, ...props }) => {
+          defineHierarchyLevel: async ({ createSelectClause, ...props }) => {
             if (!props.parentNode) {
               return [{ node: { key: rootNodeKey.id, label: "Root" } }];
             }
@@ -1163,7 +1163,7 @@ describe("Hierarchies", () => {
                 fullClassName: "BisCore.PhysicalElement",
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecInstanceId: { selector: "this.ECInstanceId" },
                       ecClassId: { selector: "this.ECClassId" },
                       nodeLabel: { selector: "idToHex(this.ECInstanceId)" },
@@ -1228,7 +1228,7 @@ describe("Hierarchies", () => {
 
         const rootNodeKey: GenericNodeKey = { type: "generic", id: "root-node" };
         const hierarchy: HierarchyDefinition = {
-          defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+          defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
             if (!parentNode) {
               return [{ node: { key: rootNodeKey.id, label: "Root" } }];
             }
@@ -1237,7 +1237,7 @@ describe("Hierarchies", () => {
                 fullClassName: "BisCore.PhysicalElement",
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecInstanceId: { selector: "this.ECInstanceId" },
                       ecClassId: { selector: "this.ECClassId" },
                       nodeLabel: { selector: "idToHex(this.ECInstanceId)" },
@@ -1352,7 +1352,7 @@ describe("Hierarchies", () => {
           imodelConnection = result.imodelConnection;
 
           hierarchy = {
-            defineHierarchyLevel: async ({ nodeSelectClauseFactory, ...props }) => {
+            defineHierarchyLevel: async ({ createSelectClause, ...props }) => {
               if (!props.parentNode) {
                 return [{ node: { key: rootNodeKey.id, label: "Root" } }];
               }
@@ -1362,7 +1362,7 @@ describe("Hierarchies", () => {
                   fullClassName: circleClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecInstanceId: { selector: "this.ECInstanceId" },
                         ecClassId: { selector: "this.ECClassId" },
                         nodeLabel: "Circle",
@@ -1594,14 +1594,14 @@ describe("Hierarchies", () => {
         const provider1 = createProvider({
           imodelAccess: imodelAccess1,
           hierarchy: {
-            async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+            async defineHierarchyLevel({ parentNode, createSelectClause }) {
               if (!parentNode) {
                 return [
                   {
                     fullClassName: subjectClassName,
                     query: {
                       ecsql: `
-                        SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        SELECT ${await createSelectClause({
                           ecClassId: { selector: `this.ECClassId` },
                           ecInstanceId: { selector: `this.ECInstanceId` },
                           nodeLabel: { selector: `this.CodeValue` },
@@ -1621,14 +1621,14 @@ describe("Hierarchies", () => {
         const provider2 = createProvider({
           imodelAccess: imodelAccess2,
           hierarchy: {
-            async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+            async defineHierarchyLevel({ parentNode, createSelectClause }) {
               if (!parentNode) {
                 return [
                   {
                     fullClassName: subjectClassName,
                     query: {
                       ecsql: `
-                        SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        SELECT ${await createSelectClause({
                           ecClassId: { selector: `this.ECClassId` },
                           ecInstanceId: { selector: `this.ECInstanceId` },
                           nodeLabel: { selector: `this.CodeValue` },
@@ -1788,12 +1788,12 @@ describe("Hierarchies", () => {
             hierarchy: createPredicateBasedHierarchyDefinition({
               classHierarchyInspector: imodelAccess,
               hierarchy: {
-                rootNodes: async ({ nodeSelectClauseFactory }) => [
+                rootNodes: async ({ createSelectClause }) => [
                   {
                     fullClassName: subjectClassName,
                     query: {
                       ecsql: `
-                        SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        SELECT ${await createSelectClause({
                           ecClassId: { selector: `this.ECClassId` },
                           ecInstanceId: { selector: `this.ECInstanceId` },
                           nodeLabel: { selector: `this.CodeValue` },
@@ -1810,13 +1810,13 @@ describe("Hierarchies", () => {
                     parentInstancesNodePredicate: subjectClassName,
                     definitions: async ({
                       parentNodeInstanceIds,
-                      nodeSelectClauseFactory,
+                      createSelectClause,
                     }: DefineInstanceNodeChildHierarchyLevelProps) => [
                       {
                         fullClassName: subjectClassName,
                         query: {
                           ecsql: `
-                            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                            SELECT ${await createSelectClause({
                               ecClassId: { selector: `this.ECClassId` },
                               ecInstanceId: { selector: `this.ECInstanceId` },
                               nodeLabel: { selector: `this.CodeValue` },

--- a/apps/full-stack-tests/src/hierarchies/HierarchySearch.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchySearch.test.ts
@@ -16,14 +16,13 @@ import { IModel } from "@itwin/core-common";
 import {
   createHierarchyProvider,
   createHierarchySearchHelper,
-  createNodesQueryClauseFactory,
   createPredicateBasedHierarchyDefinition,
   HierarchyNode,
   HierarchyNodeIdentifier,
   HierarchyNodeKey,
   mergeProviders,
 } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory, normalizeFullClassName } from "@itwin/presentation-shared";
+import { normalizeFullClassName } from "@itwin/presentation-shared";
 import { buildTestECDb } from "../ECDbUtils.js";
 import { buildTestIModel } from "../IModelUtils.js";
 import { initialize, terminate } from "../IntegrationTests.js";
@@ -34,6 +33,7 @@ import { createIModelAccess, createProvider } from "./Utils.js";
 import type { Id64String } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
 import type {
+  DefineHierarchyLevelProps,
   DefineInstanceNodeChildHierarchyLevelProps,
   GenericNodeKey,
   HierarchyDefinition,
@@ -64,20 +64,15 @@ describe("Hierarchies", () => {
           const childSubject2 = insertSubject({ imodel, codeValue: "test subject 2", parentId: rootSubject.id });
           return { rootSubject, childSubject1, childSubject2 };
         });
-        const imodelAccess = createIModelAccess(imodelConnection);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: "root subject",
@@ -106,7 +101,7 @@ describe("Hierarchies", () => {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.CodeValue` },
@@ -174,20 +169,15 @@ describe("Hierarchies", () => {
           return { rootSubject };
         });
 
-        const imodelAccess = createIModelAccess(imodelConnection);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: "root subject",
@@ -312,18 +302,16 @@ describe("Hierarchies", () => {
           const childSubject3 = insertSubject({ imodel, codeValue: "test subject 3", parentId: rootSubject.id });
           return { rootSubject, childSubject1, childSubject21, childSubject22, childSubject3 };
         });
-        const imodelAccess = createIModelAccess(imodelConnection);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
-        const createHierarchyLevelDefinition = async (whereClause: (alias: string) => string) => {
+        const createHierarchyLevelDefinition = async (
+          nodeSelectClauseFactory: DefineHierarchyLevelProps["nodeSelectClauseFactory"],
+          whereClause: (alias: string) => string,
+        ) => {
           return [
             {
               fullClassName: subjectClassName,
               query: {
                 ecsql: `
-                  SELECT ${await selectQueryFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.CodeValue` },
@@ -338,20 +326,23 @@ describe("Hierarchies", () => {
         };
 
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return createHierarchyLevelDefinition(
+                nodeSelectClauseFactory,
                 (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.childSubject1.id}`,
               );
             }
             if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 1") {
               return createHierarchyLevelDefinition(
+                nodeSelectClauseFactory,
                 (alias: string) =>
                   `WHERE ${alias}.ECInstanceId IN (${keys.childSubject21.id}, ${keys.childSubject22.id})`,
               );
             }
             if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 2.1") {
               return createHierarchyLevelDefinition(
+                nodeSelectClauseFactory,
                 (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.childSubject3.id}`,
               );
             }
@@ -445,18 +436,16 @@ describe("Hierarchies", () => {
           const childSubject4 = insertSubject({ imodel, codeValue: "test subject 4", parentId: rootSubject.id });
           return { rootSubject, childSubject1, childSubject2, childSubject3, childSubject4 };
         });
-        const imodelAccess = createIModelAccess(imodelConnection);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
-        const createHierarchyLevelDefinition = async (whereClause: (alias: string) => string) => {
+        const createHierarchyLevelDefinition = async (
+          nodeSelectClauseFactory: DefineHierarchyLevelProps["nodeSelectClauseFactory"],
+          whereClause: (alias: string) => string,
+        ) => {
           return [
             {
               fullClassName: subjectClassName,
               query: {
                 ecsql: `
-                  SELECT ${await selectQueryFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.CodeValue` },
@@ -470,9 +459,10 @@ describe("Hierarchies", () => {
         };
 
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return createHierarchyLevelDefinition(
+                nodeSelectClauseFactory,
                 (alias: string) =>
                   `WHERE ${alias}.ECInstanceId IN (${keys.childSubject1.id}, ${keys.childSubject4.id})`,
               );
@@ -483,12 +473,14 @@ describe("Hierarchies", () => {
               parentNode.parentKeys.length === 0
             ) {
               return createHierarchyLevelDefinition(
+                nodeSelectClauseFactory,
                 (alias: string) =>
                   `WHERE ${alias}.ECInstanceId IN (${keys.childSubject2.id}, ${keys.childSubject3.id})`,
               );
             }
             if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 4") {
               return createHierarchyLevelDefinition(
+                nodeSelectClauseFactory,
                 (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.childSubject1.id}`,
               );
             }
@@ -498,6 +490,7 @@ describe("Hierarchies", () => {
               parentNode.parentKeys.length === 1
             ) {
               return createHierarchyLevelDefinition(
+                nodeSelectClauseFactory,
                 (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.childSubject2.id}`,
               );
             }
@@ -582,17 +575,15 @@ describe("Hierarchies", () => {
             childSubject222,
           };
         });
-        const imodelAccess = createIModelAccess(imodelConnection);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
-        const createHierarchyLevelDefinition = async (whereClause: (alias: string) => string) => [
+        const createHierarchyLevelDefinition = async (
+          nodeSelectClauseFactory: DefineHierarchyLevelProps["nodeSelectClauseFactory"],
+          whereClause: (alias: string) => string,
+        ) => [
           {
             fullClassName: subjectClassName,
             query: {
               ecsql: `
-                SELECT ${await selectQueryFactory.createSelectClause({
+                SELECT ${await nodeSelectClauseFactory.createSelectClause({
                   ecClassId: { selector: `this.ECClassId` },
                   ecInstanceId: { selector: `this.ECInstanceId` },
                   nodeLabel: { selector: `this.CodeValue` },
@@ -604,21 +595,24 @@ describe("Hierarchies", () => {
           },
         ];
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return createHierarchyLevelDefinition(
+                nodeSelectClauseFactory,
                 (alias: string) =>
                   `WHERE ${alias}.ECInstanceId IN (${keys.childSubject1.id}, ${keys.childSubject2.id})`,
               );
             }
             if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 2") {
               return createHierarchyLevelDefinition(
+                nodeSelectClauseFactory,
                 (alias: string) =>
                   `WHERE ${alias}.ECInstanceId IN (${keys.childSubject21.id}, ${keys.childSubject22.id})`,
               );
             }
             if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 22") {
               return createHierarchyLevelDefinition(
+                nodeSelectClauseFactory,
                 (alias: string) =>
                   `WHERE ${alias}.ECInstanceId IN (${keys.childSubject221.id}, ${keys.childSubject222.id})`,
               );
@@ -693,20 +687,15 @@ describe("Hierarchies", () => {
           return { rootSubject, childSubject1, childSubject2 };
         });
 
-        const imodelAccess = createIModelAccess(imodelConnection);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: "root subject",
@@ -736,7 +725,7 @@ describe("Hierarchies", () => {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.CodeValue` },
@@ -801,20 +790,15 @@ describe("Hierarchies", () => {
           return { rootSubject, childSubject1, childSubject2 };
         });
 
-        const imodelAccess = createIModelAccess(imodelConnection);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: "root subject",
@@ -844,7 +828,7 @@ describe("Hierarchies", () => {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.CodeValue` },
@@ -888,20 +872,15 @@ describe("Hierarchies", () => {
           return { rootSubject, childSubject1, childSubject2, childSubject3 };
         });
 
-        const imodelAccess = createIModelAccess(imodelConnection);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: "root subject",
@@ -918,7 +897,7 @@ describe("Hierarchies", () => {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.CodeValue` },
@@ -938,7 +917,7 @@ describe("Hierarchies", () => {
                   fullClassName: subjectClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.CodeValue` },
@@ -988,20 +967,15 @@ describe("Hierarchies", () => {
           return { schema: s, x, y, z };
         });
         const { ecdb, schema, ...keys } = setup;
-        const imodelAccess = createIModelAccess(ecdb);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                          SELECT ${await selectQueryFactory.createSelectClause({
+                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
                             nodeLabel: "x",
@@ -1018,7 +992,7 @@ describe("Hierarchies", () => {
                   fullClassName: schema.items.Y.fullName,
                   query: {
                     ecsql: `
-                          SELECT ${await selectQueryFactory.createSelectClause({
+                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
                             nodeLabel: "y",
@@ -1032,7 +1006,7 @@ describe("Hierarchies", () => {
                   fullClassName: schema.items.Z.fullName,
                   query: {
                     ecsql: `
-                          SELECT ${await selectQueryFactory.createSelectClause({
+                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
                             nodeLabel: "z",
@@ -1091,20 +1065,15 @@ describe("Hierarchies", () => {
           return { schema: s, x, y1, y2 };
         });
         const { ecdb, schema, ...keys } = setup;
-        const imodelAccess = createIModelAccess(ecdb);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                          SELECT ${await selectQueryFactory.createSelectClause({
+                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
                             nodeLabel: "x",
@@ -1121,7 +1090,7 @@ describe("Hierarchies", () => {
                   fullClassName: schema.items.Y.fullName,
                   query: {
                     ecsql: `
-                          SELECT ${await selectQueryFactory.createSelectClause({
+                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
                             ecClassId: { selector: `this.ECClassId` },
                             ecInstanceId: { selector: `this.ECInstanceId` },
                             nodeLabel: "y",
@@ -1182,14 +1151,9 @@ describe("Hierarchies", () => {
           return { rootSubject, model, category, elements };
         });
 
-        const imodelAccess = createIModelAccess(imodelConnection);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const rootNodeKey: GenericNodeKey = { type: "generic", id: "root-node" };
         const hierarchy: HierarchyDefinition = {
-          defineHierarchyLevel: async (props) => {
+          defineHierarchyLevel: async ({ nodeSelectClauseFactory, ...props }) => {
             if (!props.parentNode) {
               return [{ node: { key: rootNodeKey.id, label: "Root" } }];
             }
@@ -1199,7 +1163,7 @@ describe("Hierarchies", () => {
                 fullClassName: "BisCore.PhysicalElement",
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecInstanceId: { selector: "this.ECInstanceId" },
                       ecClassId: { selector: "this.ECClassId" },
                       nodeLabel: { selector: "idToHex(this.ECInstanceId)" },
@@ -1262,14 +1226,9 @@ describe("Hierarchies", () => {
           return { rootSubject, model, category, rootElement, middleElement, childElement };
         });
 
-        const imodelAccess = createIModelAccess(imodelConnection);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const rootNodeKey: GenericNodeKey = { type: "generic", id: "root-node" };
         const hierarchy: HierarchyDefinition = {
-          defineHierarchyLevel: async ({ parentNode }) => {
+          defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
             if (!parentNode) {
               return [{ node: { key: rootNodeKey.id, label: "Root" } }];
             }
@@ -1278,7 +1237,7 @@ describe("Hierarchies", () => {
                 fullClassName: "BisCore.PhysicalElement",
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecInstanceId: { selector: "this.ECInstanceId" },
                       ecClassId: { selector: "this.ECClassId" },
                       nodeLabel: { selector: "idToHex(this.ECInstanceId)" },
@@ -1392,13 +1351,8 @@ describe("Hierarchies", () => {
           });
           imodelConnection = result.imodelConnection;
 
-          const imodelAccess = createIModelAccess(imodelConnection);
-          const selectQueryFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-          });
           hierarchy = {
-            defineHierarchyLevel: async (props) => {
+            defineHierarchyLevel: async ({ nodeSelectClauseFactory, ...props }) => {
               if (!props.parentNode) {
                 return [{ node: { key: rootNodeKey.id, label: "Root" } }];
               }
@@ -1408,7 +1362,7 @@ describe("Hierarchies", () => {
                   fullClassName: circleClassName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecInstanceId: { selector: "this.ECInstanceId" },
                         ecClassId: { selector: "this.ECClassId" },
                         nodeLabel: "Circle",
@@ -1640,19 +1594,14 @@ describe("Hierarchies", () => {
         const provider1 = createProvider({
           imodelAccess: imodelAccess1,
           hierarchy: {
-            async defineHierarchyLevel({ parentNode }) {
+            async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
               if (!parentNode) {
                 return [
                   {
                     fullClassName: subjectClassName,
                     query: {
                       ecsql: `
-                        SELECT ${await createNodesQueryClauseFactory({
-                          imodelAccess: imodelAccess1,
-                          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({
-                            imodelAccess: imodelAccess1,
-                          }),
-                        }).createSelectClause({
+                        SELECT ${await nodeSelectClauseFactory.createSelectClause({
                           ecClassId: { selector: `this.ECClassId` },
                           ecInstanceId: { selector: `this.ECInstanceId` },
                           nodeLabel: { selector: `this.CodeValue` },
@@ -1672,19 +1621,14 @@ describe("Hierarchies", () => {
         const provider2 = createProvider({
           imodelAccess: imodelAccess2,
           hierarchy: {
-            async defineHierarchyLevel({ parentNode }) {
+            async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
               if (!parentNode) {
                 return [
                   {
                     fullClassName: subjectClassName,
                     query: {
                       ecsql: `
-                        SELECT ${await createNodesQueryClauseFactory({
-                          imodelAccess: imodelAccess2,
-                          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({
-                            imodelAccess: imodelAccess2,
-                          }),
-                        }).createSelectClause({
+                        SELECT ${await nodeSelectClauseFactory.createSelectClause({
                           ecClassId: { selector: `this.ECClassId` },
                           ecInstanceId: { selector: `this.ECInstanceId` },
                           nodeLabel: { selector: `this.CodeValue` },
@@ -1844,17 +1788,12 @@ describe("Hierarchies", () => {
             hierarchy: createPredicateBasedHierarchyDefinition({
               classHierarchyInspector: imodelAccess,
               hierarchy: {
-                rootNodes: async () => [
+                rootNodes: async ({ nodeSelectClauseFactory }) => [
                   {
                     fullClassName: subjectClassName,
                     query: {
                       ecsql: `
-                        SELECT ${await createNodesQueryClauseFactory({
-                          imodelAccess,
-                          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({
-                            imodelAccess,
-                          }),
-                        }).createSelectClause({
+                        SELECT ${await nodeSelectClauseFactory.createSelectClause({
                           ecClassId: { selector: `this.ECClassId` },
                           ecInstanceId: { selector: `this.ECInstanceId` },
                           nodeLabel: { selector: `this.CodeValue` },
@@ -1869,17 +1808,15 @@ describe("Hierarchies", () => {
                 childNodes: [
                   {
                     parentInstancesNodePredicate: subjectClassName,
-                    definitions: async ({ parentNodeInstanceIds }: DefineInstanceNodeChildHierarchyLevelProps) => [
+                    definitions: async ({
+                      parentNodeInstanceIds,
+                      nodeSelectClauseFactory,
+                    }: DefineInstanceNodeChildHierarchyLevelProps) => [
                       {
                         fullClassName: subjectClassName,
                         query: {
                           ecsql: `
-                            SELECT ${await createNodesQueryClauseFactory({
-                              imodelAccess,
-                              instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({
-                                imodelAccess,
-                              }),
-                            }).createSelectClause({
+                            SELECT ${await nodeSelectClauseFactory.createSelectClause({
                               ecClassId: { selector: `this.ECClassId` },
                               ecInstanceId: { selector: `this.ECInstanceId` },
                               nodeLabel: { selector: `this.CodeValue` },

--- a/apps/full-stack-tests/src/hierarchies/Update.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/Update.test.ts
@@ -417,13 +417,13 @@ describe("Hierarchies", () => {
           props: { label: "codeValue" | "aspectIdentifier" } = { label: "codeValue" },
         ) {
           const hierarchy: HierarchyDefinition = {
-            async defineHierarchyLevel({ nodeSelectClauseFactory }) {
+            async defineHierarchyLevel({ createSelectClause }) {
               return [
                 {
                   fullClassName: normalizeFullClassName(Subject.classFullName),
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: props.label === "codeValue" ? `this.CodeValue` : `aspect.Identifier` },
@@ -445,13 +445,13 @@ describe("Hierarchies", () => {
 
         function createRootSubjectReferredElementsProvider() {
           const hierarchy: HierarchyDefinition = {
-            async defineHierarchyLevel({ nodeSelectClauseFactory }) {
+            async defineHierarchyLevel({ createSelectClause }) {
               return [
                 {
                   fullClassName: normalizeFullClassName(Element.classFullName),
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.CodeValue` },
@@ -474,13 +474,13 @@ describe("Hierarchies", () => {
         function createPhysicalModelsProvider() {
           const imodelAccess = createIModelAccess(imodel);
           const hierarchy: HierarchyDefinition = {
-            async defineHierarchyLevel({ nodeSelectClauseFactory }) {
+            async defineHierarchyLevel({ createSelectClause }) {
               return [
                 {
                   fullClassName: normalizeFullClassName(Subject.classFullName),
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: {

--- a/apps/full-stack-tests/src/hierarchies/grouping/AutoExpand.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/AutoExpand.test.ts
@@ -7,21 +7,19 @@ import { insertSubject } from "presentation-test-utilities";
 import { afterAll, describe, it, test } from "vitest";
 import { Subject } from "@itwin/core-backend";
 import { IModel } from "@itwin/core-common";
-import { createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
-import { createIModelAccess, createProvider } from "../Utils.js";
+import { createProvider } from "../Utils.js";
 
 import type { IModelConnection } from "@itwin/core-frontend";
-import type { HierarchyDefinition, NodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
+import type { DefineHierarchyLevelProps, HierarchyDefinition } from "@itwin/presentation-hierarchies";
 import type { Props } from "@itwin/presentation-shared";
 
 describe("Hierarchies", () => {
   describe("Grouping nodes' autoExpand setting", () => {
     type ECSqlSelectClauseGroupingParams = NonNullable<
-      Props<NodesQueryClauseFactory["createSelectClause"]>["grouping"]
+      Props<DefineHierarchyLevelProps["nodeSelectClauseFactory"]["createSelectClause"]>["grouping"]
     >;
     let subjectClassName: string;
     let emptyIModel: IModelConnection;
@@ -37,24 +35,19 @@ describe("Hierarchies", () => {
     });
 
     function createHierarchyWithSpecifiedGrouping(
-      imodel: IModelConnection,
+      _imodel: IModelConnection,
       specifiedGrouping: ECSqlSelectClauseGroupingParams,
       labelProperty?: string,
     ): HierarchyDefinition {
-      const imodelAccess = createIModelAccess(imodel);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       return {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                  SELECT ${await selectQueryFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.${labelProperty ?? "CodeValue"}` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/AutoExpand.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/AutoExpand.test.ts
@@ -19,7 +19,7 @@ import type { Props } from "@itwin/presentation-shared";
 describe("Hierarchies", () => {
   describe("Grouping nodes' autoExpand setting", () => {
     type ECSqlSelectClauseGroupingParams = NonNullable<
-      Props<DefineHierarchyLevelProps["nodeSelectClauseFactory"]["createSelectClause"]>["grouping"]
+      Props<DefineHierarchyLevelProps["createSelectClause"]>["grouping"]
     >;
     let subjectClassName: string;
     let emptyIModel: IModelConnection;
@@ -40,14 +40,14 @@ describe("Hierarchies", () => {
       labelProperty?: string,
     ): HierarchyDefinition {
       return {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.${labelProperty ?? "CodeValue"}` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/BaseClassGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/BaseClassGrouping.test.ts
@@ -35,14 +35,14 @@ describe("Hierarchies", () => {
     });
     it("doesn't create grouping nodes if provided classes aren't base for node class", async () => {
       const customHierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.UserLabel` },
@@ -76,14 +76,14 @@ describe("Hierarchies", () => {
 
     it("doesn't create grouping nodes if provided classes aren't of entity or relationship type", async () => {
       const customHierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.UserLabel` },
@@ -118,14 +118,14 @@ describe("Hierarchies", () => {
     it("creates grouping nodes if provided class is base for node class", async () => {
       const baseClassName = "BisCore.InformationContentElement";
       const customHierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.UserLabel` },
@@ -172,14 +172,14 @@ describe("Hierarchies", () => {
       });
 
       const customHierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.UserLabel` },
@@ -245,14 +245,14 @@ describe("Hierarchies", () => {
       });
 
       const customHierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.UserLabel` },
@@ -279,7 +279,7 @@ describe("Hierarchies", () => {
                 fullClassName: physicalPartitionClassName,
                 query: {
                   ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.UserLabel` },
@@ -351,14 +351,14 @@ describe("Hierarchies", () => {
       });
 
       const customHierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.CodeValue` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/BaseClassGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/BaseClassGrouping.test.ts
@@ -7,12 +7,11 @@ import { insertPhysicalPartition, insertSubject } from "presentation-test-utilit
 import { afterAll, describe, it, test } from "vitest";
 import { PhysicalPartition, Subject } from "@itwin/core-backend";
 import { IModel } from "@itwin/core-common";
-import { createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory, normalizeFullClassName } from "@itwin/presentation-shared";
+import { normalizeFullClassName } from "@itwin/presentation-shared";
 import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
-import { createIModelAccess, createProvider } from "../Utils.js";
+import { createProvider } from "../Utils.js";
 
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
@@ -35,20 +34,15 @@ describe("Hierarchies", () => {
       await terminate();
     });
     it("doesn't create grouping nodes if provided classes aren't base for node class", async () => {
-      const imodelAccess = createIModelAccess(emptyIModel);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const customHierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.UserLabel` },
@@ -81,20 +75,15 @@ describe("Hierarchies", () => {
     });
 
     it("doesn't create grouping nodes if provided classes aren't of entity or relationship type", async () => {
-      const imodelAccess = createIModelAccess(emptyIModel);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const customHierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.UserLabel` },
@@ -128,20 +117,15 @@ describe("Hierarchies", () => {
 
     it("creates grouping nodes if provided class is base for node class", async () => {
       const baseClassName = "BisCore.InformationContentElement";
-      const imodelAccess = createIModelAccess(emptyIModel);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const customHierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.UserLabel` },
@@ -187,20 +171,15 @@ describe("Hierarchies", () => {
         return { childPartition1 };
       });
 
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const customHierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.UserLabel` },
@@ -265,20 +244,15 @@ describe("Hierarchies", () => {
         return { childPartition1, childPartition2 };
       });
 
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const customHierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.UserLabel` },
@@ -305,7 +279,7 @@ describe("Hierarchies", () => {
                 fullClassName: physicalPartitionClassName,
                 query: {
                   ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.UserLabel` },
@@ -376,20 +350,15 @@ describe("Hierarchies", () => {
         return { childSubject1, childPartition2 };
       });
 
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const customHierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.CodeValue` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/ClassGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/ClassGrouping.test.ts
@@ -39,14 +39,14 @@ describe("Hierarchies", () => {
       });
 
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.CodeValue` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/ClassGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/ClassGrouping.test.ts
@@ -7,12 +7,10 @@ import { insertPhysicalPartition, insertSubject } from "presentation-test-utilit
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { PhysicalPartition, Subject } from "@itwin/core-backend";
 import { IModel } from "@itwin/core-common";
-import { createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
-import { createIModelAccess, createProvider } from "../Utils.js";
+import { createProvider } from "../Utils.js";
 
 import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
 
@@ -40,20 +38,15 @@ describe("Hierarchies", () => {
         return { childSubject1, childPartition2, childSubject3, childPartition4 };
       });
 
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.CodeValue` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/GroupHiding.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/GroupHiding.test.ts
@@ -19,7 +19,7 @@ import type { Props } from "@itwin/presentation-shared";
 describe("Hierarchies", () => {
   describe("Grouping nodes' hiding", () => {
     type ECSqlSelectClauseGroupingParams = NonNullable<
-      Props<DefineHierarchyLevelProps["nodeSelectClauseFactory"]["createSelectClause"]>["grouping"]
+      Props<DefineHierarchyLevelProps["createSelectClause"]>["grouping"]
     >;
     let subjectClassName: string;
     let physicalPartitionClassName: string;
@@ -41,14 +41,14 @@ describe("Hierarchies", () => {
       labelProperty?: string,
     ): HierarchyDefinition {
       return {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.${labelProperty ?? "CodeValue"}` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/GroupHiding.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/GroupHiding.test.ts
@@ -7,21 +7,19 @@ import { insertPhysicalPartition, insertSubject } from "presentation-test-utilit
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { PhysicalPartition, Subject } from "@itwin/core-backend";
 import { IModel } from "@itwin/core-common";
-import { createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
-import { createIModelAccess, createProvider } from "../Utils.js";
+import { createProvider } from "../Utils.js";
 
 import type { IModelConnection } from "@itwin/core-frontend";
-import type { HierarchyDefinition, NodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
+import type { DefineHierarchyLevelProps, HierarchyDefinition } from "@itwin/presentation-hierarchies";
 import type { Props } from "@itwin/presentation-shared";
 
 describe("Hierarchies", () => {
   describe("Grouping nodes' hiding", () => {
     type ECSqlSelectClauseGroupingParams = NonNullable<
-      Props<NodesQueryClauseFactory["createSelectClause"]>["grouping"]
+      Props<DefineHierarchyLevelProps["nodeSelectClauseFactory"]["createSelectClause"]>["grouping"]
     >;
     let subjectClassName: string;
     let physicalPartitionClassName: string;
@@ -38,24 +36,19 @@ describe("Hierarchies", () => {
     });
 
     function createHierarchyWithSpecifiedGrouping(
-      imodel: IModelConnection,
+      _imodel: IModelConnection,
       specifiedGrouping: ECSqlSelectClauseGroupingParams,
       labelProperty?: string,
     ): HierarchyDefinition {
-      const imodelAccess = createIModelAccess(imodel);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       return {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.${labelProperty ?? "CodeValue"}` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/LabelGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/LabelGrouping.test.ts
@@ -62,14 +62,14 @@ describe("Hierarchies", () => {
       });
 
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ nodeSelectClauseFactory, ...props }) {
+        async defineHierarchyLevel({ createSelectClause, ...props }) {
           if (!props.parentNode) {
             return [
               {
                 fullClassName: subjectClassName,
                 query: {
                   ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.UserLabel` },
@@ -143,14 +143,14 @@ describe("Hierarchies", () => {
       });
 
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ nodeSelectClauseFactory, ...props }) {
+        async defineHierarchyLevel({ createSelectClause, ...props }) {
           if (!props.parentNode) {
             return [
               {
                 fullClassName: subjectClassName,
                 query: {
                   ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.UserLabel` },
@@ -220,14 +220,14 @@ describe("Hierarchies", () => {
       });
 
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ nodeSelectClauseFactory, ...props }) {
+        async defineHierarchyLevel({ createSelectClause, ...props }) {
           if (!props.parentNode) {
             return [
               {
                 fullClassName: subjectClassName,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.UserLabel` },
@@ -263,14 +263,14 @@ describe("Hierarchies", () => {
       });
 
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ nodeSelectClauseFactory, ...props }) {
+        async defineHierarchyLevel({ createSelectClause, ...props }) {
           if (!props.parentNode) {
             return [
               {
                 fullClassName: subjectClassName,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: "merge this",
@@ -309,14 +309,14 @@ describe("Hierarchies", () => {
       });
 
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ nodeSelectClauseFactory, ...props }) {
+        async defineHierarchyLevel({ createSelectClause, ...props }) {
           if (!props.parentNode) {
             return [
               {
                 fullClassName: subjectClassName,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.CodeValue` },
@@ -336,7 +336,7 @@ describe("Hierarchies", () => {
                 fullClassName: subjectClassName,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.CodeValue` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/LabelGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/LabelGrouping.test.ts
@@ -7,12 +7,12 @@ import { insertSubject } from "presentation-test-utilities";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { Subject } from "@itwin/core-backend";
 import { IModel } from "@itwin/core-common";
-import { createNodesQueryClauseFactory, HierarchyNode } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory, normalizeFullClassName } from "@itwin/presentation-shared";
+import { HierarchyNode } from "@itwin/presentation-hierarchies";
+import { normalizeFullClassName } from "@itwin/presentation-shared";
 import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
-import { createIModelAccess, createProvider } from "../Utils.js";
+import { createProvider } from "../Utils.js";
 
 import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
 import type { EC } from "@itwin/presentation-shared";
@@ -61,20 +61,15 @@ describe("Hierarchies", () => {
         return { childSubject1, childSubject2, childSubject3, childSubject4 };
       });
 
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel(props) {
+        async defineHierarchyLevel({ nodeSelectClauseFactory, ...props }) {
           if (!props.parentNode) {
             return [
               {
                 fullClassName: subjectClassName,
                 query: {
                   ecsql: `
-                  SELECT ${await selectQueryFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.UserLabel` },
@@ -147,20 +142,15 @@ describe("Hierarchies", () => {
         return { childSubject1, childSubject2, childSubject3, childSubject4 };
       });
 
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel(props) {
+        async defineHierarchyLevel({ nodeSelectClauseFactory, ...props }) {
           if (!props.parentNode) {
             return [
               {
                 fullClassName: subjectClassName,
                 query: {
                   ecsql: `
-                  SELECT ${await selectQueryFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.UserLabel` },
@@ -229,20 +219,15 @@ describe("Hierarchies", () => {
         return { rootSubject, childSubject1, childSubject2, childSubject3 };
       });
 
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel(props) {
+        async defineHierarchyLevel({ nodeSelectClauseFactory, ...props }) {
           if (!props.parentNode) {
             return [
               {
                 fullClassName: subjectClassName,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.UserLabel` },
@@ -277,20 +262,15 @@ describe("Hierarchies", () => {
         return { rootSubject, childSubject1, childSubject2 };
       });
 
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel(props) {
+        async defineHierarchyLevel({ nodeSelectClauseFactory, ...props }) {
           if (!props.parentNode) {
             return [
               {
                 fullClassName: subjectClassName,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: "merge this",
@@ -328,20 +308,15 @@ describe("Hierarchies", () => {
         return { rootSubject, visibleSubject1, visibleSubject2 };
       });
 
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel(props) {
+        async defineHierarchyLevel({ nodeSelectClauseFactory, ...props }) {
           if (!props.parentNode) {
             return [
               {
                 fullClassName: subjectClassName,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.CodeValue` },
@@ -361,7 +336,7 @@ describe("Hierarchies", () => {
                 fullClassName: subjectClassName,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.CodeValue` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/MultiLevelGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/MultiLevelGrouping.test.ts
@@ -7,12 +7,10 @@ import { insertPhysicalPartition, insertSubject } from "presentation-test-utilit
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { PhysicalPartition, Subject } from "@itwin/core-backend";
 import { IModel } from "@itwin/core-common";
-import { createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
-import { createIModelAccess, createProvider } from "../Utils.js";
+import { createProvider } from "../Utils.js";
 
 import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
 
@@ -71,20 +69,15 @@ describe("Hierarchies", () => {
         return { childSubject1, childSubject2, childPartition3, childPartition4, childPartition5 };
       });
 
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const customHierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.UserLabel` },
@@ -112,7 +105,7 @@ describe("Hierarchies", () => {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.UserLabel` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/MultiLevelGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/MultiLevelGrouping.test.ts
@@ -70,14 +70,14 @@ describe("Hierarchies", () => {
       });
 
       const customHierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.UserLabel` },
@@ -105,7 +105,7 @@ describe("Hierarchies", () => {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.UserLabel` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/PropertiesGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/PropertiesGrouping.test.ts
@@ -12,8 +12,7 @@ import {
 import { afterAll, describe, it, test } from "vitest";
 import { Subject } from "@itwin/core-backend";
 import { IModel } from "@itwin/core-common";
-import { createIModelHierarchyProvider, createNodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
+import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 import { buildTestECDb } from "../../ECDbUtils.js";
 import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
@@ -22,13 +21,15 @@ import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
 import { createIModelAccess, createProvider } from "../Utils.js";
 
 import type { IModelConnection } from "@itwin/core-frontend";
-import type { HierarchyDefinition, NodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
+import type { DefineHierarchyLevelProps, HierarchyDefinition } from "@itwin/presentation-hierarchies";
 import type { Props } from "@itwin/presentation-shared";
 
 describe("Hierarchies", () => {
   describe("Properties grouping", () => {
     type ECSqlSelectClausePropertiesGroupingParams = NonNullable<
-      NonNullable<Props<NodesQueryClauseFactory["createSelectClause"]>["grouping"]>["byProperties"]
+      NonNullable<
+        Props<DefineHierarchyLevelProps["nodeSelectClauseFactory"]["createSelectClause"]>["grouping"]
+      >["byProperties"]
     >;
     let subjectClassName: string;
     let emptyIModel: IModelConnection;
@@ -44,23 +45,18 @@ describe("Hierarchies", () => {
     });
 
     function createHierarchyWithSpecifiedGrouping(
-      imodel: IModelConnection,
+      _imodel: IModelConnection,
       specifiedGrouping: ECSqlSelectClausePropertiesGroupingParams,
     ): HierarchyDefinition {
-      const imodelAccess = createIModelAccess(imodel);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       return {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                  SELECT ${await selectQueryFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.UserLabel` },
@@ -156,14 +152,10 @@ describe("Hierarchies", () => {
 
       it("groups by navigation property", async () => {
         const imodelAccess = createIModelAccess(emptyIModel);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const provider = createIModelHierarchyProvider({
           imodelAccess,
           hierarchyDefinition: {
-            defineHierarchyLevel: async ({ parentNode }) =>
+            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) =>
               parentNode
                 ? []
                 : [
@@ -171,7 +163,7 @@ describe("Hierarchies", () => {
                       fullClassName: "BisCore.Subject",
                       query: {
                         ecsql: `
-                          SELECT ${await selectQueryFactory.createSelectClause({
+                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
                             ecClassId: { selector: "this.ECClassId" },
                             ecInstanceId: { selector: "this.ECInstanceId" },
                             nodeLabel: { selector: "this.CodeValue" },
@@ -256,20 +248,15 @@ describe("Hierarchies", () => {
           return { childSubject1, childSubject2 };
         });
 
-        const imodelAccess = createIModelAccess(imodelConnection);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const customHierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: `BisCore.InformationContentElement`,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.UserLabel` },
@@ -372,15 +359,10 @@ describe("Hierarchies", () => {
             return { physicalElement };
           });
 
-          const imodelAccess = createIModelAccess(imodelConnection);
-          const selectQueryFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-          });
           const provider = createIModelHierarchyProvider({
             imodelAccess: createIModelAccess(imodelConnection),
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode }) =>
+              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) =>
                 parentNode
                   ? []
                   : [
@@ -388,7 +370,7 @@ describe("Hierarchies", () => {
                         fullClassName: "BisCore.GeometricElement3d",
                         query: {
                           ecsql: `
-                            SELECT ${await selectQueryFactory.createSelectClause({
+                            SELECT ${await nodeSelectClauseFactory.createSelectClause({
                               ecClassId: { selector: "this.ECClassId" },
                               ecInstanceId: { selector: "this.ECInstanceId" },
                               nodeLabel: { selector: "this.CodeValue" },
@@ -434,15 +416,10 @@ describe("Hierarchies", () => {
             return { childSubject1, childSubject2 };
           });
 
-          const imodelAccess = createIModelAccess(imodelConnection);
-          const selectQueryFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-          });
           const provider = createIModelHierarchyProvider({
             imodelAccess: createIModelAccess(imodelConnection),
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode }) =>
+              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) =>
                 parentNode
                   ? []
                   : [
@@ -450,7 +427,7 @@ describe("Hierarchies", () => {
                         fullClassName: "BisCore.InformationContentElement",
                         query: {
                           ecsql: `
-                            SELECT ${await selectQueryFactory.createSelectClause({
+                            SELECT ${await nodeSelectClauseFactory.createSelectClause({
                               ecClassId: { selector: "this.ECClassId" },
                               ecInstanceId: { selector: "this.ECInstanceId" },
                               nodeLabel: { selector: "this.CodeValue" },
@@ -515,15 +492,10 @@ describe("Hierarchies", () => {
             });
             return { childSubject1, childSubject2, childSubject3, childSubject4 };
           });
-          const imodelAccess = createIModelAccess(imodelConnection);
-          const selectQueryFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-          });
           const provider = createIModelHierarchyProvider({
             imodelAccess: createIModelAccess(imodelConnection),
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode }) =>
+              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) =>
                 parentNode
                   ? []
                   : [
@@ -531,7 +503,7 @@ describe("Hierarchies", () => {
                         fullClassName: "BisCore.Subject",
                         query: {
                           ecsql: `
-                            SELECT ${await selectQueryFactory.createSelectClause({
+                            SELECT ${await nodeSelectClauseFactory.createSelectClause({
                               ecClassId: { selector: "this.ECClassId" },
                               ecInstanceId: { selector: "this.ECInstanceId" },
                               nodeLabel: { selector: "this.CodeValue" },
@@ -598,15 +570,10 @@ describe("Hierarchies", () => {
             return { childSubject1, childSubject2, childSubject3, childSubject4 };
           });
 
-          const imodelAccess = createIModelAccess(imodelConnection);
-          const selectQueryFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-          });
           const provider = createIModelHierarchyProvider({
             imodelAccess: createIModelAccess(imodelConnection),
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode }) =>
+              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) =>
                 parentNode
                   ? []
                   : [
@@ -614,7 +581,7 @@ describe("Hierarchies", () => {
                         fullClassName: "BisCore.Subject",
                         query: {
                           ecsql: `
-                            SELECT ${await selectQueryFactory.createSelectClause({
+                            SELECT ${await nodeSelectClauseFactory.createSelectClause({
                               ecClassId: { selector: "this.ECClassId" },
                               ecInstanceId: { selector: "this.ECInstanceId" },
                               nodeLabel: { selector: "this.CodeValue" },
@@ -677,20 +644,15 @@ describe("Hierarchies", () => {
           return { schema: s, x1, x2 };
         });
         const { ecdb, schema, ...keys } = setup;
-        const imodelAccess = createIModelAccess(ecdb);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.Label` },
@@ -751,20 +713,15 @@ describe("Hierarchies", () => {
           return { schema: s, x1 };
         });
         const { ecdb, schema, ...keys } = setup;
-        const imodelAccess = createIModelAccess(ecdb);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.Label` },
@@ -823,20 +780,15 @@ describe("Hierarchies", () => {
           return { schema: s, x1, x2 };
         });
         const { ecdb, schema, ...keys } = setup;
-        const imodelAccess = createIModelAccess(ecdb);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.Label` },
@@ -906,20 +858,15 @@ describe("Hierarchies", () => {
           return { schema: s, x1 };
         });
         const { ecdb, schema, ...keys } = setup;
-        const imodelAccess = createIModelAccess(ecdb);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.Label` },
@@ -969,20 +916,15 @@ describe("Hierarchies", () => {
           return { schema: s, x1, x2 };
         });
         const { ecdb, schema, ...keys } = setup;
-        const imodelAccess = createIModelAccess(ecdb);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.Label` },
@@ -1045,20 +987,15 @@ describe("Hierarchies", () => {
           return { schema: s, x, y };
         });
         const { ecdb, schema, ...keys } = setup;
-        const imodelAccess = createIModelAccess(ecdb);
-        const selectQueryFactory = createNodesQueryClauseFactory({
-          imodelAccess,
-          instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-        });
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.Label` },
@@ -1084,7 +1021,7 @@ describe("Hierarchies", () => {
                   fullClassName: schema.items.Y.fullName,
                   query: {
                     ecsql: `
-                      SELECT ${await selectQueryFactory.createSelectClause({
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.Label` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/PropertiesGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/PropertiesGrouping.test.ts
@@ -27,9 +27,7 @@ import type { Props } from "@itwin/presentation-shared";
 describe("Hierarchies", () => {
   describe("Properties grouping", () => {
     type ECSqlSelectClausePropertiesGroupingParams = NonNullable<
-      NonNullable<
-        Props<DefineHierarchyLevelProps["nodeSelectClauseFactory"]["createSelectClause"]>["grouping"]
-      >["byProperties"]
+      NonNullable<Props<DefineHierarchyLevelProps["createSelectClause"]>["grouping"]>["byProperties"]
     >;
     let subjectClassName: string;
     let emptyIModel: IModelConnection;
@@ -49,14 +47,14 @@ describe("Hierarchies", () => {
       specifiedGrouping: ECSqlSelectClausePropertiesGroupingParams,
     ): HierarchyDefinition {
       return {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: `BisCore.InformationContentElement`,
                 query: {
                   ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.UserLabel` },
@@ -155,7 +153,7 @@ describe("Hierarchies", () => {
         const provider = createIModelHierarchyProvider({
           imodelAccess,
           hierarchyDefinition: {
-            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) =>
+            defineHierarchyLevel: async ({ parentNode, createSelectClause }) =>
               parentNode
                 ? []
                 : [
@@ -163,7 +161,7 @@ describe("Hierarchies", () => {
                       fullClassName: "BisCore.Subject",
                       query: {
                         ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: "this.ECClassId" },
                             ecInstanceId: { selector: "this.ECInstanceId" },
                             nodeLabel: { selector: "this.CodeValue" },
@@ -249,14 +247,14 @@ describe("Hierarchies", () => {
         });
 
         const customHierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: `BisCore.InformationContentElement`,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.UserLabel` },
@@ -362,7 +360,7 @@ describe("Hierarchies", () => {
           const provider = createIModelHierarchyProvider({
             imodelAccess: createIModelAccess(imodelConnection),
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) =>
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) =>
                 parentNode
                   ? []
                   : [
@@ -370,7 +368,7 @@ describe("Hierarchies", () => {
                         fullClassName: "BisCore.GeometricElement3d",
                         query: {
                           ecsql: `
-                            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                            SELECT ${await createSelectClause({
                               ecClassId: { selector: "this.ECClassId" },
                               ecInstanceId: { selector: "this.ECInstanceId" },
                               nodeLabel: { selector: "this.CodeValue" },
@@ -419,7 +417,7 @@ describe("Hierarchies", () => {
           const provider = createIModelHierarchyProvider({
             imodelAccess: createIModelAccess(imodelConnection),
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) =>
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) =>
                 parentNode
                   ? []
                   : [
@@ -427,7 +425,7 @@ describe("Hierarchies", () => {
                         fullClassName: "BisCore.InformationContentElement",
                         query: {
                           ecsql: `
-                            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                            SELECT ${await createSelectClause({
                               ecClassId: { selector: "this.ECClassId" },
                               ecInstanceId: { selector: "this.ECInstanceId" },
                               nodeLabel: { selector: "this.CodeValue" },
@@ -495,7 +493,7 @@ describe("Hierarchies", () => {
           const provider = createIModelHierarchyProvider({
             imodelAccess: createIModelAccess(imodelConnection),
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) =>
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) =>
                 parentNode
                   ? []
                   : [
@@ -503,7 +501,7 @@ describe("Hierarchies", () => {
                         fullClassName: "BisCore.Subject",
                         query: {
                           ecsql: `
-                            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                            SELECT ${await createSelectClause({
                               ecClassId: { selector: "this.ECClassId" },
                               ecInstanceId: { selector: "this.ECInstanceId" },
                               nodeLabel: { selector: "this.CodeValue" },
@@ -573,7 +571,7 @@ describe("Hierarchies", () => {
           const provider = createIModelHierarchyProvider({
             imodelAccess: createIModelAccess(imodelConnection),
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) =>
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) =>
                 parentNode
                   ? []
                   : [
@@ -581,7 +579,7 @@ describe("Hierarchies", () => {
                         fullClassName: "BisCore.Subject",
                         query: {
                           ecsql: `
-                            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                            SELECT ${await createSelectClause({
                               ecClassId: { selector: "this.ECClassId" },
                               ecInstanceId: { selector: "this.ECInstanceId" },
                               nodeLabel: { selector: "this.CodeValue" },
@@ -645,14 +643,14 @@ describe("Hierarchies", () => {
         });
         const { ecdb, schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.Label` },
@@ -714,14 +712,14 @@ describe("Hierarchies", () => {
         });
         const { ecdb, schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.Label` },
@@ -781,14 +779,14 @@ describe("Hierarchies", () => {
         });
         const { ecdb, schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.Label` },
@@ -859,14 +857,14 @@ describe("Hierarchies", () => {
         });
         const { ecdb, schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.Label` },
@@ -917,14 +915,14 @@ describe("Hierarchies", () => {
         });
         const { ecdb, schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.Label` },
@@ -988,14 +986,14 @@ describe("Hierarchies", () => {
         });
         const { ecdb, schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.Label` },
@@ -1021,7 +1019,7 @@ describe("Hierarchies", () => {
                   fullClassName: schema.items.Y.fullName,
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
                         nodeLabel: { selector: `this.Label` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/SpecialCases.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/SpecialCases.test.ts
@@ -4,13 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { afterAll, beforeAll, describe, it } from "vitest";
-import { createNodesQueryClauseFactory, HierarchyNode } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
+import { HierarchyNode } from "@itwin/presentation-hierarchies";
 import { buildTestECDb } from "../../ECDbUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { importSchema } from "../../SchemaUtils.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
-import { createIModelAccess, createProvider } from "../Utils.js";
+import { createProvider } from "../Utils.js";
 
 import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
 
@@ -46,20 +45,15 @@ describe("Hierarchies", () => {
         return { schema: s, x1, x2, y1, y2 };
       });
       const { ecdb: db, schema, ...keys } = setup;
-      const imodelAccess = createIModelAccess(db);
-      const selectQueryFactory = createNodesQueryClauseFactory({
-        imodelAccess,
-        instanceLabelSelectClauseFactory: createIModelInstanceLabelSelectClauseFactory({ imodelAccess }),
-      });
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode }) {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: "x",
@@ -80,7 +74,7 @@ describe("Hierarchies", () => {
                 fullClassName: schema.items.Y.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await selectQueryFactory.createSelectClause({
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `'y: ' || CAST(this.ECInstanceId AS TEXT)` },

--- a/apps/full-stack-tests/src/hierarchies/grouping/SpecialCases.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/SpecialCases.test.ts
@@ -46,14 +46,14 @@ describe("Hierarchies", () => {
       });
       const { ecdb: db, schema, ...keys } = setup;
       const hierarchy: HierarchyDefinition = {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: "x",
@@ -74,7 +74,7 @@ describe("Hierarchies", () => {
                 fullClassName: schema.items.Y.fullName,
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `'y: ' || CAST(this.ECInstanceId AS TEXT)` },

--- a/apps/full-stack-tests/src/hierarchies/imodel-hierarchy-merging/HierarchiesMerging.ts
+++ b/apps/full-stack-tests/src/hierarchies/imodel-hierarchy-merging/HierarchiesMerging.ts
@@ -29,15 +29,17 @@ export function createHierarchyDefinitionFactory({
   createGenericNodeForY,
 }: {
   xyzSchema: Awaited<ReturnType<typeof importSchema>>;
-  createYGroupingParams?: (
-    alias: string,
-  ) => Props<DefineHierarchyLevelProps["nodeSelectClauseFactory"]["createSelectClause"]>["grouping"];
+  createYGroupingParams?: (alias: string) => Props<DefineHierarchyLevelProps["createSelectClause"]>["grouping"];
   createGenericNodeForY?: boolean;
 }): Props<typeof createMergedHierarchyProvider>["createHierarchyDefinition"] {
   const classes = xyzSchema.items;
 
-  const rootNodes = async ({ instanceFilter, nodeSelectClauseFactory }: DefineRootHierarchyLevelProps) => {
-    const { from, joins, where } = await nodeSelectClauseFactory.createFilterClauses({
+  const rootNodes = async ({
+    instanceFilter,
+    createSelectClause,
+    createFilterClauses,
+  }: DefineRootHierarchyLevelProps) => {
+    const { from, joins, where } = await createFilterClauses({
       contentClass: { fullName: classes.X.fullName, alias: "this" },
       filter: instanceFilter,
     });
@@ -46,7 +48,7 @@ export function createHierarchyDefinitionFactory({
         fullClassName: classes.X.fullName,
         query: {
           ecsql: `
-            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+            SELECT ${await createSelectClause({
               ecClassId: { selector: `this.ECClassId` },
               ecInstanceId: { selector: `this.ECInstanceId` },
               nodeLabel: { selector: "this.Label" },
@@ -62,17 +64,15 @@ export function createHierarchyDefinitionFactory({
   const childNodesForX = async ({
     instanceFilter,
     parentNodeInstanceIds,
-    nodeSelectClauseFactory,
+    createSelectClause,
+    createFilterClauses,
   }: Pick<
     DefineInstanceNodeChildHierarchyLevelProps,
-    "instanceFilter" | "parentNodeInstanceIds" | "nodeSelectClauseFactory"
+    "instanceFilter" | "parentNodeInstanceIds" | "createSelectClause" | "createFilterClauses"
   >) => {
     const [filterY, filterZ] = await Promise.all(
       [classes.Y.fullName, classes.Z.fullName].map(async (contentClassName) =>
-        nodeSelectClauseFactory.createFilterClauses({
-          contentClass: { fullName: contentClassName, alias: "this" },
-          filter: instanceFilter,
-        }),
+        createFilterClauses({ contentClass: { fullName: contentClassName, alias: "this" }, filter: instanceFilter }),
       ),
     );
     return [
@@ -80,7 +80,7 @@ export function createHierarchyDefinitionFactory({
         fullClassName: classes.Y.fullName,
         query: {
           ecsql: `
-            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+            SELECT ${await createSelectClause({
               ecClassId: { selector: `this.ECClassId` },
               ecInstanceId: { selector: `this.ECInstanceId` },
               nodeLabel: { selector: "this.Label" },
@@ -99,7 +99,7 @@ export function createHierarchyDefinitionFactory({
         fullClassName: classes.Z.fullName,
         query: {
           ecsql: `
-            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+            SELECT ${await createSelectClause({
               ecClassId: { selector: `this.ECClassId` },
               ecInstanceId: { selector: `this.ECInstanceId` },
               nodeLabel: { selector: "this.Label" },

--- a/apps/full-stack-tests/src/hierarchies/imodel-hierarchy-merging/HierarchiesMerging.ts
+++ b/apps/full-stack-tests/src/hierarchies/imodel-hierarchy-merging/HierarchiesMerging.ts
@@ -6,21 +6,19 @@
 import { assert } from "@itwin/core-bentley";
 import {
   createMergedIModelHierarchyProvider,
-  createNodesQueryClauseFactory,
   createPredicateBasedHierarchyDefinition,
   HierarchyNodeKey,
 } from "@itwin/presentation-hierarchies";
-import { createDefaultInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 import { importSchema } from "../../SchemaUtils.js";
 import { createIModelAccess } from "../Utils.js";
 
 import type { ECDb } from "@itwin/core-backend";
 import type {
   DefineGenericNodeChildHierarchyLevelProps,
+  DefineHierarchyLevelProps,
   DefineInstanceNodeChildHierarchyLevelProps,
   DefineRootHierarchyLevelProps,
   HierarchyDefinition,
-  NodesQueryClauseFactory,
 } from "@itwin/presentation-hierarchies";
 import type { ECSqlBinding, Props } from "@itwin/presentation-shared";
 import type { ECDbBuilder } from "../../ECDbUtils.js";
@@ -31,17 +29,15 @@ export function createHierarchyDefinitionFactory({
   createGenericNodeForY,
 }: {
   xyzSchema: Awaited<ReturnType<typeof importSchema>>;
-  createYGroupingParams?: (alias: string) => Props<NodesQueryClauseFactory["createSelectClause"]>["grouping"];
+  createYGroupingParams?: (
+    alias: string,
+  ) => Props<DefineHierarchyLevelProps["nodeSelectClauseFactory"]["createSelectClause"]>["grouping"];
   createGenericNodeForY?: boolean;
 }): Props<typeof createMergedHierarchyProvider>["createHierarchyDefinition"] {
   const classes = xyzSchema.items;
 
-  const rootNodes = async ({ imodelAccess, instanceFilter }: DefineRootHierarchyLevelProps) => {
-    const queryClauseFactory = createNodesQueryClauseFactory({
-      imodelAccess,
-      instanceLabelSelectClauseFactory: createDefaultInstanceLabelSelectClauseFactory(),
-    });
-    const { from, joins, where } = await queryClauseFactory.createFilterClauses({
+  const rootNodes = async ({ instanceFilter, nodeSelectClauseFactory }: DefineRootHierarchyLevelProps) => {
+    const { from, joins, where } = await nodeSelectClauseFactory.createFilterClauses({
       contentClass: { fullName: classes.X.fullName, alias: "this" },
       filter: instanceFilter,
     });
@@ -50,7 +46,7 @@ export function createHierarchyDefinitionFactory({
         fullClassName: classes.X.fullName,
         query: {
           ecsql: `
-            SELECT ${await queryClauseFactory.createSelectClause({
+            SELECT ${await nodeSelectClauseFactory.createSelectClause({
               ecClassId: { selector: `this.ECClassId` },
               ecInstanceId: { selector: `this.ECInstanceId` },
               nodeLabel: { selector: "this.Label" },
@@ -64,17 +60,16 @@ export function createHierarchyDefinitionFactory({
     ];
   };
   const childNodesForX = async ({
-    imodelAccess,
     instanceFilter,
     parentNodeInstanceIds,
-  }: Pick<DefineInstanceNodeChildHierarchyLevelProps, "imodelAccess" | "instanceFilter" | "parentNodeInstanceIds">) => {
-    const queryClauseFactory = createNodesQueryClauseFactory({
-      imodelAccess,
-      instanceLabelSelectClauseFactory: createDefaultInstanceLabelSelectClauseFactory(),
-    });
+    nodeSelectClauseFactory,
+  }: Pick<
+    DefineInstanceNodeChildHierarchyLevelProps,
+    "instanceFilter" | "parentNodeInstanceIds" | "nodeSelectClauseFactory"
+  >) => {
     const [filterY, filterZ] = await Promise.all(
       [classes.Y.fullName, classes.Z.fullName].map(async (contentClassName) =>
-        queryClauseFactory.createFilterClauses({
+        nodeSelectClauseFactory.createFilterClauses({
           contentClass: { fullName: contentClassName, alias: "this" },
           filter: instanceFilter,
         }),
@@ -85,7 +80,7 @@ export function createHierarchyDefinitionFactory({
         fullClassName: classes.Y.fullName,
         query: {
           ecsql: `
-            SELECT ${await queryClauseFactory.createSelectClause({
+            SELECT ${await nodeSelectClauseFactory.createSelectClause({
               ecClassId: { selector: `this.ECClassId` },
               ecInstanceId: { selector: `this.ECInstanceId` },
               nodeLabel: { selector: "this.Label" },
@@ -104,7 +99,7 @@ export function createHierarchyDefinitionFactory({
         fullClassName: classes.Z.fullName,
         query: {
           ecsql: `
-            SELECT ${await queryClauseFactory.createSelectClause({
+            SELECT ${await nodeSelectClauseFactory.createSelectClause({
               ecClassId: { selector: `this.ECClassId` },
               ecInstanceId: { selector: `this.ECInstanceId` },
               nodeLabel: { selector: "this.Label" },

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/Grouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/Grouping.test.ts
@@ -46,7 +46,7 @@ describe("Hierarchies", () => {
           const hierarchyProvider = createIModelHierarchyProvider({
             imodelAccess,
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
                 if (!parentNode) {
                   // The hierarchy definition requests `BisCore.PhysicalElement` nodes to be return as
                   // root nodes and have them grouped by label
@@ -55,7 +55,7 @@ describe("Hierarchies", () => {
                       fullClassName: "BisCore.PhysicalElement",
                       query: {
                         ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: "this.ECClassId" },
                             ecInstanceId: { selector: "this.ECInstanceId" },
                             nodeLabel: { selector: "this.UserLabel" },
@@ -119,7 +119,7 @@ describe("Hierarchies", () => {
           const hierarchyProvider = createIModelHierarchyProvider({
             imodelAccess,
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
                 if (!parentNode) {
                   // The hierarchy definition requests `BisCore.PhysicalElement` nodes to be returned as root
                   // nodes and have them merged based on label
@@ -128,7 +128,7 @@ describe("Hierarchies", () => {
                       fullClassName: "BisCore.PhysicalElement",
                       query: {
                         ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: "this.ECClassId" },
                             ecInstanceId: { selector: "this.ECInstanceId" },
                             nodeLabel: { selector: "this.UserLabel" },
@@ -170,7 +170,7 @@ describe("Hierarchies", () => {
           const hierarchyProvider = createIModelHierarchyProvider({
             imodelAccess,
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
                 if (!parentNode) {
                   // The hierarchy definition requests `BisCore.Category` nodes to be returned as root nodes and have
                   // them grouped by class.
@@ -179,7 +179,7 @@ describe("Hierarchies", () => {
                       fullClassName: "BisCore.Category",
                       query: {
                         ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: "this.ECClassId" },
                             ecInstanceId: { selector: "this.ECInstanceId" },
                             nodeLabel: { selector: "this.CodeValue" },
@@ -237,7 +237,7 @@ describe("Hierarchies", () => {
           const hierarchyProvider = createIModelHierarchyProvider({
             imodelAccess,
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
                 if (!parentNode) {
                   // The hierarchy definition requests `BisCore.Category` nodes to be grouped by the following classes:
                   // - `BisCore.Element`
@@ -247,7 +247,7 @@ describe("Hierarchies", () => {
                       fullClassName: "BisCore.Category",
                       query: {
                         ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: "this.ECClassId" },
                             ecInstanceId: { selector: "this.ECInstanceId" },
                             nodeLabel: { selector: "this.CodeValue" },
@@ -308,7 +308,7 @@ describe("Hierarchies", () => {
           const hierarchyProvider = createIModelHierarchyProvider({
             imodelAccess,
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
                 if (!parentNode) {
                   // The hierarchy definition requests `BisCore.RepositoryLink` nodes to be returned as root nodes and have
                   // them grouped by the `Format` property.
@@ -317,7 +317,7 @@ describe("Hierarchies", () => {
                       fullClassName: "BisCore.RepositoryLink",
                       query: {
                         ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: "this.ECClassId" },
                             ecInstanceId: { selector: "this.ECInstanceId" },
                             nodeLabel: { selector: "this.UserLabel" },
@@ -391,7 +391,7 @@ describe("Hierarchies", () => {
           const hierarchyProvider = createIModelHierarchyProvider({
             imodelAccess,
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
                 if (!parentNode) {
                   // The hierarchy definition requests `BisCore.PhysicalMaterial` nodes to be returned as root nodes and have
                   // them grouped by the `Density` property value in given ranges.
@@ -400,7 +400,7 @@ describe("Hierarchies", () => {
                       fullClassName: "BisCore.PhysicalMaterial",
                       query: {
                         ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: "this.ECClassId" },
                             ecInstanceId: { selector: "this.ECInstanceId" },
                             nodeLabel: { selector: "this.UserLabel" },
@@ -478,7 +478,7 @@ describe("Hierarchies", () => {
         const hierarchyProvider = createIModelHierarchyProvider({
           imodelAccess,
           hierarchyDefinition: {
-            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+            defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
               if (!parentNode) {
                 // The hierarchy definition requests `BisCore.RepositoryLink` nodes to be returned as root nodes and have
                 // them grouped by the `Format` property.
@@ -487,7 +487,7 @@ describe("Hierarchies", () => {
                     fullClassName: "BisCore.RepositoryLink",
                     query: {
                       ecsql: `
-                        SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        SELECT ${await createSelectClause({
                           ecClassId: { selector: "this.ECClassId" },
                           ecInstanceId: { selector: "this.ECInstanceId" },
                           nodeLabel: { selector: "this.UserLabel" },
@@ -599,7 +599,7 @@ describe("Hierarchies", () => {
           const hierarchyProvider = createIModelHierarchyProvider({
             imodelAccess,
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
                 if (!parentNode) {
                   // The hierarchy definition requests `BisCore.RepositoryLink` nodes to be returned as root nodes and have
                   // them grouped by label only if there's more than one instance with the same label.
@@ -608,7 +608,7 @@ describe("Hierarchies", () => {
                       fullClassName: "BisCore.RepositoryLink",
                       query: {
                         ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: "this.ECClassId" },
                             ecInstanceId: { selector: "this.ECInstanceId" },
                             nodeLabel: { selector: "this.UserLabel" },
@@ -652,7 +652,7 @@ describe("Hierarchies", () => {
           const hierarchyProvider = createIModelHierarchyProvider({
             imodelAccess,
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
                 if (!parentNode) {
                   // The hierarchy definition requests `BisCore.RepositoryLink` nodes to be returned as root nodes and have
                   // them grouped by class only if the grouping node has siblings.
@@ -661,7 +661,7 @@ describe("Hierarchies", () => {
                       fullClassName: "BisCore.RepositoryLink",
                       query: {
                         ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: "this.ECClassId" },
                             ecInstanceId: { selector: "this.ECInstanceId" },
                             nodeLabel: { selector: "this.UserLabel" },
@@ -705,7 +705,7 @@ describe("Hierarchies", () => {
           const hierarchyProvider = createIModelHierarchyProvider({
             imodelAccess,
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
                 if (!parentNode) {
                   return [
                     {
@@ -714,7 +714,7 @@ describe("Hierarchies", () => {
                         ecsql:
                           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Grouping.AutoExpandExample
                           `
-                            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                            SELECT ${await createSelectClause({
                               ecClassId: { selector: "this.ECClassId" },
                               ecInstanceId: { selector: "this.ECInstanceId" },
                               nodeLabel: { selector: "this.UserLabel" },

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyDefinitions.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyDefinitions.test.ts
@@ -106,7 +106,7 @@ describe("Hierarchies", () => {
                 {
                   fullClassName: "BisCore.PhysicalElement",
                   query: {
-                    // Define the query without using `NodesQueryClauseFactory` - we'll parse the results manually. But to create
+                    // Define the query without using `nodeSelectClauseFactory` - we'll parse the results manually. But to create
                     // an instances node we need at least a class name, instance id, and a label.
                     ecsql: `
                       SELECT

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyDefinitions.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyDefinitions.test.ts
@@ -52,7 +52,7 @@ describe("Hierarchies", () => {
         const imodelAccess = createIModelAccess(imodelConnection);
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyDefinitions.Simple
         const hierarchyDefinition: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             // For root nodes, simply return one generic node
             if (!parentNode) {
               return [{ node: { key: "physical-elements", label: "Physical elements" } }];
@@ -64,7 +64,7 @@ describe("Hierarchies", () => {
                   fullClassName: "BisCore.PhysicalElement",
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "x.ECClassId" },
                         ecInstanceId: { selector: "x.ECInstanceId" },
                         nodeLabel: { selector: "x.UserLabel" },
@@ -106,7 +106,7 @@ describe("Hierarchies", () => {
                 {
                   fullClassName: "BisCore.PhysicalElement",
                   query: {
-                    // Define the query without using `nodeSelectClauseFactory` - we'll parse the results manually. But to create
+                    // Define the query without using `createSelectClause` - we'll parse the results manually. But to create
                     // an instances node we need at least a class name, instance id, and a label.
                     ecsql: `
                       SELECT
@@ -153,7 +153,7 @@ describe("Hierarchies", () => {
         };
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyDefinitions.PreProcessNode
         const hierarchyDefinition: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             // For root nodes, return all physical elements
             if (!parentNode) {
               return [
@@ -161,7 +161,7 @@ describe("Hierarchies", () => {
                   fullClassName: "BisCore.PhysicalElement",
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "x.ECClassId" },
                         ecInstanceId: { selector: "x.ECInstanceId" },
                         nodeLabel: { selector: "x.UserLabel" },
@@ -199,7 +199,7 @@ describe("Hierarchies", () => {
         const imodelAccess = createIModelAccess(imodelConnection);
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyDefinitions.PostProcessNode
         const hierarchyDefinition: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             // For root nodes, return all physical elements grouped by class
             if (!parentNode) {
               return [
@@ -207,7 +207,7 @@ describe("Hierarchies", () => {
                   fullClassName: "BisCore.PhysicalElement",
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "x.ECClassId" },
                         ecInstanceId: { selector: "x.ECInstanceId" },
                         nodeLabel: { selector: "x.UserLabel" },
@@ -263,13 +263,13 @@ describe("Hierarchies", () => {
                 // For the root node, return a query that selects all physical elements
                 parentGenericNodePredicate: async (parentKey) => parentKey.id === "physical-elements",
                 definitions: async ({
-                  nodeSelectClauseFactory,
+                  createSelectClause,
                 }: DefineGenericNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> => [
                   {
                     fullClassName: "BisCore.PhysicalElement",
                     query: {
                       ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "x.ECClassId" },
                         ecInstanceId: { selector: "x.ECInstanceId" },
                         nodeLabel: { selector: "x.UserLabel" },

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyLevelFiltering.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyLevelFiltering.test.ts
@@ -81,14 +81,14 @@ describe("Hierarchies", () => {
       it("creates filterable instances node", async () => {
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyLevelFiltering.InstanceNodesQueryDefinition
         const hierarchyDefinition: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
                   fullClassName: "BisCore.PhysicalElement",
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "this.ECClassId" },
                         ecInstanceId: { selector: "this.ECInstanceId" },
                         nodeLabel: { selector: "this.UserLabel" },
@@ -117,22 +117,22 @@ describe("Hierarchies", () => {
       it("applies filter", async () => {
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyLevelFiltering.ApplyFilter
         const hierarchyDefinition: HierarchyDefinition = {
-          async defineHierarchyLevel(props) {
+          async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
             // `createFilterClauses` function returns `from`, `joins`, and `where` clauses which need to be used in the
             // query in appropriate places
-            const { from, joins, where } = await props.nodeSelectClauseFactory.createFilterClauses({
+            const { from, joins, where } = await createFilterClauses({
               // specify the content class whose instances are used to build nodes - this should
               // generally match the instance whose ECClassId and ECInstanceId are used in the SELECT clause
               contentClass: { fullName: "BisCore.PhysicalElement", alias: "this" },
               // specify the filter that we get from props for this hierarchy level
-              filter: props.instanceFilter,
+              filter: instanceFilter,
             });
             return [
               {
                 fullClassName: "BisCore.PhysicalElement",
                 query: {
                   ecsql: `
-                    SELECT ${await props.nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: "this.ECClassId" },
                       ecInstanceId: { selector: "this.ECInstanceId" },
                       nodeLabel: { selector: "this.UserLabel" },
@@ -151,7 +151,7 @@ describe("Hierarchies", () => {
           imodelAccess: createIModelAccess(imodelConnection),
           hierarchyDefinition,
         });
-        const instanceFilter: GenericInstanceFilter = {
+        const testInstanceFilter: GenericInstanceFilter = {
           propertyClassNames: ["BisCore.PhysicalElement"],
           relatedInstances: [],
           rules: {
@@ -175,7 +175,7 @@ describe("Hierarchies", () => {
           },
         };
         validateHierarchyLevel({
-          nodes: await collect(provider.getNodes({ parentNode: undefined, instanceFilter })),
+          nodes: await collect(provider.getNodes({ parentNode: undefined, instanceFilter: testInstanceFilter })),
           expect: [
             NodeValidators.createForInstanceNode({ label: "B" }),
             NodeValidators.createForInstanceNode({ label: "C" }),

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyNodeLabels.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyNodeLabels.test.ts
@@ -78,7 +78,7 @@ describe("Hierarchies", () => {
 
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.NodeLabels.IModelInstanceLabelSelectClauseFactory
         const hierarchyDefinition: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, instanceLabelSelectClauseFactory, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
             // For root nodes, return a query that selects all physical elements
             if (!parentNode) {
               return [
@@ -89,12 +89,13 @@ describe("Hierarchies", () => {
                       SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: "x.ECClassId" },
                         ecInstanceId: { selector: "x.ECInstanceId" },
+                        // Use `{ of: ... }` to delegate label creation to the instance label select clause factory used 
+                        // by `nodeSelectClauseFactory`, which defaults to the result of `createIModelInstanceLabelSelectClauseFactory`.
                         nodeLabel: {
-                          // Use iModel instance label select clause factory to create the label selector
-                          selector: await instanceLabelSelectClauseFactory.createSelectClause({
+                          of: {
                             classAlias: "x",
                             className: "BisCore.PhysicalElement", // This is optional, but helps create a more optimal selector
-                          }),
+                          },
                         },
                       })}
                       FROM BisCore.PhysicalElement x

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyNodeLabels.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyNodeLabels.test.ts
@@ -78,7 +78,7 @@ describe("Hierarchies", () => {
 
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.NodeLabels.IModelInstanceLabelSelectClauseFactory
         const hierarchyDefinition: HierarchyDefinition = {
-          async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
             // For root nodes, return a query that selects all physical elements
             if (!parentNode) {
               return [
@@ -86,11 +86,11 @@ describe("Hierarchies", () => {
                   fullClassName: "BisCore.PhysicalElement",
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "x.ECClassId" },
                         ecInstanceId: { selector: "x.ECInstanceId" },
                         // Use `{ of: ... }` to delegate label creation to the instance label select clause factory used
-                        // by `nodeSelectClauseFactory`, which defaults to the result of `createIModelInstanceLabelSelectClauseFactory`.
+                        // by `createSelectClause`, which defaults to the result of `createIModelInstanceLabelSelectClauseFactory`.
                         nodeLabel: {
                           of: {
                             classAlias: "x",
@@ -135,14 +135,14 @@ describe("Hierarchies", () => {
         const hierarchyProvider = createIModelHierarchyProvider({
           imodelAccess,
           hierarchyDefinition: {
-            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+            defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
               if (!parentNode) {
                 return [
                   {
                     fullClassName: "BisCore.PhysicalElement",
                     query: {
                       ecsql: `
-                        SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        SELECT ${await createSelectClause({
                           ecClassId: { selector: "x.ECClassId" },
                           ecInstanceId: { selector: "x.ECInstanceId" },
                           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.NodeLabels.CustomLabelSelector
@@ -223,7 +223,7 @@ describe("Hierarchies", () => {
         const hierarchyProvider = createIModelHierarchyProvider({
           imodelAccess,
           hierarchyDefinition: {
-            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+            defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
               if (!parentNode) {
                 return [
                   // The hierarchy definition returns nodes for `myPhysicalObjectClassName` element type, grouped by `DoubleProperty` property value
@@ -231,7 +231,7 @@ describe("Hierarchies", () => {
                     fullClassName: myPhysicalObjectClassName,
                     query: {
                       ecsql: `
-                        SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        SELECT ${await createSelectClause({
                           ecClassId: { selector: "this.ECClassId" },
                           ecInstanceId: { selector: "this.ECInstanceId" },
                           nodeLabel: { selector: "this.UserLabel" },

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyNodeLabels.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyNodeLabels.test.ts
@@ -89,7 +89,7 @@ describe("Hierarchies", () => {
                       SELECT ${await nodeSelectClauseFactory.createSelectClause({
                         ecClassId: { selector: "x.ECClassId" },
                         ecInstanceId: { selector: "x.ECInstanceId" },
-                        // Use `{ of: ... }` to delegate label creation to the instance label select clause factory used 
+                        // Use `{ of: ... }` to delegate label creation to the instance label select clause factory used
                         // by `nodeSelectClauseFactory`, which defaults to the result of `createIModelInstanceLabelSelectClauseFactory`.
                         nodeLabel: {
                           of: {

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchySearch.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchySearch.test.ts
@@ -118,7 +118,7 @@ describe("Hierarchies", () => {
       // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchySearch.HierarchyDefinition
       function createHierarchyDefinition(): HierarchyDefinition {
         return {
-          defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+          defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
             const createHierarchyLevelDefinition = async ({
               whereClause,
               bindings,
@@ -130,7 +130,7 @@ describe("Hierarchies", () => {
                 fullClassName: "BisCore.PhysicalElement",
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: "this.ECClassId" },
                       ecInstanceId: { selector: "this.ECInstanceId" },
                       nodeLabel: { selector: "this.UserLabel" },
@@ -356,14 +356,14 @@ describe("Hierarchies", () => {
         const imodelAccess = createIModelAccess(imodelConnection);
         // Define a hierarchy such that all elements except root are grouped by label.
         const hierarchyDefinition: HierarchyDefinition = {
-          defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+          defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
             if (!parentNode) {
               return [
                 {
                   fullClassName: "BisCore.PhysicalElement",
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "this.ECClassId" },
                         ecInstanceId: { selector: "this.ECInstanceId" },
                         nodeLabel: { selector: "this.UserLabel" },
@@ -382,7 +382,7 @@ describe("Hierarchies", () => {
                 fullClassName: "BisCore.PhysicalElement",
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: "this.ECClassId" },
                       ecInstanceId: { selector: "this.ECInstanceId" },
                       nodeLabel: { selector: "this.UserLabel" },
@@ -476,14 +476,14 @@ describe("Hierarchies", () => {
         const imodelAccess = createIModelAccess(imodelConnection);
         // Define a hierarchy such that all elements except root are grouped by label.
         const hierarchyDefinition: HierarchyDefinition = {
-          defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+          defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
             if (!parentNode) {
               return [
                 {
                   fullClassName: "BisCore.PhysicalElement",
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "this.ECClassId" },
                         ecInstanceId: { selector: "this.ECInstanceId" },
                         nodeLabel: { selector: "this.UserLabel" },
@@ -502,7 +502,7 @@ describe("Hierarchies", () => {
                 fullClassName: "BisCore.PhysicalElement",
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: "this.ECClassId" },
                       ecInstanceId: { selector: "this.ECInstanceId" },
                       nodeLabel: { selector: "this.UserLabel" },
@@ -577,14 +577,14 @@ describe("Hierarchies", () => {
         const imodelAccess = createIModelAccess(imodelConnection);
         // Define a hierarchy such that all elements except root are grouped by label.
         const hierarchyDefinition: HierarchyDefinition = {
-          defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+          defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
             if (!parentNode) {
               return [
                 {
                   fullClassName: "BisCore.PhysicalElement",
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "this.ECClassId" },
                         ecInstanceId: { selector: "this.ECInstanceId" },
                         nodeLabel: { selector: "this.UserLabel" },
@@ -603,7 +603,7 @@ describe("Hierarchies", () => {
                 fullClassName: "BisCore.PhysicalElement",
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: "this.ECClassId" },
                       ecInstanceId: { selector: "this.ECInstanceId" },
                       nodeLabel: { selector: "this.UserLabel" },

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/Localization.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/Localization.test.ts
@@ -83,7 +83,7 @@ describe("Hierarchies", () => {
         const hierarchyProvider = createIModelHierarchyProvider({
           imodelAccess,
           hierarchyDefinition: {
-            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+            defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
               if (!parentNode) {
                 // The hierarchy definition returns nodes for `myPhysicalObjectClassName` element type, grouped by `IntProperty` property value,
                 // with options to create groups for out-of-range and unspecified values - labels of those grouping nodes get localized
@@ -92,7 +92,7 @@ describe("Hierarchies", () => {
                     fullClassName: myPhysicalObjectClassName,
                     query: {
                       ecsql: `
-                        SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        SELECT ${await createSelectClause({
                           ecClassId: { selector: "this.ECClassId" },
                           ecInstanceId: { selector: "this.ECInstanceId" },
                           nodeLabel: { selector: "this.UserLabel" },

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/MergedIModelHierarchies.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/MergedIModelHierarchies.test.ts
@@ -99,10 +99,10 @@ describe("Hierarchies", () => {
 
         // Define an utility for creating instance nodes query definitions, that we'll use in our hierarchy definition.
         async function createInstanceNodesQueryDefinition({
-          nodeSelectClauseFactory,
+          createSelectClause,
           fullClassName,
           whereClauseFactory,
-        }: Pick<DefineInstanceNodeChildHierarchyLevelProps, "nodeSelectClauseFactory"> & {
+        }: Pick<DefineInstanceNodeChildHierarchyLevelProps, "createSelectClause"> & {
           fullClassName: EC.FullClassName;
           whereClauseFactory?: (props: { alias: string }) => Promise<string>;
         }) {
@@ -111,7 +111,7 @@ describe("Hierarchies", () => {
             fullClassName,
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
                   nodeLabel: { of: { classAlias: "this", className: fullClassName } },

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/MergedIModelHierarchies.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/MergedIModelHierarchies.test.ts
@@ -99,14 +99,13 @@ describe("Hierarchies", () => {
 
         // Define an utility for creating instance nodes query definitions, that we'll use in our hierarchy definition.
         async function createInstanceNodesQueryDefinition({
-          instanceLabelSelectClauseFactory,
           nodeSelectClauseFactory,
           fullClassName,
           whereClauseFactory,
-        }: Pick<
-          DefineInstanceNodeChildHierarchyLevelProps,
-          "instanceLabelSelectClauseFactory" | "nodeSelectClauseFactory"
-        > & { fullClassName: EC.FullClassName; whereClauseFactory?: (props: { alias: string }) => Promise<string> }) {
+        }: Pick<DefineInstanceNodeChildHierarchyLevelProps, "nodeSelectClauseFactory"> & {
+          fullClassName: EC.FullClassName;
+          whereClauseFactory?: (props: { alias: string }) => Promise<string>;
+        }) {
           const whereClause = whereClauseFactory ? await whereClauseFactory({ alias: "this" }) : undefined;
           return {
             fullClassName,
@@ -115,12 +114,7 @@ describe("Hierarchies", () => {
                 SELECT ${await nodeSelectClauseFactory.createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
-                  nodeLabel: {
-                    selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                      classAlias: "this",
-                      className: fullClassName,
-                    }),
-                  },
+                  nodeLabel: { of: { classAlias: "this", className: fullClassName } },
                 })}
                 FROM ${fullClassName} AS this
                 ${whereClause ? `WHERE ${whereClause}` : ""}

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/Migration.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/Migration.test.ts
@@ -33,12 +33,11 @@ import { HierarchyDefinition } from "@itwin/presentation-hierarchies";
 // __PUBLISH_EXTRACT_END__
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.HierarchyNodesDefinitionImports
 import {
-  createNodesQueryClauseFactory,
+  DefineHierarchyLevelProps,
   HierarchyLevelDefinition,
   HierarchyNodesDefinition,
   InstancesNodeKey,
 } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
 import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
@@ -190,41 +189,37 @@ describe("Hierarchies", () => {
           });
           const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.InstanceNodesOfSpecificClassesDefinition
-          const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-          const selectClauseFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: labelsFactory,
-          });
-          const definition: HierarchyNodesDefinition = {
-            fullClassName: "BisCore.GeometricModel",
-            query: {
-              ecsql: `
-                SELECT ${await selectClauseFactory.createSelectClause({
-                  ecClassId: { selector: "this.ECClassId" },
-                  ecInstanceId: { selector: "this.ECInstanceId" },
-                  nodeLabel: {
-                    selector: await labelsFactory.createSelectClause({
-                      className: "BisCore.GeometricModel",
-                      classAlias: "this",
-                    }),
+          const hierarchyDefinition: HierarchyDefinition = {
+            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              if (parentNode) {
+                return [];
+              }
+              return [
+                {
+                  fullClassName: "BisCore.GeometricModel",
+                  query: {
+                    ecsql: `
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        ecClassId: { selector: "this.ECClassId" },
+                        ecInstanceId: { selector: "this.ECInstanceId" },
+                        nodeLabel: { of: { className: "BisCore.GeometricModel", classAlias: "this" } },
+                        hasChildren: true,
+                        grouping: {
+                          byClass: true,
+                          byLabel: { action: "group", hideIfNoSiblings: true, hideIfOneGroupedNode: true },
+                        },
+                      })}
+                      FROM BisCore.GeometricModel [this]
+                      INNER JOIN BisCore.InformationPartitionElement [partition] ON [partition].[ECInstanceId] = [this].[ModeledElement].[Id]
+                      WHERE NOT [this].[IsPrivate] AND [this].[ECClassId] IS NOT (BisCore.GeometricModel2d)
+                    `,
                   },
-                  hasChildren: true,
-                  grouping: {
-                    byClass: true,
-                    byLabel: { action: "group", hideIfNoSiblings: true, hideIfOneGroupedNode: true },
-                  },
-                })}
-                FROM BisCore.GeometricModel [this]
-                INNER JOIN BisCore.InformationPartitionElement [partition] ON [partition].[ECInstanceId] = [this].[ModeledElement].[Id]
-                WHERE NOT [this].[IsPrivate] AND [this].[ECClassId] IS NOT (BisCore.GeometricModel2d)
-              `,
+                },
+              ];
             },
           };
           // __PUBLISH_EXTRACT_END__
-          const provider = createIModelHierarchyProvider({
-            imodelAccess,
-            hierarchyDefinition: { defineHierarchyLevel: async ({ parentNode }) => (parentNode ? [] : [definition]) },
-          });
+          const provider = createIModelHierarchyProvider({ imodelAccess, hierarchyDefinition });
           await validateHierarchy({
             provider,
             expect: [
@@ -251,28 +246,19 @@ describe("Hierarchies", () => {
           });
           const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.RelatedInstanceNodesDefinition
-          const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-          const selectClauseFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: labelsFactory,
-          });
-          const createDefinition = async ({
+          const createChildDefinition = async ({
             parentNode,
-          }: {
+            nodeSelectClauseFactory,
+          }: Pick<DefineHierarchyLevelProps, "nodeSelectClauseFactory"> & {
             parentNode: HierarchyNode & { key: InstancesNodeKey };
           }): Promise<HierarchyNodesDefinition> => ({
             fullClassName: "BisCore.GeometricElement3d",
             query: {
               ecsql: `
-                SELECT ${await selectClauseFactory.createSelectClause({
+                SELECT ${await nodeSelectClauseFactory.createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
-                  nodeLabel: {
-                    selector: await labelsFactory.createSelectClause({
-                      className: "BisCore.GeometricElement3d",
-                      classAlias: "this",
-                    }),
-                  },
+                  nodeLabel: { of: { className: "BisCore.GeometricElement3d", classAlias: "this" } },
                 })}
                 FROM BisCore.GeometricElement3d [this]
                 INNER JOIN BisCore.SpatialCategory [category] ON [category].[ECInstanceId] = [this].[Category].[Id]
@@ -285,31 +271,29 @@ describe("Hierarchies", () => {
             },
           });
           // __PUBLISH_EXTRACT_END__
-          const rootLevelDefinition: HierarchyNodesDefinition = {
-            fullClassName: "BisCore.PhysicalModel",
-            query: {
-              ecsql: `
-                SELECT ${await selectClauseFactory.createSelectClause({
-                  ecClassId: { selector: "this.ECClassId" },
-                  ecInstanceId: { selector: "this.ECInstanceId" },
-                  nodeLabel: {
-                    selector: await labelsFactory.createSelectClause({
-                      className: "BisCore.PhysicalModel",
-                      classAlias: "this",
-                    }),
-                  },
-                })}
-                FROM BisCore.PhysicalModel [this]
-              `,
-            },
-          };
           const provider = createIModelHierarchyProvider({
             imodelAccess,
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode }) =>
-                parentNode && HierarchyNode.isInstancesNode(parentNode)
-                  ? [await createDefinition({ parentNode })]
-                  : [rootLevelDefinition],
+              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+                if (parentNode && HierarchyNode.isInstancesNode(parentNode)) {
+                  return [await createChildDefinition({ parentNode, nodeSelectClauseFactory })];
+                }
+                return [
+                  {
+                    fullClassName: "BisCore.PhysicalModel",
+                    query: {
+                      ecsql: `
+                        SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          ecClassId: { selector: "this.ECClassId" },
+                          ecInstanceId: { selector: "this.ECInstanceId" },
+                          nodeLabel: { of: { className: "BisCore.PhysicalModel", classAlias: "this" } },
+                        })}
+                        FROM BisCore.PhysicalModel [this]
+                      `,
+                    },
+                  },
+                ];
+              },
             },
           });
           await validateHierarchy({
@@ -360,14 +344,10 @@ describe("Hierarchies", () => {
           });
           const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.CustomQueryInstanceNodesDefinition
-          const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-          const selectClauseFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: labelsFactory,
-          });
           const createDefinition = async ({
             parentNode,
-          }: {
+            nodeSelectClauseFactory,
+          }: Pick<DefineHierarchyLevelProps, "nodeSelectClauseFactory"> & {
             parentNode: HierarchyNode & { key: InstancesNodeKey };
           }): Promise<HierarchyLevelDefinition> => {
             if (
@@ -394,15 +374,10 @@ describe("Hierarchies", () => {
                       fullClassName: `${schema.schemaName}.MyChildElement`,
                       query: {
                         ecsql: `
-                          SELECT ${await selectClauseFactory.createSelectClause({
+                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
                             ecClassId: { selector: "this.ECClassId" },
                             ecInstanceId: { selector: "this.ECInstanceId" },
-                            nodeLabel: {
-                              selector: await labelsFactory.createSelectClause({
-                                className: `${schema.schemaName}.MyChildElement`,
-                                classAlias: "this",
-                              }),
-                            },
+                            nodeLabel: { of: { className: `${schema.schemaName}.MyChildElement`, classAlias: "this" } },
                           })}
                           FROM ${schema.schemaName}.MyChildElement this
                           WHERE this.ECInstanceId IN (
@@ -417,33 +392,29 @@ describe("Hierarchies", () => {
             return [];
           };
           // __PUBLISH_EXTRACT_END__
-          const rootLevelDefinition: HierarchyLevelDefinition = [
-            {
-              fullClassName: schema.items.MyParentElement.fullName,
-              query: {
-                ecsql: `
-                SELECT ${await selectClauseFactory.createSelectClause({
-                  ecClassId: { selector: "this.ECClassId" },
-                  ecInstanceId: { selector: "this.ECInstanceId" },
-                  nodeLabel: {
-                    selector: await labelsFactory.createSelectClause({
-                      className: schema.items.MyParentElement.fullName,
-                      classAlias: "this",
-                    }),
-                  },
-                })}
-                FROM ${schema.items.MyParentElement.fullName} [this]
-              `,
-              },
-            },
-          ];
           const provider = createIModelHierarchyProvider({
             imodelAccess,
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode }) =>
-                parentNode && HierarchyNode.isInstancesNode(parentNode)
-                  ? createDefinition({ parentNode })
-                  : rootLevelDefinition,
+              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+                if (parentNode && HierarchyNode.isInstancesNode(parentNode)) {
+                  return createDefinition({ parentNode, nodeSelectClauseFactory });
+                }
+                return [
+                  {
+                    fullClassName: schema.items.MyParentElement.fullName,
+                    query: {
+                      ecsql: `
+                        SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          ecClassId: { selector: "this.ECClassId" },
+                          ecInstanceId: { selector: "this.ECInstanceId" },
+                          nodeLabel: { of: { className: schema.items.MyParentElement.fullName, classAlias: "this" } },
+                        })}
+                        FROM ${schema.items.MyParentElement.fullName} [this]
+                      `,
+                    },
+                  },
+                ];
+              },
             },
           });
           await validateHierarchy({
@@ -472,37 +443,33 @@ describe("Hierarchies", () => {
           });
           const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.BaseClassGrouping
-          const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-          const selectClauseFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: labelsFactory,
-          });
-          const definition: HierarchyNodesDefinition = {
-            fullClassName: "BisCore.GeometricElement",
-            query: {
-              ecsql: `
-                SELECT ${await selectClauseFactory.createSelectClause({
-                  ecClassId: { selector: "this.ECClassId" },
-                  ecInstanceId: { selector: "this.ECInstanceId" },
-                  nodeLabel: {
-                    selector: await labelsFactory.createSelectClause({
-                      className: "BisCore.GeometricElement",
-                      classAlias: "this",
-                    }),
+          const hierarchyDefinition: HierarchyDefinition = {
+            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              if (parentNode) {
+                return [];
+              }
+              return [
+                {
+                  fullClassName: "BisCore.GeometricElement",
+                  query: {
+                    ecsql: `
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        ecClassId: { selector: "this.ECClassId" },
+                        ecInstanceId: { selector: "this.ECInstanceId" },
+                        nodeLabel: { of: { className: "BisCore.GeometricElement", classAlias: "this" } },
+                        grouping: {
+                          byBaseClasses: { fullClassNames: ["BisCore.GeometricElement3d", "BisCore.PhysicalElement"] },
+                        },
+                      })}
+                      FROM BisCore.GeometricElement [this]
+                    `,
                   },
-                  grouping: {
-                    byBaseClasses: { fullClassNames: ["BisCore.GeometricElement3d", "BisCore.PhysicalElement"] },
-                  },
-                })}
-                FROM BisCore.GeometricElement [this]
-              `,
+                },
+              ];
             },
           };
           // __PUBLISH_EXTRACT_END__
-          const provider = createIModelHierarchyProvider({
-            imodelAccess,
-            hierarchyDefinition: { defineHierarchyLevel: async ({ parentNode }) => (parentNode ? [] : [definition]) },
-          });
+          const provider = createIModelHierarchyProvider({ imodelAccess, hierarchyDefinition });
           await validateHierarchy({
             provider,
             expect: [
@@ -522,35 +489,31 @@ describe("Hierarchies", () => {
         it("groups by class", async () => {
           const imodelAccess = createIModelAccess(emptyIModel);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.ClassGrouping
-          const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-          const selectClauseFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: labelsFactory,
-          });
-          const definition: HierarchyNodesDefinition = {
-            fullClassName: "BisCore.Element",
-            query: {
-              ecsql: `
-                SELECT ${await selectClauseFactory.createSelectClause({
-                  ecClassId: { selector: "this.ECClassId" },
-                  ecInstanceId: { selector: "this.ECInstanceId" },
-                  nodeLabel: {
-                    selector: await labelsFactory.createSelectClause({
-                      className: "BisCore.Element",
-                      classAlias: "this",
-                    }),
+          const hierarchyDefinition: HierarchyDefinition = {
+            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              if (parentNode) {
+                return [];
+              }
+              return [
+                {
+                  fullClassName: "BisCore.Element",
+                  query: {
+                    ecsql: `
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        ecClassId: { selector: "this.ECClassId" },
+                        ecInstanceId: { selector: "this.ECInstanceId" },
+                        nodeLabel: { of: { className: "BisCore.Element", classAlias: "this" } },
+                        grouping: { byClass: true },
+                      })}
+                      FROM BisCore.Element [this]
+                    `,
                   },
-                  grouping: { byClass: true },
-                })}
-                FROM BisCore.Element [this]
-              `,
+                },
+              ];
             },
           };
           // __PUBLISH_EXTRACT_END__
-          const provider = createIModelHierarchyProvider({
-            imodelAccess,
-            hierarchyDefinition: { defineHierarchyLevel: async ({ parentNode }) => (parentNode ? [] : [definition]) },
-          });
+          const provider = createIModelHierarchyProvider({ imodelAccess, hierarchyDefinition });
           await validateHierarchy({
             provider,
             expect: [
@@ -588,52 +551,48 @@ describe("Hierarchies", () => {
           });
           const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.PropertyGrouping
-          const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-          const selectClauseFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: labelsFactory,
-          });
-          const definition: HierarchyNodesDefinition = {
-            fullClassName: "BisCore.GeometricElement3d",
-            query: {
-              ecsql: `
-                SELECT ${await selectClauseFactory.createSelectClause({
-                  ecClassId: { selector: "this.ECClassId" },
-                  ecInstanceId: { selector: "this.ECInstanceId" },
-                  nodeLabel: {
-                    selector: await labelsFactory.createSelectClause({
-                      className: "BisCore.GeometricElement3d",
-                      classAlias: "this",
-                    }),
-                  },
-                  grouping: {
-                    byProperties: {
-                      propertiesClassName: "BisCore.GeometricElement3d",
-                      createGroupForOutOfRangeValues: true,
-                      createGroupForUnspecifiedValues: true,
-                      propertyGroups: [
-                        {
-                          propertyClassAlias: "this",
-                          propertyName: "Yaw",
-                          ranges: [
-                            { fromValue: 0, toValue: 0, rangeLabel: "Zero" },
-                            { fromValue: -360, toValue: 0, rangeLabel: "Negative" },
-                            { fromValue: 0, toValue: 360, rangeLabel: "Positive" },
-                          ],
+          const hierarchyDefinition: HierarchyDefinition = {
+            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              if (parentNode) {
+                return [];
+              }
+              return [
+                {
+                  fullClassName: "BisCore.GeometricElement3d",
+                  query: {
+                    ecsql: `
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        ecClassId: { selector: "this.ECClassId" },
+                        ecInstanceId: { selector: "this.ECInstanceId" },
+                        nodeLabel: { of: { className: "BisCore.GeometricElement3d", classAlias: "this" } },
+                        grouping: {
+                          byProperties: {
+                            propertiesClassName: "BisCore.GeometricElement3d",
+                            createGroupForOutOfRangeValues: true,
+                            createGroupForUnspecifiedValues: true,
+                            propertyGroups: [
+                              {
+                                propertyClassAlias: "this",
+                                propertyName: "Yaw",
+                                ranges: [
+                                  { fromValue: 0, toValue: 0, rangeLabel: "Zero" },
+                                  { fromValue: -360, toValue: 0, rangeLabel: "Negative" },
+                                  { fromValue: 0, toValue: 360, rangeLabel: "Positive" },
+                                ],
+                              },
+                            ],
+                          },
                         },
-                      ],
-                    },
+                      })}
+                      FROM BisCore.GeometricElement3d [this]
+                    `,
                   },
-                })}
-                FROM BisCore.GeometricElement3d [this]
-              `,
+                },
+              ];
             },
           };
           // __PUBLISH_EXTRACT_END__
-          const provider = createIModelHierarchyProvider({
-            imodelAccess,
-            hierarchyDefinition: { defineHierarchyLevel: async ({ parentNode }) => (parentNode ? [] : [definition]) },
-          });
+          const provider = createIModelHierarchyProvider({ imodelAccess, hierarchyDefinition });
           await validateHierarchy({
             provider,
             expect: [
@@ -655,35 +614,31 @@ describe("Hierarchies", () => {
           });
           const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.LabelGrouping
-          const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-          const selectClauseFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: labelsFactory,
-          });
-          const definition: HierarchyNodesDefinition = {
-            fullClassName: "BisCore.Element",
-            query: {
-              ecsql: `
-                SELECT ${await selectClauseFactory.createSelectClause({
-                  ecClassId: { selector: "this.ECClassId" },
-                  ecInstanceId: { selector: "this.ECInstanceId" },
-                  nodeLabel: {
-                    selector: await labelsFactory.createSelectClause({
-                      className: "BisCore.Element",
-                      classAlias: "this",
-                    }),
+          const hierarchyDefinition: HierarchyDefinition = {
+            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              if (parentNode) {
+                return [];
+              }
+              return [
+                {
+                  fullClassName: "BisCore.Element",
+                  query: {
+                    ecsql: `
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        ecClassId: { selector: "this.ECClassId" },
+                        ecInstanceId: { selector: "this.ECInstanceId" },
+                        nodeLabel: { of: { className: "BisCore.Element", classAlias: "this" } },
+                        grouping: { byLabel: { hideIfNoSiblings: true, hideIfOneGroupedNode: true } },
+                      })}
+                      FROM BisCore.Element [this]
+                    `,
                   },
-                  grouping: { byLabel: { hideIfNoSiblings: true, hideIfOneGroupedNode: true } },
-                })}
-                FROM BisCore.Element [this]
-              `,
+                },
+              ];
             },
           };
           // __PUBLISH_EXTRACT_END__
-          const provider = createIModelHierarchyProvider({
-            imodelAccess,
-            hierarchyDefinition: { defineHierarchyLevel: async ({ parentNode }) => (parentNode ? [] : [definition]) },
-          });
+          const provider = createIModelHierarchyProvider({ imodelAccess, hierarchyDefinition });
           await validateHierarchy({
             provider,
             expect: [
@@ -715,35 +670,31 @@ describe("Hierarchies", () => {
           });
           const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.SameLabelGrouping
-          const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-          const selectClauseFactory = createNodesQueryClauseFactory({
-            imodelAccess,
-            instanceLabelSelectClauseFactory: labelsFactory,
-          });
-          const definition: HierarchyNodesDefinition = {
-            fullClassName: "BisCore.Element",
-            query: {
-              ecsql: `
-                SELECT ${await selectClauseFactory.createSelectClause({
-                  ecClassId: { selector: "this.ECClassId" },
-                  ecInstanceId: { selector: "this.ECInstanceId" },
-                  nodeLabel: {
-                    selector: await labelsFactory.createSelectClause({
-                      className: "BisCore.Element",
-                      classAlias: "this",
-                    }),
+          const hierarchyDefinition: HierarchyDefinition = {
+            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              if (parentNode) {
+                return [];
+              }
+              return [
+                {
+                  fullClassName: "BisCore.Element",
+                  query: {
+                    ecsql: `
+                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        ecClassId: { selector: "this.ECClassId" },
+                        ecInstanceId: { selector: "this.ECInstanceId" },
+                        nodeLabel: { of: { className: "BisCore.Element", classAlias: "this" } },
+                        grouping: { byLabel: { action: "merge" } },
+                      })}
+                      FROM BisCore.Element [this]
+                    `,
                   },
-                  grouping: { byLabel: { action: "merge" } },
-                })}
-                FROM BisCore.Element [this]
-              `,
+                },
+              ];
             },
           };
           // __PUBLISH_EXTRACT_END__
-          const provider = createIModelHierarchyProvider({
-            imodelAccess,
-            hierarchyDefinition: { defineHierarchyLevel: async ({ parentNode }) => (parentNode ? [] : [definition]) },
-          });
+          const provider = createIModelHierarchyProvider({ imodelAccess, hierarchyDefinition });
           await validateHierarchy({
             provider,
             expect: [

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/Migration.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/Migration.test.ts
@@ -190,7 +190,7 @@ describe("Hierarchies", () => {
           const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.InstanceNodesOfSpecificClassesDefinition
           const hierarchyDefinition: HierarchyDefinition = {
-            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+            defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
               if (parentNode) {
                 return [];
               }
@@ -199,7 +199,7 @@ describe("Hierarchies", () => {
                   fullClassName: "BisCore.GeometricModel",
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "this.ECClassId" },
                         ecInstanceId: { selector: "this.ECInstanceId" },
                         nodeLabel: { of: { className: "BisCore.GeometricModel", classAlias: "this" } },
@@ -248,14 +248,14 @@ describe("Hierarchies", () => {
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.RelatedInstanceNodesDefinition
           const createChildDefinition = async ({
             parentNode,
-            nodeSelectClauseFactory,
-          }: Pick<DefineHierarchyLevelProps, "nodeSelectClauseFactory"> & {
+            createSelectClause,
+          }: Pick<DefineHierarchyLevelProps, "createSelectClause"> & {
             parentNode: HierarchyNode & { key: InstancesNodeKey };
           }): Promise<HierarchyNodesDefinition> => ({
             fullClassName: "BisCore.GeometricElement3d",
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
                   nodeLabel: { of: { className: "BisCore.GeometricElement3d", classAlias: "this" } },
@@ -274,16 +274,16 @@ describe("Hierarchies", () => {
           const provider = createIModelHierarchyProvider({
             imodelAccess,
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
                 if (parentNode && HierarchyNode.isInstancesNode(parentNode)) {
-                  return [await createChildDefinition({ parentNode, nodeSelectClauseFactory })];
+                  return [await createChildDefinition({ parentNode, createSelectClause })];
                 }
                 return [
                   {
                     fullClassName: "BisCore.PhysicalModel",
                     query: {
                       ecsql: `
-                        SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        SELECT ${await createSelectClause({
                           ecClassId: { selector: "this.ECClassId" },
                           ecInstanceId: { selector: "this.ECInstanceId" },
                           nodeLabel: { of: { className: "BisCore.PhysicalModel", classAlias: "this" } },
@@ -346,8 +346,8 @@ describe("Hierarchies", () => {
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.CustomQueryInstanceNodesDefinition
           const createDefinition = async ({
             parentNode,
-            nodeSelectClauseFactory,
-          }: Pick<DefineHierarchyLevelProps, "nodeSelectClauseFactory"> & {
+            createSelectClause,
+          }: Pick<DefineHierarchyLevelProps, "createSelectClause"> & {
             parentNode: HierarchyNode & { key: InstancesNodeKey };
           }): Promise<HierarchyLevelDefinition> => {
             if (
@@ -374,7 +374,7 @@ describe("Hierarchies", () => {
                       fullClassName: `${schema.schemaName}.MyChildElement`,
                       query: {
                         ecsql: `
-                          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                          SELECT ${await createSelectClause({
                             ecClassId: { selector: "this.ECClassId" },
                             ecInstanceId: { selector: "this.ECInstanceId" },
                             nodeLabel: { of: { className: `${schema.schemaName}.MyChildElement`, classAlias: "this" } },
@@ -395,16 +395,16 @@ describe("Hierarchies", () => {
           const provider = createIModelHierarchyProvider({
             imodelAccess,
             hierarchyDefinition: {
-              defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+              defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
                 if (parentNode && HierarchyNode.isInstancesNode(parentNode)) {
-                  return createDefinition({ parentNode, nodeSelectClauseFactory });
+                  return createDefinition({ parentNode, createSelectClause });
                 }
                 return [
                   {
                     fullClassName: schema.items.MyParentElement.fullName,
                     query: {
                       ecsql: `
-                        SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                        SELECT ${await createSelectClause({
                           ecClassId: { selector: "this.ECClassId" },
                           ecInstanceId: { selector: "this.ECInstanceId" },
                           nodeLabel: { of: { className: schema.items.MyParentElement.fullName, classAlias: "this" } },
@@ -444,7 +444,7 @@ describe("Hierarchies", () => {
           const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.BaseClassGrouping
           const hierarchyDefinition: HierarchyDefinition = {
-            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+            defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
               if (parentNode) {
                 return [];
               }
@@ -453,7 +453,7 @@ describe("Hierarchies", () => {
                   fullClassName: "BisCore.GeometricElement",
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "this.ECClassId" },
                         ecInstanceId: { selector: "this.ECInstanceId" },
                         nodeLabel: { of: { className: "BisCore.GeometricElement", classAlias: "this" } },
@@ -490,7 +490,7 @@ describe("Hierarchies", () => {
           const imodelAccess = createIModelAccess(emptyIModel);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.ClassGrouping
           const hierarchyDefinition: HierarchyDefinition = {
-            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+            defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
               if (parentNode) {
                 return [];
               }
@@ -499,7 +499,7 @@ describe("Hierarchies", () => {
                   fullClassName: "BisCore.Element",
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "this.ECClassId" },
                         ecInstanceId: { selector: "this.ECInstanceId" },
                         nodeLabel: { of: { className: "BisCore.Element", classAlias: "this" } },
@@ -552,7 +552,7 @@ describe("Hierarchies", () => {
           const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.PropertyGrouping
           const hierarchyDefinition: HierarchyDefinition = {
-            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+            defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
               if (parentNode) {
                 return [];
               }
@@ -561,7 +561,7 @@ describe("Hierarchies", () => {
                   fullClassName: "BisCore.GeometricElement3d",
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "this.ECClassId" },
                         ecInstanceId: { selector: "this.ECInstanceId" },
                         nodeLabel: { of: { className: "BisCore.GeometricElement3d", classAlias: "this" } },
@@ -615,7 +615,7 @@ describe("Hierarchies", () => {
           const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.LabelGrouping
           const hierarchyDefinition: HierarchyDefinition = {
-            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+            defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
               if (parentNode) {
                 return [];
               }
@@ -624,7 +624,7 @@ describe("Hierarchies", () => {
                   fullClassName: "BisCore.Element",
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "this.ECClassId" },
                         ecInstanceId: { selector: "this.ECInstanceId" },
                         nodeLabel: { of: { className: "BisCore.Element", classAlias: "this" } },
@@ -671,7 +671,7 @@ describe("Hierarchies", () => {
           const imodelAccess = createIModelAccess(imodelConnection);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.SameLabelGrouping
           const hierarchyDefinition: HierarchyDefinition = {
-            defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+            defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
               if (parentNode) {
                 return [];
               }
@@ -680,7 +680,7 @@ describe("Hierarchies", () => {
                   fullClassName: "BisCore.Element",
                   query: {
                     ecsql: `
-                      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      SELECT ${await createSelectClause({
                         ecClassId: { selector: "this.ECClassId" },
                         ecInstanceId: { selector: "this.ECInstanceId" },
                         nodeLabel: { of: { className: "BisCore.Element", classAlias: "this" } },

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/ReadmeExample.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/ReadmeExample.test.ts
@@ -55,13 +55,13 @@ function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider
     classHierarchyInspector: imodelAccess,
     hierarchy: {
       // For root nodes, select all BisCore.GeometricModel3d instances
-      rootNodes: async ({ nodeSelectClauseFactory }) => [
+      rootNodes: async ({ createSelectClause }) => [
         {
           fullClassName: "BisCore.GeometricModel3d",
           query: {
             ecsql: `
               SELECT
-                ${await nodeSelectClauseFactory.createSelectClause({
+                ${await createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
                   nodeLabel: { of: { classAlias: "this", className: "BisCore.GeometricModel3d" } },
@@ -77,14 +77,14 @@ function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider
           parentInstancesNodePredicate: "BisCore.Model",
           definitions: async ({
             parentNodeInstanceIds,
-            nodeSelectClauseFactory,
+            createSelectClause,
           }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> => [
             {
               fullClassName: "BisCore.Element",
               query: {
                 ecsql: `
                   SELECT
-                    ${await nodeSelectClauseFactory.createSelectClause({
+                    ${await createSelectClause({
                       ecClassId: { selector: "this.ECClassId" },
                       ecInstanceId: { selector: "this.ECInstanceId" },
                       nodeLabel: { of: { classAlias: "this", className: "BisCore.Element" } },

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/ReadmeExample.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/ReadmeExample.test.ts
@@ -55,7 +55,7 @@ function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider
     classHierarchyInspector: imodelAccess,
     hierarchy: {
       // For root nodes, select all BisCore.GeometricModel3d instances
-      rootNodes: async ({ instanceLabelSelectClauseFactory, nodeSelectClauseFactory }) => [
+      rootNodes: async ({ nodeSelectClauseFactory }) => [
         {
           fullClassName: "BisCore.GeometricModel3d",
           query: {
@@ -64,12 +64,7 @@ function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider
                 ${await nodeSelectClauseFactory.createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
-                  nodeLabel: {
-                    selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                      classAlias: "this",
-                      className: "BisCore.GeometricModel3d",
-                    }),
-                  },
+                  nodeLabel: { of: { classAlias: "this", className: "BisCore.GeometricModel3d" } },
                 })}
               FROM BisCore.GeometricModel3d this
             `,
@@ -82,7 +77,6 @@ function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider
           parentInstancesNodePredicate: "BisCore.Model",
           definitions: async ({
             parentNodeInstanceIds,
-            instanceLabelSelectClauseFactory,
             nodeSelectClauseFactory,
           }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> => [
             {
@@ -93,12 +87,7 @@ function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider
                     ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: "this.ECClassId" },
                       ecInstanceId: { selector: "this.ECInstanceId" },
-                      nodeLabel: {
-                        selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                          classAlias: "this",
-                          className: "BisCore.Element",
-                        }),
-                      },
+                      nodeLabel: { of: { classAlias: "this", className: "BisCore.Element" } },
                       grouping: { byClass: true },
                     })}
                   FROM BisCore.Element this

--- a/apps/performance-tests/src/hierarchies/HideIfNoChildren.test.ts
+++ b/apps/performance-tests/src/hierarchies/HideIfNoChildren.test.ts
@@ -14,7 +14,6 @@ import type { IModelDb } from "@itwin/core-backend";
 import type {
   DefineInstanceNodeChildHierarchyLevelProps,
   HierarchyLevelDefinition,
-  NodesQueryClauseFactory,
 } from "@itwin/presentation-hierarchies";
 
 describe("hide if no children", () => {
@@ -32,18 +31,18 @@ describe("hide if no children", () => {
           return createPredicateBasedHierarchyDefinition({
             classHierarchyInspector: imodelAccess,
             hierarchy: {
-              rootNodes: async ({ nodeSelectClauseFactory: queryFactory }) =>
-                createPhysicalElementsHierarchyLevelDefinition({ queryFactory, limit: 5 }),
+              rootNodes: async ({ nodeSelectClauseFactory }) =>
+                createPhysicalElementsHierarchyLevelDefinition({ nodeSelectClauseFactory, limit: 5 }),
               childNodes: [
                 {
                   parentInstancesNodePredicate: `BisCore.PhysicalElement`,
                   definitions: async ({
                     parentNode,
-                    nodeSelectClauseFactory: queryFactory,
+                    nodeSelectClauseFactory,
                   }: DefineInstanceNodeChildHierarchyLevelProps) => {
                     const depth = parentNode.parentKeys.length + 1;
                     return createPhysicalElementsHierarchyLevelDefinition({
-                      queryFactory,
+                      nodeSelectClauseFactory,
                       limit: 1000,
                       hideIfNoChildren: true,
                       hasChildren: depth >= 2 ? false : undefined,
@@ -72,18 +71,18 @@ describe("hide if no children", () => {
           return createPredicateBasedHierarchyDefinition({
             classHierarchyInspector: imodelAccess,
             hierarchy: {
-              rootNodes: async ({ nodeSelectClauseFactory: queryFactory }) =>
-                createPhysicalElementsHierarchyLevelDefinition({ queryFactory, limit: 5 }),
+              rootNodes: async ({ nodeSelectClauseFactory }) =>
+                createPhysicalElementsHierarchyLevelDefinition({ nodeSelectClauseFactory, limit: 5 }),
               childNodes: [
                 {
                   parentInstancesNodePredicate: `BisCore.PhysicalElement`,
                   definitions: async ({
                     parentNode,
-                    nodeSelectClauseFactory: queryFactory,
+                    nodeSelectClauseFactory,
                   }: DefineInstanceNodeChildHierarchyLevelProps) => {
                     const depth = parentNode.parentKeys.length + 1;
                     return createPhysicalElementsHierarchyLevelDefinition({
-                      queryFactory,
+                      nodeSelectClauseFactory,
                       limit: 1000,
                       hideIfNoChildren: true,
                       hasChildren: depth >= 2 ? true : undefined,
@@ -103,27 +102,27 @@ describe("hide if no children", () => {
 });
 
 async function createPhysicalElementsHierarchyLevelDefinition(props: {
-  queryFactory: NodesQueryClauseFactory;
+  nodeSelectClauseFactory: DefineInstanceNodeChildHierarchyLevelProps["nodeSelectClauseFactory"];
   limit: number;
   hasChildren?: boolean;
   hideIfNoChildren?: boolean;
 }): Promise<HierarchyLevelDefinition> {
-  const { queryFactory, limit, hasChildren, hideIfNoChildren } = props;
+  const { nodeSelectClauseFactory, limit, hasChildren, hideIfNoChildren } = props;
   return [
     {
       fullClassName: `BisCore.PhysicalElement`,
       query: {
         ecsql: `
-        SELECT ${await queryFactory.createSelectClause({
-          ecClassId: { selector: `this.ECClassId` },
-          ecInstanceId: { selector: `this.ECInstanceId` },
-          nodeLabel: { selector: `this.UserLabel` },
-          hasChildren,
-          hideIfNoChildren,
-        })}
-        FROM BisCore.PhysicalElement AS this
-        LIMIT ${limit}
-      `,
+          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+            ecClassId: { selector: `this.ECClassId` },
+            ecInstanceId: { selector: `this.ECInstanceId` },
+            nodeLabel: { selector: `this.UserLabel` },
+            hasChildren,
+            hideIfNoChildren,
+          })}
+          FROM BisCore.PhysicalElement AS this
+          LIMIT ${limit}
+        `,
       },
     },
   ];

--- a/apps/performance-tests/src/hierarchies/HideIfNoChildren.test.ts
+++ b/apps/performance-tests/src/hierarchies/HideIfNoChildren.test.ts
@@ -31,18 +31,18 @@ describe("hide if no children", () => {
           return createPredicateBasedHierarchyDefinition({
             classHierarchyInspector: imodelAccess,
             hierarchy: {
-              rootNodes: async ({ nodeSelectClauseFactory }) =>
-                createPhysicalElementsHierarchyLevelDefinition({ nodeSelectClauseFactory, limit: 5 }),
+              rootNodes: async ({ createSelectClause }) =>
+                createPhysicalElementsHierarchyLevelDefinition({ createSelectClause, limit: 5 }),
               childNodes: [
                 {
                   parentInstancesNodePredicate: `BisCore.PhysicalElement`,
                   definitions: async ({
                     parentNode,
-                    nodeSelectClauseFactory,
+                    createSelectClause,
                   }: DefineInstanceNodeChildHierarchyLevelProps) => {
                     const depth = parentNode.parentKeys.length + 1;
                     return createPhysicalElementsHierarchyLevelDefinition({
-                      nodeSelectClauseFactory,
+                      createSelectClause,
                       limit: 1000,
                       hideIfNoChildren: true,
                       hasChildren: depth >= 2 ? false : undefined,
@@ -71,18 +71,18 @@ describe("hide if no children", () => {
           return createPredicateBasedHierarchyDefinition({
             classHierarchyInspector: imodelAccess,
             hierarchy: {
-              rootNodes: async ({ nodeSelectClauseFactory }) =>
-                createPhysicalElementsHierarchyLevelDefinition({ nodeSelectClauseFactory, limit: 5 }),
+              rootNodes: async ({ createSelectClause }) =>
+                createPhysicalElementsHierarchyLevelDefinition({ createSelectClause, limit: 5 }),
               childNodes: [
                 {
                   parentInstancesNodePredicate: `BisCore.PhysicalElement`,
                   definitions: async ({
                     parentNode,
-                    nodeSelectClauseFactory,
+                    createSelectClause,
                   }: DefineInstanceNodeChildHierarchyLevelProps) => {
                     const depth = parentNode.parentKeys.length + 1;
                     return createPhysicalElementsHierarchyLevelDefinition({
-                      nodeSelectClauseFactory,
+                      createSelectClause,
                       limit: 1000,
                       hideIfNoChildren: true,
                       hasChildren: depth >= 2 ? true : undefined,
@@ -102,18 +102,18 @@ describe("hide if no children", () => {
 });
 
 async function createPhysicalElementsHierarchyLevelDefinition(props: {
-  nodeSelectClauseFactory: DefineInstanceNodeChildHierarchyLevelProps["nodeSelectClauseFactory"];
+  createSelectClause: DefineInstanceNodeChildHierarchyLevelProps["createSelectClause"];
   limit: number;
   hasChildren?: boolean;
   hideIfNoChildren?: boolean;
 }): Promise<HierarchyLevelDefinition> {
-  const { nodeSelectClauseFactory, limit, hasChildren, hideIfNoChildren } = props;
+  const { createSelectClause, limit, hasChildren, hideIfNoChildren } = props;
   return [
     {
       fullClassName: `BisCore.PhysicalElement`,
       query: {
         ecsql: `
-          SELECT ${await nodeSelectClauseFactory.createSelectClause({
+          SELECT ${await createSelectClause({
             ecClassId: { selector: `this.ECClassId` },
             ecInstanceId: { selector: `this.ECInstanceId` },
             nodeLabel: { selector: `this.UserLabel` },

--- a/apps/performance-tests/src/hierarchies/RunHierarchyTest.ts
+++ b/apps/performance-tests/src/hierarchies/RunHierarchyTest.ts
@@ -10,7 +10,7 @@ import { Datasets } from "../util/Datasets.js";
 import { run } from "../util/TestUtilities.js";
 import { StatelessHierarchyProvider } from "./StatelessHierarchyProvider.js";
 
-import type { DefineHierarchyLevelProps, NodesQueryClauseFactory } from "@itwin/presentation-hierarchies";
+import type { DefineHierarchyLevelProps } from "@itwin/presentation-hierarchies";
 import type { EC, Props } from "@itwin/presentation-shared";
 import type { IModelName } from "../util/Datasets.js";
 import type { RunOptions } from "../util/TestUtilities.js";
@@ -24,7 +24,7 @@ export function runHierarchyTest(
   testProps: {
     iModelName: IModelName;
     fullClassName?: EC.FullClassName;
-    nodeSelectProps?: Partial<Props<NodesQueryClauseFactory["createSelectClause"]>>;
+    nodeSelectProps?: Partial<Props<DefineHierarchyLevelProps["nodeSelectClauseFactory"]["createSelectClause"]>>;
     expectedNodeCount?: number;
   } & Omit<RunOptions<never>, "setup" | "test" | "cleanup">,
 ) {

--- a/apps/performance-tests/src/hierarchies/RunHierarchyTest.ts
+++ b/apps/performance-tests/src/hierarchies/RunHierarchyTest.ts
@@ -24,7 +24,7 @@ export function runHierarchyTest(
   testProps: {
     iModelName: IModelName;
     fullClassName?: EC.FullClassName;
-    nodeSelectProps?: Partial<Props<DefineHierarchyLevelProps["nodeSelectClauseFactory"]["createSelectClause"]>>;
+    nodeSelectProps?: Partial<Props<DefineHierarchyLevelProps["createSelectClause"]>>;
     expectedNodeCount?: number;
   } & Omit<RunOptions<never>, "setup" | "test" | "cleanup">,
 ) {
@@ -37,8 +37,8 @@ export function runHierarchyTest(
       return {
         iModel,
         getHierarchyFactory: () => ({
-          async defineHierarchyLevel(props: DefineHierarchyLevelProps) {
-            if (props.parentNode) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }: DefineHierarchyLevelProps) {
+            if (parentNode) {
               return [];
             }
 
@@ -47,7 +47,7 @@ export function runHierarchyTest(
                 fullClassName,
                 query: {
                   ecsql: `
-                    SELECT ${await props.nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ...nodeSelectProps,
                       ecClassId: nodeSelectProps?.ecClassId ?? { selector: `this.ECClassId` },
                       ecInstanceId: nodeSelectProps?.ecInstanceId ?? { selector: `this.ECInstanceId` },

--- a/apps/performance-tests/src/hierarchies/Search.test.ts
+++ b/apps/performance-tests/src/hierarchies/Search.test.ts
@@ -53,7 +53,7 @@ describe("search", () => {
       const iModel = SnapshotDb.openFile(Datasets.getIModelPath("50k flat elements"));
       const fullClassName = normalizeFullClassName(PhysicalElement.classFullName);
       const createHierarchyLevelDefinition = async (
-        nodeSelectClauseFactory: DefineHierarchyLevelProps["nodeSelectClauseFactory"],
+        createSelectClause: DefineHierarchyLevelProps["createSelectClause"],
         whereClause: (alias: string) => string,
       ) => {
         return [
@@ -61,7 +61,7 @@ describe("search", () => {
             fullClassName,
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: `this.ECClassId` },
                   ecInstanceId: { selector: `this.ECInstanceId` },
                   nodeLabel: { selector: `this.UserLabel` },
@@ -76,7 +76,7 @@ describe("search", () => {
       return {
         iModel,
         getHierarchyFactory: () => ({
-          async defineHierarchyLevel(props: DefineHierarchyLevelProps) {
+          async defineHierarchyLevel({ parentNode, createSelectClause }: DefineHierarchyLevelProps) {
             // A hierarchy with this structure is created:
             //
             //        id:21 -> all other BisCore.PhysicalElement
@@ -87,30 +87,28 @@ describe("search", () => {
             //
             // We need to split the hierarchy in 50 parts to reduce the time of the test.
 
-            if (!props.parentNode) {
+            if (!parentNode) {
               return createHierarchyLevelDefinition(
-                props.nodeSelectClauseFactory,
+                createSelectClause,
                 (alias) => `WHERE ${alias}.ECInstanceId = ${physicalElementsSmallestDecimalId}`,
               );
             }
             if (
-              HierarchyNode.isInstancesNode(props.parentNode) &&
-              props.parentNode.key.instanceKeys.some(
-                ({ id }) => Id64.getLocalId(id) === physicalElementsSmallestDecimalId,
-              )
+              HierarchyNode.isInstancesNode(parentNode) &&
+              parentNode.key.instanceKeys.some(({ id }) => Id64.getLocalId(id) === physicalElementsSmallestDecimalId)
             ) {
               return createHierarchyLevelDefinition(
-                props.nodeSelectClauseFactory,
+                createSelectClause,
                 (alias) => `WHERE ${alias}.ECInstanceId IN (${parentIdsArr.join(", ")})`,
               );
             }
 
             if (
-              HierarchyNode.isInstancesNode(props.parentNode) &&
-              props.parentNode.key.instanceKeys.some(({ id }) => parentIdsArr.includes(Id64.getLocalId(id)))
+              HierarchyNode.isInstancesNode(parentNode) &&
+              parentNode.key.instanceKeys.some(({ id }) => parentIdsArr.includes(Id64.getLocalId(id)))
             ) {
               return createHierarchyLevelDefinition(
-                props.nodeSelectClauseFactory,
+                createSelectClause,
                 (alias) =>
                   `WHERE ${alias}.ECInstanceId NOT IN (${physicalElementsSmallestDecimalId}, ${parentIdsArr.join(", ")})`,
               );

--- a/apps/test-app/frontend/src/components/tree-widget/MultiDataSourceTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/MultiDataSourceTree.tsx
@@ -260,7 +260,7 @@ function createModelsHierarchyDefinition({ imodelAccess }: { imodelAccess: IMode
   return createPredicateBasedHierarchyDefinition({
     classHierarchyInspector: imodelAccess,
     hierarchy: {
-      rootNodes: async ({ instanceLabelSelectClauseFactory, nodeSelectClauseFactory }) => [
+      rootNodes: async ({ nodeSelectClauseFactory }) => [
         {
           fullClassName: "BisCore.Subject",
           query: {
@@ -268,12 +268,7 @@ function createModelsHierarchyDefinition({ imodelAccess }: { imodelAccess: IMode
               SELECT ${await nodeSelectClauseFactory.createSelectClause({
                 ecClassId: { selector: "this.ECClassId" },
                 ecInstanceId: { selector: "this.ECInstanceId" },
-                nodeLabel: {
-                  selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                    classAlias: "this",
-                    className: "BisCore.Subject",
-                  }),
-                },
+                nodeLabel: { of: { classAlias: "this", className: "BisCore.Subject" } },
                 hasChildren: true,
                 extendedData: { nodeType: "root-subject" },
               })}
@@ -287,7 +282,6 @@ function createModelsHierarchyDefinition({ imodelAccess }: { imodelAccess: IMode
         {
           parentInstancesNodePredicate: "BisCore.Subject",
           definitions: async ({
-            instanceLabelSelectClauseFactory,
             nodeSelectClauseFactory,
           }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> => [
             {
@@ -297,12 +291,7 @@ function createModelsHierarchyDefinition({ imodelAccess }: { imodelAccess: IMode
                   SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: "this.ECClassId" },
                     ecInstanceId: { selector: "this.ECInstanceId" },
-                    nodeLabel: {
-                      selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                        classAlias: "this",
-                        className: "BisCore.Model",
-                      }),
-                    },
+                    nodeLabel: { of: { classAlias: "this", className: "BisCore.Model" } },
                     grouping: { byClass: true },
                     extendedData: { nodeType: "model" },
                   })}
@@ -314,11 +303,7 @@ function createModelsHierarchyDefinition({ imodelAccess }: { imodelAccess: IMode
         },
         {
           parentInstancesNodePredicate: "BisCore.Model",
-          definitions: async ({
-            parentNode,
-            instanceLabelSelectClauseFactory,
-            nodeSelectClauseFactory,
-          }: DefineInstanceNodeChildHierarchyLevelProps) => [
+          definitions: async ({ parentNode, nodeSelectClauseFactory }: DefineInstanceNodeChildHierarchyLevelProps) => [
             {
               fullClassName: "BisCore.Model" as const,
               query: {
@@ -326,12 +311,7 @@ function createModelsHierarchyDefinition({ imodelAccess }: { imodelAccess: IMode
                   SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: "this.ECClassId" },
                     ecInstanceId: { selector: "this.ECInstanceId" },
-                    nodeLabel: {
-                      selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                        classAlias: "this",
-                        className: "BisCore.Model",
-                      }),
-                    },
+                    nodeLabel: { of: { classAlias: "this", className: "BisCore.Model" } },
                     grouping: { byClass: true },
                     extendedData: { nodeType: "model" },
                   })}

--- a/apps/test-app/frontend/src/components/tree-widget/MultiDataSourceTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/MultiDataSourceTree.tsx
@@ -260,12 +260,12 @@ function createModelsHierarchyDefinition({ imodelAccess }: { imodelAccess: IMode
   return createPredicateBasedHierarchyDefinition({
     classHierarchyInspector: imodelAccess,
     hierarchy: {
-      rootNodes: async ({ nodeSelectClauseFactory }) => [
+      rootNodes: async ({ createSelectClause }) => [
         {
           fullClassName: "BisCore.Subject",
           query: {
             ecsql: `
-              SELECT ${await nodeSelectClauseFactory.createSelectClause({
+              SELECT ${await createSelectClause({
                 ecClassId: { selector: "this.ECClassId" },
                 ecInstanceId: { selector: "this.ECInstanceId" },
                 nodeLabel: { of: { classAlias: "this", className: "BisCore.Subject" } },
@@ -282,13 +282,13 @@ function createModelsHierarchyDefinition({ imodelAccess }: { imodelAccess: IMode
         {
           parentInstancesNodePredicate: "BisCore.Subject",
           definitions: async ({
-            nodeSelectClauseFactory,
+            createSelectClause,
           }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> => [
             {
               fullClassName: "BisCore.Model",
               query: {
                 ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: "this.ECClassId" },
                     ecInstanceId: { selector: "this.ECInstanceId" },
                     nodeLabel: { of: { classAlias: "this", className: "BisCore.Model" } },
@@ -303,12 +303,12 @@ function createModelsHierarchyDefinition({ imodelAccess }: { imodelAccess: IMode
         },
         {
           parentInstancesNodePredicate: "BisCore.Model",
-          definitions: async ({ parentNode, nodeSelectClauseFactory }: DefineInstanceNodeChildHierarchyLevelProps) => [
+          definitions: async ({ parentNode, createSelectClause }: DefineInstanceNodeChildHierarchyLevelProps) => [
             {
               fullClassName: "BisCore.Model" as const,
               query: {
                 ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: "this.ECClassId" },
                     ecInstanceId: { selector: "this.ECInstanceId" },
                     nodeLabel: { of: { classAlias: "this", className: "BisCore.Model" } },

--- a/packages/hierarchies-react/README.md
+++ b/packages/hierarchies-react/README.md
@@ -145,22 +145,17 @@ type IModelAccess = Props<typeof useIModelUnifiedSelectionTree>["imodelAccess"];
 // The hierarchy definition describes the hierarchy using ECSQL queries; here it just returns all `BisCore.PhysicalModel` instances
 function getHierarchyDefinition({ imodelAccess }: { imodelAccess: IModelAccess }): HierarchyDefinition {
   return {
-    // The `instanceLabelSelectClauseFactory` and `nodeSelectClauseFactory` are provided automatically by the hierarchy provider
-    defineHierarchyLevel: async ({ instanceLabelSelectClauseFactory, nodeSelectClauseFactory }) => [
+    // The `createSelectClause` function is provided automatically by the hierarchy provider
+    defineHierarchyLevel: async ({ createSelectClause }) => [
       {
         fullClassName: "BisCore.PhysicalModel",
         query: {
           ecsql: `
             SELECT
-              ${await nodeSelectClauseFactory.createSelectClause({
+              ${await createSelectClause({
                 ecClassId: { selector: "this.ECClassId" },
                 ecInstanceId: { selector: "this.ECInstanceId" },
-                nodeLabel: {
-                  selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                    classAlias: "this",
-                    className: "BisCore.PhysicalModel",
-                  }),
-                },
+                nodeLabel: { of: { classAlias: "this", className: "BisCore.PhysicalModel" } },
                 hasChildren: false,
               })}
             FROM BisCore.PhysicalModel this

--- a/packages/hierarchies/README.md
+++ b/packages/hierarchies/README.md
@@ -109,7 +109,7 @@ function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider
     classHierarchyInspector: imodelAccess,
     hierarchy: {
       // For root nodes, select all BisCore.GeometricModel3d instances
-      rootNodes: async ({ instanceLabelSelectClauseFactory, nodeSelectClauseFactory }) => [
+      rootNodes: async ({ nodeSelectClauseFactory }) => [
         {
           fullClassName: "BisCore.GeometricModel3d",
           query: {
@@ -118,12 +118,7 @@ function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider
                 ${await nodeSelectClauseFactory.createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
-                  nodeLabel: {
-                    selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                      classAlias: "this",
-                      className: "BisCore.GeometricModel3d",
-                    }),
-                  },
+                  nodeLabel: { of: { classAlias: "this", className: "BisCore.GeometricModel3d" } },
                 })}
               FROM BisCore.GeometricModel3d this
             `,
@@ -136,7 +131,6 @@ function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider
           parentInstancesNodePredicate: "BisCore.Model",
           definitions: async ({
             parentNodeInstanceIds,
-            instanceLabelSelectClauseFactory,
             nodeSelectClauseFactory,
           }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> => [
             {
@@ -147,12 +141,7 @@ function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider
                     ${await nodeSelectClauseFactory.createSelectClause({
                       ecClassId: { selector: "this.ECClassId" },
                       ecInstanceId: { selector: "this.ECInstanceId" },
-                      nodeLabel: {
-                        selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                          classAlias: "this",
-                          className: "BisCore.Element",
-                        }),
-                      },
+                      nodeLabel: { of: { classAlias: "this", className: "BisCore.Element" } },
                       grouping: { byClass: true },
                     })}
                   FROM BisCore.Element this

--- a/packages/hierarchies/README.md
+++ b/packages/hierarchies/README.md
@@ -109,13 +109,13 @@ function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider
     classHierarchyInspector: imodelAccess,
     hierarchy: {
       // For root nodes, select all BisCore.GeometricModel3d instances
-      rootNodes: async ({ nodeSelectClauseFactory }) => [
+      rootNodes: async ({ createSelectClause }) => [
         {
           fullClassName: "BisCore.GeometricModel3d",
           query: {
             ecsql: `
               SELECT
-                ${await nodeSelectClauseFactory.createSelectClause({
+                ${await createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
                   nodeLabel: { of: { classAlias: "this", className: "BisCore.GeometricModel3d" } },
@@ -131,14 +131,14 @@ function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider
           parentInstancesNodePredicate: "BisCore.Model",
           definitions: async ({
             parentNodeInstanceIds,
-            nodeSelectClauseFactory,
+            createSelectClause,
           }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> => [
             {
               fullClassName: "BisCore.Element",
               query: {
                 ecsql: `
                   SELECT
-                    ${await nodeSelectClauseFactory.createSelectClause({
+                    ${await createSelectClause({
                       ecClassId: { selector: "this.ECClassId" },
                       ecInstanceId: { selector: "this.ECInstanceId" },
                       nodeLabel: { of: { classAlias: "this", className: "BisCore.Element" } },

--- a/packages/hierarchies/api/presentation-hierarchies.api.md
+++ b/packages/hierarchies/api/presentation-hierarchies.api.md
@@ -76,12 +76,6 @@ export function createLimitingECSqlQueryExecutor(baseExecutor: ECSqlQueryExecuto
 export function createMergedIModelHierarchyProvider(props: MergedIModelHierarchyProviderProps): HierarchyProvider & Disposable;
 
 // @public
-export function createNodesQueryClauseFactory(props: {
-    imodelAccess: ECSchemaProvider & ECClassHierarchyInspector;
-    instanceLabelSelectClauseFactory: IInstanceLabelSelectClauseFactory;
-}): NodesQueryClauseFactory;
-
-// @public
 export function createPredicateBasedHierarchyDefinition(props: PredicateBasedHierarchyDefinitionProps): HierarchyDefinition;
 
 // @public
@@ -97,7 +91,6 @@ export interface DefineHierarchyLevelProps {
         imodelKey: string;
     };
     instanceFilter?: GenericInstanceFilter;
-    instanceLabelSelectClauseFactory: IInstanceLabelSelectClauseFactory;
     nodeSelectClauseFactory: NodesQueryClauseFactory;
     parentNode: HierarchyDefinitionParentNode | undefined;
 }
@@ -558,6 +551,7 @@ interface IModelHierarchyProviderProps {
     hierarchyDefinition: HierarchyDefinition;
     imodelAccess: IModelAccess;
     imodelChanged?: Event_2<() => void>;
+    instanceLabelSelectClauseFactory?: IInstanceLabelSelectClauseFactory;
     localizedStrings?: Partial<IModelHierarchyProviderLocalizedStrings>;
     queryCacheSize?: number;
     queryConcurrency?: number;
@@ -612,10 +606,11 @@ export interface LimitingECSqlQueryExecutor {
 }
 
 // @alpha
-interface MergedIModelHierarchyProviderProps extends Omit<IModelHierarchyProviderProps, "imodelAccess" | "imodelChanged"> {
+interface MergedIModelHierarchyProviderProps extends Omit<IModelHierarchyProviderProps, "imodelAccess" | "imodelChanged" | "instanceLabelSelectClauseFactory"> {
     imodels: Array<{
         imodelAccess: IModelAccess;
         imodelChanged?: Event_2<() => void>;
+        instanceLabelSelectClauseFactory?: IInstanceLabelSelectClauseFactory;
     }>;
 }
 
@@ -651,20 +646,6 @@ export type NodePreProcessor = <TNode extends ProcessedGenericHierarchyNode | Pr
 }) => Promise<TNode | undefined>;
 
 // @public
-export enum NodeSelectClauseColumnNames {
-    AutoExpand = "AutoExpand",
-    DisplayLabel = "DisplayLabel",
-    ECInstanceId = "ECInstanceId",
-    ExtendedData = "ExtendedData",
-    FullClassName = "FullClassName",
-    Grouping = "Grouping",
-    HasChildren = "HasChildren",
-    HideIfNoChildren = "HideIfNoChildren",
-    HideNodeInHierarchy = "HideNodeInHierarchy",
-    SupportsFiltering = "SupportsFiltering"
-}
-
-// @public
 interface NodeSelectClauseProps {
     // (undocumented)
     autoExpand?: boolean | ECSqlValueSelector;
@@ -685,13 +666,15 @@ interface NodeSelectClauseProps {
     // (undocumented)
     hideNodeInHierarchy?: boolean | ECSqlValueSelector;
     // (undocumented)
-    nodeLabel: string | ECSqlValueSelector;
+    nodeLabel: string | ECSqlValueSelector | {
+        of: Props<IInstanceLabelSelectClauseFactory["createSelectClause"]>;
+    };
     // (undocumented)
     supportsFiltering?: boolean | ECSqlValueSelector;
 }
 
 // @public
-export interface NodesQueryClauseFactory {
+interface NodesQueryClauseFactory {
     createFilterClauses(props: {
         contentClass: {
             fullName: EC.FullClassName;

--- a/packages/hierarchies/api/presentation-hierarchies.api.md
+++ b/packages/hierarchies/api/presentation-hierarchies.api.md
@@ -86,12 +86,11 @@ export type DefineGenericNodeChildHierarchyLevelProps = Omit<DefineHierarchyLeve
 };
 
 // @public
-export interface DefineHierarchyLevelProps {
+export interface DefineHierarchyLevelProps extends Pick<NodesQueryClauseFactory, "createSelectClause" | "createFilterClauses"> {
     imodelAccess: LimitingECSqlQueryExecutor & ECSchemaProvider & ECClassHierarchyInspector & {
         imodelKey: string;
     };
     instanceFilter?: GenericInstanceFilter;
-    nodeSelectClauseFactory: NodesQueryClauseFactory;
     parentNode: HierarchyDefinitionParentNode | undefined;
 }
 

--- a/packages/hierarchies/api/presentation-hierarchies.exports.csv
+++ b/packages/hierarchies/api/presentation-hierarchies.exports.csv
@@ -6,7 +6,6 @@ public;function;createHierarchySearchHelper
 public;function;createIModelHierarchyProvider
 public;function;createLimitingECSqlQueryExecutor
 alpha;function;createMergedIModelHierarchyProvider
-public;function;createNodesQueryClauseFactory
 public;function;createPredicateBasedHierarchyDefinition
 public;type;DefineGenericNodeChildHierarchyLevelProps
 public;interface;DefineHierarchyLevelProps
@@ -43,8 +42,6 @@ public;function;mergeProviders
 public;type;NodeParser
 public;type;NodePostProcessor
 public;type;NodePreProcessor
-public;enum;NodeSelectClauseColumnNames
-public;interface;NodesQueryClauseFactory
 public;interface;NonGroupingHierarchyNode
 public;type;ProcessedHierarchyNode
 public;namespace;ProcessedHierarchyNode

--- a/packages/hierarchies/learning/PresentationRulesMigrationGuide.md
+++ b/packages/hierarchies/learning/PresentationRulesMigrationGuide.md
@@ -263,7 +263,7 @@ import {
 } from "@itwin/presentation-hierarchies";
 
 const hierarchyDefinition: HierarchyDefinition = {
-  defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+  defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
     if (parentNode) {
       return [];
     }
@@ -272,7 +272,7 @@ const hierarchyDefinition: HierarchyDefinition = {
         fullClassName: "BisCore.GeometricModel",
         query: {
           ecsql: `
-            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+            SELECT ${await createSelectClause({
               ecClassId: { selector: "this.ECClassId" },
               ecInstanceId: { selector: "this.ECInstanceId" },
               nodeLabel: { of: { className: "BisCore.GeometricModel", classAlias: "this" } },
@@ -355,14 +355,14 @@ import {
 
 const createChildDefinition = async ({
   parentNode,
-  nodeSelectClauseFactory,
-}: Pick<DefineHierarchyLevelProps, "nodeSelectClauseFactory"> & {
+  createSelectClause,
+}: Pick<DefineHierarchyLevelProps, "createSelectClause"> & {
   parentNode: HierarchyNode & { key: InstancesNodeKey };
 }): Promise<HierarchyNodesDefinition> => ({
   fullClassName: "BisCore.GeometricElement3d",
   query: {
     ecsql: `
-      SELECT ${await nodeSelectClauseFactory.createSelectClause({
+      SELECT ${await createSelectClause({
         ecClassId: { selector: "this.ECClassId" },
         ecInstanceId: { selector: "this.ECInstanceId" },
         nodeLabel: { of: { className: "BisCore.GeometricElement3d", classAlias: "this" } },
@@ -446,8 +446,8 @@ The purpose of a custom query instance nodes specification in Presentation Rules
 
   const createDefinition = async ({
     parentNode,
-    nodeSelectClauseFactory,
-  }: Pick<DefineHierarchyLevelProps, "nodeSelectClauseFactory"> & {
+    createSelectClause,
+  }: Pick<DefineHierarchyLevelProps, "createSelectClause"> & {
     parentNode: HierarchyNode & { key: InstancesNodeKey };
   }): Promise<HierarchyLevelDefinition> => {
     if (
@@ -474,7 +474,7 @@ The purpose of a custom query instance nodes specification in Presentation Rules
               fullClassName: `${schema.schemaName}.MyChildElement`,
               query: {
                 ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: "this.ECClassId" },
                     ecInstanceId: { selector: "this.ECInstanceId" },
                     nodeLabel: { of: { className: `${schema.schemaName}.MyChildElement`, classAlias: "this" } },
@@ -569,7 +569,7 @@ import {
 } from "@itwin/presentation-hierarchies";
 
 const hierarchyDefinition: HierarchyDefinition = {
-  defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+  defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
     if (parentNode) {
       return [];
     }
@@ -578,7 +578,7 @@ const hierarchyDefinition: HierarchyDefinition = {
         fullClassName: "BisCore.GeometricElement",
         query: {
           ecsql: `
-            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+            SELECT ${await createSelectClause({
               ecClassId: { selector: "this.ECClassId" },
               ecInstanceId: { selector: "this.ECInstanceId" },
               nodeLabel: { of: { className: "BisCore.GeometricElement", classAlias: "this" } },
@@ -627,7 +627,7 @@ import {
 } from "@itwin/presentation-hierarchies";
 
 const hierarchyDefinition: HierarchyDefinition = {
-  defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+  defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
     if (parentNode) {
       return [];
     }
@@ -636,7 +636,7 @@ const hierarchyDefinition: HierarchyDefinition = {
         fullClassName: "BisCore.Element",
         query: {
           ecsql: `
-            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+            SELECT ${await createSelectClause({
               ecClassId: { selector: "this.ECClassId" },
               ecInstanceId: { selector: "this.ECInstanceId" },
               nodeLabel: { of: { className: "BisCore.Element", classAlias: "this" } },
@@ -720,7 +720,7 @@ import {
 } from "@itwin/presentation-hierarchies";
 
 const hierarchyDefinition: HierarchyDefinition = {
-  defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+  defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
     if (parentNode) {
       return [];
     }
@@ -729,7 +729,7 @@ const hierarchyDefinition: HierarchyDefinition = {
         fullClassName: "BisCore.GeometricElement3d",
         query: {
           ecsql: `
-            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+            SELECT ${await createSelectClause({
               ecClassId: { selector: "this.ECClassId" },
               ecInstanceId: { selector: "this.ECInstanceId" },
               nodeLabel: { of: { className: "BisCore.GeometricElement3d", classAlias: "this" } },
@@ -793,7 +793,7 @@ import {
 } from "@itwin/presentation-hierarchies";
 
 const hierarchyDefinition: HierarchyDefinition = {
-  defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+  defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
     if (parentNode) {
       return [];
     }
@@ -802,7 +802,7 @@ const hierarchyDefinition: HierarchyDefinition = {
         fullClassName: "BisCore.Element",
         query: {
           ecsql: `
-            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+            SELECT ${await createSelectClause({
               ecClassId: { selector: "this.ECClassId" },
               ecInstanceId: { selector: "this.ECInstanceId" },
               nodeLabel: { of: { className: "BisCore.Element", classAlias: "this" } },
@@ -884,7 +884,7 @@ import {
 } from "@itwin/presentation-hierarchies";
 
 const hierarchyDefinition: HierarchyDefinition = {
-  defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+  defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
     if (parentNode) {
       return [];
     }
@@ -893,7 +893,7 @@ const hierarchyDefinition: HierarchyDefinition = {
         fullClassName: "BisCore.Element",
         query: {
           ecsql: `
-            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+            SELECT ${await createSelectClause({
               ecClassId: { selector: "this.ECClassId" },
               ecInstanceId: { selector: "this.ECInstanceId" },
               nodeLabel: { of: { className: "BisCore.Element", classAlias: "this" } },

--- a/packages/hierarchies/learning/PresentationRulesMigrationGuide.md
+++ b/packages/hierarchies/learning/PresentationRulesMigrationGuide.md
@@ -192,12 +192,11 @@ Matching `HierarchyNodesDefinition`:
 
 ```ts
 import {
-  createNodesQueryClauseFactory,
+  DefineHierarchyLevelProps,
   HierarchyLevelDefinition,
   HierarchyNodesDefinition,
   InstancesNodeKey,
 } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 
 const definition: HierarchyNodesDefinition = {
   node: {
@@ -257,41 +256,39 @@ Matching `HierarchyNodesDefinition`:
 
 ```ts
 import {
-  createNodesQueryClauseFactory,
+  DefineHierarchyLevelProps,
   HierarchyLevelDefinition,
   HierarchyNodesDefinition,
   InstancesNodeKey,
 } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 
-const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-const selectClauseFactory = createNodesQueryClauseFactory({
-  imodelAccess,
-  instanceLabelSelectClauseFactory: labelsFactory,
-});
-const definition: HierarchyNodesDefinition = {
-  fullClassName: "BisCore.GeometricModel",
-  query: {
-    ecsql: `
-      SELECT ${await selectClauseFactory.createSelectClause({
-        ecClassId: { selector: "this.ECClassId" },
-        ecInstanceId: { selector: "this.ECInstanceId" },
-        nodeLabel: {
-          selector: await labelsFactory.createSelectClause({
-            className: "BisCore.GeometricModel",
-            classAlias: "this",
-          }),
+const hierarchyDefinition: HierarchyDefinition = {
+  defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    if (parentNode) {
+      return [];
+    }
+    return [
+      {
+        fullClassName: "BisCore.GeometricModel",
+        query: {
+          ecsql: `
+            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+              ecClassId: { selector: "this.ECClassId" },
+              ecInstanceId: { selector: "this.ECInstanceId" },
+              nodeLabel: { of: { className: "BisCore.GeometricModel", classAlias: "this" } },
+              hasChildren: true,
+              grouping: {
+                byClass: true,
+                byLabel: { action: "group", hideIfNoSiblings: true, hideIfOneGroupedNode: true },
+              },
+            })}
+            FROM BisCore.GeometricModel [this]
+            INNER JOIN BisCore.InformationPartitionElement [partition] ON [partition].[ECInstanceId] = [this].[ModeledElement].[Id]
+            WHERE NOT [this].[IsPrivate] AND [this].[ECClassId] IS NOT (BisCore.GeometricModel2d)
+          `,
         },
-        hasChildren: true,
-        grouping: {
-          byClass: true,
-          byLabel: { action: "group", hideIfNoSiblings: true, hideIfOneGroupedNode: true },
-        },
-      })}
-      FROM BisCore.GeometricModel [this]
-      INNER JOIN BisCore.InformationPartitionElement [partition] ON [partition].[ECInstanceId] = [this].[ModeledElement].[Id]
-      WHERE NOT [this].[IsPrivate] AND [this].[ECClassId] IS NOT (BisCore.GeometricModel2d)
-    `,
+      },
+    ];
   },
 };
 ```
@@ -350,35 +347,25 @@ Matching `HierarchyNodesDefinition`:
 import { HierarchyNode } from "@itwin/presentation-hierarchies";
 
 import {
-  createNodesQueryClauseFactory,
+  DefineHierarchyLevelProps,
   HierarchyLevelDefinition,
   HierarchyNodesDefinition,
   InstancesNodeKey,
 } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 
-const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-const selectClauseFactory = createNodesQueryClauseFactory({
-  imodelAccess,
-  instanceLabelSelectClauseFactory: labelsFactory,
-});
-const createDefinition = async ({
+const createChildDefinition = async ({
   parentNode,
-}: {
+  nodeSelectClauseFactory,
+}: Pick<DefineHierarchyLevelProps, "nodeSelectClauseFactory"> & {
   parentNode: HierarchyNode & { key: InstancesNodeKey };
 }): Promise<HierarchyNodesDefinition> => ({
   fullClassName: "BisCore.GeometricElement3d",
   query: {
     ecsql: `
-      SELECT ${await selectClauseFactory.createSelectClause({
+      SELECT ${await nodeSelectClauseFactory.createSelectClause({
         ecClassId: { selector: "this.ECClassId" },
         ecInstanceId: { selector: "this.ECInstanceId" },
-        nodeLabel: {
-          selector: await labelsFactory.createSelectClause({
-            className: "BisCore.GeometricElement3d",
-            classAlias: "this",
-          }),
-        },
+        nodeLabel: { of: { className: "BisCore.GeometricElement3d", classAlias: "this" } },
       })}
       FROM BisCore.GeometricElement3d [this]
       INNER JOIN BisCore.SpatialCategory [category] ON [category].[ECInstanceId] = [this].[Category].[Id]
@@ -451,21 +438,16 @@ The purpose of a custom query instance nodes specification in Presentation Rules
   import { HierarchyNode } from "@itwin/presentation-hierarchies";
 
   import {
-    createNodesQueryClauseFactory,
+    DefineHierarchyLevelProps,
     HierarchyLevelDefinition,
     HierarchyNodesDefinition,
     InstancesNodeKey,
   } from "@itwin/presentation-hierarchies";
-  import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 
-  const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-  const selectClauseFactory = createNodesQueryClauseFactory({
-    imodelAccess,
-    instanceLabelSelectClauseFactory: labelsFactory,
-  });
   const createDefinition = async ({
     parentNode,
-  }: {
+    nodeSelectClauseFactory,
+  }: Pick<DefineHierarchyLevelProps, "nodeSelectClauseFactory"> & {
     parentNode: HierarchyNode & { key: InstancesNodeKey };
   }): Promise<HierarchyLevelDefinition> => {
     if (
@@ -492,15 +474,10 @@ The purpose of a custom query instance nodes specification in Presentation Rules
               fullClassName: `${schema.schemaName}.MyChildElement`,
               query: {
                 ecsql: `
-                  SELECT ${await selectClauseFactory.createSelectClause({
+                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
                     ecClassId: { selector: "this.ECClassId" },
                     ecInstanceId: { selector: "this.ECInstanceId" },
-                    nodeLabel: {
-                      selector: await labelsFactory.createSelectClause({
-                        className: `${schema.schemaName}.MyChildElement`,
-                        classAlias: "this",
-                      }),
-                    },
+                    nodeLabel: { of: { className: `${schema.schemaName}.MyChildElement`, classAlias: "this" } },
                   })}
                   FROM ${schema.schemaName}.MyChildElement this
                   WHERE this.ECInstanceId IN (
@@ -585,37 +562,35 @@ Matching `HierarchyDefinition`:
 
 ```ts
 import {
-  createNodesQueryClauseFactory,
+  DefineHierarchyLevelProps,
   HierarchyLevelDefinition,
   HierarchyNodesDefinition,
   InstancesNodeKey,
 } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 
-const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-const selectClauseFactory = createNodesQueryClauseFactory({
-  imodelAccess,
-  instanceLabelSelectClauseFactory: labelsFactory,
-});
-const definition: HierarchyNodesDefinition = {
-  fullClassName: "BisCore.GeometricElement",
-  query: {
-    ecsql: `
-      SELECT ${await selectClauseFactory.createSelectClause({
-        ecClassId: { selector: "this.ECClassId" },
-        ecInstanceId: { selector: "this.ECInstanceId" },
-        nodeLabel: {
-          selector: await labelsFactory.createSelectClause({
-            className: "BisCore.GeometricElement",
-            classAlias: "this",
-          }),
+const hierarchyDefinition: HierarchyDefinition = {
+  defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    if (parentNode) {
+      return [];
+    }
+    return [
+      {
+        fullClassName: "BisCore.GeometricElement",
+        query: {
+          ecsql: `
+            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+              ecClassId: { selector: "this.ECClassId" },
+              ecInstanceId: { selector: "this.ECInstanceId" },
+              nodeLabel: { of: { className: "BisCore.GeometricElement", classAlias: "this" } },
+              grouping: {
+                byBaseClasses: { fullClassNames: ["BisCore.GeometricElement3d", "BisCore.PhysicalElement"] },
+              },
+            })}
+            FROM BisCore.GeometricElement [this]
+          `,
         },
-        grouping: {
-          byBaseClasses: { fullClassNames: ["BisCore.GeometricElement3d", "BisCore.PhysicalElement"] },
-        },
-      })}
-      FROM BisCore.GeometricElement [this]
-    `,
+      },
+    ];
   },
 };
 ```
@@ -645,35 +620,33 @@ Matching `HierarchyDefinition`:
 
 ```ts
 import {
-  createNodesQueryClauseFactory,
+  DefineHierarchyLevelProps,
   HierarchyLevelDefinition,
   HierarchyNodesDefinition,
   InstancesNodeKey,
 } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 
-const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-const selectClauseFactory = createNodesQueryClauseFactory({
-  imodelAccess,
-  instanceLabelSelectClauseFactory: labelsFactory,
-});
-const definition: HierarchyNodesDefinition = {
-  fullClassName: "BisCore.Element",
-  query: {
-    ecsql: `
-      SELECT ${await selectClauseFactory.createSelectClause({
-        ecClassId: { selector: "this.ECClassId" },
-        ecInstanceId: { selector: "this.ECInstanceId" },
-        nodeLabel: {
-          selector: await labelsFactory.createSelectClause({
-            className: "BisCore.Element",
-            classAlias: "this",
-          }),
+const hierarchyDefinition: HierarchyDefinition = {
+  defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    if (parentNode) {
+      return [];
+    }
+    return [
+      {
+        fullClassName: "BisCore.Element",
+        query: {
+          ecsql: `
+            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+              ecClassId: { selector: "this.ECClassId" },
+              ecInstanceId: { selector: "this.ECInstanceId" },
+              nodeLabel: { of: { className: "BisCore.Element", classAlias: "this" } },
+              grouping: { byClass: true },
+            })}
+            FROM BisCore.Element [this]
+          `,
         },
-        grouping: { byClass: true },
-      })}
-      FROM BisCore.Element [this]
-    `,
+      },
+    ];
   },
 };
 ```
@@ -740,52 +713,50 @@ Matching `HierarchyDefinition`:
 
 ```ts
 import {
-  createNodesQueryClauseFactory,
+  DefineHierarchyLevelProps,
   HierarchyLevelDefinition,
   HierarchyNodesDefinition,
   InstancesNodeKey,
 } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 
-const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-const selectClauseFactory = createNodesQueryClauseFactory({
-  imodelAccess,
-  instanceLabelSelectClauseFactory: labelsFactory,
-});
-const definition: HierarchyNodesDefinition = {
-  fullClassName: "BisCore.GeometricElement3d",
-  query: {
-    ecsql: `
-      SELECT ${await selectClauseFactory.createSelectClause({
-        ecClassId: { selector: "this.ECClassId" },
-        ecInstanceId: { selector: "this.ECInstanceId" },
-        nodeLabel: {
-          selector: await labelsFactory.createSelectClause({
-            className: "BisCore.GeometricElement3d",
-            classAlias: "this",
-          }),
-        },
-        grouping: {
-          byProperties: {
-            propertiesClassName: "BisCore.GeometricElement3d",
-            createGroupForOutOfRangeValues: true,
-            createGroupForUnspecifiedValues: true,
-            propertyGroups: [
-              {
-                propertyClassAlias: "this",
-                propertyName: "Yaw",
-                ranges: [
-                  { fromValue: 0, toValue: 0, rangeLabel: "Zero" },
-                  { fromValue: -360, toValue: 0, rangeLabel: "Negative" },
-                  { fromValue: 0, toValue: 360, rangeLabel: "Positive" },
-                ],
+const hierarchyDefinition: HierarchyDefinition = {
+  defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    if (parentNode) {
+      return [];
+    }
+    return [
+      {
+        fullClassName: "BisCore.GeometricElement3d",
+        query: {
+          ecsql: `
+            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+              ecClassId: { selector: "this.ECClassId" },
+              ecInstanceId: { selector: "this.ECInstanceId" },
+              nodeLabel: { of: { className: "BisCore.GeometricElement3d", classAlias: "this" } },
+              grouping: {
+                byProperties: {
+                  propertiesClassName: "BisCore.GeometricElement3d",
+                  createGroupForOutOfRangeValues: true,
+                  createGroupForUnspecifiedValues: true,
+                  propertyGroups: [
+                    {
+                      propertyClassAlias: "this",
+                      propertyName: "Yaw",
+                      ranges: [
+                        { fromValue: 0, toValue: 0, rangeLabel: "Zero" },
+                        { fromValue: -360, toValue: 0, rangeLabel: "Negative" },
+                        { fromValue: 0, toValue: 360, rangeLabel: "Positive" },
+                      ],
+                    },
+                  ],
+                },
               },
-            ],
-          },
+            })}
+            FROM BisCore.GeometricElement3d [this]
+          `,
         },
-      })}
-      FROM BisCore.GeometricElement3d [this]
-    `,
+      },
+    ];
   },
 };
 ```
@@ -815,35 +786,33 @@ Matching `HierarchyDefinition`:
 
 ```ts
 import {
-  createNodesQueryClauseFactory,
+  DefineHierarchyLevelProps,
   HierarchyLevelDefinition,
   HierarchyNodesDefinition,
   InstancesNodeKey,
 } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 
-const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-const selectClauseFactory = createNodesQueryClauseFactory({
-  imodelAccess,
-  instanceLabelSelectClauseFactory: labelsFactory,
-});
-const definition: HierarchyNodesDefinition = {
-  fullClassName: "BisCore.Element",
-  query: {
-    ecsql: `
-      SELECT ${await selectClauseFactory.createSelectClause({
-        ecClassId: { selector: "this.ECClassId" },
-        ecInstanceId: { selector: "this.ECInstanceId" },
-        nodeLabel: {
-          selector: await labelsFactory.createSelectClause({
-            className: "BisCore.Element",
-            classAlias: "this",
-          }),
+const hierarchyDefinition: HierarchyDefinition = {
+  defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    if (parentNode) {
+      return [];
+    }
+    return [
+      {
+        fullClassName: "BisCore.Element",
+        query: {
+          ecsql: `
+            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+              ecClassId: { selector: "this.ECClassId" },
+              ecInstanceId: { selector: "this.ECInstanceId" },
+              nodeLabel: { of: { className: "BisCore.Element", classAlias: "this" } },
+              grouping: { byLabel: { hideIfNoSiblings: true, hideIfOneGroupedNode: true } },
+            })}
+            FROM BisCore.Element [this]
+          `,
         },
-        grouping: { byLabel: { hideIfNoSiblings: true, hideIfOneGroupedNode: true } },
-      })}
-      FROM BisCore.Element [this]
-    `,
+      },
+    ];
   },
 };
 ```
@@ -908,35 +877,33 @@ Matching `HierarchyDefinition`:
 
 ```ts
 import {
-  createNodesQueryClauseFactory,
+  DefineHierarchyLevelProps,
   HierarchyLevelDefinition,
   HierarchyNodesDefinition,
   InstancesNodeKey,
 } from "@itwin/presentation-hierarchies";
-import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 
-const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-const selectClauseFactory = createNodesQueryClauseFactory({
-  imodelAccess,
-  instanceLabelSelectClauseFactory: labelsFactory,
-});
-const definition: HierarchyNodesDefinition = {
-  fullClassName: "BisCore.Element",
-  query: {
-    ecsql: `
-      SELECT ${await selectClauseFactory.createSelectClause({
-        ecClassId: { selector: "this.ECClassId" },
-        ecInstanceId: { selector: "this.ECInstanceId" },
-        nodeLabel: {
-          selector: await labelsFactory.createSelectClause({
-            className: "BisCore.Element",
-            classAlias: "this",
-          }),
+const hierarchyDefinition: HierarchyDefinition = {
+  defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    if (parentNode) {
+      return [];
+    }
+    return [
+      {
+        fullClassName: "BisCore.Element",
+        query: {
+          ecsql: `
+            SELECT ${await nodeSelectClauseFactory.createSelectClause({
+              ecClassId: { selector: "this.ECClassId" },
+              ecInstanceId: { selector: "this.ECInstanceId" },
+              nodeLabel: { of: { className: "BisCore.Element", classAlias: "this" } },
+              grouping: { byLabel: { action: "merge" } },
+            })}
+            FROM BisCore.Element [this]
+          `,
         },
-        grouping: { byLabel: { action: "merge" } },
-      })}
-      FROM BisCore.Element [this]
-    `,
+      },
+    ];
   },
 };
 ```

--- a/packages/hierarchies/learning/imodel/Grouping.md
+++ b/packages/hierarchies/learning/imodel/Grouping.md
@@ -19,7 +19,7 @@ import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 const hierarchyProvider = createIModelHierarchyProvider({
   imodelAccess,
   hierarchyDefinition: {
-    defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
       if (!parentNode) {
         // The hierarchy definition requests `BisCore.PhysicalElement` nodes to be return as
         // root nodes and have them grouped by label
@@ -28,7 +28,7 @@ const hierarchyProvider = createIModelHierarchyProvider({
             fullClassName: "BisCore.PhysicalElement",
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
                   nodeLabel: { selector: "this.UserLabel" },
@@ -82,7 +82,7 @@ import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 const hierarchyProvider = createIModelHierarchyProvider({
   imodelAccess,
   hierarchyDefinition: {
-    defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
       if (!parentNode) {
         // The hierarchy definition requests `BisCore.PhysicalElement` nodes to be returned as root
         // nodes and have them merged based on label
@@ -91,7 +91,7 @@ const hierarchyProvider = createIModelHierarchyProvider({
             fullClassName: "BisCore.PhysicalElement",
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
                   nodeLabel: { selector: "this.UserLabel" },
@@ -139,7 +139,7 @@ import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 const hierarchyProvider = createIModelHierarchyProvider({
   imodelAccess,
   hierarchyDefinition: {
-    defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
       if (!parentNode) {
         // The hierarchy definition requests `BisCore.Category` nodes to be returned as root nodes and have
         // them grouped by class.
@@ -148,7 +148,7 @@ const hierarchyProvider = createIModelHierarchyProvider({
             fullClassName: "BisCore.Category",
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
                   nodeLabel: { selector: "this.CodeValue" },
@@ -210,7 +210,7 @@ import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 const hierarchyProvider = createIModelHierarchyProvider({
   imodelAccess,
   hierarchyDefinition: {
-    defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
       if (!parentNode) {
         // The hierarchy definition requests `BisCore.Category` nodes to be grouped by the following classes:
         // - `BisCore.Element`
@@ -220,7 +220,7 @@ const hierarchyProvider = createIModelHierarchyProvider({
             fullClassName: "BisCore.Category",
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
                   nodeLabel: { selector: "this.CodeValue" },
@@ -288,7 +288,7 @@ import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 const hierarchyProvider = createIModelHierarchyProvider({
   imodelAccess,
   hierarchyDefinition: {
-    defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
       if (!parentNode) {
         // The hierarchy definition requests `BisCore.RepositoryLink` nodes to be returned as root nodes and have
         // them grouped by the `Format` property.
@@ -297,7 +297,7 @@ const hierarchyProvider = createIModelHierarchyProvider({
             fullClassName: "BisCore.RepositoryLink",
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
                   nodeLabel: { selector: "this.UserLabel" },
@@ -378,7 +378,7 @@ import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 const hierarchyProvider = createIModelHierarchyProvider({
   imodelAccess,
   hierarchyDefinition: {
-    defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
       if (!parentNode) {
         // The hierarchy definition requests `BisCore.PhysicalMaterial` nodes to be returned as root nodes and have
         // them grouped by the `Density` property value in given ranges.
@@ -387,7 +387,7 @@ const hierarchyProvider = createIModelHierarchyProvider({
             fullClassName: "BisCore.PhysicalMaterial",
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
                   nodeLabel: { selector: "this.UserLabel" },
@@ -465,7 +465,7 @@ import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 const hierarchyProvider = createIModelHierarchyProvider({
   imodelAccess,
   hierarchyDefinition: {
-    defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
       if (!parentNode) {
         // The hierarchy definition requests `BisCore.RepositoryLink` nodes to be returned as root nodes and have
         // them grouped by the `Format` property.
@@ -474,7 +474,7 @@ const hierarchyProvider = createIModelHierarchyProvider({
             fullClassName: "BisCore.RepositoryLink",
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
                   nodeLabel: { selector: "this.UserLabel" },
@@ -595,7 +595,7 @@ import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 const hierarchyProvider = createIModelHierarchyProvider({
   imodelAccess,
   hierarchyDefinition: {
-    defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
       if (!parentNode) {
         // The hierarchy definition requests `BisCore.RepositoryLink` nodes to be returned as root nodes and have
         // them grouped by label only if there's more than one instance with the same label.
@@ -604,7 +604,7 @@ const hierarchyProvider = createIModelHierarchyProvider({
             fullClassName: "BisCore.RepositoryLink",
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
                   nodeLabel: { selector: "this.UserLabel" },
@@ -651,7 +651,7 @@ import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 const hierarchyProvider = createIModelHierarchyProvider({
   imodelAccess,
   hierarchyDefinition: {
-    defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
       if (!parentNode) {
         // The hierarchy definition requests `BisCore.RepositoryLink` nodes to be returned as root nodes and have
         // them grouped by class only if the grouping node has siblings.
@@ -660,7 +660,7 @@ const hierarchyProvider = createIModelHierarchyProvider({
             fullClassName: "BisCore.RepositoryLink",
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
                   nodeLabel: { selector: "this.UserLabel" },
@@ -704,7 +704,7 @@ In certain scenarios it may be required to automatically expand the grouping nod
 
 ```ts
 `
-  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+  SELECT ${await createSelectClause({
     ecClassId: { selector: "this.ECClassId" },
     ecInstanceId: { selector: "this.ECInstanceId" },
     nodeLabel: { selector: "this.UserLabel" },

--- a/packages/hierarchies/learning/imodel/HierarchyDefinition.md
+++ b/packages/hierarchies/learning/imodel/HierarchyDefinition.md
@@ -60,7 +60,7 @@ const hierarchyDefinition: HierarchyDefinition = {
 
 ## Custom parsing
 
-By default, it's expected that the nodes' SELECT clause is created using `NodesQueryClauseFactory.createSelectClause` and then specifying `parseNode` callback in the hierarchy definition is not necessary, as the default parser knows how parse ECSQL rows.
+By default, it's expected that the nodes' SELECT clause is created using the `nodeSelectClauseFactory.createSelectClause` function (available through `defineHierarchyLevel` props) and then specifying `parseNode` callback in the hierarchy definition is not necessary, as the default parser knows how to parse ECSQL rows.
 
 However, some hierarchy definitions may choose to write SELECT clause manually and then they need to provide a custom `parseNode` callback to parse the ECSQL result row into a `SourceInstanceHierarchyNode` object. Example:
 
@@ -84,7 +84,7 @@ const hierarchyDefinition: HierarchyDefinition = {
         {
           fullClassName: "BisCore.PhysicalElement",
           query: {
-            // Define the query without using `NodesQueryClauseFactory` - we'll parse the results manually. But to create
+            // Define the query without using `nodeSelectClauseFactory` - we'll parse the results manually. But to create
             // an instances node we need at least a class name, instance id, and a label.
             ecsql: `
               SELECT

--- a/packages/hierarchies/learning/imodel/HierarchyDefinition.md
+++ b/packages/hierarchies/learning/imodel/HierarchyDefinition.md
@@ -27,7 +27,7 @@ import {
 } from "@itwin/presentation-hierarchies";
 
 const hierarchyDefinition: HierarchyDefinition = {
-  async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+  async defineHierarchyLevel({ parentNode, createSelectClause }) {
     // For root nodes, simply return one generic node
     if (!parentNode) {
       return [{ node: { key: "physical-elements", label: "Physical elements" } }];
@@ -39,7 +39,7 @@ const hierarchyDefinition: HierarchyDefinition = {
           fullClassName: "BisCore.PhysicalElement",
           query: {
             ecsql: `
-              SELECT ${await nodeSelectClauseFactory.createSelectClause({
+              SELECT ${await createSelectClause({
                 ecClassId: { selector: "x.ECClassId" },
                 ecInstanceId: { selector: "x.ECInstanceId" },
                 nodeLabel: { selector: "x.UserLabel" },
@@ -60,7 +60,7 @@ const hierarchyDefinition: HierarchyDefinition = {
 
 ## Custom parsing
 
-By default, it's expected that the nodes' SELECT clause is created using the `nodeSelectClauseFactory.createSelectClause` function (available through `defineHierarchyLevel` props) and then specifying `parseNode` callback in the hierarchy definition is not necessary, as the default parser knows how to parse ECSQL rows.
+By default, it's expected that the nodes' SELECT clause is created using the `createSelectClause` function (available through `defineHierarchyLevel` props) and then specifying `parseNode` callback in the hierarchy definition is not necessary, as the default parser knows how to parse ECSQL rows.
 
 However, some hierarchy definitions may choose to write SELECT clause manually and then they need to provide a custom `parseNode` callback to parse the ECSQL result row into a `SourceInstanceHierarchyNode` object. Example:
 
@@ -84,7 +84,7 @@ const hierarchyDefinition: HierarchyDefinition = {
         {
           fullClassName: "BisCore.PhysicalElement",
           query: {
-            // Define the query without using `nodeSelectClauseFactory` - we'll parse the results manually. But to create
+            // Define the query without using `createSelectClause` - we'll parse the results manually. But to create
             // an instances node we need at least a class name, instance id, and a label.
             ecsql: `
               SELECT
@@ -132,7 +132,7 @@ import {
 } from "@itwin/presentation-hierarchies";
 
 const hierarchyDefinition: HierarchyDefinition = {
-  async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+  async defineHierarchyLevel({ parentNode, createSelectClause }) {
     // For root nodes, return all physical elements
     if (!parentNode) {
       return [
@@ -140,7 +140,7 @@ const hierarchyDefinition: HierarchyDefinition = {
           fullClassName: "BisCore.PhysicalElement",
           query: {
             ecsql: `
-              SELECT ${await nodeSelectClauseFactory.createSelectClause({
+              SELECT ${await createSelectClause({
                 ecClassId: { selector: "x.ECClassId" },
                 ecInstanceId: { selector: "x.ECInstanceId" },
                 nodeLabel: { selector: "x.UserLabel" },
@@ -188,7 +188,7 @@ import {
 } from "@itwin/presentation-hierarchies";
 
 const hierarchyDefinition: HierarchyDefinition = {
-  async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+  async defineHierarchyLevel({ parentNode, createSelectClause }) {
     // For root nodes, return all physical elements grouped by class
     if (!parentNode) {
       return [
@@ -196,7 +196,7 @@ const hierarchyDefinition: HierarchyDefinition = {
           fullClassName: "BisCore.PhysicalElement",
           query: {
             ecsql: `
-              SELECT ${await nodeSelectClauseFactory.createSelectClause({
+              SELECT ${await createSelectClause({
                 ecClassId: { selector: "x.ECClassId" },
                 ecInstanceId: { selector: "x.ECInstanceId" },
                 nodeLabel: { selector: "x.UserLabel" },
@@ -255,13 +255,13 @@ const hierarchyDefinition = createPredicateBasedHierarchyDefinition({
         // For the root node, return a query that selects all physical elements
         parentGenericNodePredicate: async (parentKey) => parentKey.id === "physical-elements",
         definitions: async ({
-          nodeSelectClauseFactory,
+          createSelectClause,
         }: DefineGenericNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> => [
           {
             fullClassName: "BisCore.PhysicalElement",
             query: {
               ecsql: `
-              SELECT ${await nodeSelectClauseFactory.createSelectClause({
+              SELECT ${await createSelectClause({
                 ecClassId: { selector: "x.ECClassId" },
                 ecInstanceId: { selector: "x.ECInstanceId" },
                 nodeLabel: { selector: "x.UserLabel" },

--- a/packages/hierarchies/learning/imodel/HierarchyLevelFiltering.md
+++ b/packages/hierarchies/learning/imodel/HierarchyLevelFiltering.md
@@ -79,7 +79,7 @@ The callback argument allows the filter to be assigned to the node. Upon that no
 
 As mentioned in the previous section, hierarchy definition gets the applied filter as the `DefineHierarchyLevelProps.instanceFilter` argument to its `defineHierarchyLevel` function. And it's definition's job to apply this filter on the returned `InstanceNodesQueryDefinition`.
 
-While the library can't do that automatically, it does provide a helper function that can be used to apply the filter on the query. The function is available as `NodesQueryClauseFactory.createFilterClauses` retrieved from `createNodesQueryClauseFactory` (which can also be used to create SELECT clauses). The function takes information about the class the nodes represent and the filter, and returns a set of clauses that can be used to apply the filter on the query:
+While the library can't do that automatically, it does provide a helper function that can be used to apply the filter on the query. The function is available as `nodeSelectClauseFactory.createFilterClauses` through the `defineHierarchyLevel` props. The function takes information about the class the nodes represent and the filter, and returns a set of clauses that can be used to apply the filter on the query:
 
 <!-- [[include: [Presentation.Hierarchies.HierarchyLevelFiltering.Imports, Presentation.Hierarchies.HierarchyLevelFiltering.ApplyFilter], ts]] -->
 <!-- BEGIN EXTRACTION -->

--- a/packages/hierarchies/learning/imodel/HierarchyLevelFiltering.md
+++ b/packages/hierarchies/learning/imodel/HierarchyLevelFiltering.md
@@ -37,14 +37,14 @@ To make an instance node filterable, the hierarchy definition should set `suppor
 import { HierarchyDefinition } from "@itwin/presentation-hierarchies";
 
 const hierarchyDefinition: HierarchyDefinition = {
-  async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+  async defineHierarchyLevel({ parentNode, createSelectClause }) {
     if (!parentNode) {
       return [
         {
           fullClassName: "BisCore.PhysicalElement",
           query: {
             ecsql: `
-              SELECT ${await nodeSelectClauseFactory.createSelectClause({
+              SELECT ${await createSelectClause({
                 ecClassId: { selector: "this.ECClassId" },
                 ecInstanceId: { selector: "this.ECInstanceId" },
                 nodeLabel: { selector: "this.UserLabel" },
@@ -79,7 +79,7 @@ The callback argument allows the filter to be assigned to the node. Upon that no
 
 As mentioned in the previous section, hierarchy definition gets the applied filter as the `DefineHierarchyLevelProps.instanceFilter` argument to its `defineHierarchyLevel` function. And it's definition's job to apply this filter on the returned `InstanceNodesQueryDefinition`.
 
-While the library can't do that automatically, it does provide a helper function that can be used to apply the filter on the query. The function is available as `nodeSelectClauseFactory.createFilterClauses` through the `defineHierarchyLevel` props. The function takes information about the class the nodes represent and the filter, and returns a set of clauses that can be used to apply the filter on the query:
+While the library can't do that automatically, it does provide a helper function that can be used to apply the filter on the query. The function is available as `createFilterClauses` through the `defineHierarchyLevel` props. The function takes information about the class the nodes represent and the filter, and returns a set of clauses that can be used to apply the filter on the query:
 
 <!-- [[include: [Presentation.Hierarchies.HierarchyLevelFiltering.Imports, Presentation.Hierarchies.HierarchyLevelFiltering.ApplyFilter], ts]] -->
 <!-- BEGIN EXTRACTION -->
@@ -88,22 +88,22 @@ While the library can't do that automatically, it does provide a helper function
 import { HierarchyDefinition } from "@itwin/presentation-hierarchies";
 
 const hierarchyDefinition: HierarchyDefinition = {
-  async defineHierarchyLevel(props) {
+  async defineHierarchyLevel({ instanceFilter, createSelectClause, createFilterClauses }) {
     // `createFilterClauses` function returns `from`, `joins`, and `where` clauses which need to be used in the
     // query in appropriate places
-    const { from, joins, where } = await props.nodeSelectClauseFactory.createFilterClauses({
+    const { from, joins, where } = await createFilterClauses({
       // specify the content class whose instances are used to build nodes - this should
       // generally match the instance whose ECClassId and ECInstanceId are used in the SELECT clause
       contentClass: { fullName: "BisCore.PhysicalElement", alias: "this" },
       // specify the filter that we get from props for this hierarchy level
-      filter: props.instanceFilter,
+      filter: instanceFilter,
     });
     return [
       {
         fullClassName: "BisCore.PhysicalElement",
         query: {
           ecsql: `
-            SELECT ${await props.nodeSelectClauseFactory.createSelectClause({
+            SELECT ${await createSelectClause({
               ecClassId: { selector: "this.ECClassId" },
               ecInstanceId: { selector: "this.ECInstanceId" },
               nodeLabel: { selector: "this.UserLabel" },

--- a/packages/hierarchies/learning/imodel/HierarchyNodeLabels.md
+++ b/packages/hierarchies/learning/imodel/HierarchyNodeLabels.md
@@ -48,9 +48,9 @@ expect(await collectHierarchy(hierarchyProvider)).toMatchObject([{ label: "Examp
 
 ## ECInstances-based node labels
 
-In case of instance nodes, the hierarchy definition returns a query object which is used to fetch the nodes. Generally, the SELECT clause of the query defines how to select the label from iModel, and, when the query is executed, the parser reads and assigns the label to the node. A custom parser may decide to use other means to get the label - see the [custom parsing](./HierarchyDefinition.md#custom-parsing) section for more details. However, usually, consumers will want to use the `nodeSelectClauseFactory.createSelectClause` function (available through `defineHierarchyLevel` props) to create the SELECT clause for the query, as it works with the default parser.
+In case of instance nodes, the hierarchy definition returns a query object which is used to fetch the nodes. Generally, the SELECT clause of the query defines how to select the label from iModel, and, when the query is executed, the parser reads and assigns the label to the node. A custom parser may decide to use other means to get the label - see the [custom parsing](./HierarchyDefinition.md#custom-parsing) section for more details. However, usually, consumers will want to use the `createSelectClause` function (available through `defineHierarchyLevel` props) to create the SELECT clause for the query, as it works with the default parser.
 
-The `nodeSelectClauseFactory.createSelectClause` function has a required `nodeLabel` attribute whose type is one of the following:
+The `createSelectClause` function has a required `nodeLabel` attribute whose type is one of the following:
 
 - A string — simply uses the same given string for all nodes returned by the query. This is not a recommended approach, unless the hierarchy definition author is sure the query returns only a single node.
 
@@ -66,7 +66,7 @@ The `nodeSelectClauseFactory.createSelectClause` function has a required `nodeLa
   import { ECSql } from "@itwin/presentation-shared";
 
   const hierarchyDefinition: HierarchyDefinition = {
-    async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+    async defineHierarchyLevel({ parentNode, createSelectClause }) {
       // For root nodes, return a query that selects all physical elements
       if (!parentNode) {
         return [
@@ -74,11 +74,11 @@ The `nodeSelectClauseFactory.createSelectClause` function has a required `nodeLa
             fullClassName: "BisCore.PhysicalElement",
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: "x.ECClassId" },
                   ecInstanceId: { selector: "x.ECInstanceId" },
                   // Use `{ of: ... }` to delegate label creation to the instance label select clause factory used
-                  // by `nodeSelectClauseFactory`, which defaults to the result of `createIModelInstanceLabelSelectClauseFactory`.
+                  // by `createSelectClause`, which defaults to the result of `createIModelInstanceLabelSelectClauseFactory`.
                   nodeLabel: {
                     of: {
                       classAlias: "x",
@@ -163,7 +163,7 @@ By a request of `HierarchyDefinition`, the hierarchy provider groups instance no
   const hierarchyProvider = createIModelHierarchyProvider({
     imodelAccess,
     hierarchyDefinition: {
-      defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+      defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
         if (!parentNode) {
           return [
             // The hierarchy definition returns nodes for `myPhysicalObjectClassName` element type, grouped by `DoubleProperty` property value
@@ -171,7 +171,7 @@ By a request of `HierarchyDefinition`, the hierarchy provider groups instance no
               fullClassName: myPhysicalObjectClassName,
               query: {
                 ecsql: `
-                  SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                  SELECT ${await createSelectClause({
                     ecClassId: { selector: "this.ECClassId" },
                     ecInstanceId: { selector: "this.ECInstanceId" },
                     nodeLabel: { selector: "this.UserLabel" },

--- a/packages/hierarchies/learning/imodel/HierarchyNodeLabels.md
+++ b/packages/hierarchies/learning/imodel/HierarchyNodeLabels.md
@@ -48,15 +48,15 @@ expect(await collectHierarchy(hierarchyProvider)).toMatchObject([{ label: "Examp
 
 ## ECInstances-based node labels
 
-In case of instance nodes, the hierarchy definition returns a query object which is used to fetch the nodes. Generally, the SELECT clause of the query defines how to select the label from iModel, and, when the query is executed, the parser reads and assigns the label to the node. A custom parser may decide to use other means to get the label - see the [custom parsing](./HierarchyDefinition.md#custom-parsing) section for more details. However, usually, consumers will want to use `NodesQueryClauseFactory.createSelectClause` to create the SELECT clause for the query, as it works with the default parser.
+In case of instance nodes, the hierarchy definition returns a query object which is used to fetch the nodes. Generally, the SELECT clause of the query defines how to select the label from iModel, and, when the query is executed, the parser reads and assigns the label to the node. A custom parser may decide to use other means to get the label - see the [custom parsing](./HierarchyDefinition.md#custom-parsing) section for more details. However, usually, consumers will want to use the `nodeSelectClauseFactory.createSelectClause` function (available through `defineHierarchyLevel` props) to create the SELECT clause for the query, as it works with the default parser.
 
-The `NodesQueryClauseFactory.createSelectClause` function has a required `nodeLabel` attribute whose type is either a string or an ECSQL selector object.
+The `nodeSelectClauseFactory.createSelectClause` function has a required `nodeLabel` attribute whose type is one of the following:
 
-- The string option simply uses the same given string for all nodes returned by the query. This is not a recommended approach, unless the hierarchy definition author is sure the query returns only a single node.
+- A string — simply uses the same given string for all nodes returned by the query. This is not a recommended approach, unless the hierarchy definition author is sure the query returns only a single node.
 
-- The ECSQL selector object generally looks like this: `{ selector: "class_alias.PropertyName" }`. This results in an ECSQL query like `SELECT class_alias.PropertyName FROM ...`, which suggests the selector has to be a valid ECSQL clause to add to a SELECT clause.
+- An ECSQL selector object — generally looks like this: `{ selector: "class_alias.PropertyName" }`. This results in an ECSQL query like `SELECT class_alias.PropertyName FROM ...`, which suggests the selector has to be a valid ECSQL clause to add to a SELECT clause.
 
-  While consumers are free to specify any ECSQL selector for their nodes, the library provides a few helper functions to make it easier to create the selector. The functions are delivered with the `@itwin/presentation-shared` package and are documented in its [README](https://github.com/iTwin/presentation/blob/master/packages/shared/README.md#instance-labels). The recommended one for iModel instances' labels is the [iModel instance label select clause factory](https://github.com/iTwin/presentation/blob/master/packages/shared/README.md#createimodelinstancelabelselectclausefactory), which knows how to create unique labels for iModel instances. A quick example of its usage for hierarchies:
+- An `{ of: { classAlias, className? } }` object — a convenience shorthand that delegates label creation to the instance label select clause factory configured on the hierarchy provider. This is the recommended approach for labeling iModel instance nodes, as it automatically creates unique labels based on the instance's display label rules. A quick example of its usage for hierarchies:
 
   <!-- [[include: [Presentation.Hierarchies.NodeLabels.Imports, Presentation.Hierarchies.NodeLabels.IModelInstanceLabelSelectClauseFactory], ts]] -->
   <!-- BEGIN EXTRACTION -->
@@ -66,7 +66,7 @@ The `NodesQueryClauseFactory.createSelectClause` function has a required `nodeLa
   import { ECSql } from "@itwin/presentation-shared";
 
   const hierarchyDefinition: HierarchyDefinition = {
-    async defineHierarchyLevel({ parentNode, instanceLabelSelectClauseFactory, nodeSelectClauseFactory }) {
+    async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
       // For root nodes, return a query that selects all physical elements
       if (!parentNode) {
         return [
@@ -77,12 +77,13 @@ The `NodesQueryClauseFactory.createSelectClause` function has a required `nodeLa
                 SELECT ${await nodeSelectClauseFactory.createSelectClause({
                   ecClassId: { selector: "x.ECClassId" },
                   ecInstanceId: { selector: "x.ECInstanceId" },
+                  // Use `{ of: ... }` to delegate label creation to the instance label select clause factory used
+                  // by `nodeSelectClauseFactory`, which defaults to the result of `createIModelInstanceLabelSelectClauseFactory`.
                   nodeLabel: {
-                    // Use iModel instance label select clause factory to create the label selector
-                    selector: await instanceLabelSelectClauseFactory.createSelectClause({
+                    of: {
                       classAlias: "x",
                       className: "BisCore.PhysicalElement", // This is optional, but helps create a more optimal selector
-                    }),
+                    },
                   },
                 })}
                 FROM BisCore.PhysicalElement x

--- a/packages/hierarchies/learning/imodel/HierarchySearch.md
+++ b/packages/hierarchies/learning/imodel/HierarchySearch.md
@@ -32,7 +32,7 @@ import { ECSqlBinding } from "@itwin/presentation-shared";
 
 function createHierarchyDefinition(): HierarchyDefinition {
   return {
-    defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
       const createHierarchyLevelDefinition = async ({
         whereClause,
         bindings,
@@ -44,7 +44,7 @@ function createHierarchyDefinition(): HierarchyDefinition {
           fullClassName: "BisCore.PhysicalElement",
           query: {
             ecsql: `
-              SELECT ${await nodeSelectClauseFactory.createSelectClause({
+              SELECT ${await createSelectClause({
                 ecClassId: { selector: "this.ECClassId" },
                 ecInstanceId: { selector: "this.ECInstanceId" },
                 nodeLabel: { selector: "this.UserLabel" },

--- a/packages/hierarchies/learning/imodel/Localization.md
+++ b/packages/hierarchies/learning/imodel/Localization.md
@@ -15,7 +15,7 @@ import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 const hierarchyProvider = createIModelHierarchyProvider({
   imodelAccess,
   hierarchyDefinition: {
-    defineHierarchyLevel: async ({ parentNode, nodeSelectClauseFactory }) => {
+    defineHierarchyLevel: async ({ parentNode, createSelectClause }) => {
       if (!parentNode) {
         // The hierarchy definition returns nodes for `myPhysicalObjectClassName` element type, grouped by `IntProperty` property value,
         // with options to create groups for out-of-range and unspecified values - labels of those grouping nodes get localized
@@ -24,7 +24,7 @@ const hierarchyProvider = createIModelHierarchyProvider({
             fullClassName: myPhysicalObjectClassName,
             query: {
               ecsql: `
-                SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                SELECT ${await createSelectClause({
                   ecClassId: { selector: "this.ECClassId" },
                   ecInstanceId: { selector: "this.ECInstanceId" },
                   nodeLabel: { selector: "this.UserLabel" },

--- a/packages/hierarchies/learning/imodel/MergedIModelHierarchies.md
+++ b/packages/hierarchies/learning/imodel/MergedIModelHierarchies.md
@@ -35,10 +35,10 @@ const imodels = [
 
 // Define an utility for creating instance nodes query definitions, that we'll use in our hierarchy definition.
 async function createInstanceNodesQueryDefinition({
-  nodeSelectClauseFactory,
+  createSelectClause,
   fullClassName,
   whereClauseFactory,
-}: Pick<DefineInstanceNodeChildHierarchyLevelProps, "nodeSelectClauseFactory"> & {
+}: Pick<DefineInstanceNodeChildHierarchyLevelProps, "createSelectClause"> & {
   fullClassName: EC.FullClassName;
   whereClauseFactory?: (props: { alias: string }) => Promise<string>;
 }) {
@@ -47,7 +47,7 @@ async function createInstanceNodesQueryDefinition({
     fullClassName,
     query: {
       ecsql: `
-        SELECT ${await nodeSelectClauseFactory.createSelectClause({
+        SELECT ${await createSelectClause({
           ecClassId: { selector: "this.ECClassId" },
           ecInstanceId: { selector: "this.ECInstanceId" },
           nodeLabel: { of: { classAlias: "this", className: fullClassName } },

--- a/packages/hierarchies/learning/imodel/MergedIModelHierarchies.md
+++ b/packages/hierarchies/learning/imodel/MergedIModelHierarchies.md
@@ -35,11 +35,10 @@ const imodels = [
 
 // Define an utility for creating instance nodes query definitions, that we'll use in our hierarchy definition.
 async function createInstanceNodesQueryDefinition({
-  instanceLabelSelectClauseFactory,
   nodeSelectClauseFactory,
   fullClassName,
   whereClauseFactory,
-}: Pick<DefineInstanceNodeChildHierarchyLevelProps, "instanceLabelSelectClauseFactory" | "nodeSelectClauseFactory"> & {
+}: Pick<DefineInstanceNodeChildHierarchyLevelProps, "nodeSelectClauseFactory"> & {
   fullClassName: EC.FullClassName;
   whereClauseFactory?: (props: { alias: string }) => Promise<string>;
 }) {
@@ -51,12 +50,7 @@ async function createInstanceNodesQueryDefinition({
         SELECT ${await nodeSelectClauseFactory.createSelectClause({
           ecClassId: { selector: "this.ECClassId" },
           ecInstanceId: { selector: "this.ECInstanceId" },
-          nodeLabel: {
-            selector: await instanceLabelSelectClauseFactory.createSelectClause({
-              classAlias: "this",
-              className: fullClassName,
-            }),
-          },
+          nodeLabel: { of: { classAlias: "this", className: fullClassName } },
         })}
         FROM ${fullClassName} AS this
         ${whereClause ? `WHERE ${whereClause}` : ""}

--- a/packages/hierarchies/package.json
+++ b/packages/hierarchies/package.json
@@ -42,7 +42,7 @@
     "lint": "eslint \"./src/**/*.ts\"",
     "test": "vitest run",
     "test:watch": "vitest",
-    "extract-api": "betools extract-api --entry=presentation-hierarchies --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api --includeUnexportedApis",
+    "extract-api": "betools extract-api --entry=lib/esm/presentation-hierarchies --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api --includeUnexportedApis",
     "check-internal": "node ../../scripts/checkInternal.js --apiSummary ./api/presentation-hierarchies.api.md",
     "update-extractions": "node ../../scripts/updateExtractions.js --targets=./README.md,./learning",
     "check-extractions": "node ../../scripts/updateExtractions.js --targets=./README.md,./learning --check",

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyDefinition.ts
@@ -4,13 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { GenericInstanceFilter } from "@itwin/core-common";
-import type {
-  EC,
-  ECClassHierarchyInspector,
-  ECSchemaProvider,
-  ECSqlQueryDef,
-  IInstanceLabelSelectClauseFactory,
-} from "@itwin/presentation-shared";
+import type { EC, ECClassHierarchyInspector, ECSchemaProvider, ECSqlQueryDef } from "@itwin/presentation-shared";
 import type { NonGroupingHierarchyNode, ParentHierarchyNode } from "../HierarchyNode.js";
 import type {
   ProcessedGenericHierarchyNode,
@@ -137,21 +131,6 @@ export interface DefineHierarchyLevelProps {
 
   /** Optional hierarchy level filter. */
   instanceFilter?: GenericInstanceFilter;
-
-  /**
-   * A factory for creating ECSQL select clauses for instance labels. Created using
-   * `createIModelInstanceLabelSelectClauseFactory` from `@itwin/presentation-shared` and scoped
-   * to the iModel identified by `imodelAccess`.
-   *
-   * Example:
-   * ```ts
-   * const labelClause = await instanceLabelSelectClauseFactory.createSelectClause({ classAlias: "this", className: "SomeSchema.SomeClass" });
-   * ```
-   *
-   * Using this factory is optional — consumers may create their own `IInstanceLabelSelectClauseFactory`
-   * and use it instead, or just define instance label select clauses manually without a factory.
-   */
-  instanceLabelSelectClauseFactory: IInstanceLabelSelectClauseFactory;
 
   /**
    * A factory for creating ECSQL select clauses for hierarchy nodes. Created using

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyDefinition.ts
@@ -122,7 +122,10 @@ export type HierarchyDefinitionParentNode = Omit<NonGroupingHierarchyNode, "chil
  * Props for `HierarchyDefinition.defineHierarchyLevel`.
  * @public
  */
-export interface DefineHierarchyLevelProps {
+export interface DefineHierarchyLevelProps extends Pick<
+  NodesQueryClauseFactory,
+  "createSelectClause" | "createFilterClauses"
+> {
   /** The iModel for which the hierarchy definition is being requested for. */
   imodelAccess: LimitingECSqlQueryExecutor & ECSchemaProvider & ECClassHierarchyInspector & { imodelKey: string };
 
@@ -131,24 +134,6 @@ export interface DefineHierarchyLevelProps {
 
   /** Optional hierarchy level filter. */
   instanceFilter?: GenericInstanceFilter;
-
-  /**
-   * A factory for creating ECSQL select clauses for hierarchy nodes. Created using
-   * `createNodesQueryClauseFactory` and scoped to the iModel identified by `imodelAccess`.
-   *
-   * Example:
-   * ```ts
-   * const selectClause = await nodeSelectClauseFactory.createSelectClause({
-   *   ecClassId: { selector: "this.ECClassId" },
-   *   ecInstanceId: { selector: "this.ECInstanceId" },
-   *   nodeLabel: { selector: "this.UserLabel" },
-   * });
-   * ```
-   *
-   * While using this factory is optional, and consumers may create their own `NodesQueryClauseFactory`,
-   * it's strongly recommended to use it to ensure the select clause format is consistent with the parser.
-   */
-  nodeSelectClauseFactory: NodesQueryClauseFactory;
 }
 
 /**

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
@@ -178,6 +178,16 @@ interface IModelHierarchyProviderProps {
     /** A list of search trees that define paths from root to search target nodes. */
     paths: HierarchySearchTree[];
   };
+
+  /**
+   * A factory for creating ECSQL select clauses for instance labels. The clause is injected into
+   * hierarchy node queries to select labels for instance-based nodes.
+   *
+   * Defaults to the result of `createIModelInstanceLabelSelectClauseFactory` called with the provided `imodelAccess`.
+   *
+   * @see `IInstanceLabelSelectClauseFactory`
+   */
+  instanceLabelSelectClauseFactory?: IInstanceLabelSelectClauseFactory;
 }
 
 /**
@@ -187,8 +197,11 @@ interface IModelHierarchyProviderProps {
  * @public
  */
 export function createIModelHierarchyProvider(props: IModelHierarchyProviderProps): HierarchyProvider & Disposable {
-  const { imodelAccess, imodelChanged, ...restProps } = props;
-  return createMergedIModelHierarchyProvider({ ...restProps, imodels: [{ imodelAccess, imodelChanged }] });
+  const { imodelAccess, imodelChanged, instanceLabelSelectClauseFactory, ...restProps } = props;
+  return createMergedIModelHierarchyProvider({
+    ...restProps,
+    imodels: [{ imodelAccess, imodelChanged, instanceLabelSelectClauseFactory }],
+  });
 }
 
 /**
@@ -197,7 +210,7 @@ export function createIModelHierarchyProvider(props: IModelHierarchyProviderProp
  */
 interface MergedIModelHierarchyProviderProps extends Omit<
   IModelHierarchyProviderProps,
-  "imodelAccess" | "imodelChanged"
+  "imodelAccess" | "imodelChanged" | "instanceLabelSelectClauseFactory"
 > {
   /**
    * A list of iModels to create merged hierarchy for.
@@ -220,6 +233,16 @@ interface MergedIModelHierarchyProviderProps extends Omit<
      * subscribes to the event to know that it needs to reload the data, and unsubscribes on disposal.
      */
     imodelChanged?: Event<() => void>;
+
+    /**
+     * A factory for creating ECSQL select clauses for instance labels. The clause is injected into
+     * hierarchy node queries to select labels for instance-based nodes.
+     *
+     * Defaults to the result of `createIModelInstanceLabelSelectClauseFactory` called with the provided `imodelAccess`.
+     *
+     * @see `IInstanceLabelSelectClauseFactory`
+     */
+    instanceLabelSelectClauseFactory?: IInstanceLabelSelectClauseFactory;
   }>;
 }
 
@@ -245,10 +268,7 @@ type WithSourceNameOverride<T> = T & { sourceName?: string };
 
 class IModelHierarchyProviderImpl implements HierarchyProvider {
   private _imodels: Array<
-    MergedIModelHierarchyProviderProps["imodels"][number] & {
-      instanceLabelSelectClauseFactory: IInstanceLabelSelectClauseFactory;
-      nodeSelectClauseFactory: NodesQueryClauseFactory;
-    }
+    MergedIModelHierarchyProviderProps["imodels"][number] & { nodeSelectClauseFactory: NodesQueryClauseFactory }
   >;
   private _hierarchyChanged: BeEvent<(args: EventArgs<HierarchyProvider["hierarchyChanged"]>) => void>;
   private _valuesFormatter: IPrimitiveValueFormatter;
@@ -272,10 +292,12 @@ class IModelHierarchyProviderImpl implements HierarchyProvider {
     this.#componentId = Guid.createValue();
     this.#componentName = "IModelHierarchyProviderImpl";
     this.#sourceName = props.sourceName ?? `${this.#componentName}:${this.#componentId}`;
-    this._imodels = props.imodels.map(({ imodelAccess, imodelChanged }) => {
-      const instanceLabelSelectClauseFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
+    this._imodels = props.imodels.map(({ imodelAccess, imodelChanged, instanceLabelSelectClauseFactory }) => {
+      if (!instanceLabelSelectClauseFactory) {
+        instanceLabelSelectClauseFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
+      }
       const nodeSelectClauseFactory = createNodesQueryClauseFactory({ imodelAccess, instanceLabelSelectClauseFactory });
-      return { imodelAccess, imodelChanged, instanceLabelSelectClauseFactory, nodeSelectClauseFactory };
+      return { imodelAccess, imodelChanged, nodeSelectClauseFactory };
     });
     this._hierarchyChanged = new BeEvent();
     this._activeHierarchyDefinition = this._sourceHierarchyDefinition = getRxjsHierarchyDefinition(
@@ -411,7 +433,7 @@ class IModelHierarchyProviderImpl implements HierarchyProvider {
     });
 
     return from(this._imodels).pipe(
-      mergeMap(({ imodelAccess, instanceLabelSelectClauseFactory, nodeSelectClauseFactory }, imodelAccessIndex) => {
+      mergeMap(({ imodelAccess, nodeSelectClauseFactory }, imodelAccessIndex) => {
         let parentNode = props.parentNode;
         if (
           parentNode &&
@@ -437,13 +459,7 @@ class IModelHierarchyProviderImpl implements HierarchyProvider {
           }
         }
         return this._activeHierarchyDefinition
-          .defineHierarchyLevel({
-            ...defineHierarchyLevelProps,
-            parentNode,
-            imodelAccess,
-            instanceLabelSelectClauseFactory,
-            nodeSelectClauseFactory,
-          })
+          .defineHierarchyLevel({ ...defineHierarchyLevelProps, parentNode, imodelAccess, nodeSelectClauseFactory })
           .pipe(
             mergeAll(),
             map(

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
@@ -413,10 +413,7 @@ class IModelHierarchyProviderImpl implements HierarchyProvider {
   }
 
   private createHierarchyLevelDefinitionsObservable(
-    props: Omit<
-      DefineHierarchyLevelProps,
-      "imodelAccess" | "instanceLabelSelectClauseFactory" | "nodeSelectClauseFactory"
-    > &
+    props: Omit<DefineHierarchyLevelProps, "imodelAccess" | "createSelectClause" | "createFilterClauses"> &
       RequestContextProp,
   ): Observable<
     { imodelAccess: IModelAccess; imodelAccessIndex: number } & (
@@ -459,7 +456,7 @@ class IModelHierarchyProviderImpl implements HierarchyProvider {
           }
         }
         return this._activeHierarchyDefinition
-          .defineHierarchyLevel({ ...defineHierarchyLevelProps, parentNode, imodelAccess, nodeSelectClauseFactory })
+          .defineHierarchyLevel({ ...defineHierarchyLevelProps, ...nodeSelectClauseFactory, parentNode, imodelAccess })
           .pipe(
             mergeAll(),
             map(
@@ -483,10 +480,10 @@ class IModelHierarchyProviderImpl implements HierarchyProvider {
   }
 
   private createSourceNodesObservable(
-    props: Omit<
-      DefineHierarchyLevelProps,
-      "imodelAccess" | "instanceLabelSelectClauseFactory" | "nodeSelectClauseFactory"
-    > & { hierarchyLevelSizeLimit?: number | "unbounded"; targetInstanceKeys?: InstanceKey[] } & RequestContextProp,
+    props: Omit<DefineHierarchyLevelProps, "imodelAccess" | "createSelectClause" | "createFilterClauses"> & {
+      hierarchyLevelSizeLimit?: number | "unbounded";
+      targetInstanceKeys?: InstanceKey[];
+    } & RequestContextProp,
   ): SourceNodesObservable {
     const createSourceNodesFromDefinition = (
       imodelAccess: IModelAccess,

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
@@ -456,7 +456,17 @@ class IModelHierarchyProviderImpl implements HierarchyProvider {
           }
         }
         return this._activeHierarchyDefinition
-          .defineHierarchyLevel({ ...defineHierarchyLevelProps, ...nodeSelectClauseFactory, parentNode, imodelAccess })
+          .defineHierarchyLevel({
+            ...defineHierarchyLevelProps,
+            createSelectClause: async (selectClauseProps) =>
+              nodeSelectClauseFactory.createSelectClause(selectClauseProps),
+            /* v8 ignore start */
+            createFilterClauses: async (filterClausesProps) =>
+              nodeSelectClauseFactory.createFilterClauses(filterClausesProps),
+            /* v8 ignore stop */
+            parentNode,
+            imodelAccess,
+          })
           .pipe(
             mergeAll(),
             map(

--- a/packages/hierarchies/src/hierarchies/imodel/NodeSelectQueryFactory.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/NodeSelectQueryFactory.ts
@@ -80,7 +80,7 @@ interface ECSqlValueSelector {
 interface NodeSelectClauseProps {
   ecClassId: ECSqlValueSelector;
   ecInstanceId: ECSqlValueSelector;
-  nodeLabel: string | ECSqlValueSelector;
+  nodeLabel: string | ECSqlValueSelector | { of: Props<IInstanceLabelSelectClauseFactory["createSelectClause"]> };
   extendedData?: { [key: string]: Id64String | string | number | boolean | ECSqlValueSelector };
   autoExpand?: boolean | ECSqlValueSelector;
   supportsFiltering?: boolean | ECSqlValueSelector;
@@ -260,7 +260,6 @@ export interface NodesQueryClauseFactory {
 
 /**
  * Creates an instance of `NodeSelectQueryFactory`.
- * @public
  */
 export function createNodesQueryClauseFactory(props: {
   imodelAccess: ECSchemaProvider & ECClassHierarchyInspector;
@@ -288,7 +287,11 @@ class NodeSelectQueryFactory {
     return `
       ec_ClassName(${props.ecClassId.selector}) AS ${NodeSelectClauseColumnNames.FullClassName},
       ${props.ecInstanceId.selector} AS ${NodeSelectClauseColumnNames.ECInstanceId},
-      ${createECSqlValueSelector(props.nodeLabel)} AS ${NodeSelectClauseColumnNames.DisplayLabel},
+      ${createECSqlValueSelector(
+        typeof props.nodeLabel === "object" && "of" in props.nodeLabel
+          ? { selector: await this._instanceLabelSelectClauseFactory.createSelectClause(props.nodeLabel.of) }
+          : props.nodeLabel,
+      )} AS ${NodeSelectClauseColumnNames.DisplayLabel},
       CAST(${createECSqlValueSelector(props.hasChildren)} AS BOOLEAN) AS ${NodeSelectClauseColumnNames.HasChildren},
       CAST(${createECSqlValueSelector(props.hideIfNoChildren)} AS BOOLEAN) AS ${NodeSelectClauseColumnNames.HideIfNoChildren},
       CAST(${createECSqlValueSelector(props.hideNodeInHierarchy)} AS BOOLEAN) AS ${NodeSelectClauseColumnNames.HideNodeInHierarchy},

--- a/packages/hierarchies/src/presentation-hierarchies.ts
+++ b/packages/hierarchies/src/presentation-hierarchies.ts
@@ -22,11 +22,6 @@ export type {
 export { createPredicateBasedHierarchyDefinition } from "./hierarchies/imodel/PredicateBasedHierarchyDefinition.js";
 export type { LimitingECSqlQueryExecutor } from "./hierarchies/imodel/LimitingECSqlQueryExecutor.js";
 export { createLimitingECSqlQueryExecutor } from "./hierarchies/imodel/LimitingECSqlQueryExecutor.js";
-export type { NodesQueryClauseFactory } from "./hierarchies/imodel/NodeSelectQueryFactory.js";
-export {
-  NodeSelectClauseColumnNames,
-  createNodesQueryClauseFactory,
-} from "./hierarchies/imodel/NodeSelectQueryFactory.js";
 export {
   createIModelHierarchyProvider,
   createMergedIModelHierarchyProvider,

--- a/packages/hierarchies/src/test/imodel/IModelHierarchyProvider.test.ts
+++ b/packages/hierarchies/src/test/imodel/IModelHierarchyProvider.test.ts
@@ -637,12 +637,14 @@ describe("createIModelHierarchyProvider", () => {
       expect(hierarchyDefinition.defineHierarchyLevel).toHaveBeenNthCalledWith(1, {
         imodelAccess,
         parentNode: undefined,
-        nodeSelectClauseFactory: expect.anything(),
+        createSelectClause: expect.any(Function),
+        createFilterClauses: expect.any(Function),
       });
       expect(hierarchyDefinition.defineHierarchyLevel).toHaveBeenNthCalledWith(2, {
         imodelAccess,
         parentNode: rootNodes[0],
-        nodeSelectClauseFactory: expect.anything(),
+        createSelectClause: expect.any(Function),
+        createFilterClauses: expect.any(Function),
       });
     });
   });

--- a/packages/hierarchies/src/test/imodel/IModelHierarchyProvider.test.ts
+++ b/packages/hierarchies/src/test/imodel/IModelHierarchyProvider.test.ts
@@ -93,14 +93,14 @@ describe("createIModelHierarchyProvider", () => {
       imodelAccess,
       instanceLabelSelectClauseFactory,
       hierarchyDefinition: {
-        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+        async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
                 fullClassName: "a.b",
                 query: {
                   ecsql: `
-                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                    SELECT ${await createSelectClause({
                       ecClassId: { selector: "this.ECClassId" },
                       ecInstanceId: { selector: "this.ECInstanceId" },
                       nodeLabel: { of: { classAlias: "this" } },

--- a/packages/hierarchies/src/test/imodel/IModelHierarchyProvider.test.ts
+++ b/packages/hierarchies/src/test/imodel/IModelHierarchyProvider.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../../hierarchies/imodel/SearchHierarchyDefinition.js";
 import {
   createIModelAccessStub,
+  createInstanceLabelSelectClauseFactoryStub,
   createTestGenericNode,
   createTestGenericNodeKey,
   createTestInstanceKey,
@@ -74,6 +75,48 @@ describe("createIModelHierarchyProvider", () => {
     expect(nodes).toEqual([
       { ...node, key: createTestGenericNodeKey({ source: sourceName }), parentKeys: [], children: false },
     ]);
+  });
+
+  it("uses custom instanceLabelSelectClauseFactory when provided", async () => {
+    imodelAccess.createQueryReader.mockReturnValue(
+      createAsyncIterator<RowDef>([
+        {
+          [NodeSelectClauseColumnNames.FullClassName]: "a.b",
+          [NodeSelectClauseColumnNames.ECInstanceId]: "0x123",
+          [NodeSelectClauseColumnNames.DisplayLabel]: "test label",
+        },
+      ]),
+    );
+    const instanceLabelSelectClauseFactory = createInstanceLabelSelectClauseFactoryStub();
+    const createSelectClauseSpy = vi.spyOn(instanceLabelSelectClauseFactory, "createSelectClause");
+    using provider = createIModelHierarchyProvider({
+      imodelAccess,
+      instanceLabelSelectClauseFactory,
+      hierarchyDefinition: {
+        async defineHierarchyLevel({ parentNode, nodeSelectClauseFactory }) {
+          if (!parentNode) {
+            return [
+              {
+                fullClassName: "a.b",
+                query: {
+                  ecsql: `
+                    SELECT ${await nodeSelectClauseFactory.createSelectClause({
+                      ecClassId: { selector: "this.ECClassId" },
+                      ecInstanceId: { selector: "this.ECInstanceId" },
+                      nodeLabel: { of: { classAlias: "this" } },
+                    })}
+                    FROM a.b
+                  `,
+                },
+              },
+            ];
+          }
+          return [];
+        },
+      },
+    });
+    await collect(provider.getNodes({ parentNode: undefined }));
+    expect(createSelectClauseSpy).toHaveBeenCalled();
   });
 
   it("loads root instance nodes", async () => {
@@ -594,13 +637,11 @@ describe("createIModelHierarchyProvider", () => {
       expect(hierarchyDefinition.defineHierarchyLevel).toHaveBeenNthCalledWith(1, {
         imodelAccess,
         parentNode: undefined,
-        instanceLabelSelectClauseFactory: expect.anything(),
         nodeSelectClauseFactory: expect.anything(),
       });
       expect(hierarchyDefinition.defineHierarchyLevel).toHaveBeenNthCalledWith(2, {
         imodelAccess,
         parentNode: rootNodes[0],
-        instanceLabelSelectClauseFactory: expect.anything(),
         nodeSelectClauseFactory: expect.anything(),
       });
     });

--- a/packages/hierarchies/src/test/imodel/NodeSelectQueryFactory.test.ts
+++ b/packages/hierarchies/src/test/imodel/NodeSelectQueryFactory.test.ts
@@ -272,6 +272,29 @@ describe("createNodesQueryClauseFactory", () => {
       );
     });
 
+    it("creates valid clause with instance label factory props", async () => {
+      const result = await factory.createSelectClause({
+        ecClassId: { selector: "class_id" },
+        ecInstanceId: { selector: "instance_id" },
+        nodeLabel: { of: { classAlias: "this" } },
+      });
+      const labelClause = await instanceLabelSelectClauseFactory.createSelectClause({ classAlias: "this" });
+      expect(trimWhitespace(result)).toBe(
+        trimWhitespace(`
+        ec_ClassName(class_id) AS ${NodeSelectClauseColumnNames.FullClassName},
+        instance_id AS ${NodeSelectClauseColumnNames.ECInstanceId},
+        ${labelClause} AS ${NodeSelectClauseColumnNames.DisplayLabel},
+        CAST(NULL AS BOOLEAN) AS ${NodeSelectClauseColumnNames.HasChildren},
+        CAST(NULL AS BOOLEAN) AS ${NodeSelectClauseColumnNames.HideIfNoChildren},
+        CAST(NULL AS BOOLEAN) AS ${NodeSelectClauseColumnNames.HideNodeInHierarchy},
+        CAST(NULL AS TEXT) AS ${NodeSelectClauseColumnNames.Grouping},
+        CAST(NULL AS TEXT) AS ${NodeSelectClauseColumnNames.ExtendedData},
+        CAST(NULL AS BOOLEAN) AS ${NodeSelectClauseColumnNames.AutoExpand},
+        CAST(NULL AS BOOLEAN) AS ${NodeSelectClauseColumnNames.SupportsFiltering}
+      `),
+      );
+    });
+
     it("creates valid clause with null props", async () => {
       const result = await factory.createSelectClause({
         ecClassId: { selector: "class_id" },

--- a/packages/hierarchies/src/test/imodel/PredicateBasedHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/PredicateBasedHierarchyDefinition.test.ts
@@ -7,7 +7,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPredicateBasedHierarchyDefinition } from "../../hierarchies/imodel/PredicateBasedHierarchyDefinition.js";
 import { createIModelAccessStub, createTestGenericNodeKey, createTestSourceGenericNode } from "../Utils.js";
 
-import type { IInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 import type {
   DefineHierarchyLevelProps,
   GenericHierarchyNodeDefinition,
@@ -20,7 +19,6 @@ describe("createPredicateBasedHierarchyDefinition", () => {
   const imodelKey = "test-imodel-key";
 
   let imodelAccess: ReturnType<typeof createIModelAccessStub> & { imodelKey: string };
-  const instanceLabelSelectClauseFactory: IInstanceLabelSelectClauseFactory = { createSelectClause: vi.fn() };
   const nodeSelectClauseFactory: NodesQueryClauseFactory = {
     createSelectClause: vi.fn(),
     createFilterClauses: vi.fn(),
@@ -30,11 +28,8 @@ describe("createPredicateBasedHierarchyDefinition", () => {
     imodelAccess = { ...createIModelAccessStub(), imodelKey };
   });
 
-  function constProps(): Pick<
-    DefineHierarchyLevelProps,
-    "imodelAccess" | "instanceLabelSelectClauseFactory" | "nodeSelectClauseFactory"
-  > {
-    return { imodelAccess, instanceLabelSelectClauseFactory, nodeSelectClauseFactory };
+  function constProps(): Pick<DefineHierarchyLevelProps, "imodelAccess" | "nodeSelectClauseFactory"> {
+    return { imodelAccess, nodeSelectClauseFactory };
   }
 
   it("returns root hierarchy level definition", async () => {

--- a/packages/hierarchies/src/test/imodel/PredicateBasedHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/PredicateBasedHierarchyDefinition.test.ts
@@ -28,8 +28,11 @@ describe("createPredicateBasedHierarchyDefinition", () => {
     imodelAccess = { ...createIModelAccessStub(), imodelKey };
   });
 
-  function constProps(): Pick<DefineHierarchyLevelProps, "imodelAccess" | "nodeSelectClauseFactory"> {
-    return { imodelAccess, nodeSelectClauseFactory };
+  function constProps(): Pick<
+    DefineHierarchyLevelProps,
+    "imodelAccess" | "createSelectClause" | "createFilterClauses"
+  > {
+    return { imodelAccess, ...nodeSelectClauseFactory };
   }
 
   it("returns root hierarchy level definition", async () => {

--- a/packages/hierarchies/src/test/imodel/SearchHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/SearchHierarchyDefinition.test.ts
@@ -22,7 +22,7 @@ import {
   createTestProcessedInstanceNode,
 } from "../Utils.js";
 
-import type { ECClassHierarchyInspector, IInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
+import type { ECClassHierarchyInspector } from "@itwin/presentation-shared";
 import type { HierarchyNodeIdentifier } from "../../hierarchies/HierarchyNodeIdentifier.js";
 import type { HierarchySearchTree } from "../../hierarchies/HierarchySearch.js";
 import type {
@@ -373,12 +373,11 @@ describe("SearchHierarchyDefinition", () => {
 
   describe("defineHierarchyLevel", () => {
     const stubIModelAccess = { ...createIModelAccessStub(), imodelKey: "test-imodel" };
-    const instanceLabelSelectClauseFactory: IInstanceLabelSelectClauseFactory = { createSelectClause: vi.fn() };
     const nodeSelectClauseFactory: NodesQueryClauseFactory = {
       createSelectClause: vi.fn(),
       createFilterClauses: vi.fn(),
     };
-    const constProps = { imodelAccess: stubIModelAccess, instanceLabelSelectClauseFactory, nodeSelectClauseFactory };
+    const constProps = { imodelAccess: stubIModelAccess, ...nodeSelectClauseFactory };
 
     it("returns source definitions when search identifiers are not applicable to the level", async () => {
       const sourceDefs: HierarchyLevelDefinition = [{ fullClassName: "Schema:Class", query: { ecsql: "SELECT *" } }];

--- a/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
+++ b/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
@@ -297,8 +297,8 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
               SELECT
                 CASE
                   WHEN (
-                    json_extract([partition].JsonProperties, '$.PhysicalPartition.Model.Content') IS NOT NULL
-                    OR json_extract([partition].JsonProperties, '$.GraphicalPartition3d.Model.Content') IS NOT NULL
+                    json_extract(p.JsonProperties, '$.PhysicalPartition.Model.Content') IS NOT NULL
+                    OR json_extract(p.JsonProperties, '$.GraphicalPartition3d.Model.Content') IS NOT NULL
                   ) THEN 1
                   ELSE 0
                 END IsHidden,
@@ -314,13 +314,14 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                     `
                     : "1"
                 } HasChildren,
-                m.*,
+                m.*
               FROM Bis.GeometricModel3d m
-              JOIN bis.InformationPartitionElement [partition] ON [partition].ECInstanceId = m.ModeledElement.Id
+              JOIN bis.InformationPartitionElement p ON p.ECInstanceId = m.ModeledElement.Id
               WHERE
                 m.ECInstanceId IN (${childModelIds.map(() => "?").join(",")})
             ) model
             JOIN ${modelFilterClauses.from} this ON this.ECInstanceId = model.ECInstanceId
+            JOIN bis.InformationPartitionElement [partition] ON [partition].ECInstanceId = this.ModeledElement.Id
             ${modelFilterClauses.joins}
             ${modelFilterClauses.where ? `AND (model.IsHidden OR ${modelFilterClauses.where})` : ""}
           `,

--- a/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
+++ b/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
@@ -25,7 +25,6 @@ import { Guid } from "@itwin/core-bentley";
 import {
   createPredicateBasedHierarchyDefinition,
   HierarchyNode,
-  NodeSelectClauseColumnNames,
   ProcessedHierarchyNode,
   RowsLimitExceededError,
 } from "@itwin/presentation-hierarchies";
@@ -201,7 +200,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
   private async createRootHierarchyLevelDefinition(
     props: DefineRootHierarchyLevelProps,
   ): Promise<HierarchyLevelDefinition> {
-    const { nodeSelectClauseFactory, instanceLabelSelectClauseFactory } = props;
+    const { nodeSelectClauseFactory } = props;
     const instanceFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
       filter: props.instanceFilter,
       contentClass: { fullName: "BisCore.Subject", alias: "this" },
@@ -215,12 +214,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
               ${await nodeSelectClauseFactory.createSelectClause({
                 ecClassId: { selector: ECSql.createRawPropertyValueSelector("this", "ECClassId") },
                 ecInstanceId: { selector: "this.ECInstanceId" },
-                nodeLabel: {
-                  selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                    classAlias: "this",
-                    className: "BisCore.Subject",
-                  }),
-                },
+                nodeLabel: { of: { classAlias: "this", className: "BisCore.Subject" } },
                 extendedData: { imageId: "icon-imodel-hollow-2", isSubject: true },
                 autoExpand: true,
                 supportsFiltering: true,
@@ -240,7 +234,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
     parentNodeInstanceIds: subjectIds,
     instanceFilter,
     nodeSelectClauseFactory,
-    instanceLabelSelectClauseFactory,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
     const [subjectFilterClauses, modelFilterClauses] = await Promise.all([
       nodeSelectClauseFactory.createFilterClauses({
@@ -266,12 +259,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
               ${await nodeSelectClauseFactory.createSelectClause({
                 ecClassId: { selector: "this.ECClassId" },
                 ecInstanceId: { selector: "this.ECInstanceId" },
-                nodeLabel: {
-                  selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                    classAlias: "this",
-                    className: "BisCore.Subject",
-                  }),
-                },
+                nodeLabel: { of: { classAlias: "this", className: "BisCore.Subject" } },
                 hideIfNoChildren: true,
                 hasChildren: { selector: `InVirtualSet(?, this.ECInstanceId)` },
                 grouping: { byLabel: { action: "merge", groupId: "subject" } },
@@ -295,44 +283,38 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
         fullClassName: "BisCore.GeometricModel3d",
         query: {
           ecsql: `
-            SELECT model.ECInstanceId AS ECInstanceId, model.*
+            SELECT
+              ${await nodeSelectClauseFactory.createSelectClause({
+                ecClassId: { selector: "model.ECClassId" },
+                ecInstanceId: { selector: "model.ECInstanceId" },
+                nodeLabel: { of: { classAlias: "partition", className: "BisCore.InformationPartitionElement" } },
+                hideNodeInHierarchy: { selector: "model.IsHidden" },
+                hasChildren: this._hierarchyConfig.showEmptyModels ? { selector: "model.HasChildren" } : true,
+                extendedData: { imageId: "icon-model", isModel: true },
+                supportsFiltering: true,
+              })}
             FROM (
               SELECT
-                ${await nodeSelectClauseFactory.createSelectClause({
-                  ecClassId: { selector: "m.ECClassId" },
-                  ecInstanceId: { selector: "m.ECInstanceId" },
-                  nodeLabel: {
-                    selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                      classAlias: "partition",
-                      className: "BisCore.InformationPartitionElement",
-                    }),
-                  },
-                  hideNodeInHierarchy: {
-                    selector: `
-                      CASE
-                        WHEN (
-                          json_extract([partition].JsonProperties, '$.PhysicalPartition.Model.Content') IS NOT NULL
-                          OR json_extract([partition].JsonProperties, '$.GraphicalPartition3d.Model.Content') IS NOT NULL
-                        ) THEN 1
-                        ELSE 0
-                      END
-                    `,
-                  },
-                  hasChildren: this._hierarchyConfig.showEmptyModels
-                    ? {
-                        selector: `
-                          IFNULL((
-                            SELECT 1
-                            FROM ${this._hierarchyConfig.elementClassSpecification} e
-                            WHERE e.Model.Id = m.ECInstanceId
-                            LIMIT 1
-                          ), 0)
-                        `,
-                      }
-                    : true,
-                  extendedData: { imageId: "icon-model", isModel: true },
-                  supportsFiltering: true,
-                })}
+                CASE
+                  WHEN (
+                    json_extract([partition].JsonProperties, '$.PhysicalPartition.Model.Content') IS NOT NULL
+                    OR json_extract([partition].JsonProperties, '$.GraphicalPartition3d.Model.Content') IS NOT NULL
+                  ) THEN 1
+                  ELSE 0
+                END IsHidden,
+                ${
+                  this._hierarchyConfig.showEmptyModels
+                    ? `
+                      IFNULL((
+                        SELECT 1
+                        FROM ${this._hierarchyConfig.elementClassSpecification} e
+                        WHERE e.Model.Id = m.ECInstanceId
+                        LIMIT 1
+                      ), 0)
+                    `
+                    : "1"
+                } HasChildren,
+                m.*,
               FROM Bis.GeometricModel3d m
               JOIN bis.InformationPartitionElement [partition] ON [partition].ECInstanceId = m.ModeledElement.Id
               WHERE
@@ -340,7 +322,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
             ) model
             JOIN ${modelFilterClauses.from} this ON this.ECInstanceId = model.ECInstanceId
             ${modelFilterClauses.joins}
-            ${modelFilterClauses.where ? `AND (model.${NodeSelectClauseColumnNames.HideNodeInHierarchy} OR ${modelFilterClauses.where})` : ""}
+            ${modelFilterClauses.where ? `AND (model.IsHidden OR ${modelFilterClauses.where})` : ""}
           `,
           bindings: childModelIds.map((id): ECSqlBinding => ({ type: "id", value: id })),
         },
@@ -382,7 +364,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
     parentNodeInstanceIds: modelIds,
     instanceFilter,
     nodeSelectClauseFactory,
-    instanceLabelSelectClauseFactory,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
     const instanceFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
       filter: instanceFilter,
@@ -397,12 +378,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
               ${await nodeSelectClauseFactory.createSelectClause({
                 ecClassId: { selector: "this.ECClassId" },
                 ecInstanceId: { selector: "this.ECInstanceId" },
-                nodeLabel: {
-                  selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                    classAlias: "this",
-                    className: "BisCore.SpatialCategory",
-                  }),
-                },
+                nodeLabel: { of: { classAlias: "this", className: "BisCore.SpatialCategory" } },
                 grouping: { byLabel: { action: "merge", groupId: "category" } },
                 hasChildren: true,
                 extendedData: {
@@ -436,7 +412,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
     parentNode,
     instanceFilter,
     nodeSelectClauseFactory,
-    instanceLabelSelectClauseFactory,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
     const modelIds = parseIdsSelectorResult(parentNode.extendedData?.modelIds);
     if (modelIds.length === 0) {
@@ -455,12 +430,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
               ${await nodeSelectClauseFactory.createSelectClause({
                 ecClassId: { selector: "this.ECClassId" },
                 ecInstanceId: { selector: "this.ECInstanceId" },
-                nodeLabel: {
-                  selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                    classAlias: "this",
-                    className: this._hierarchyConfig.elementClassSpecification,
-                  }),
-                },
+                nodeLabel: { of: { classAlias: "this", className: this._hierarchyConfig.elementClassSpecification } },
                 grouping: { byClass: this._hierarchyConfig.elementClassGrouping !== "disable" },
                 hasChildren: {
                   selector: `
@@ -504,7 +474,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
     parentNodeInstanceIds: elementIds,
     instanceFilter,
     nodeSelectClauseFactory,
-    instanceLabelSelectClauseFactory,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
     const instanceFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
       filter: instanceFilter,
@@ -519,12 +488,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
               ${await nodeSelectClauseFactory.createSelectClause({
                 ecClassId: { selector: "this.ECClassId" },
                 ecInstanceId: { selector: "this.ECInstanceId" },
-                nodeLabel: {
-                  selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                    classAlias: "this",
-                    className: this._hierarchyConfig.elementClassSpecification,
-                  }),
-                },
+                nodeLabel: { of: { classAlias: "this", className: this._hierarchyConfig.elementClassSpecification } },
                 grouping: { byClass: this._hierarchyConfig.elementClassGrouping !== "disable" },
                 hasChildren: {
                   selector: `

--- a/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
+++ b/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
@@ -197,12 +197,13 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
     return this._impl.defineHierarchyLevel(props);
   }
 
-  private async createRootHierarchyLevelDefinition(
-    props: DefineRootHierarchyLevelProps,
-  ): Promise<HierarchyLevelDefinition> {
-    const { nodeSelectClauseFactory } = props;
-    const instanceFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
-      filter: props.instanceFilter,
+  private async createRootHierarchyLevelDefinition({
+    instanceFilter,
+    createSelectClause,
+    createFilterClauses,
+  }: DefineRootHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
+    const instanceFilterClauses = await createFilterClauses({
+      filter: instanceFilter,
       contentClass: { fullName: "BisCore.Subject", alias: "this" },
     });
     return [
@@ -211,7 +212,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
         query: {
           ecsql: `
             SELECT
-              ${await nodeSelectClauseFactory.createSelectClause({
+              ${await createSelectClause({
                 ecClassId: { selector: ECSql.createRawPropertyValueSelector("this", "ECClassId") },
                 ecInstanceId: { selector: "this.ECInstanceId" },
                 nodeLabel: { of: { classAlias: "this", className: "BisCore.Subject" } },
@@ -233,14 +234,12 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
   private async createSubjectChildrenQuery({
     parentNodeInstanceIds: subjectIds,
     instanceFilter,
-    nodeSelectClauseFactory,
+    createSelectClause,
+    createFilterClauses,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
     const [subjectFilterClauses, modelFilterClauses] = await Promise.all([
-      nodeSelectClauseFactory.createFilterClauses({
-        filter: instanceFilter,
-        contentClass: { fullName: "BisCore.Subject", alias: "this" },
-      }),
-      nodeSelectClauseFactory.createFilterClauses({
+      createFilterClauses({ filter: instanceFilter, contentClass: { fullName: "BisCore.Subject", alias: "this" } }),
+      createFilterClauses({
         filter: instanceFilter,
         contentClass: { fullName: "BisCore.GeometricModel3d", alias: "this" },
       }),
@@ -256,7 +255,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
         query: {
           ecsql: `
             SELECT
-              ${await nodeSelectClauseFactory.createSelectClause({
+              ${await createSelectClause({
                 ecClassId: { selector: "this.ECClassId" },
                 ecInstanceId: { selector: "this.ECInstanceId" },
                 nodeLabel: { of: { classAlias: "this", className: "BisCore.Subject" } },
@@ -284,7 +283,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
         query: {
           ecsql: `
             SELECT
-              ${await nodeSelectClauseFactory.createSelectClause({
+              ${await createSelectClause({
                 ecClassId: { selector: "model.ECClassId" },
                 ecInstanceId: { selector: "model.ECInstanceId" },
                 nodeLabel: { of: { classAlias: "partition", className: "BisCore.InformationPartitionElement" } },
@@ -333,7 +332,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
 
   private async createISubModeledElementChildrenQuery({
     parentNodeInstanceIds: elementIds,
-    nodeSelectClauseFactory,
+    createSelectClause,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
     // note: we do not apply hierarchy level filtering on this hierarchy level, because it's always
     // hidden - the filter will get applied on the child hierarchy levels
@@ -343,7 +342,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
         query: {
           ecsql: `
             SELECT
-              ${await nodeSelectClauseFactory.createSelectClause({
+              ${await createSelectClause({
                 ecClassId: { selector: "this.ECClassId" },
                 ecInstanceId: { selector: "this.ECInstanceId" },
                 nodeLabel: "", // doesn't matter - the node is always hidden
@@ -364,9 +363,10 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
   private async createGeometricModel3dChildrenQuery({
     parentNodeInstanceIds: modelIds,
     instanceFilter,
-    nodeSelectClauseFactory,
+    createSelectClause,
+    createFilterClauses,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
-    const instanceFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
+    const instanceFilterClauses = await createFilterClauses({
       filter: instanceFilter,
       contentClass: { fullName: "BisCore.SpatialCategory", alias: "this" },
     });
@@ -376,7 +376,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
         query: {
           ecsql: `
             SELECT
-              ${await nodeSelectClauseFactory.createSelectClause({
+              ${await createSelectClause({
                 ecClassId: { selector: "this.ECClassId" },
                 ecInstanceId: { selector: "this.ECInstanceId" },
                 nodeLabel: { of: { classAlias: "this", className: "BisCore.SpatialCategory" } },
@@ -412,13 +412,14 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
     parentNodeInstanceIds: categoryIds,
     parentNode,
     instanceFilter,
-    nodeSelectClauseFactory,
+    createSelectClause,
+    createFilterClauses,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
     const modelIds = parseIdsSelectorResult(parentNode.extendedData?.modelIds);
     if (modelIds.length === 0) {
       throw new Error(`Invalid category node "${parentNode.label}" - missing model information.`);
     }
-    const instanceFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
+    const instanceFilterClauses = await createFilterClauses({
       filter: instanceFilter,
       contentClass: { fullName: this._hierarchyConfig.elementClassSpecification, alias: "this" },
     });
@@ -428,7 +429,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
         query: {
           ecsql: `
             SELECT
-              ${await nodeSelectClauseFactory.createSelectClause({
+              ${await createSelectClause({
                 ecClassId: { selector: "this.ECClassId" },
                 ecInstanceId: { selector: "this.ECInstanceId" },
                 nodeLabel: { of: { classAlias: "this", className: this._hierarchyConfig.elementClassSpecification } },
@@ -474,9 +475,10 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
   private async createGeometricElement3dChildrenQuery({
     parentNodeInstanceIds: elementIds,
     instanceFilter,
-    nodeSelectClauseFactory,
+    createSelectClause,
+    createFilterClauses,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
-    const instanceFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
+    const instanceFilterClauses = await createFilterClauses({
       filter: instanceFilter,
       contentClass: { fullName: this._hierarchyConfig.elementClassSpecification, alias: "this" },
     });
@@ -486,7 +488,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
         query: {
           ecsql: `
             SELECT
-              ${await nodeSelectClauseFactory.createSelectClause({
+              ${await createSelectClause({
                 ecClassId: { selector: "this.ECClassId" },
                 ecInstanceId: { selector: "this.ECInstanceId" },
                 nodeLabel: { of: { classAlias: "this", className: this._hierarchyConfig.elementClassSpecification } },


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/1306.

I'm not a big fan of the `nodeSelectClauseFactory` prop name in `DefineHierarchyLevelProps`, thinking about getting rid of that prop and instead spreading `NodesQueryClauseFactory` type into `DefineHierarchyLevelProps`. From the consumer's point of view that would look like this:
```ts
// before
async function createRootHierarchyLevelDefinition({ nodeSelectClauseFactory, instanceFilter }: DefineRootHierarchyLevelProps) {
  const { from, joins, where } = await nodeSelectClauseFactory.createFilterClauses({
    filter: instanceFilter,
    contentClass: { fullName: "BisCore.Subject", alias: "this" },
  });
  return [
    {
      fullClassName: "BisCore.Subject",
      query: {
        ecsql: `
          SELECT
            ${await nodeSelectClauseFactory.createSelectClause({
              ecClassId: { selector: "this.ECClassId" },
              ecInstanceId: { selector: "this.ECInstanceId" },
              nodeLabel: { of: { classAlias: "this", className: "BisCore.Subject" } },
            })}
          FROM ${from} this
          ${joins}
          WHERE this.Parent.Id IS NULL ${where ? `AND ${where}` : ""}
        `,
      },
    },
  ];
}

// after
async function createRootHierarchyLevelDefinition({ createSelectClause, createFilterClauses, instanceFilter }: DefineRootHierarchyLevelProps) {
  const { from, joins, where } = await createFilterClauses({
    filter: instanceFilter,
    contentClass: { fullName: "BisCore.Subject", alias: "this" },
  });
  return [
    {
      fullClassName: "BisCore.Subject",
      query: {
        ecsql: `
          SELECT
            ${await createSelectClause({
              ecClassId: { selector: "this.ECClassId" },
              ecInstanceId: { selector: "this.ECInstanceId" },
              nodeLabel: { of: { classAlias: "this", className: "BisCore.Subject" } },
            })}
          FROM ${from} this
          ${joins}
          WHERE this.Parent.Id IS NULL ${where ? `AND ${where}` : ""}
        `,
      },
    },
  ];
}
```

@iTwin/itwinjs-core-presentation, interested in your opinions.