### PR TITLE
Update to TypeScript 6

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,12 +2,15 @@
   "editor.insertSpaces": true,
   "editor.tabSize": 2,
   "editor.trimAutoWhitespace": true,
-  "oxc.fmt.configPath": ".oxfmtrc.json",
   "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "file",
   "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit"
+    "source.fixAll": "explicit",
+    "source.format.oxc": "always",
   },
+  "oxc.enable.oxfmt": true,
+  "oxc.fmt.configPath": ".oxfmtrc.json",
 
   "eslint.useFlatConfig": true,
   "eslint.workingDirectories": [

--- a/apps/full-stack-tests/tsconfig.json
+++ b/apps/full-stack-tests/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
     "noEmit": true,
     "sourceMap": true,
     "esModuleInterop": true,
@@ -10,7 +8,7 @@
     "noUnusedLocals": false,
     "jsx": "react-jsx",
     "outDir": "lib",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
   },
-  "include": ["src", "vitest.config.ts"]
+  "include": ["src", "vitest.config.ts"],
 }

--- a/apps/full-stack-tests/tsconfig.json
+++ b/apps/full-stack-tests/tsconfig.json
@@ -8,7 +8,7 @@
     "noUnusedLocals": false,
     "jsx": "react-jsx",
     "outDir": "lib",
-    "resolveJsonModule": true,
+    "resolveJsonModule": true
   },
-  "include": ["src", "vitest.config.ts"],
+  "include": ["src", "vitest.config.ts"]
 }

--- a/apps/load-tests/backend/package.json
+++ b/apps/load-tests/backend/package.json
@@ -2,6 +2,7 @@
   "name": "@load-tests/backend",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "start": "rimraf temp && node --max-http-header-size=16000 ./lib/main.js",
     "build": "tsc",

--- a/apps/load-tests/backend/tsconfig.json
+++ b/apps/load-tests/backend/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "module": "CommonJS",
-    "moduleResolution": "Node",
     "outDir": "./lib",
+    "rootDir": "./src",
     "sourceMap": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["node"],
   },
-  "include": ["src"]
+  "include": ["src"],
 }

--- a/apps/load-tests/backend/tsconfig.json
+++ b/apps/load-tests/backend/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "./src",
     "sourceMap": true,
     "esModuleInterop": true,
-    "types": ["node"],
+    "types": ["node"]
   },
-  "include": ["src"],
+  "include": ["src"]
 }

--- a/apps/load-tests/tests/package.json
+++ b/apps/load-tests/tests/package.json
@@ -7,6 +7,7 @@
     "name": "Bentley Systems, Inc.",
     "url": "https://www.bentley.com"
   },
+  "type": "module",
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",

--- a/apps/load-tests/tests/src/processors/models-tree-stateless.ts
+++ b/apps/load-tests/tests/src/processors/models-tree-stateless.ts
@@ -26,7 +26,7 @@ import {
 } from "@itwin/presentation-hierarchies";
 import { defaultHierarchyConfiguration, ModelsTreeDefinition } from "@itwin/presentation-models-tree";
 import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
-import { doRequest, getCurrentIModelName, loadNodes, loadVariables, openIModelConnectionIfNeeded } from "./common";
+import { doRequest, getCurrentIModelName, loadNodes, loadVariables, openIModelConnectionIfNeeded } from "./common.js";
 
 console.log(`Frontend PID: ${process.pid}`);
 const ENABLE_REQUESTS_LOGGING = false;

--- a/apps/load-tests/tests/src/processors/models-tree.ts
+++ b/apps/load-tests/tests/src/processors/models-tree.ts
@@ -14,8 +14,8 @@ import {
   PresentationRpcResponseData,
   PresentationStatus,
 } from "@itwin/presentation-common";
-import RULESET_ModelsTree from "../rulesets/ModelsTree-GroupedByClass.PresentationRuleSet.json";
-import { doRequest, getCurrentIModelName, loadNodes, loadVariables, openIModelConnectionIfNeeded } from "./common";
+import RULESET_ModelsTree from "../rulesets/ModelsTree-GroupedByClass.PresentationRuleSet.json" with { type: "json" };
+import { doRequest, getCurrentIModelName, loadNodes, loadVariables, openIModelConnectionIfNeeded } from "./common.js";
 
 /* eslint-disable @typescript-eslint/no-deprecated */
 

--- a/apps/load-tests/tests/tsconfig.json
+++ b/apps/load-tests/tests/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "module": "CommonJS",
-    "moduleResolution": "Node",
     "outDir": "./lib",
     "sourceMap": true,
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "rootDir": "./src",
   },
-  "include": ["src"]
+  "include": ["src"],
 }

--- a/apps/load-tests/tests/tsconfig.json
+++ b/apps/load-tests/tests/tsconfig.json
@@ -5,7 +5,7 @@
     "sourceMap": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "rootDir": "./src",
+    "rootDir": "./src"
   },
-  "include": ["src"],
+  "include": ["src"]
 }

--- a/apps/test-app/backend/tsconfig.json
+++ b/apps/test-app/backend/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "./lib",
     "sourceMap": true,
-    "rootDir": "./src",
+    "rootDir": "./src"
   },
-  "include": ["src"],
+  "include": ["src"]
 }

--- a/apps/test-app/backend/tsconfig.json
+++ b/apps/test-app/backend/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./lib",
-    "sourceMap": true
+    "sourceMap": true,
+    "rootDir": "./src",
   },
-  "include": ["src"]
+  "include": ["src"],
 }

--- a/apps/test-app/common/tsconfig.json
+++ b/apps/test-app/common/tsconfig.json
@@ -5,7 +5,7 @@
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
-    "rootDir": "./src",
+    "rootDir": "./src"
   },
-  "include": ["src"],
+  "include": ["src"]
 }

--- a/apps/test-app/common/tsconfig.json
+++ b/apps/test-app/common/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
     "outDir": "./lib",
     "sourceMap": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "rootDir": "./src",
   },
-  "include": ["src"]
+  "include": ["src"],
 }

--- a/apps/test-app/frontend/tsconfig.json
+++ b/apps/test-app/frontend/tsconfig.json
@@ -8,7 +8,9 @@
     "outDir": "./lib",
     "sourceMap": true,
     "esModuleInterop": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "rootDir": ".",
+    "noEmit": true,
   },
-  "include": ["src", "vite.config.mts"]
+  "include": ["src", "vite.config.mts"],
 }

--- a/apps/test-app/frontend/tsconfig.json
+++ b/apps/test-app/frontend/tsconfig.json
@@ -10,7 +10,7 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "rootDir": ".",
-    "noEmit": true,
+    "noEmit": true
   },
-  "include": ["src", "vite.config.mts"],
+  "include": ["src", "vite.config.mts"]
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lint-staged": "^15.5.2",
     "markdown-link-check": "^3.14.2",
     "npm-run-all": "^4.1.5",
-    "oxfmt": "^0.41.0",
+    "oxfmt": "^0.47.0",
     "rimraf": "catalog:build-tools",
     "yaml": "^2.8.3",
     "yargs": "^17.7.2"

--- a/packages/components/api/presentation-components.api.md
+++ b/packages/components/api/presentation-components.api.md
@@ -70,7 +70,6 @@ import { ReactElement } from 'react';
 import { ReactNode } from 'react';
 import { RenderedItemsRange } from '@itwin/components-react';
 import { Ruleset } from '@itwin/presentation-common';
-import { RulesetVariable } from '@itwin/presentation-common';
 import { SchemaContext } from '@itwin/ecschema-metadata';
 import { SelectionChangeType } from '@itwin/presentation-frontend';
 import { SelectionHandler } from '@itwin/presentation-frontend';
@@ -94,7 +93,6 @@ import { TreeRendererProps } from '@itwin/components-react';
 import { TreeSelectionModificationEventArgs } from '@itwin/components-react';
 import { TreeSelectionReplacementEventArgs } from '@itwin/components-react';
 import { TypeEditor } from '@itwin/components-react';
-import { UnitSystemKey } from '@itwin/core-quantity';
 import { ViewportProps } from '@itwin/imodel-components-react';
 
 // @public
@@ -530,16 +528,7 @@ export function PresentationTree<TEventHandler extends TreeEventHandler>(input: 
 export class PresentationTreeDataProvider implements IPresentationTreeDataProvider, Disposable {
     [Symbol.dispose](): void;
     constructor(props: PresentationTreeDataProviderProps);
-    createRequestOptions(parentKey: NodeKey | undefined, instanceFilter?: InstanceFilterDefinition): {
-        instanceFilter?: InstanceFilterDefinition | undefined;
-        sizeLimit?: number | undefined;
-        parentKey?: NodeKey | undefined;
-        rulesetOrId: Ruleset | string;
-        rulesetVariables?: RulesetVariable[] | undefined;
-        imodel: IModelConnection;
-        locale?: string;
-        unitSystem?: UnitSystemKey;
-    };
+    createRequestOptions(parentKey: NodeKey | undefined, instanceFilter?: InstanceFilterDefinition): Paged<HierarchyRequestOptions<IModelConnection, NodeKey>>;
     // @deprecated (undocumented)
     dispose(): void;
     getFilteredNodePaths(filter: string): Promise<NodePathElement[]>;

--- a/packages/components/src/presentation-components/tree/DataProvider.ts
+++ b/packages/components/src/presentation-components/tree/DataProvider.ts
@@ -253,7 +253,10 @@ export class PresentationTreeDataProvider implements IPresentationTreeDataProvid
   }
 
   /** Creates options for nodes requests. */
-  public createRequestOptions(parentKey: NodeKey | undefined, instanceFilter?: InstanceFilterDefinition) {
+  public createRequestOptions(
+    parentKey: NodeKey | undefined,
+    instanceFilter?: InstanceFilterDefinition,
+  ): Paged<HierarchyRequestOptions<IModelConnection, NodeKey>> {
     const isHierarchyLevelLimitingSupported = !!this.hierarchyLevelSizeLimit && parentKey;
     return {
       ...this.createBaseRequestOptions(),

--- a/packages/components/src/presentation-components/tree/FilteredDataProvider.ts
+++ b/packages/components/src/presentation-components/tree/FilteredDataProvider.ts
@@ -15,7 +15,14 @@ import {
   TreeNodeItem,
 } from "@itwin/components-react";
 import { IModelConnection } from "@itwin/core-frontend";
-import { InstanceFilterDefinition, Node, NodeKey, NodePathElement } from "@itwin/presentation-common";
+import {
+  HierarchyRequestOptions,
+  InstanceFilterDefinition,
+  Node,
+  NodeKey,
+  NodePathElement,
+  Paged,
+} from "@itwin/presentation-common";
 import { memoize } from "../common/Utils.js";
 import { PresentationTreeDataProvider } from "./DataProvider.js";
 import {
@@ -153,7 +160,10 @@ export class FilteredPresentationTreeDataProvider implements IFilteredPresentati
     return this._parentDataProvider.getFilteredNodePaths(filter);
   }
 
-  public createRequestOptions(parentKey?: NodeKey, instanceFilter?: InstanceFilterDefinition) {
+  public createRequestOptions(
+    parentKey?: NodeKey,
+    instanceFilter?: InstanceFilterDefinition,
+  ): Paged<HierarchyRequestOptions<IModelConnection, NodeKey>> {
     return this._parentDataProvider.createRequestOptions(parentKey, instanceFilter);
   }
 

--- a/packages/components/src/styles.d.ts
+++ b/packages/components/src/styles.d.ts
@@ -2,6 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Internal
+ */
 
 declare module "*.css" {
   const classes: { readonly [key: string]: string };

--- a/packages/components/src/styles.d.ts
+++ b/packages/components/src/styles.d.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module "*.css" {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module "*.scss" {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}

--- a/packages/components/tsconfig.cjs.json
+++ b/packages/components/tsconfig.cjs.json
@@ -1,9 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "module": "CommonJS",
-    "moduleResolution": "Node",
-    "outDir": "lib/cjs"
+    "moduleResolution": "Bundler",
+    "rootDir": "./src",
+    "outDir": "lib/cjs",
   },
-  "include": ["src/presentation-components", "src/presentation-components.ts"]
+  "include": ["src/styles.d.ts", "src/presentation-components", "src/presentation-components.ts"],
 }

--- a/packages/components/tsconfig.cjs.json
+++ b/packages/components/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "module": "CommonJS",
     "moduleResolution": "Bundler",
     "rootDir": "./src",
-    "outDir": "lib/cjs",
+    "outDir": "lib/cjs"
   },
-  "include": ["src/styles.d.ts", "src/presentation-components", "src/presentation-components.ts"],
+  "include": ["src/styles.d.ts", "src/presentation-components", "src/presentation-components.ts"]
 }

--- a/packages/components/tsconfig.esm.json
+++ b/packages/components/tsconfig.esm.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "lib/esm",
+    "outDir": "lib/esm"
   },
-  "include": ["src/styles.d.ts", "src/presentation-components", "src/presentation-components.ts"],
+  "include": ["src/styles.d.ts", "src/presentation-components", "src/presentation-components.ts"]
 }

--- a/packages/components/tsconfig.esm.json
+++ b/packages/components/tsconfig.esm.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "outDir": "lib/esm"
+    "noEmit": false,
+    "rootDir": "./src",
+    "outDir": "lib/esm",
   },
-  "include": ["src/presentation-components", "src/presentation-components.ts"]
+  "include": ["src/styles.d.ts", "src/presentation-components", "src/presentation-components.ts"],
 }

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -7,7 +7,9 @@
     "inlineSources": true,
     "declaration": true,
     "declarationMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "rootDir": ".",
+    "noEmit": true,
   },
-  "include": ["src", "vitest.config.ts"]
+  "include": ["src", "vitest.config.ts"],
 }

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -9,7 +9,7 @@
     "declarationMap": true,
     "resolveJsonModule": true,
     "rootDir": ".",
-    "noEmit": true,
+    "noEmit": true
   },
-  "include": ["src", "vitest.config.ts"],
+  "include": ["src", "vitest.config.ts"]
 }

--- a/packages/core-interop/tsconfig.cjs.json
+++ b/packages/core-interop/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "module": "CommonJS",
     "moduleResolution": "Bundler",
     "rootDir": "./src",
-    "outDir": "lib/cjs",
+    "outDir": "lib/cjs"
   },
-  "include": ["src/presentation-core-interop", "src/presentation-core-interop.ts"],
+  "include": ["src/presentation-core-interop", "src/presentation-core-interop.ts"]
 }

--- a/packages/core-interop/tsconfig.cjs.json
+++ b/packages/core-interop/tsconfig.cjs.json
@@ -1,9 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "module": "CommonJS",
-    "moduleResolution": "Node",
-    "outDir": "lib/cjs"
+    "moduleResolution": "Bundler",
+    "rootDir": "./src",
+    "outDir": "lib/cjs",
   },
-  "include": ["src/presentation-core-interop", "src/presentation-core-interop.ts"]
+  "include": ["src/presentation-core-interop", "src/presentation-core-interop.ts"],
 }

--- a/packages/core-interop/tsconfig.esm.json
+++ b/packages/core-interop/tsconfig.esm.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "lib/esm",
+    "outDir": "lib/esm"
   },
-  "include": ["src/presentation-core-interop", "src/presentation-core-interop.ts"],
+  "include": ["src/presentation-core-interop", "src/presentation-core-interop.ts"]
 }

--- a/packages/core-interop/tsconfig.esm.json
+++ b/packages/core-interop/tsconfig.esm.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "outDir": "lib/esm"
+    "noEmit": false,
+    "rootDir": "./src",
+    "outDir": "lib/esm",
   },
-  "include": ["src/presentation-core-interop", "src/presentation-core-interop.ts"]
+  "include": ["src/presentation-core-interop", "src/presentation-core-interop.ts"],
 }

--- a/packages/core-interop/tsconfig.json
+++ b/packages/core-interop/tsconfig.json
@@ -8,7 +8,9 @@
     "declarationMap": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
-    "lib": ["ES2022"]
+    "lib": ["ES2022"],
+    "rootDir": ".",
+    "noEmit": true,
   },
-  "include": ["src", "vitest.config.ts"]
+  "include": ["src", "vitest.config.ts"],
 }

--- a/packages/core-interop/tsconfig.json
+++ b/packages/core-interop/tsconfig.json
@@ -10,7 +10,7 @@
     "resolveJsonModule": true,
     "lib": ["ES2022"],
     "rootDir": ".",
-    "noEmit": true,
+    "noEmit": true
   },
-  "include": ["src", "vitest.config.ts"],
+  "include": ["src", "vitest.config.ts"]
 }

--- a/packages/hierarchies-react/src/styles.d.ts
+++ b/packages/hierarchies-react/src/styles.d.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module "*.css" {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}

--- a/packages/hierarchies-react/tsconfig.cjs.json
+++ b/packages/hierarchies-react/tsconfig.cjs.json
@@ -1,14 +1,17 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "module": "CommonJS",
-    "moduleResolution": "Node",
-    "outDir": "lib/cjs"
+    "moduleResolution": "Bundler",
+    "rootDir": "./src",
+    "outDir": "lib/cjs",
   },
   "include": [
+    "src/styles.d.ts",
     "src/presentation-hierarchies-react",
     "src/presentation-hierarchies-react.ts",
     "src/presentation-hierarchies-react-core.ts",
-    "src/presentation-hierarchies-react-itwinui.ts"
-  ]
+    "src/presentation-hierarchies-react-itwinui.ts",
+  ],
 }

--- a/packages/hierarchies-react/tsconfig.cjs.json
+++ b/packages/hierarchies-react/tsconfig.cjs.json
@@ -5,13 +5,13 @@
     "module": "CommonJS",
     "moduleResolution": "Bundler",
     "rootDir": "./src",
-    "outDir": "lib/cjs",
+    "outDir": "lib/cjs"
   },
   "include": [
     "src/styles.d.ts",
     "src/presentation-hierarchies-react",
     "src/presentation-hierarchies-react.ts",
     "src/presentation-hierarchies-react-core.ts",
-    "src/presentation-hierarchies-react-itwinui.ts",
-  ],
+    "src/presentation-hierarchies-react-itwinui.ts"
+  ]
 }

--- a/packages/hierarchies-react/tsconfig.esm.json
+++ b/packages/hierarchies-react/tsconfig.esm.json
@@ -3,13 +3,13 @@
   "compilerOptions": {
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "lib/esm",
+    "outDir": "lib/esm"
   },
   "include": [
     "src/styles.d.ts",
     "src/presentation-hierarchies-react",
     "src/presentation-hierarchies-react.ts",
     "src/presentation-hierarchies-react-core.ts",
-    "src/presentation-hierarchies-react-itwinui.ts",
-  ],
+    "src/presentation-hierarchies-react-itwinui.ts"
+  ]
 }

--- a/packages/hierarchies-react/tsconfig.esm.json
+++ b/packages/hierarchies-react/tsconfig.esm.json
@@ -1,14 +1,15 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "outDir": "lib/esm"
+    "noEmit": false,
+    "rootDir": "./src",
+    "outDir": "lib/esm",
   },
   "include": [
+    "src/styles.d.ts",
     "src/presentation-hierarchies-react",
     "src/presentation-hierarchies-react.ts",
     "src/presentation-hierarchies-react-core.ts",
-    "src/presentation-hierarchies-react-itwinui.ts"
-  ]
+    "src/presentation-hierarchies-react-itwinui.ts",
+  ],
 }

--- a/packages/hierarchies-react/tsconfig.json
+++ b/packages/hierarchies-react/tsconfig.json
@@ -10,7 +10,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "rootDir": ".",
-    "noEmit": true,
+    "noEmit": true
   },
-  "include": ["src", "vitest.config.ts"],
+  "include": ["src", "vitest.config.ts"]
 }

--- a/packages/hierarchies-react/tsconfig.json
+++ b/packages/hierarchies-react/tsconfig.json
@@ -8,7 +8,9 @@
     "declaration": true,
     "declarationMap": true,
     "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "rootDir": ".",
+    "noEmit": true,
   },
-  "include": ["src", "vitest.config.ts"]
+  "include": ["src", "vitest.config.ts"],
 }

--- a/packages/hierarchies/tsconfig.cjs.json
+++ b/packages/hierarchies/tsconfig.cjs.json
@@ -1,9 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "module": "CommonJS",
-    "moduleResolution": "Node",
-    "outDir": "lib/cjs"
+    "moduleResolution": "Bundler",
+    "rootDir": "./src",
+    "outDir": "lib/cjs",
   },
-  "include": ["src/hierarchies", "src/presentation-hierarchies.ts"]
+  "include": ["src/hierarchies", "src/presentation-hierarchies.ts"],
 }

--- a/packages/hierarchies/tsconfig.cjs.json
+++ b/packages/hierarchies/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "module": "CommonJS",
     "moduleResolution": "Bundler",
     "rootDir": "./src",
-    "outDir": "lib/cjs",
+    "outDir": "lib/cjs"
   },
-  "include": ["src/hierarchies", "src/presentation-hierarchies.ts"],
+  "include": ["src/hierarchies", "src/presentation-hierarchies.ts"]
 }

--- a/packages/hierarchies/tsconfig.esm.json
+++ b/packages/hierarchies/tsconfig.esm.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "outDir": "lib/esm"
+    "noEmit": false,
+    "rootDir": "./src",
+    "outDir": "lib/esm",
   },
-  "include": ["src/hierarchies", "src/presentation-hierarchies.ts"]
+  "include": ["src/hierarchies", "src/presentation-hierarchies.ts"],
 }

--- a/packages/hierarchies/tsconfig.esm.json
+++ b/packages/hierarchies/tsconfig.esm.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "lib/esm",
+    "outDir": "lib/esm"
   },
-  "include": ["src/hierarchies", "src/presentation-hierarchies.ts"],
+  "include": ["src/hierarchies", "src/presentation-hierarchies.ts"]
 }

--- a/packages/hierarchies/tsconfig.json
+++ b/packages/hierarchies/tsconfig.json
@@ -9,7 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "rootDir": ".",
-    "noEmit": true,
+    "noEmit": true
   },
-  "include": ["src", "vitest.config.ts"],
+  "include": ["src", "vitest.config.ts"]
 }

--- a/packages/hierarchies/tsconfig.json
+++ b/packages/hierarchies/tsconfig.json
@@ -7,7 +7,9 @@
     "declaration": true,
     "declarationMap": true,
     "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "rootDir": ".",
+    "noEmit": true,
   },
-  "include": ["src", "vitest.config.ts"]
+  "include": ["src", "vitest.config.ts"],
 }

--- a/packages/models-tree/tsconfig.cjs.json
+++ b/packages/models-tree/tsconfig.cjs.json
@@ -1,8 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "module": "CommonJS",
-    "moduleResolution": "Node",
-    "outDir": "lib/cjs"
-  }
+    "moduleResolution": "Bundler",
+    "rootDir": "./src",
+    "outDir": "lib/cjs",
+  },
 }

--- a/packages/models-tree/tsconfig.cjs.json
+++ b/packages/models-tree/tsconfig.cjs.json
@@ -5,6 +5,6 @@
     "module": "CommonJS",
     "moduleResolution": "Bundler",
     "rootDir": "./src",
-    "outDir": "lib/cjs",
-  },
+    "outDir": "lib/cjs"
+  }
 }

--- a/packages/models-tree/tsconfig.esm.json
+++ b/packages/models-tree/tsconfig.esm.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "outDir": "lib/esm"
-  }
+    "noEmit": false,
+    "rootDir": "./src",
+    "outDir": "lib/esm",
+  },
 }

--- a/packages/models-tree/tsconfig.esm.json
+++ b/packages/models-tree/tsconfig.esm.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "lib/esm",
-  },
+    "outDir": "lib/esm"
+  }
 }

--- a/packages/models-tree/tsconfig.json
+++ b/packages/models-tree/tsconfig.json
@@ -7,7 +7,9 @@
     "declaration": true,
     "declarationMap": true,
     "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "rootDir": ".",
+    "noEmit": true,
   },
-  "include": ["src"]
+  "include": ["src"],
 }

--- a/packages/models-tree/tsconfig.json
+++ b/packages/models-tree/tsconfig.json
@@ -9,7 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "rootDir": ".",
-    "noEmit": true,
+    "noEmit": true
   },
-  "include": ["src"],
+  "include": ["src"]
 }

--- a/packages/opentelemetry/tsconfig.cjs.json
+++ b/packages/opentelemetry/tsconfig.cjs.json
@@ -1,9 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "module": "CommonJS",
-    "moduleResolution": "Node",
-    "outDir": "lib/cjs"
+    "moduleResolution": "Bundler",
+    "rootDir": "./src",
+    "outDir": "lib/cjs",
   },
-  "include": ["src/presentation-opentelemetry", "src/presentation-opentelemetry.ts"]
+  "include": ["src/presentation-opentelemetry", "src/presentation-opentelemetry.ts"],
 }

--- a/packages/opentelemetry/tsconfig.cjs.json
+++ b/packages/opentelemetry/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "module": "CommonJS",
     "moduleResolution": "Bundler",
     "rootDir": "./src",
-    "outDir": "lib/cjs",
+    "outDir": "lib/cjs"
   },
-  "include": ["src/presentation-opentelemetry", "src/presentation-opentelemetry.ts"],
+  "include": ["src/presentation-opentelemetry", "src/presentation-opentelemetry.ts"]
 }

--- a/packages/opentelemetry/tsconfig.esm.json
+++ b/packages/opentelemetry/tsconfig.esm.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "outDir": "lib/esm"
+    "noEmit": false,
+    "rootDir": "./src",
+    "outDir": "lib/esm",
   },
-  "include": ["src/presentation-opentelemetry", "src/presentation-opentelemetry.ts"]
+  "include": ["src/presentation-opentelemetry", "src/presentation-opentelemetry.ts"],
 }

--- a/packages/opentelemetry/tsconfig.esm.json
+++ b/packages/opentelemetry/tsconfig.esm.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "lib/esm",
+    "outDir": "lib/esm"
   },
-  "include": ["src/presentation-opentelemetry", "src/presentation-opentelemetry.ts"],
+  "include": ["src/presentation-opentelemetry", "src/presentation-opentelemetry.ts"]
 }

--- a/packages/opentelemetry/tsconfig.json
+++ b/packages/opentelemetry/tsconfig.json
@@ -9,7 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "rootDir": ".",
-    "noEmit": true,
+    "noEmit": true
   },
-  "include": ["src", "vitest.config.ts"],
+  "include": ["src", "vitest.config.ts"]
 }

--- a/packages/opentelemetry/tsconfig.json
+++ b/packages/opentelemetry/tsconfig.json
@@ -7,7 +7,9 @@
     "declaration": true,
     "declarationMap": true,
     "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "rootDir": ".",
+    "noEmit": true,
   },
-  "include": ["src", "vitest.config.ts"]
+  "include": ["src", "vitest.config.ts"],
 }

--- a/packages/shared/tsconfig.cjs.json
+++ b/packages/shared/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "module": "CommonJS",
     "moduleResolution": "Bundler",
     "rootDir": "./src",
-    "outDir": "lib/cjs",
+    "outDir": "lib/cjs"
   },
-  "include": ["src/shared", "src/presentation-shared.ts"],
+  "include": ["src/shared", "src/presentation-shared.ts"]
 }

--- a/packages/shared/tsconfig.cjs.json
+++ b/packages/shared/tsconfig.cjs.json
@@ -1,9 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "module": "CommonJS",
-    "moduleResolution": "Node",
-    "outDir": "lib/cjs"
+    "moduleResolution": "Bundler",
+    "rootDir": "./src",
+    "outDir": "lib/cjs",
   },
-  "include": ["src/shared", "src/presentation-shared.ts"]
+  "include": ["src/shared", "src/presentation-shared.ts"],
 }

--- a/packages/shared/tsconfig.esm.json
+++ b/packages/shared/tsconfig.esm.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "lib/esm",
+    "outDir": "lib/esm"
   },
-  "include": ["src/shared", "src/presentation-shared.ts"],
+  "include": ["src/shared", "src/presentation-shared.ts"]
 }

--- a/packages/shared/tsconfig.esm.json
+++ b/packages/shared/tsconfig.esm.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "outDir": "lib/esm"
+    "noEmit": false,
+    "rootDir": "./src",
+    "outDir": "lib/esm",
   },
-  "include": ["src/shared", "src/presentation-shared.ts"]
+  "include": ["src/shared", "src/presentation-shared.ts"],
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -8,7 +8,7 @@
     "declarationMap": true,
     "rootDir": ".",
     "noEmit": true,
-    "types": ["node"],
+    "types": ["node"]
   },
-  "include": ["src"],
+  "include": ["src"]
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -5,7 +5,10 @@
     "sourceMap": true,
     "esModuleInterop": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "rootDir": ".",
+    "noEmit": true,
+    "types": ["node"],
   },
-  "include": ["src", "vitest.config.ts"]
+  "include": ["src"],
 }

--- a/packages/test-utilities/tsconfig.cjs.json
+++ b/packages/test-utilities/tsconfig.cjs.json
@@ -1,8 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "module": "CommonJS",
-    "moduleResolution": "Node",
-    "outDir": "lib/cjs"
-  }
+    "moduleResolution": "Bundler",
+    "rootDir": "./src",
+    "outDir": "lib/cjs",
+  },
 }

--- a/packages/test-utilities/tsconfig.cjs.json
+++ b/packages/test-utilities/tsconfig.cjs.json
@@ -5,6 +5,6 @@
     "module": "CommonJS",
     "moduleResolution": "Bundler",
     "rootDir": "./src",
-    "outDir": "lib/cjs",
-  },
+    "outDir": "lib/cjs"
+  }
 }

--- a/packages/test-utilities/tsconfig.esm.json
+++ b/packages/test-utilities/tsconfig.esm.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "outDir": "lib/esm"
-  }
+    "noEmit": false,
+    "rootDir": "./src",
+    "outDir": "lib/esm",
+  },
 }

--- a/packages/test-utilities/tsconfig.esm.json
+++ b/packages/test-utilities/tsconfig.esm.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "lib/esm",
-  },
+    "outDir": "lib/esm"
+  }
 }

--- a/packages/test-utilities/tsconfig.json
+++ b/packages/test-utilities/tsconfig.json
@@ -2,10 +2,13 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./lib",
+    "rootDir": ".",
+    "noEmit": true,
     "sourceMap": true,
     "esModuleInterop": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "types": ["node"],
   },
-  "include": ["src"]
+  "include": ["src"],
 }

--- a/packages/test-utilities/tsconfig.json
+++ b/packages/test-utilities/tsconfig.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "declaration": true,
     "declarationMap": true,
-    "types": ["node"],
+    "types": ["node"]
   },
-  "include": ["src"],
+  "include": ["src"]
 }

--- a/packages/testing/tsconfig.cjs.json
+++ b/packages/testing/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "module": "CommonJS",
     "moduleResolution": "Bundler",
     "rootDir": "./src",
-    "outDir": "lib/cjs",
+    "outDir": "lib/cjs"
   },
-  "include": ["src/presentation-testing", "src/presentation-testing.ts"],
+  "include": ["src/presentation-testing", "src/presentation-testing.ts"]
 }

--- a/packages/testing/tsconfig.cjs.json
+++ b/packages/testing/tsconfig.cjs.json
@@ -1,9 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "module": "CommonJS",
-    "moduleResolution": "Node",
-    "outDir": "lib/cjs"
+    "moduleResolution": "Bundler",
+    "rootDir": "./src",
+    "outDir": "lib/cjs",
   },
-  "include": ["src/presentation-testing", "src/presentation-testing.ts"]
+  "include": ["src/presentation-testing", "src/presentation-testing.ts"],
 }

--- a/packages/testing/tsconfig.esm.json
+++ b/packages/testing/tsconfig.esm.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "lib/esm",
+    "outDir": "lib/esm"
   },
-  "include": ["src/presentation-testing", "src/presentation-testing.ts"],
+  "include": ["src/presentation-testing", "src/presentation-testing.ts"]
 }

--- a/packages/testing/tsconfig.esm.json
+++ b/packages/testing/tsconfig.esm.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "outDir": "lib/esm"
+    "noEmit": false,
+    "rootDir": "./src",
+    "outDir": "lib/esm",
   },
-  "include": ["src/presentation-testing", "src/presentation-testing.ts"]
+  "include": ["src/presentation-testing", "src/presentation-testing.ts"],
 }

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -7,7 +7,10 @@
     "declaration": true,
     "declarationMap": true,
     "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "rootDir": ".",
+    "noEmit": true,
+    "types": ["node"],
   },
-  "include": ["src", "vitest.config.ts"]
+  "include": ["src", "vitest.config.ts"],
 }

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -10,7 +10,7 @@
     "resolveJsonModule": true,
     "rootDir": ".",
     "noEmit": true,
-    "types": ["node"],
+    "types": ["node"]
   },
-  "include": ["src", "vitest.config.ts"],
+  "include": ["src", "vitest.config.ts"]
 }

--- a/packages/unified-selection-react/tsconfig.cjs.json
+++ b/packages/unified-selection-react/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "module": "CommonJS",
     "moduleResolution": "Bundler",
     "rootDir": "./src",
-    "outDir": "lib/cjs",
+    "outDir": "lib/cjs"
   },
-  "include": ["src/unified-selection-react", "src/unified-selection-react.ts"],
+  "include": ["src/unified-selection-react", "src/unified-selection-react.ts"]
 }

--- a/packages/unified-selection-react/tsconfig.cjs.json
+++ b/packages/unified-selection-react/tsconfig.cjs.json
@@ -1,9 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "module": "CommonJS",
-    "moduleResolution": "Node",
-    "outDir": "lib/cjs"
+    "moduleResolution": "Bundler",
+    "rootDir": "./src",
+    "outDir": "lib/cjs",
   },
-  "include": ["src/unified-selection-react", "src/unified-selection-react.ts"]
+  "include": ["src/unified-selection-react", "src/unified-selection-react.ts"],
 }

--- a/packages/unified-selection-react/tsconfig.esm.json
+++ b/packages/unified-selection-react/tsconfig.esm.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "outDir": "lib/esm"
+    "noEmit": false,
+    "rootDir": "./src",
+    "outDir": "lib/esm",
   },
-  "include": ["src/unified-selection-react", "src/unified-selection-react.ts"]
+  "include": ["src/unified-selection-react", "src/unified-selection-react.ts"],
 }

--- a/packages/unified-selection-react/tsconfig.esm.json
+++ b/packages/unified-selection-react/tsconfig.esm.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "lib/esm",
+    "outDir": "lib/esm"
   },
-  "include": ["src/unified-selection-react", "src/unified-selection-react.ts"],
+  "include": ["src/unified-selection-react", "src/unified-selection-react.ts"]
 }

--- a/packages/unified-selection-react/tsconfig.json
+++ b/packages/unified-selection-react/tsconfig.json
@@ -10,7 +10,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "rootDir": ".",
-    "noEmit": true,
+    "noEmit": true
   },
-  "include": ["src", "vitest.config.ts"],
+  "include": ["src", "vitest.config.ts"]
 }

--- a/packages/unified-selection-react/tsconfig.json
+++ b/packages/unified-selection-react/tsconfig.json
@@ -8,7 +8,9 @@
     "declaration": true,
     "declarationMap": true,
     "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "rootDir": ".",
+    "noEmit": true,
   },
-  "include": ["src", "vitest.config.ts"]
+  "include": ["src", "vitest.config.ts"],
 }

--- a/packages/unified-selection/tsconfig.cjs.json
+++ b/packages/unified-selection/tsconfig.cjs.json
@@ -1,9 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "module": "CommonJS",
-    "moduleResolution": "Node",
-    "outDir": "lib/cjs"
+    "moduleResolution": "Bundler",
+    "rootDir": "./src",
+    "outDir": "lib/cjs",
   },
-  "include": ["src/unified-selection", "src/unified-selection.ts"]
+  "include": ["src/unified-selection", "src/unified-selection.ts"],
 }

--- a/packages/unified-selection/tsconfig.cjs.json
+++ b/packages/unified-selection/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "module": "CommonJS",
     "moduleResolution": "Bundler",
     "rootDir": "./src",
-    "outDir": "lib/cjs",
+    "outDir": "lib/cjs"
   },
-  "include": ["src/unified-selection", "src/unified-selection.ts"],
+  "include": ["src/unified-selection", "src/unified-selection.ts"]
 }

--- a/packages/unified-selection/tsconfig.esm.json
+++ b/packages/unified-selection/tsconfig.esm.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "outDir": "lib/esm"
+    "noEmit": false,
+    "rootDir": "./src",
+    "outDir": "lib/esm",
   },
-  "include": ["src/unified-selection", "src/unified-selection.ts"]
+  "include": ["src/unified-selection", "src/unified-selection.ts"],
 }

--- a/packages/unified-selection/tsconfig.esm.json
+++ b/packages/unified-selection/tsconfig.esm.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "lib/esm",
+    "outDir": "lib/esm"
   },
-  "include": ["src/unified-selection", "src/unified-selection.ts"],
+  "include": ["src/unified-selection", "src/unified-selection.ts"]
 }

--- a/packages/unified-selection/tsconfig.json
+++ b/packages/unified-selection/tsconfig.json
@@ -9,7 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "rootDir": ".",
-    "noEmit": true,
+    "noEmit": true
   },
-  "include": ["src", "vitest.config.ts"],
+  "include": ["src", "vitest.config.ts"]
 }

--- a/packages/unified-selection/tsconfig.json
+++ b/packages/unified-selection/tsconfig.json
@@ -7,7 +7,9 @@
     "declaration": true,
     "declarationMap": true,
     "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "rootDir": ".",
+    "noEmit": true,
   },
-  "include": ["src", "vitest.config.ts"]
+  "include": ["src", "vitest.config.ts"],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,8 +223,8 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
       oxfmt:
-        specifier: ^0.41.0
-        version: 0.41.0
+        specifier: ^0.47.0
+        version: 0.47.0
       rimraf:
         specifier: catalog:build-tools
         version: 6.1.3
@@ -3099,124 +3099,124 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@oxfmt/binding-android-arm-eabi@0.41.0':
-    resolution: {integrity: sha512-REfrqeMKGkfMP+m/ScX4f5jJBSmVNYcpoDF8vP8f8eYPDuPGZmzp56NIUsYmx3h7f6NzC6cE3gqh8GDWrJHCKw==}
+  '@oxfmt/binding-android-arm-eabi@0.47.0':
+    resolution: {integrity: sha512-KrMQRdMi/upr81qT4ijK6X6BNp6jqpMY7FwILQnwIy9QLc3qpnhUx5rsCLGzn4ewsCQ0CNAspN2ogmP1GXLyLw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.41.0':
-    resolution: {integrity: sha512-s0b1dxNgb2KomspFV2LfogC2XtSJB42POXF4bMCLJyvQmAGos4ZtjGPfQreToQEaY0FQFjz3030ggI36rF1q5g==}
+  '@oxfmt/binding-android-arm64@0.47.0':
+    resolution: {integrity: sha512-r4ixS/PeUpAFKgrpDoZ5pSkthjZzVzKd95525Aazj+aOv9H4ulK5zYHGb7wFY5n5kZxHK8TbOJUZgoEb1ohddQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.41.0':
-    resolution: {integrity: sha512-EGXGualADbv/ZmamE7/2DbsrYmjoPlAmHEpTL4vapLF4EfVD6fr8/uQDFnPJkUBjiSWFJZtFNsGeN1B6V3owmA==}
+  '@oxfmt/binding-darwin-arm64@0.47.0':
+    resolution: {integrity: sha512-CLWxiKpMl+195cm09CuaWEhJK0CirRkoMa07aR9+9AFPat2LfIKtwx1JqxZM0MTvcMe6+adlJNdVL6jdInvq3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.41.0':
-    resolution: {integrity: sha512-WxySJEvdQQYMmyvISH3qDpTvoS0ebnIP63IMxLLWowJyPp/AAH0hdWtlo+iGNK5y3eVfa5jZguwNaQkDKWpGSw==}
+  '@oxfmt/binding-darwin-x64@0.47.0':
+    resolution: {integrity: sha512-Xq5fjTYDC50faUeLSm0rZdBqoTgleXEdD7NpJdARtQIczkCJn3xNjMUSQQkUmh4CtxkKTNL68lytcOK3e/osgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.41.0':
-    resolution: {integrity: sha512-Y2kzMkv3U3oyuYaR4wTfGjOTYTXiFC/hXmG0yVASKkbh02BJkvD98Ij8bIevr45hNZ0DmZEgqiXF+9buD4yMYQ==}
+  '@oxfmt/binding-freebsd-x64@0.47.0':
+    resolution: {integrity: sha512-QOU9ZIJ52p5askcEC0QJvvr8trHAWoonul8bgISo6gYUL3s50zkqafBYcNAr9LJZQbsZtPfIWHk9+5+nUp1qJQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.41.0':
-    resolution: {integrity: sha512-ptazDjdUyhket01IjPTT6ULS1KFuBfTUU97osTP96X5y/0oso+AgAaJzuH81oP0+XXyrWIHbRzozSAuQm4p48g==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.47.0':
+    resolution: {integrity: sha512-oJxDM1aBhPvz9gmElBv8UpxyiqhwfjcbrSxT5F0xtuUzY6dQI27/AQPIt3eu3Z5Yvn0kQl5R7MA3Z+MbnRvCBw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.41.0':
-    resolution: {integrity: sha512-UkoL2OKxFD+56bPEBcdGn+4juTW4HRv/T6w1dIDLnvKKWr6DbarB/mtHXlADKlFiJubJz8pRkttOR7qjYR6lTA==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.47.0':
+    resolution: {integrity: sha512-g8Lh50VS4ibGz2q6v7r9UZY4D0dM16SdrFYOMzhqIoCwGcai8VMIRUAcqn1/jlCsOOzUXJ741+kCeJt0cofakQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.41.0':
-    resolution: {integrity: sha512-gofu0PuumSOHYczD8p62CPY4UF6ee+rSLZJdUXkpwxg6pILiwSDBIouPskjF/5nF3A7QZTz2O9KFNkNxxFN9tA==}
+  '@oxfmt/binding-linux-arm64-gnu@0.47.0':
+    resolution: {integrity: sha512-YrNT1vQ0asaXoRbrvYENPqmBfOQ9Xr8enPNOULeYfg44VjCcrUowFy5QZr+WawE0zyP8cH9e9Gxxg0fDEFzhcg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-musl@0.41.0':
-    resolution: {integrity: sha512-VfVZxL0+6RU86T8F8vKiDBa+iHsr8PAjQmKGBzSCAX70b6x+UOMFl+2dNihmKmUwqkCazCPfYjt6SuAPOeQJ3g==}
+  '@oxfmt/binding-linux-arm64-musl@0.47.0':
+    resolution: {integrity: sha512-IxtQC/sbBi4ubbY+MdwdanRWrG9InQJVZqyMsBa5IUaQcnSg86gQme574HxXMC1p4bo4YhV99zQ+wNnGCvEgzw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.41.0':
-    resolution: {integrity: sha512-bwzokz2eGvdfJbc0i+zXMJ4BBjQPqg13jyWpEEZDOrBCQ91r8KeY2Mi2kUeuMTZNFXju+jcAbAbpyJxRGla0eg==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.47.0':
+    resolution: {integrity: sha512-EWXEhOMbWO0q6eJSbu0QLkU8cKi0ljlYLngeDs2Ocu/pm1rrLwyQiYzlFbdnMRURI4w9ndr1sI9rSbhlJ5o23Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.41.0':
-    resolution: {integrity: sha512-POLM//PCH9uqDeNDwWL3b3DkMmI3oI2cU6hwc2lnztD1o7dzrQs3R9nq555BZ6wI7t2lyhT9CS+CRaz5X0XqLA==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.47.0':
+    resolution: {integrity: sha512-tZrjS11TUiDuEpRaqdk8K9F9xETRyKXfuZKmdeW+Gj7coBnm7+8sBEfyt033EAFEQSlkniAXvBLh+Qja2ioGBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.41.0':
-    resolution: {integrity: sha512-NNK7PzhFqLUwx/G12Xtm6scGv7UITvyGdAR5Y+TlqsG+essnuRWR4jRNODWRjzLZod0T3SayRbnkSIWMBov33w==}
+  '@oxfmt/binding-linux-riscv64-musl@0.47.0':
+    resolution: {integrity: sha512-KBFy+2CFKUCZzYwX2ZOPQKck1vjQbz+hextuc19G4r0WRJwadfAeuQMQRQvB+Ivc8brlbOVg7et8K7E467440g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.41.0':
-    resolution: {integrity: sha512-qVf/zDC5cN9eKe4qI/O/m445er1IRl6swsSl7jHkqmOSVfknwCe5JXitYjZca+V/cNJSU/xPlC5EFMabMMFDpw==}
+  '@oxfmt/binding-linux-s390x-gnu@0.47.0':
+    resolution: {integrity: sha512-REUPFKVGSiK99B+9eaPhluEVglzaoj/SMykNC5SUiV2RSsBfV5lWN7Y0iCIc251Wz3GaeAGZsJ/zj3gjarxdFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.41.0':
-    resolution: {integrity: sha512-ojxYWu7vUb6ysYqVCPHuAPVZHAI40gfZ0PDtZAMwVmh2f0V8ExpPIKoAKr7/8sNbAXJBBpZhs2coypIo2jJX4w==}
+  '@oxfmt/binding-linux-x64-gnu@0.47.0':
+    resolution: {integrity: sha512-KVftVSVEDeIfRW3TIeLe3aNI/iY4m1fu5mDwHcisKMZSCMKLkrhFsjowC7o9RoqNPxbbglm2+/6KAKBIts2t0Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-musl@0.41.0':
-    resolution: {integrity: sha512-O2exZLBxoCMIv2vlvcbkdedazJPTdG0VSup+0QUCfYQtx751zCZNboX2ZUOiQ/gDTdhtXvSiot0h6GEGkOyalA==}
+  '@oxfmt/binding-linux-x64-musl@0.47.0':
+    resolution: {integrity: sha512-DTsmGEaA2860Aq5VUyDO8/MT9NFxwVL93RnRYmpMwK6DsSkThmvEpqoUDDljziEpAedMRG19SCogrNbINSbLUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-openharmony-arm64@0.41.0':
-    resolution: {integrity: sha512-N+31/VoL+z+NNBt8viy3I4NaIdPbiYeOnB884LKqvXldaE2dRztdPv3q5ipfZYv0RwFp7JfqS4I27K/DSHCakg==}
+  '@oxfmt/binding-openharmony-arm64@0.47.0':
+    resolution: {integrity: sha512-8r5BDro7fLOBoq1JXHLVSs55OlrxQhEso4HVo0TcY7OXJUPYfjPoOaYL5us+yIwqyP9rQwN+rxuiNFSmaxSuOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.41.0':
-    resolution: {integrity: sha512-Z7NAtu/RN8kjCQ1y5oDD0nTAeRswh3GJ93qwcW51srmidP7XPBmZbLlwERu1W5veCevQJtPS9xmkpcDTYsGIwQ==}
+  '@oxfmt/binding-win32-arm64-msvc@0.47.0':
+    resolution: {integrity: sha512-qtz/gzm8IjSPUlseZ0ofW8zyHLoZsuP5HTfcGGkWkUblB89JT8GNYH3ICqjbDsqsGqXum0/ZndXTFplSdXFIcg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.41.0':
-    resolution: {integrity: sha512-uNxxP3l4bJ6VyzIeRqCmBU2Q0SkCFgIhvx9/9dJ9V8t/v+jP1IBsuaLwCXGR8JPHtkj4tFp+RHtUmU2ZYAUpMA==}
+  '@oxfmt/binding-win32-ia32-msvc@0.47.0':
+    resolution: {integrity: sha512-5vIcdcIDE7nCx+MXN6sm8kbC4zajDB31E86rez4i45iHNH/2NjdKlJ720xcHTr3eeiMcttCGPHPhE1TjtBDGZw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.41.0':
-    resolution: {integrity: sha512-49ZSpbZ1noozyPapE8SUOSm3IN0Ze4b5nkO+4+7fq6oEYQQJFhE0saj5k/Gg4oewVPdjn0L3ZFeWk2Vehjcw7A==}
+  '@oxfmt/binding-win32-x64-msvc@0.47.0':
+    resolution: {integrity: sha512-Sr59Y5ms54ONBjxFeWhVlGyQcHXxcl9DxC23f6yXlRkcos7LXBLoO+KDfxexjHIOZh7cWqrWduzvUjJ+pHp8cQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -6748,8 +6748,8 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
-  oxfmt@0.41.0:
-    resolution: {integrity: sha512-sKLdJZdQ3bw6x9qKiT7+eID4MNEXlDHf5ZacfIircrq6Qwjk0L6t2/JQlZZrVHTXJawK3KaMuBoJnEJPcqCEdg==}
+  oxfmt@0.47.0:
+    resolution: {integrity: sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -10196,7 +10196,7 @@ snapshots:
       rimraf: 6.1.3
       tree-kill: 1.2.2
       typedoc: 0.26.11(typescript@5.6.3)
-      typedoc-plugin-merge-modules: 6.1.0(typedoc@0.26.11(typescript@6.0.2))
+      typedoc-plugin-merge-modules: 6.1.0(typedoc@0.26.11(typescript@5.6.3))
       typescript: 5.6.3
       wtfnode: 0.9.4
       yargs: 17.7.2
@@ -11084,61 +11084,61 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
-  '@oxfmt/binding-android-arm-eabi@0.41.0':
+  '@oxfmt/binding-android-arm-eabi@0.47.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.41.0':
+  '@oxfmt/binding-android-arm64@0.47.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.41.0':
+  '@oxfmt/binding-darwin-arm64@0.47.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.41.0':
+  '@oxfmt/binding-darwin-x64@0.47.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.41.0':
+  '@oxfmt/binding-freebsd-x64@0.47.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.41.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.47.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.41.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.47.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.41.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.47.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.41.0':
+  '@oxfmt/binding-linux-arm64-musl@0.47.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.41.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.47.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.41.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.47.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.41.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.47.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.41.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.47.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.41.0':
+  '@oxfmt/binding-linux-x64-gnu@0.47.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.41.0':
+  '@oxfmt/binding-linux-x64-musl@0.47.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.41.0':
+  '@oxfmt/binding-openharmony-arm64@0.47.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.41.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.47.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.41.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.47.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.41.0':
+  '@oxfmt/binding-win32-x64-msvc@0.47.0':
     optional: true
 
   '@parcel/watcher-android-arm64@2.5.6':
@@ -15270,29 +15270,29 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  oxfmt@0.41.0:
+  oxfmt@0.47.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.41.0
-      '@oxfmt/binding-android-arm64': 0.41.0
-      '@oxfmt/binding-darwin-arm64': 0.41.0
-      '@oxfmt/binding-darwin-x64': 0.41.0
-      '@oxfmt/binding-freebsd-x64': 0.41.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.41.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.41.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.41.0
-      '@oxfmt/binding-linux-arm64-musl': 0.41.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.41.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.41.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.41.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.41.0
-      '@oxfmt/binding-linux-x64-gnu': 0.41.0
-      '@oxfmt/binding-linux-x64-musl': 0.41.0
-      '@oxfmt/binding-openharmony-arm64': 0.41.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.41.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.41.0
-      '@oxfmt/binding-win32-x64-msvc': 0.41.0
+      '@oxfmt/binding-android-arm-eabi': 0.47.0
+      '@oxfmt/binding-android-arm64': 0.47.0
+      '@oxfmt/binding-darwin-arm64': 0.47.0
+      '@oxfmt/binding-darwin-x64': 0.47.0
+      '@oxfmt/binding-freebsd-x64': 0.47.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.47.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.47.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.47.0
+      '@oxfmt/binding-linux-arm64-musl': 0.47.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.47.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.47.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.47.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.47.0
+      '@oxfmt/binding-linux-x64-gnu': 0.47.0
+      '@oxfmt/binding-linux-x64-musl': 0.47.0
+      '@oxfmt/binding-openharmony-arm64': 0.47.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.47.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.47.0
+      '@oxfmt/binding-win32-x64-msvc': 0.47.0
 
   p-cancelable@2.1.1: {}
 
@@ -16411,7 +16411,7 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typedoc-plugin-merge-modules@6.1.0(typedoc@0.26.11(typescript@6.0.2)):
+  typedoc-plugin-merge-modules@6.1.0(typedoc@0.26.11(typescript@5.6.3)):
     dependencies:
       typedoc: 0.26.11(typescript@5.6.3)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,8 +47,8 @@ catalogs:
       specifier: ^6.1.3
       version: 6.1.3
     typescript:
-      specifier: ~5.7.3
-      version: 5.7.3
+      specifier: ~6.0.0
+      version: 6.0.2
     vite:
       specifier: ^8.0.10
       version: 8.0.10
@@ -284,7 +284,7 @@ importers:
         version: 5.8.4(@itwin/core-backend@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))(@opentelemetry/api@1.9.1))(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))(@itwin/ecschema-rpcinterface-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@itwin/imodel-components-react':
         specifier: catalog:appui
         version: 5.28.1(e24bef75024b3d87bcddb3418493ed11)
@@ -389,7 +389,7 @@ importers:
         version: 1.99.0
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
       vitest:
         specifier: catalog:test-tools
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
@@ -416,7 +416,7 @@ importers:
         version: 5.8.4(@itwin/core-backend@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))(@opentelemetry/api@1.9.1))(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))(@itwin/ecschema-rpcinterface-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@itwin/express-server':
         specifier: catalog:itwinjs-core-dev
         version: 5.8.4(@itwin/core-backend@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))(@opentelemetry/api@1.9.1))(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))
@@ -437,7 +437,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
 
   apps/load-tests/tests:
     devDependencies:
@@ -455,7 +455,7 @@ importers:
         version: 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@itwin/presentation-common':
         specifier: catalog:itwinjs-core-dev
         version: 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))
@@ -494,7 +494,7 @@ importers:
         version: 7.8.2
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
 
   apps/performance-tests:
     devDependencies:
@@ -518,7 +518,7 @@ importers:
         version: 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@itwin/presentation-core-interop':
         specifier: workspace:*
         version: link:../../packages/core-interop
@@ -557,7 +557,7 @@ importers:
         version: 7.8.2
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
       vitest:
         specifier: catalog:test-tools
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
@@ -584,7 +584,7 @@ importers:
         version: 5.8.4(@itwin/core-backend@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))(@opentelemetry/api@1.9.1))(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))(@itwin/ecschema-rpcinterface-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@itwin/express-server':
         specifier: catalog:itwinjs-core-dev
         version: 5.8.4(@itwin/core-backend@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))(@opentelemetry/api@1.9.1))(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))
@@ -626,7 +626,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
 
   apps/test-app/common:
     devDependencies:
@@ -644,7 +644,7 @@ importers:
         version: 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@itwin/presentation-common':
         specifier: catalog:itwinjs-core-dev
         version: 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))
@@ -656,7 +656,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
 
   apps/test-app/frontend:
     devDependencies:
@@ -707,7 +707,7 @@ importers:
         version: 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@itwin/imodel-components-react':
         specifier: catalog:appui
         version: 5.28.1(e24bef75024b3d87bcddb3418493ed11)
@@ -803,7 +803,7 @@ importers:
         version: 1.99.0
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
       vite:
         specifier: catalog:build-tools
         version: 8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3)
@@ -879,7 +879,7 @@ importers:
         version: 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@itwin/imodel-components-react':
         specifier: catalog:appui
         version: 5.28.1(e24bef75024b3d87bcddb3418493ed11)
@@ -945,7 +945,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
       vitest:
         specifier: catalog:test-tools
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
@@ -979,7 +979,7 @@ importers:
         version: 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@vitest/coverage-v8':
         specifier: catalog:test-tools
         version: 4.1.5(vitest@4.1.5)
@@ -997,7 +997,7 @@ importers:
         version: 1.0.0(rxjs@7.8.2)
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
       vitest:
         specifier: catalog:test-tools
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
@@ -1028,7 +1028,7 @@ importers:
         version: 5.8.4(@types/node@24.12.2)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@types/natural-compare-lite':
         specifier: ^1.4.2
         version: 1.4.2
@@ -1052,7 +1052,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
       vitest:
         specifier: catalog:test-tools
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
@@ -1095,7 +1095,7 @@ importers:
         version: 5.8.4(@types/node@24.12.2)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@itwin/itwinui-react':
         specifier: catalog:itwinui
         version: 3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1146,7 +1146,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
       vitest:
         specifier: catalog:test-tools
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
@@ -1168,7 +1168,7 @@ importers:
         version: 5.8.4(@types/node@24.12.2)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@itwin/presentation-hierarchies':
         specifier: workspace:^
         version: link:../hierarchies
@@ -1183,7 +1183,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
 
   packages/opentelemetry:
     devDependencies:
@@ -1192,7 +1192,7 @@ importers:
         version: 5.8.4(@types/node@24.12.2)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@itwin/presentation-common':
         specifier: catalog:itwinjs-core-dev
         version: 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))
@@ -1219,7 +1219,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
       vitest:
         specifier: catalog:test-tools
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
@@ -1235,7 +1235,7 @@ importers:
         version: 5.8.4(@types/node@24.12.2)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@types/node':
         specifier: catalog:build-tools
         version: 24.12.2
@@ -1253,7 +1253,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
       vitest:
         specifier: catalog:test-tools
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
@@ -1271,7 +1271,7 @@ importers:
         version: 5.8.4
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@types/node':
         specifier: catalog:build-tools
         version: 24.12.2
@@ -1286,7 +1286,7 @@ importers:
         version: 7.8.2
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
 
   packages/testing:
     dependencies:
@@ -1329,7 +1329,7 @@ importers:
         version: 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@itwin/presentation-backend':
         specifier: catalog:itwinjs-core-dev
         version: 5.8.4(@itwin/core-backend@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))(@opentelemetry/api@1.9.1))(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))(@itwin/presentation-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))))
@@ -1362,7 +1362,7 @@ importers:
         version: link:../test-utilities
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
       vitest:
         specifier: catalog:test-tools
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
@@ -1387,7 +1387,7 @@ importers:
         version: 5.8.4(@types/node@24.12.2)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@types/node':
         specifier: catalog:build-tools
         version: 24.12.2
@@ -1408,7 +1408,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
       vitest:
         specifier: catalog:test-tools
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
@@ -1420,7 +1420,7 @@ importers:
         version: 5.8.4(@types/node@24.12.2)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.0.0(eslint@9.39.4)(typescript@5.7.3)
+        version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
       '@itwin/unified-selection':
         specifier: workspace:^
         version: link:../unified-selection
@@ -1456,7 +1456,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 5.7.3
+        version: 6.0.2
       vitest:
         specifier: catalog:test-tools
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
@@ -7780,13 +7780,13 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -10196,7 +10196,7 @@ snapshots:
       rimraf: 6.1.3
       tree-kill: 1.2.2
       typedoc: 0.26.11(typescript@5.6.3)
-      typedoc-plugin-merge-modules: 6.1.0(typedoc@0.26.11(typescript@5.7.3))
+      typedoc-plugin-merge-modules: 6.1.0(typedoc@0.26.11(typescript@6.0.2))
       typescript: 5.6.3
       wtfnode: 0.9.4
       yargs: 17.7.2
@@ -10346,13 +10346,13 @@ snapshots:
       '@itwin/ecschema-metadata': 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4))
       '@itwin/ecschema-rpcinterface-common': 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))
 
-  '@itwin/eslint-plugin@6.0.0(eslint@9.39.4)(typescript@5.7.3)':
+  '@itwin/eslint-plugin@6.0.0(eslint@9.39.4)(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.7.3))(eslint@9.39.4)(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.2))(eslint@9.39.4)(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@6.0.2)
       eslint: 9.39.4
       eslint-formatter-visualstudio: 8.40.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.7.3))(eslint@9.39.4)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.2))(eslint@9.39.4)
       eslint-plugin-jam3: 0.2.3
       eslint-plugin-jsdoc: 51.4.1(eslint@9.39.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4)
@@ -10360,7 +10360,7 @@ snapshots:
       eslint-plugin-react: 7.37.5(eslint@9.39.4)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4)
       luxon: 3.7.2
-      typescript: 5.7.3
+      typescript: 6.0.2
       workspace-tools: 0.36.4
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
@@ -11912,40 +11912,31 @@ snapshots:
       '@types/node': 22.19.17
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.7.3))(eslint@9.39.4)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.2))(eslint@9.39.4)(typescript@6.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@6.0.2)
       '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/type-utils': 8.59.0(eslint@9.39.4)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.59.0(eslint@9.39.4)(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4)(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.59.0
       eslint: 9.39.4
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.5.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.0
       '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.59.0
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.59.0(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.7.3)
-      '@typescript-eslint/types': 8.59.0
-      debug: 4.4.3(supports-color@8.1.1)
-      typescript: 5.7.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -11958,47 +11949,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.59.0(typescript@6.0.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@6.0.2)
+      '@typescript-eslint/types': 8.59.0
+      debug: 4.4.3(supports-color@8.1.1)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.59.0':
     dependencies:
       '@typescript-eslint/types': 8.59.0
       '@typescript-eslint/visitor-keys': 8.59.0
 
-  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.7.3)':
-    dependencies:
-      typescript: 5.7.3
-
   '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.59.0(eslint@9.39.4)(typescript@5.7.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@6.0.2)':
+    dependencies:
+      typescript: 6.0.2
+
+  '@typescript-eslint/type-utils@8.59.0(eslint@9.39.4)(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4)(typescript@6.0.2)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4
-      ts-api-utils: 2.5.0(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.5.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.59.0': {}
-
-  '@typescript-eslint/typescript-estree@8.59.0(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.59.0(typescript@5.7.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.7.3)
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/visitor-keys': 8.59.0
-      debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 10.2.5
-      semver: 7.7.4
-      tinyglobby: 0.2.16
-      ts-api-utils: 2.5.0(typescript@5.7.3)
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/typescript-estree@8.59.0(typescript@5.9.3)':
     dependencies:
@@ -12015,14 +12000,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.0(eslint@9.39.4)(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.59.0(typescript@6.0.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.0(typescript@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@6.0.2)
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
+      debug: 4.4.3(supports-color@8.1.1)
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@6.0.2)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.59.0(eslint@9.39.4)(typescript@6.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
       '@typescript-eslint/scope-manager': 8.59.0
       '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.2)
       eslint: 9.39.4
-      typescript: 5.7.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13456,17 +13456,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.7.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@6.0.2)
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.7.3))(eslint@9.39.4):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.2))(eslint@9.39.4):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13477,7 +13477,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.7.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4)
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13489,7 +13489,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@6.0.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -16335,13 +16335,13 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.5
 
-  ts-api-utils@2.5.0(typescript@5.7.3):
-    dependencies:
-      typescript: 5.7.3
-
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-api-utils@2.5.0(typescript@6.0.2):
+    dependencies:
+      typescript: 6.0.2
 
   ts-key-enum@2.0.13: {}
 
@@ -16411,7 +16411,7 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typedoc-plugin-merge-modules@6.1.0(typedoc@0.26.11(typescript@5.7.3)):
+  typedoc-plugin-merge-modules@6.1.0(typedoc@0.26.11(typescript@6.0.2)):
     dependencies:
       typedoc: 0.26.11(typescript@5.6.3)
 
@@ -16426,9 +16426,9 @@ snapshots:
 
   typescript@5.6.3: {}
 
-  typescript@5.7.3: {}
-
   typescript@5.9.3: {}
+
+  typescript@6.0.2: {}
 
   uc.micro@1.0.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ catalogs:
       version: 5.28.1
   build-tools:
     '@itwin/build-tools':
-      specifier: ^5.8.4
-      version: 5.8.4
+      specifier: ^5.10.0-dev.1
+      version: 5.10.0-dev.1
     '@itwin/eslint-plugin':
       specifier: ^6.0.0
       version: 6.0.0
@@ -245,7 +245,7 @@ importers:
         version: 5.8.4(@itwin/core-bentley@5.8.4)
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/components-react':
         specifier: catalog:appui
         version: 5.28.1(@itwin/appui-abstract@5.8.4(@itwin/core-bentley@5.8.4))(@itwin/core-bentley@5.8.4)(@itwin/core-react@5.28.1(@itwin/appui-abstract@5.8.4(@itwin/core-bentley@5.8.4))(@itwin/core-bentley@5.8.4)(@itwin/itwinui-react@3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/itwinui-react@3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -398,7 +398,7 @@ importers:
     devDependencies:
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/core-backend':
         specifier: catalog:itwinjs-core-dev
         version: 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))(@opentelemetry/api@1.9.1)
@@ -443,7 +443,7 @@ importers:
     devDependencies:
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/core-bentley':
         specifier: catalog:itwinjs-core-dev
         version: 5.8.4
@@ -503,7 +503,7 @@ importers:
         version: 1.0.4
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/core-backend':
         specifier: catalog:itwinjs-core-dev
         version: 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))(@opentelemetry/api@1.9.1)
@@ -566,7 +566,7 @@ importers:
     devDependencies:
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/core-backend':
         specifier: catalog:itwinjs-core-dev
         version: 5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-common@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-geometry@5.8.4))(@itwin/core-geometry@5.8.4)(@itwin/ecschema-metadata@5.8.4(@itwin/core-bentley@5.8.4)(@itwin/core-quantity@5.8.4(@itwin/core-bentley@5.8.4)))(@opentelemetry/api@1.9.1)
@@ -632,7 +632,7 @@ importers:
     devDependencies:
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/core-bentley':
         specifier: catalog:itwinjs-core-dev
         version: 5.8.4
@@ -671,7 +671,7 @@ importers:
         version: 5.28.1(8df7b0427c66dc08c73cdc44f3df3a0e)
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/components-react':
         specifier: catalog:appui
         version: 5.28.1(@itwin/appui-abstract@5.8.4(@itwin/core-bentley@5.8.4))(@itwin/core-bentley@5.8.4)(@itwin/core-react@5.28.1(@itwin/appui-abstract@5.8.4(@itwin/core-bentley@5.8.4))(@itwin/core-bentley@5.8.4)(@itwin/itwinui-react@3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/itwinui-react@3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -852,7 +852,7 @@ importers:
         version: 5.8.4(@itwin/core-bentley@5.8.4)
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/components-react':
         specifier: catalog:appui
         version: 5.28.1(@itwin/appui-abstract@5.8.4(@itwin/core-bentley@5.8.4))(@itwin/core-bentley@5.8.4)(@itwin/core-react@5.28.1(@itwin/appui-abstract@5.8.4(@itwin/core-bentley@5.8.4))(@itwin/core-bentley@5.8.4)(@itwin/itwinui-react@3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/itwinui-react@3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -961,7 +961,7 @@ importers:
     devDependencies:
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/core-bentley':
         specifier: catalog:itwinjs-core-dev
         version: 5.8.4
@@ -1025,7 +1025,7 @@ importers:
     devDependencies:
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
         version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
@@ -1092,7 +1092,7 @@ importers:
     devDependencies:
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
         version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
@@ -1165,7 +1165,7 @@ importers:
     devDependencies:
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
         version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
@@ -1189,7 +1189,7 @@ importers:
     devDependencies:
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
         version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
@@ -1232,7 +1232,7 @@ importers:
     devDependencies:
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
         version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
@@ -1305,7 +1305,7 @@ importers:
         version: 5.8.4(@itwin/core-bentley@5.8.4)
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/components-react':
         specifier: catalog:appui
         version: 5.28.1(@itwin/appui-abstract@5.8.4(@itwin/core-bentley@5.8.4))(@itwin/core-bentley@5.8.4)(@itwin/core-react@5.28.1(@itwin/appui-abstract@5.8.4(@itwin/core-bentley@5.8.4))(@itwin/core-bentley@5.8.4)(@itwin/itwinui-react@3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@itwin/itwinui-react@3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1384,7 +1384,7 @@ importers:
     devDependencies:
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
         version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
@@ -1417,7 +1417,7 @@ importers:
     devDependencies:
       '@itwin/build-tools':
         specifier: catalog:build-tools
-        version: 5.8.4(@types/node@24.12.2)
+        version: 5.10.0-dev.1(@types/node@24.12.2)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
         version: 6.0.0(eslint@9.39.4)(typescript@6.0.2)
@@ -2220,6 +2220,9 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@gerrit0/mini-shiki@3.23.0':
+    resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
+
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
     engines: {node: '>=12.10.0'}
@@ -2420,8 +2423,8 @@ packages:
       react-redux: ^7.2.2 || ^8.0.0 || ^9.0.0
       redux: ^4.1.0 || ^5.0.0
 
-  '@itwin/build-tools@5.8.4':
-    resolution: {integrity: sha512-BhT6VCVxTPpDbiTOUypyjq4Ms+L9kQzfp0D0lKFar+BUbkPUXZ20msGbaWCP0PVDarq3313nevCVK/502HwpZg==}
+  '@itwin/build-tools@5.10.0-dev.1':
+    resolution: {integrity: sha512-DTyourHfTLEaphiX1yLwc5Rxmg0CEtnNqBK18jAk3IAmmcTZ3cZjQ2YRPCh8uzHPgpnihmMblJtn1SxcqDv9Aw==}
     hasBin: true
 
   '@itwin/cloud-agnostic-core@3.0.5':
@@ -3495,23 +3498,17 @@ packages:
   '@rushstack/ts-command-line@5.3.9':
     resolution: {integrity: sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==}
 
-  '@shikijs/core@1.29.2':
-    resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
 
-  '@shikijs/engine-javascript@1.29.2':
-    resolution: {integrity: sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==}
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
 
-  '@shikijs/engine-oniguruma@1.29.2':
-    resolution: {integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==}
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
 
-  '@shikijs/langs@1.29.2':
-    resolution: {integrity: sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==}
-
-  '@shikijs/themes@1.29.2':
-    resolution: {integrity: sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==}
-
-  '@shikijs/types@1.29.2':
-    resolution: {integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==}
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -3867,9 +3864,6 @@ packages:
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
-  '@types/mdast@4.0.4':
-    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
-
   '@types/natural-compare-lite@1.4.2':
     resolution: {integrity: sha512-kk1ie31cI6AUm17qOi72lEOBfpRhcknJPsJQoKBulaZC9y00MHUWqxGTk/luWEnenLB+lHoNThrKAKdYVydlew==}
 
@@ -3988,9 +3982,6 @@ packages:
   '@typespec/ts-http-runtime@0.3.5':
     resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
     engines: {node: '>=20.0.0'}
-
-  '@ungap/structured-clone@1.3.0':
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@upstash/redis@1.37.0':
     resolution: {integrity: sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==}
@@ -4418,9 +4409,6 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  ccount@2.0.1:
-    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
-
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -4444,12 +4432,6 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
-  character-entities-html4@2.1.0:
-    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
-
-  character-entities-legacy@3.0.0:
-    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -4544,9 +4526,6 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
-
-  comma-separated-tokens@2.0.3:
-    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -4881,9 +4860,6 @@ packages:
     peerDependencies:
       typescript: ^5.4.4 || ^6.0.2
 
-  devlop@1.1.0:
-    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
   diff@7.0.0:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
@@ -4961,9 +4937,6 @@ packages:
     resolution: {integrity: sha512-0zgNu0MmWR/kzFm+B+LlvpLOX8l3wt1z+BJIYv2Uxc2bEqWBT3jNsX1IhPVP5OJijjZO5ewCOIy0n/bsfJfjdw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
-
-  emoji-regex-xs@1.0.0:
-    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -5640,12 +5613,6 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hast-util-to-html@9.0.5:
-    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
-
-  hast-util-whitespace@3.0.0:
-    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
-
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
@@ -5669,9 +5636,6 @@ packages:
 
   html-link-extractor@1.0.5:
     resolution: {integrity: sha512-ADd49pudM157uWHwHQPUSX4ssMsvR/yHIswOR5CUfBdK9g9ZYGMhVSE6KZVHJ6kCkR0gH4htsfzU6zECDNVwyw==}
-
-  html-void-elements@3.0.0:
-    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
@@ -6393,9 +6357,6 @@ packages:
   md5@2.3.0:
     resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
 
-  mdast-util-to-hast@13.2.1:
-    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
-
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
@@ -6430,21 +6391,6 @@ packages:
 
   micro-memoize@4.2.0:
     resolution: {integrity: sha512-dRxIsNh0XosO9sd3aASUabKOzG9dloLO41g74XUGThpHBoGm1ttakPT5in14CuW/EDedkniaShFHbymmmKGOQA==}
-
-  micromark-util-character@2.1.1:
-    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
-
-  micromark-util-encode@2.0.1:
-    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
-
-  micromark-util-sanitize-uri@2.0.1:
-    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
-
-  micromark-util-symbol@2.0.1:
-    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
-
-  micromark-util-types@2.0.2:
-    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -6713,9 +6659,6 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
-
-  oniguruma-to-es@2.3.0:
-    resolution: {integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==}
 
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
@@ -6986,9 +6929,6 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  property-information@7.1.0:
-    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
-
   protobufjs@7.5.5:
     resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
@@ -7149,15 +7089,6 @@ packages:
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
-
-  regex-recursion@5.1.1:
-    resolution: {integrity: sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==}
-
-  regex-utilities@2.3.0:
-    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
-
-  regex@5.1.1:
-    resolution: {integrity: sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -7383,9 +7314,6 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
-  shiki@1.29.2:
-    resolution: {integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==}
-
   shimmer@1.2.1:
     resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
 
@@ -7461,9 +7389,6 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-
-  space-separated-tokens@2.0.2:
-    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
@@ -7554,9 +7479,6 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
-
-  stringify-entities@4.0.4:
-    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   stringify-object@3.3.0:
     resolution: {integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==}
@@ -7698,9 +7620,6 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  trim-lines@3.0.1:
-    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
-
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
@@ -7763,17 +7682,17 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typedoc-plugin-merge-modules@6.1.0:
-    resolution: {integrity: sha512-AZIyw+H1oG3xpJOq1b2CVnpK7A6OIddi7FsjljsbmQ7vx6dtaorEoz/DQPcGSOzWhWdJPqqdncIzVySuoffS2w==}
+  typedoc-plugin-merge-modules@7.0.0:
+    resolution: {integrity: sha512-DQyfbbPNBElhpdpGrlkS+CrhGD3iooDjp/PHT8O1D/jumLCB+7XAY3jHiqob7d01o25EfwEOJWVwJK+9J6WlBg==}
     peerDependencies:
-      typedoc: 0.26.x || ^0.27.1
+      typedoc: 0.28.x
 
-  typedoc@0.26.11:
-    resolution: {integrity: sha512-sFEgRRtrcDl2FxVP58Ze++ZK2UQAEvtvvH8rRlig1Ja3o7dDaMHmaBfvJmdGnNEFaLTpQsN8dpvZaTqJSu/Ugw==}
-    engines: {node: '>= 18'}
+  typedoc@0.28.19:
+    resolution: {integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==}
+    engines: {node: '>= 18', pnpm: '>= 10'}
     hasBin: true
     peerDependencies:
-      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || ^5.7.0
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x || ^5.7.0
 
   typescript@5.6.3:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
@@ -7824,21 +7743,6 @@ packages:
     resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
     engines: {node: '>=12'}
 
-  unist-util-is@6.0.1:
-    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
-
-  unist-util-position@5.0.0:
-    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
-
-  unist-util-stringify-position@4.0.0:
-    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
-
-  unist-util-visit-parents@6.0.2:
-    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
-
-  unist-util-visit@5.1.0:
-    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
-
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -7888,12 +7792,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  vfile-message@4.0.3:
-    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
-
-  vfile@6.0.3:
-    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-plugin-static-copy@4.1.0:
     resolution: {integrity: sha512-9XOarNV7LgP0KBB7AApxdgFikLXx3daZdqjC3AevYsL6MrUH62zphonLUs2a6LZc1HN1GY+vQdheZ8VVJb6dQQ==}
@@ -8223,9 +8121,6 @@ packages:
         optional: true
       react:
         optional: true
-
-  zwitch@2.0.4:
-    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -9980,6 +9875,14 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@gerrit0/mini-shiki@3.23.0':
+    dependencies:
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@grpc/grpc-js@1.14.3':
     dependencies:
       '@grpc/proto-loader': 0.8.0
@@ -10183,7 +10086,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@itwin/build-tools@5.8.4(@types/node@24.12.2)':
+  '@itwin/build-tools@5.10.0-dev.1(@types/node@24.12.2)':
     dependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@24.12.2)
       chalk: 3.0.0
@@ -10195,8 +10098,8 @@ snapshots:
       mocha-junit-reporter: 2.2.1(mocha@11.7.5)
       rimraf: 6.1.3
       tree-kill: 1.2.2
-      typedoc: 0.26.11(typescript@5.6.3)
-      typedoc-plugin-merge-modules: 6.1.0(typedoc@0.26.11(typescript@5.6.3))
+      typedoc: 0.28.19(typescript@5.6.3)
+      typedoc-plugin-merge-modules: 7.0.0(typedoc@0.28.19(typescript@6.0.2))
       typescript: 5.6.3
       wtfnode: 0.9.4
       yargs: 17.7.2
@@ -11338,35 +11241,20 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@shikijs/core@1.29.2':
+  '@shikijs/engine-oniguruma@3.23.0':
     dependencies:
-      '@shikijs/engine-javascript': 1.29.2
-      '@shikijs/engine-oniguruma': 1.29.2
-      '@shikijs/types': 1.29.2
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-      hast-util-to-html: 9.0.5
-
-  '@shikijs/engine-javascript@1.29.2':
-    dependencies:
-      '@shikijs/types': 1.29.2
-      '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 2.3.0
-
-  '@shikijs/engine-oniguruma@1.29.2':
-    dependencies:
-      '@shikijs/types': 1.29.2
+      '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/langs@1.29.2':
+  '@shikijs/langs@3.23.0':
     dependencies:
-      '@shikijs/types': 1.29.2
+      '@shikijs/types': 3.23.0
 
-  '@shikijs/themes@1.29.2':
+  '@shikijs/themes@3.23.0':
     dependencies:
-      '@shikijs/types': 1.29.2
+      '@shikijs/types': 3.23.0
 
-  '@shikijs/types@1.29.2':
+  '@shikijs/types@3.23.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -11855,10 +11743,6 @@ snapshots:
     dependencies:
       '@types/node': 24.12.2
 
-  '@types/mdast@4.0.4':
-    dependencies:
-      '@types/unist': 3.0.3
-
   '@types/natural-compare-lite@1.4.2': {}
 
   '@types/node@12.20.55': {}
@@ -12038,8 +11922,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
-
-  '@ungap/structured-clone@1.3.0': {}
 
   '@upstash/redis@1.37.0':
     dependencies:
@@ -12622,8 +12504,6 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  ccount@2.0.1: {}
-
   chai@6.2.2: {}
 
   chalk-template@1.1.2:
@@ -12647,10 +12527,6 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
-
-  character-entities-html4@2.1.0: {}
-
-  character-entities-legacy@3.0.0: {}
 
   chardet@2.1.1: {}
 
@@ -12762,8 +12638,6 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
-
-  comma-separated-tokens@2.0.3: {}
 
   commander@12.1.0: {}
 
@@ -13162,10 +13036,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  devlop@1.1.0:
-    dependencies:
-      dequal: 2.0.3
-
   diff@7.0.0: {}
 
   diff@8.0.4: {}
@@ -13250,8 +13120,6 @@ snapshots:
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
-
-  emoji-regex-xs@1.0.0: {}
 
   emoji-regex@10.6.0: {}
 
@@ -14114,24 +13982,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hast-util-to-html@9.0.5:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      ccount: 2.0.1
-      comma-separated-tokens: 2.0.3
-      hast-util-whitespace: 3.0.0
-      html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.1
-      property-information: 7.1.0
-      space-separated-tokens: 2.0.2
-      stringify-entities: 4.0.4
-      zwitch: 2.0.4
-
-  hast-util-whitespace@3.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-
   he@1.2.0: {}
 
   hosted-git-info@2.8.9: {}
@@ -14152,8 +14002,6 @@ snapshots:
   html-link-extractor@1.0.5:
     dependencies:
       cheerio: 1.2.0
-
-  html-void-elements@3.0.0: {}
 
   htmlparser2@10.1.0:
     dependencies:
@@ -14899,18 +14747,6 @@ snapshots:
       crypt: 0.0.2
       is-buffer: 1.1.6
 
-  mdast-util-to-hast@13.2.1:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.3.0
-      devlop: 1.1.0
-      micromark-util-sanitize-uri: 2.0.1
-      trim-lines: 3.0.1
-      unist-util-position: 5.0.0
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-
   mdurl@2.0.0: {}
 
   media-typer@0.3.0: {}
@@ -14932,23 +14768,6 @@ snapshots:
   methods@1.1.2: {}
 
   micro-memoize@4.2.0: {}
-
-  micromark-util-character@2.1.1:
-    dependencies:
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-util-encode@2.0.1: {}
-
-  micromark-util-sanitize-uri@2.0.1:
-    dependencies:
-      micromark-util-character: 2.1.1
-      micromark-util-encode: 2.0.1
-      micromark-util-symbol: 2.0.1
-
-  micromark-util-symbol@2.0.1: {}
-
-  micromark-util-types@2.0.2: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -15219,12 +15038,6 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
-
-  oniguruma-to-es@2.3.0:
-    dependencies:
-      emoji-regex-xs: 1.0.0
-      regex: 5.1.1
-      regex-recursion: 5.1.1
 
   open@10.2.0:
     dependencies:
@@ -15511,8 +15324,6 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  property-information@7.1.0: {}
-
   protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -15698,17 +15509,6 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
-
-  regex-recursion@5.1.1:
-    dependencies:
-      regex: 5.1.1
-      regex-utilities: 2.3.0
-
-  regex-utilities@2.3.0: {}
-
-  regex@5.1.1:
-    dependencies:
-      regex-utilities: 2.3.0
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -15980,17 +15780,6 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
-  shiki@1.29.2:
-    dependencies:
-      '@shikijs/core': 1.29.2
-      '@shikijs/engine-javascript': 1.29.2
-      '@shikijs/engine-oniguruma': 1.29.2
-      '@shikijs/langs': 1.29.2
-      '@shikijs/themes': 1.29.2
-      '@shikijs/types': 1.29.2
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-
   shimmer@1.2.1: {}
 
   side-channel-list@1.0.1:
@@ -16079,8 +15868,6 @@ snapshots:
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
-
-  space-separated-tokens@2.0.2: {}
 
   spawndamnit@3.0.1:
     dependencies:
@@ -16208,11 +15995,6 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  stringify-entities@4.0.4:
-    dependencies:
-      character-entities-html4: 2.1.0
-      character-entities-legacy: 3.0.0
-
   stringify-object@3.3.0:
     dependencies:
       get-own-enumerable-property-symbols: 3.0.2
@@ -16329,8 +16111,6 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  trim-lines@3.0.1: {}
-
   truncate-utf8-bytes@1.0.2:
     dependencies:
       utf8-byte-length: 1.0.5
@@ -16411,16 +16191,16 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typedoc-plugin-merge-modules@6.1.0(typedoc@0.26.11(typescript@5.6.3)):
+  typedoc-plugin-merge-modules@7.0.0(typedoc@0.28.19(typescript@6.0.2)):
     dependencies:
-      typedoc: 0.26.11(typescript@5.6.3)
+      typedoc: 0.28.19(typescript@5.6.3)
 
-  typedoc@0.26.11(typescript@5.6.3):
+  typedoc@0.28.19(typescript@5.6.3):
     dependencies:
+      '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
       markdown-it: 14.1.1
-      minimatch: 9.0.9
-      shiki: 1.29.2
+      minimatch: 10.2.5
       typescript: 5.6.3
       yaml: 2.8.3
 
@@ -16462,29 +16242,6 @@ snapshots:
     dependencies:
       crypto-random-string: 4.0.0
 
-  unist-util-is@6.0.1:
-    dependencies:
-      '@types/unist': 3.0.3
-
-  unist-util-position@5.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-
-  unist-util-stringify-position@4.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-
-  unist-util-visit-parents@6.0.2:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.1
-
-  unist-util-visit@5.1.0:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.1
-      unist-util-visit-parents: 6.0.2
-
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
@@ -16524,16 +16281,6 @@ snapshots:
   validator@13.15.35: {}
 
   vary@1.1.2: {}
-
-  vfile-message@4.0.3:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-stringify-position: 4.0.0
-
-  vfile@6.0.3:
-    dependencies:
-      '@types/unist': 3.0.3
-      vfile-message: 4.0.3
 
   vite-plugin-static-copy@4.1.0(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3)):
     dependencies:
@@ -16812,5 +16559,3 @@ snapshots:
       '@types/react': 18.3.28
       immer: 10.2.0
       react: 18.3.1
-
-  zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ catalogs:
     eslint: ^9.39.4
     eslint-plugin-react: ^7.37.5
     rimraf: ^6.1.3
-    typescript: ~5.7.3
+    typescript: ~6.0.0
     vite: ^8.0.10
   itwinjs-core:
     '@itwin/core-bentley': ^5.8.4
@@ -83,4 +83,4 @@ onlyBuiltDependencies:
 
 resolutionMode: lowest-direct
 
-strictPeerDependencies: true
+strictPeerDependencies: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalogs:
     '@itwin/core-react': ^5.28.1
     '@itwin/imodel-components-react': ^5.28.1
   build-tools:
-    '@itwin/build-tools': ^5.8.4
+    '@itwin/build-tools': ^5.10.0-dev.1
     '@itwin/eslint-plugin': ^6.0.0
     '@types/node': ^24.12.2
     '@vitejs/plugin-react': ^6.0.1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ES2022",
-    "lib": ["dom", "ES2022"],
+    "lib": ["dom", "ESNext"],
     "strict": true,
     "skipLibCheck": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Updated repo to use TypeScript 6. Key changes:
`@types` package are not picked up automatically. `types` field needs to be added.
`rootDir` is required. For typecheking tsconfig set that to `.` and for build tsconfig used `./src` to avoid introducing `src` folder under `lib`
`"moduleResolution": "Node"` previously used for commonjs build is deprecated and will be removed in 7.0. Didn't want to ignore compiler deprecations to be ready for 7.0. Use `"moduleResolution": "Bundler"` as that was only one non deprecated mode that working with `"module": "CommonJS"`.
Added module declarations for `.css` and `.scss` files.
Switched `load-tests` to ESM to reduce `CommonJS` usage in the repo. I think only dual build packages should use `CommonJS`.

Strict peer deps settings can be turned back on after build-tools and eslint-plugin new versions are consumed.