### PR TITLE
Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
     "eslint-config-prettier": "^9.1.2",
     "fast-glob": "^3.3.3",
     "husky": "^9.1.7",
-    "lage": "^2.15.9",
+    "lage": "^2.15.12",
     "lint-staged": "^15.5.2",
     "markdown-link-check": "^3.14.2",
     "npm-run-all": "^4.1.5",
     "oxfmt": "^0.47.0",
     "rimraf": "catalog:build-tools",
-    "yaml": "^2.8.3",
+    "yaml": "^2.8.4",
     "yargs": "^17.7.2"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,8 +211,8 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       lage:
-        specifier: ^2.15.9
-        version: 2.15.9
+        specifier: ^2.15.12
+        version: 2.15.12
       lint-staged:
         specifier: ^15.5.2
         version: 15.5.2
@@ -229,8 +229,8 @@ importers:
         specifier: catalog:build-tools
         version: 6.1.3
       yaml:
-        specifier: ^2.8.3
-        version: 2.8.3
+        specifier: ^2.8.4
+        version: 2.8.4
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -392,7 +392,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: catalog:test-tools
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))
 
   apps/load-tests/backend:
     devDependencies:
@@ -560,7 +560,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: catalog:test-tools
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))
 
   apps/test-app/backend:
     devDependencies:
@@ -764,7 +764,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: catalog:build-tools
-        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))
       classnames:
         specifier: catalog:react
         version: 2.5.1
@@ -806,10 +806,10 @@ importers:
         version: 6.0.2
       vite:
         specifier: catalog:build-tools
-        version: 8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3)
+        version: 8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4)
       vite-plugin-static-copy:
         specifier: ^4.1.0
-        version: 4.1.0(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
+        version: 4.1.0(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))
 
   packages/components:
     dependencies:
@@ -948,7 +948,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: catalog:test-tools
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))
 
   packages/core-interop:
     dependencies:
@@ -1000,7 +1000,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: catalog:test-tools
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))
 
   packages/hierarchies:
     dependencies:
@@ -1055,7 +1055,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: catalog:test-tools
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))
 
   packages/hierarchies-react:
     dependencies:
@@ -1149,7 +1149,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: catalog:test-tools
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))
 
   packages/models-tree:
     dependencies:
@@ -1222,7 +1222,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: catalog:test-tools
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))
 
   packages/shared:
     dependencies:
@@ -1256,7 +1256,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: catalog:test-tools
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))
 
   packages/test-utilities:
     devDependencies:
@@ -1332,7 +1332,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: catalog:test-tools
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))
 
   packages/unified-selection-react:
     devDependencies:
@@ -1380,7 +1380,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: catalog:test-tools
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))
 
 packages:
 
@@ -5717,8 +5717,8 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -6067,8 +6067,8 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  lage@2.15.9:
-    resolution: {integrity: sha512-xK8xzEgsjUyUkcpnTiWaxL001NdwJ7RQovoqSg8g/Ipe39mzhEaSfzR/M4CLgsnHuESaZpgWFzgqHCq9pxoS1w==}
+  lage@2.15.12:
+    resolution: {integrity: sha512-4q7IqUo9Czae79DfRDfn+DJFc9eiQjEVh0t5GLGCXcWlwL1fkZgP2TE7LBtc2hBq4+FANB407a2VXkstdIQumg==}
     engines: {node: '>=16.14.0'}
     hasBin: true
 
@@ -7337,8 +7337,8 @@ packages:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
 
-  socks@2.8.7:
-    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+  socks@2.8.8:
+    resolution: {integrity: sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   source-map-js@1.2.1:
@@ -8038,8 +8038,8 @@ packages:
     resolution: {integrity: sha512-LjoIFHCtSfkGzPsmYmfDsW+TShtQBcY7lwH1yLQ5brJHXRhjteUnVE2ThCbz1madq8JUZIAjFiavfnIFeTO8CQ==}
     engines: {node: '>=8'}
 
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+  yaml@2.8.4:
+    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -10058,7 +10058,7 @@ snapshots:
       rimraf: 6.1.3
       tree-kill: 1.2.2
       typedoc: 0.28.19(typescript@5.6.3)
-      typedoc-plugin-merge-modules: 7.0.0(typedoc@0.28.19(typescript@6.0.2))
+      typedoc-plugin-merge-modules: 7.0.0(typedoc@0.28.19(typescript@5.6.3))
       typescript: 5.6.3
       wtfnode: 0.9.4
       yargs: 17.7.2
@@ -11907,10 +11907,10 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4)
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
@@ -11924,7 +11924,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -11935,13 +11935,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -12724,7 +12724,7 @@ snapshots:
       '@cspell/cspell-types': 9.8.0
       comment-json: 4.6.2
       smol-toml: 1.6.1
-      yaml: 2.8.3
+      yaml: 2.8.4
 
   cspell-dictionary@9.8.0:
     dependencies:
@@ -14117,7 +14117,7 @@ snapshots:
       hasown: 2.0.3
       side-channel: 1.1.0
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -14475,7 +14475,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  lage@2.15.9:
+  lage@2.15.12:
     dependencies:
       glob-hasher: 1.4.2
     optionalDependencies:
@@ -14577,7 +14577,7 @@ snapshots:
       micromatch: 4.0.8
       pidtree: 0.6.0
       string-argv: 0.3.2
-      yaml: 2.8.3
+      yaml: 2.8.4
     transitivePeerDependencies:
       - supports-color
 
@@ -15836,13 +15836,13 @@ snapshots:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
-      socks: 2.8.7
+      socks: 2.8.8
     transitivePeerDependencies:
       - supports-color
 
-  socks@2.8.7:
+  socks@2.8.8:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
@@ -16171,7 +16171,7 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typedoc-plugin-merge-modules@7.0.0(typedoc@0.28.19(typescript@6.0.2)):
+  typedoc-plugin-merge-modules@7.0.0(typedoc@0.28.19(typescript@5.6.3)):
     dependencies:
       typedoc: 0.28.19(typescript@5.6.3)
 
@@ -16182,7 +16182,7 @@ snapshots:
       markdown-it: 14.1.1
       minimatch: 10.2.5
       typescript: 5.6.3
-      yaml: 2.8.3
+      yaml: 2.8.4
 
   typescript@5.6.3: {}
 
@@ -16262,15 +16262,15 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plugin-static-copy@4.1.0(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3)):
+  vite-plugin-static-copy@4.1.0(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.4
       picocolors: 1.1.1
       tinyglobby: 0.2.16
-      vite: 8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4)
 
-  vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3):
+  vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -16281,12 +16281,12 @@ snapshots:
       '@types/node': 24.12.2
       fsevents: 2.3.3
       sass: 1.99.0
-      yaml: 2.8.3
+      yaml: 2.8.4
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -16303,7 +16303,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.12.2)(sass@1.99.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -16502,7 +16502,7 @@ snapshots:
 
   yaml-js@0.3.1: {}
 
-  yaml@2.8.3: {}
+  yaml@2.8.4: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
before:
```
4 vulnerabilities found
Severity: 1 low | 2 moderate | 1 high
```

after:
```
3 vulnerabilities found
Severity: 1 low | 1 moderate | 1 high
```

As usual, the rest come from `@itwin/build-tools > mocha`.