### PR TITLE
Hierarchies: Use `ECDb` instead of `IModelConnection` in full stack tests

### DIFF
--- a/apps/full-stack-tests/src/ECDbUtils.ts
+++ b/apps/full-stack-tests/src/ECDbUtils.ts
@@ -284,20 +284,26 @@ export async function createChangedDbs<
 export async function buildTestECDb<TResult extends {} | undefined>(
   setup: (ecdbBuilder: ECDbBuilder, testName: string) => TResult | Promise<TResult>,
 ): Promise<TResult & { ecdb: ECDb } & Disposable>;
+export async function buildTestECDb<TResult extends {} | undefined>(
+  name: string,
+  setup: (ecdbBuilder: ECDbBuilder, testName: string) => TResult | Promise<TResult>,
+): Promise<TResult & { ecdb: ECDb } & Disposable>;
 export async function buildTestECDb(
   setup?: (ecdbBuilder: ECDbBuilder, testName: string) => void | Promise<void>,
 ): Promise<{ ecdb: ECDb } & Disposable>;
 export async function buildTestECDb<TResult extends {} | undefined>(
+  nameOrSetup?: string | ((ecdbBuilder: ECDbBuilder, testName: string) => TResult | Promise<TResult>),
   setup?: (ecdbBuilder: ECDbBuilder, testName: string) => TResult | Promise<TResult>,
 ): Promise<TResult & { ecdb: ECDb } & Disposable> {
-  const testName = getTestName();
+  const testName = typeof nameOrSetup === "string" ? nameOrSetup : getTestName();
+  const setupFn = typeof nameOrSetup === "function" ? nameOrSetup : setup;
   const name = createFileNameFromString(testName);
   const outputFilePath = setupOutputFileLocation(name);
   const ecdb = new ECDb();
   let setupResult: TResult | undefined;
   try {
     ecdb.createDb(outputFilePath);
-    setupResult = await setup?.(new ECDbBuilder(ecdb, outputFilePath), testName);
+    setupResult = await setupFn?.(new ECDbBuilder(ecdb, outputFilePath), testName);
     ecdb.saveChanges("Created test ECDb");
   } catch (e) {
     ecdb[Symbol.dispose]();

--- a/apps/full-stack-tests/src/ECDbUtils.ts
+++ b/apps/full-stack-tests/src/ECDbUtils.ts
@@ -286,7 +286,7 @@ export async function buildTestECDb<TResult extends {} | undefined>(
 ): Promise<TResult & { ecdb: ECDb } & Disposable>;
 export async function buildTestECDb<TResult extends {} | undefined>(
   name: string,
-  setup: (ecdbBuilder: ECDbBuilder, testName: string) => TResult | Promise<TResult>,
+  setup?: (ecdbBuilder: ECDbBuilder, testName: string) => TResult | Promise<TResult>,
 ): Promise<TResult & { ecdb: ECDb } & Disposable>;
 export async function buildTestECDb(
   setup?: (ecdbBuilder: ECDbBuilder, testName: string) => void | Promise<void>,

--- a/apps/full-stack-tests/src/hierarchies/CustomNodes.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/CustomNodes.test.ts
@@ -5,29 +5,28 @@
 
 import { afterAll, describe, it, test } from "vitest";
 import { HierarchyNode } from "@itwin/presentation-hierarchies";
-import { buildTestIModel } from "../IModelUtils.js";
+import { buildTestECDb } from "../ECDbUtils.js";
 import { initialize, terminate } from "../IntegrationTests.js";
 import { NodeValidators, validateHierarchy } from "./HierarchyValidation.js";
 import { createProvider } from "./Utils.js";
 
-import type { IModelConnection } from "@itwin/core-frontend";
-
 describe("Hierarchies", () => {
   describe("Generic nodes", () => {
-    let emptyIModel!: IModelConnection;
+    let suiteSetup!: Awaited<ReturnType<typeof buildTestECDb>>;
 
     test.beforeAll(async (_, suite) => {
       await initialize();
-      emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodelConnection;
+      suiteSetup = await buildTestECDb(suite.fullTestName!);
     });
 
     afterAll(async () => {
+      suiteSetup[Symbol.dispose]();
       await terminate();
     });
 
     it("creates generic root nodes", async () => {
       const provider = createProvider({
-        imodel: emptyIModel,
+        ecdb: suiteSetup.ecdb,
         hierarchy: {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {
@@ -48,7 +47,7 @@ describe("Hierarchies", () => {
 
     it("creates generic child nodes", async () => {
       const provider = createProvider({
-        imodel: emptyIModel,
+        ecdb: suiteSetup.ecdb,
         hierarchy: {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {
@@ -81,7 +80,7 @@ describe("Hierarchies", () => {
 
     it("creates hidden generic nodes", async () => {
       const provider = createProvider({
-        imodel: emptyIModel,
+        ecdb: suiteSetup.ecdb,
         hierarchy: {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {
@@ -110,7 +109,7 @@ describe("Hierarchies", () => {
 
     it("hides generic nodes with no children", async () => {
       const provider = createProvider({
-        imodel: emptyIModel,
+        ecdb: suiteSetup.ecdb,
         hierarchy: {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {

--- a/apps/full-stack-tests/src/hierarchies/Formatting.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/Formatting.test.ts
@@ -3,44 +3,44 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-  insertDrawingCategory,
-  insertDrawingGraphic,
-  insertDrawingModelWithPartition,
-  insertPhysicalElement,
-  insertPhysicalModelWithPartition,
-  insertPhysicalPartition,
-  insertPhysicalSubModel,
-  insertSheetIndexFolder,
-  insertSpatialCategory,
-} from "presentation-test-utilities";
 import { afterAll, describe, expect, it, test, vi } from "vitest";
-import { Subject, withEditTxn } from "@itwin/core-backend";
 import { Guid, Id64 } from "@itwin/core-bentley";
-import { IModel } from "@itwin/core-common";
 import { createValueFormatter } from "@itwin/presentation-core-interop";
-import { ECSql, julianToDateTime, normalizeFullClassName } from "@itwin/presentation-shared";
-import { buildTestIModel } from "../IModelUtils.js";
+import { ECSql } from "@itwin/presentation-shared";
+import { buildTestECDb } from "../ECDbUtils.js";
 import { initialize, terminate } from "../IntegrationTests.js";
 import { importSchema } from "../SchemaUtils.js";
 import { validateHierarchy } from "./HierarchyValidation.js";
 import { createIModelAccess, createProvider } from "./Utils.js";
 
-import type { IModelConnection } from "@itwin/core-frontend";
 import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
-import type { EC } from "@itwin/presentation-shared";
 
 describe("Hierarchies", () => {
-  let emptyIModel: IModelConnection;
-  let subjectClassName: EC.FullClassName;
+  let suiteSetup!: Awaited<ReturnType<typeof setupSuite>>;
+
+  async function setupSuite(fullTestName: string) {
+    return buildTestECDb(fullTestName, async (builder, testName) => {
+      const s = await importSchema(
+        testName,
+        builder,
+        `
+          <ECEntityClass typeName="X">
+            <ECProperty propertyName="UserLabel" typeName="string" />
+          </ECEntityClass>
+        `,
+      );
+      builder.insertInstance(s.items.X.fullName, { userLabel: "" });
+      return { schema: s };
+    });
+  }
 
   test.beforeAll(async (_, suite) => {
     await initialize();
-    emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodelConnection;
-    subjectClassName = normalizeFullClassName(Subject.classFullName);
+    suiteSetup = await setupSuite(suite.fullTestName!);
   });
 
   afterAll(async () => {
+    suiteSetup[Symbol.dispose]();
     await terminate();
   });
 
@@ -72,7 +72,7 @@ describe("Hierarchies", () => {
         },
       };
       await validateHierarchy({
-        provider: createProvider({ imodel: emptyIModel, hierarchy }),
+        provider: createProvider({ ecdb: suiteSetup.ecdb, hierarchy }),
         expect: [
           {
             node: (node) => {
@@ -87,36 +87,24 @@ describe("Hierarchies", () => {
 
     describe("KindOfQuantity", () => {
       it("formats instance node labels", async () => {
-        const { imodelConnection, schema } = await buildTestIModel(async (imodel, testName) => {
-          return withEditTxn(imodel, async (txn) => {
-            // eslint-disable-next-line @typescript-eslint/no-shadow
-            const schema = await importSchema(
-              testName,
-              imodel,
-              `
-                <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
-                <ECSchemaReference name="Units" version="01.00.07" alias="u" />
-                <ECSchemaReference name="Formats" version="01.00.00" alias="f" />
-                <KindOfQuantity typeName="LENGTH" persistenceUnit="u:M" presentationUnits="f:DefaultRealU(1)[u:M];f:DefaultRealU(1)[u:FT];f:DefaultRealU(2)[u:US_SURVEY_FT];f:AmerFI" relativeError="0.0001" />
-                <ECEntityClass typeName="ClassX">
-                  <BaseClass>bis:PhysicalElement</BaseClass>
-                  <ECProperty propertyName="PropX" typeName="double" kindOfQuantity="LENGTH" />
-                </ECEntityClass>
-              `,
-            );
-            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
-            const category = insertSpatialCategory({ txn, codeValue: "category" });
-            const element = insertPhysicalElement({
-              txn,
-              classFullName: schema.items.ClassX.fullName,
-              modelId: model.id,
-              categoryId: category.id,
-              ["PropX"]: 123.456,
-            });
-            return { schema, model, category, element };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECSchemaReference name="Units" version="01.00.07" alias="u" />
+              <ECSchemaReference name="Formats" version="01.00.00" alias="f" />
+              <KindOfQuantity typeName="LENGTH" persistenceUnit="u:M" presentationUnits="f:DefaultRealU(1)[u:M];f:DefaultRealU(1)[u:FT];f:DefaultRealU(2)[u:US_SURVEY_FT];f:AmerFI" relativeError="0.0001" />
+              <ECEntityClass typeName="ClassX">
+                <ECProperty propertyName="PropX" typeName="double" kindOfQuantity="LENGTH" />
+              </ECEntityClass>
+            `,
+          );
+          const element = builder.insertInstance(s.items.ClassX.fullName, { propX: 123.456 });
+          return { schema: s, element };
         });
-        const imodelAccess = createIModelAccess(imodelConnection);
+        const { ecdb, schema } = setup;
+        const ecdbAccess = createIModelAccess(ecdb);
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
@@ -132,7 +120,7 @@ describe("Hierarchies", () => {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
                           await ECSql.createPrimitivePropertyValueSelectorProps({
-                            schemaProvider: imodelAccess,
+                            schemaProvider: ecdbAccess,
                             propertyClassName: schema.items.ClassX.fullName,
                             propertyClassAlias: "this",
                             propertyName: "PropX",
@@ -152,7 +140,7 @@ describe("Hierarchies", () => {
         };
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
             formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "metric" }),
           }),
@@ -160,7 +148,7 @@ describe("Hierarchies", () => {
         });
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
             formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "imperial" }),
           }),
@@ -168,7 +156,7 @@ describe("Hierarchies", () => {
         });
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
             formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "usCustomary" }),
           }),
@@ -176,7 +164,7 @@ describe("Hierarchies", () => {
         });
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
             formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "usSurvey" }),
           }),
@@ -209,7 +197,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: emptyIModel, hierarchy }),
+          provider: createProvider({ ecdb: suiteSetup.ecdb, hierarchy }),
           expect: [
             {
               node: (node) => {
@@ -225,13 +213,28 @@ describe("Hierarchies", () => {
 
     describe("DateTime", () => {
       it("formats instance node labels", async () => {
-        const imodelAccess = createIModelAccess(emptyIModel);
+        const rawDateTimeValue = new Date();
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="LastMod" typeName="dateTime" />
+              </ECEntityClass>
+            `,
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { lastMod: rawDateTimeValue });
+          return { schema: s, x1 };
+        });
+        const { ecdb, schema } = setup;
+        const ecdbAccess = createIModelAccess(ecdb);
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
-                  fullClassName: subjectClassName,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                     SELECT ${await createSelectClause({
@@ -241,17 +244,16 @@ describe("Hierarchies", () => {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
                           await ECSql.createPrimitivePropertyValueSelectorProps({
-                            schemaProvider: imodelAccess,
-                            propertyClassName: "BisCore.Subject",
+                            schemaProvider: ecdbAccess,
+                            propertyClassName: schema.items.X.fullName,
                             propertyClassAlias: "this",
                             propertyName: "LastMod",
                           }),
                           { type: "String", value: "]" },
                         ]),
                       },
-                      extendedData: { lastMod: { selector: ECSql.createRawPropertyValueSelector("this", "LastMod") } },
                     })}
-                    FROM ${subjectClassName} AS this
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                   },
                 },
@@ -261,12 +263,11 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: emptyIModel, hierarchy }),
+          provider: createProvider({ ecdb, hierarchy }),
           expect: [
             {
               node: (node) => {
-                const unformattedLastMod = node.extendedData!.lastMod as number;
-                const expectedLabel = `[${julianToDateTime(unformattedLastMod).toLocaleString()}]`;
+                const expectedLabel = `[${rawDateTimeValue.toLocaleString()}]`;
                 const actualLabel = node.label;
                 expect(actualLabel).toBe(expectedLabel);
               },
@@ -298,7 +299,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: emptyIModel, hierarchy }),
+          provider: createProvider({ ecdb: suiteSetup.ecdb, hierarchy }),
           expect: [
             {
               node: (node) => {
@@ -334,7 +335,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: emptyIModel, hierarchy }),
+          provider: createProvider({ ecdb: suiteSetup.ecdb, hierarchy }),
           expect: [
             {
               node: (node) => {
@@ -350,22 +351,28 @@ describe("Hierarchies", () => {
 
     describe("Boolean", () => {
       it("formats instance node labels", async () => {
-        const { imodelConnection, modelClassName } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const p1 = insertPhysicalPartition({ txn, codeValue: "p1", parentId: IModel.rootSubjectId });
-            insertPhysicalSubModel({ txn, modeledElementId: p1.id, isPrivate: false });
-            const p2 = insertPhysicalPartition({ txn, codeValue: "p2", parentId: IModel.rootSubjectId });
-            const m2 = insertPhysicalSubModel({ txn, modeledElementId: p2.id, isPrivate: true });
-            return { modelClassName: m2.className };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="IsPrivate" typeName="boolean" />
+              </ECEntityClass>
+            `,
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { isPrivate: false });
+          const x2 = builder.insertInstance(s.items.X.fullName, { isPrivate: true });
+          return { schema: s, x1, x2 };
         });
-        const imodelAccess = createIModelAccess(imodelConnection);
+        const { ecdb, schema } = setup;
+        const ecdbAccess = createIModelAccess(ecdb);
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
-                  fullClassName: modelClassName,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                     SELECT ${await createSelectClause({
@@ -375,8 +382,8 @@ describe("Hierarchies", () => {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
                           await ECSql.createPrimitivePropertyValueSelectorProps({
-                            schemaProvider: imodelAccess,
-                            propertyClassName: modelClassName,
+                            schemaProvider: ecdbAccess,
+                            propertyClassName: schema.items.X.fullName,
                             propertyClassAlias: "this",
                             propertyName: "IsPrivate",
                           }),
@@ -384,7 +391,7 @@ describe("Hierarchies", () => {
                         ]),
                       },
                     })}
-                    FROM ${modelClassName} AS this
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                   },
                 },
@@ -394,7 +401,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: imodelConnection, hierarchy }),
+          provider: createProvider({ ecdb, hierarchy }),
           expect: [
             { node: (node) => expect(node.label).toBe(`[false]`) },
             { node: (node) => expect(node.label).toBe(`[true]`) },
@@ -424,7 +431,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: emptyIModel, hierarchy }),
+          provider: createProvider({ ecdb: suiteSetup.ecdb, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`true-false`) }],
         });
       });
@@ -432,18 +439,27 @@ describe("Hierarchies", () => {
 
     describe("Integer", () => {
       it("formats instance node labels", async () => {
-        const { imodelConnection, sheetIndexFolder } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            return { sheetIndexFolder: insertSheetIndexFolder({ txn, entryPriority: 2 }) };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="EntryPriority" typeName="int" />
+              </ECEntityClass>
+            `,
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { entryPriority: 2 });
+          return { schema: s, x1 };
         });
-        const imodelAccess = createIModelAccess(imodelConnection);
+        const { ecdb, schema } = setup;
+        const ecdbAccess = createIModelAccess(ecdb);
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
-                  fullClassName: sheetIndexFolder.className,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                     SELECT ${await createSelectClause({
@@ -453,8 +469,8 @@ describe("Hierarchies", () => {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
                           await ECSql.createPrimitivePropertyValueSelectorProps({
-                            schemaProvider: imodelAccess,
-                            propertyClassName: sheetIndexFolder.className,
+                            schemaProvider: ecdbAccess,
+                            propertyClassName: schema.items.X.fullName,
                             propertyClassAlias: "this",
                             propertyName: "EntryPriority",
                           }),
@@ -462,7 +478,7 @@ describe("Hierarchies", () => {
                         ]),
                       },
                     })}
-                    FROM ${sheetIndexFolder.className} AS this
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                   },
                 },
@@ -472,7 +488,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: imodelConnection, hierarchy }),
+          provider: createProvider({ ecdb, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`[2]`) }],
         });
       });
@@ -498,7 +514,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: emptyIModel, hierarchy }),
+          provider: createProvider({ ecdb: suiteSetup.ecdb, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`[124]`) }],
         });
       });
@@ -506,27 +522,27 @@ describe("Hierarchies", () => {
 
     describe("Double", () => {
       it("formats instance node labels", async () => {
-        const { imodelConnection, element } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
-            const category = insertSpatialCategory({ txn, codeValue: "category" });
-            // eslint-disable-next-line @typescript-eslint/no-shadow
-            const element = insertPhysicalElement({
-              txn,
-              modelId: model.id,
-              categoryId: category.id,
-              placement: { origin: { x: 1.23, y: 4.56, z: 7.89 }, angles: { yaw: 90.789 } },
-            });
-            return { model, category, element };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="Yaw" typeName="double" />
+              </ECEntityClass>
+            `,
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { yaw: 90.789 });
+          return { schema: s, x1 };
         });
-        const imodelAccess = createIModelAccess(imodelConnection);
+        const { ecdb, schema } = setup;
+        const ecdbAccess = createIModelAccess(ecdb);
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
-                  fullClassName: element.className,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                     SELECT ${await createSelectClause({
@@ -536,8 +552,8 @@ describe("Hierarchies", () => {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
                           await ECSql.createPrimitivePropertyValueSelectorProps({
-                            schemaProvider: imodelAccess,
-                            propertyClassName: element.className,
+                            schemaProvider: ecdbAccess,
+                            propertyClassName: schema.items.X.fullName,
                             propertyClassAlias: "this",
                             propertyName: "Yaw",
                           }),
@@ -545,7 +561,7 @@ describe("Hierarchies", () => {
                         ]),
                       },
                     })}
-                    FROM ${element.className} AS this
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                   },
                 },
@@ -555,7 +571,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: imodelConnection, hierarchy }),
+          provider: createProvider({ ecdb, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`[90.79]`) }],
         });
       });
@@ -582,7 +598,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: emptyIModel, hierarchy }),
+          provider: createProvider({ ecdb: suiteSetup.ecdb, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`[123.79]`) }],
         });
       });
@@ -590,27 +606,27 @@ describe("Hierarchies", () => {
 
     describe("Point2d", () => {
       it("formats instance node labels", async () => {
-        const { imodelConnection, element } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const model = insertDrawingModelWithPartition({ txn, codeValue: "model" });
-            const category = insertDrawingCategory({ txn, codeValue: "category" });
-            // eslint-disable-next-line @typescript-eslint/no-shadow
-            const element = insertDrawingGraphic({
-              txn,
-              modelId: model.id,
-              categoryId: category.id,
-              placement: { origin: { x: 1.477, y: 2.588 }, angle: 0 },
-            });
-            return { model, category, element };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="Origin" typeName="point2d" />
+              </ECEntityClass>
+            `,
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { origin: { x: 1.477, y: 2.588 } });
+          return { schema: s, x1 };
         });
-        const imodelAccess = createIModelAccess(imodelConnection);
+        const { ecdb, schema } = setup;
+        const ecdbAccess = createIModelAccess(ecdb);
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
-                  fullClassName: element.className,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                     SELECT ${await createSelectClause({
@@ -620,8 +636,8 @@ describe("Hierarchies", () => {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
                           await ECSql.createPrimitivePropertyValueSelectorProps({
-                            schemaProvider: imodelAccess,
-                            propertyClassName: element.className,
+                            schemaProvider: ecdbAccess,
+                            propertyClassName: schema.items.X.fullName,
                             propertyClassAlias: "this",
                             propertyName: "Origin",
                           }),
@@ -629,7 +645,7 @@ describe("Hierarchies", () => {
                         ]),
                       },
                     })}
-                    FROM ${element.className} AS this
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                   },
                 },
@@ -639,7 +655,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: imodelConnection, hierarchy }),
+          provider: createProvider({ ecdb, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`[(1.48, 2.59)]`) }],
         });
       });
@@ -666,7 +682,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: emptyIModel, hierarchy }),
+          provider: createProvider({ ecdb: suiteSetup.ecdb, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`[(1.48, 2.59)]`) }],
         });
       });
@@ -674,27 +690,27 @@ describe("Hierarchies", () => {
 
     describe("Point3d", () => {
       it("formats instance node labels", async () => {
-        const { imodelConnection, element } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
-            const category = insertSpatialCategory({ txn, codeValue: "category" });
-            // eslint-disable-next-line @typescript-eslint/no-shadow
-            const element = insertPhysicalElement({
-              txn,
-              modelId: model.id,
-              categoryId: category.id,
-              placement: { origin: { x: 1.234, y: 4.567, z: 7.89 }, angles: {} },
-            });
-            return { model, category, element };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="Origin" typeName="point3d" />
+              </ECEntityClass>
+            `,
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { origin: { x: 1.234, y: 4.567, z: 7.89 } });
+          return { schema: s, x1 };
         });
-        const imodelAccess = createIModelAccess(imodelConnection);
+        const { ecdb, schema } = setup;
+        const ecdbAccess = createIModelAccess(ecdb);
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
-                  fullClassName: element.className,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                     SELECT ${await createSelectClause({
@@ -704,8 +720,8 @@ describe("Hierarchies", () => {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
                           await ECSql.createPrimitivePropertyValueSelectorProps({
-                            schemaProvider: imodelAccess,
-                            propertyClassName: element.className,
+                            schemaProvider: ecdbAccess,
+                            propertyClassName: schema.items.X.fullName,
                             propertyClassAlias: "this",
                             propertyName: "Origin",
                           }),
@@ -713,7 +729,7 @@ describe("Hierarchies", () => {
                         ]),
                       },
                     })}
-                    FROM ${element.className} AS this
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                   },
                 },
@@ -723,7 +739,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: imodelConnection, hierarchy }),
+          provider: createProvider({ ecdb, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`[(1.23, 4.57, 7.89)]`) }],
         });
       });
@@ -750,7 +766,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: emptyIModel, hierarchy }),
+          provider: createProvider({ ecdb: suiteSetup.ecdb, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`[(1.48, 2.59, 3.70)]`) }],
         });
       });
@@ -759,27 +775,27 @@ describe("Hierarchies", () => {
     describe("Guid", () => {
       it("formats instance node labels", async () => {
         const guid = Guid.createValue();
-        const { imodelConnection, element } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
-            const category = insertSpatialCategory({ txn, codeValue: "category" });
-            // eslint-disable-next-line @typescript-eslint/no-shadow
-            const element = insertPhysicalElement({
-              txn,
-              modelId: model.id,
-              categoryId: category.id,
-              federationGuid: guid,
-            });
-            return { model, category, element };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="FederationGuid" typeName="string" />
+              </ECEntityClass>
+            `,
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { federationGuid: guid });
+          return { schema: s, x1 };
         });
-        const imodelAccess = createIModelAccess(imodelConnection);
+        const { ecdb, schema } = setup;
+        const ecdbAccess = createIModelAccess(ecdb);
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
-                  fullClassName: element.className,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                     SELECT ${await createSelectClause({
@@ -789,8 +805,8 @@ describe("Hierarchies", () => {
                         selector: ECSql.createConcatenatedValueJsonSelector([
                           { type: "String", value: "[" },
                           await ECSql.createPrimitivePropertyValueSelectorProps({
-                            schemaProvider: imodelAccess,
-                            propertyClassName: element.className,
+                            schemaProvider: ecdbAccess,
+                            propertyClassName: schema.items.X.fullName,
                             propertyClassAlias: "this",
                             propertyName: "FederationGuid",
                           }),
@@ -798,7 +814,7 @@ describe("Hierarchies", () => {
                         ]),
                       },
                     })}
-                    FROM ${element.className} AS this
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                   },
                 },
@@ -808,7 +824,7 @@ describe("Hierarchies", () => {
           },
         };
         await validateHierarchy({
-          provider: createProvider({ imodel: imodelConnection, hierarchy }),
+          provider: createProvider({ ecdb, hierarchy }),
           expect: [{ node: (node) => expect(node.label).toBe(`[${guid}]`) }],
         });
       });
@@ -826,7 +842,7 @@ describe("Hierarchies", () => {
           if (!parentNode) {
             return [
               {
-                fullClassName: subjectClassName,
+                fullClassName: suiteSetup.schema.items.X.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
@@ -834,7 +850,7 @@ describe("Hierarchies", () => {
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.UserLabel` },
                     })}
-                    FROM ${subjectClassName} AS this
+                    FROM ${suiteSetup.schema.items.X.fullName} AS this
                   `,
                 },
               },
@@ -844,8 +860,8 @@ describe("Hierarchies", () => {
         },
       };
 
-      const provider = createProvider({ imodel: emptyIModel, hierarchy, queryCacheSize: 10 });
-      const queryReaderSpy = vi.spyOn(emptyIModel, "createQueryReader");
+      const provider = createProvider({ ecdb: suiteSetup.ecdb, hierarchy, queryCacheSize: 10 });
+      const queryReaderSpy = vi.spyOn(suiteSetup.ecdb, "createQueryReader");
       await validateHierarchy({ provider, expect: [{ node: (node) => expect(node.label).toBe("") }] });
       expect(queryReaderSpy).toHaveBeenCalledOnce();
       queryReaderSpy.mockClear();

--- a/apps/full-stack-tests/src/hierarchies/HierarchyLevelInstanceKeys.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchyLevelInstanceKeys.test.ts
@@ -4,38 +4,46 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { collect } from "presentation-test-utilities";
-import { afterAll, describe, expect, it, test } from "vitest";
-import { DictionaryModel, InformationPartitionElement, LinkModel, Model, Subject } from "@itwin/core-backend";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { HierarchyNode } from "@itwin/presentation-hierarchies";
-import { InstanceKey, normalizeFullClassName } from "@itwin/presentation-shared";
-import { buildTestIModel } from "../IModelUtils.js";
+import { InstanceKey } from "@itwin/presentation-shared";
+import { buildTestECDb } from "../ECDbUtils.js";
 import { initialize, terminate } from "../IntegrationTests.js";
-import { createClassECSqlSelector, createProvider } from "./Utils.js";
+import { importSchema } from "../SchemaUtils.js";
+import { createProvider } from "./Utils.js";
 
-import type { IModelConnection } from "@itwin/core-frontend";
 import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
 
 describe("Hierarchies", () => {
   describe("Hierarchy level instance keys", () => {
-    let imodel: IModelConnection;
-
-    test.beforeAll(async (_, suite) => {
+    beforeAll(async () => {
       await initialize();
-
-      imodel = (await buildTestIModel(suite.fullTestName!)).imodelConnection;
     });
 
     afterAll(async () => {
-      await imodel.close();
       await terminate();
     });
 
     it("gets instance keys for root hierarchy level", async () => {
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="X">
+              <ECProperty propertyName="CodeValue" typeName="string" />
+            </ECEntityClass>
+          `,
+        );
+        const x1 = builder.insertInstance(s.items.X.fullName, { codeValue: "root" });
+        return { schema: s, x1 };
+      });
+      const { ecdb, schema, ...keys } = setup;
       const hierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ createSelectClause }) {
           return [
             {
-              fullClassName: normalizeFullClassName(Subject.classFullName),
+              fullClassName: schema.items.X.fullName,
               query: {
                 ecsql: `
                   SELECT ${await createSelectClause({
@@ -43,42 +51,70 @@ describe("Hierarchies", () => {
                     ecInstanceId: { selector: `this.ECInstanceId` },
                     nodeLabel: { selector: `this.CodeValue` },
                   })}
-                  FROM ${createClassECSqlSelector(Subject.classFullName)} AS this
+                  FROM ${schema.items.X.fullName} AS this
                 `,
               },
             },
           ];
         },
       };
-      const provider = createProvider({ imodel, hierarchy });
-      const keys = await collect(provider.getNodeInstanceKeys({ parentNode: undefined }));
-      expect(keys).toMatchObject([{ className: "BisCore.Subject", id: "0x1" }]);
+      const provider = createProvider({ ecdb, hierarchy });
+      const instanceKeys = await collect(provider.getNodeInstanceKeys({ parentNode: undefined }));
+      expect(instanceKeys).toMatchObject([{ className: schema.items.X.fullName, id: keys.x1.id }]);
     });
 
     it("gets instance keys for instance node's child hierarchy level", async () => {
-      const rootSubjectKey: InstanceKey = { className: normalizeFullClassName(Subject.classFullName), id: "0x1" };
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="X">
+              <ECProperty propertyName="CodeValue" typeName="string" />
+            </ECEntityClass>
+            <ECEntityClass typeName="Y">
+              <ECProperty propertyName="Label" typeName="string" />
+            </ECEntityClass>
+            <ECRelationshipClass typeName="XY" strength="referencing" strengthDirection="forward" modifier="None">
+              <Source multiplicity="(0..1)" roleLabel="owns" polymorphic="false">
+                <Class class="X" />
+              </Source>
+              <Target multiplicity="(0..*)" roleLabel="owned by" polymorphic="false">
+                <Class class="Y" />
+              </Target>
+            </ECRelationshipClass>
+          `,
+        );
+        const x1 = builder.insertInstance(s.items.X.fullName, { codeValue: "parent" });
+        const y1 = builder.insertInstance(s.items.Y.fullName, { label: "child1" });
+        const y2 = builder.insertInstance(s.items.Y.fullName, { label: "child2" });
+        builder.insertRelationship(s.items.XY.fullName, x1.id, y1.id);
+        builder.insertRelationship(s.items.XY.fullName, x1.id, y2.id);
+        return { schema: s, x1, y1, y2 };
+      });
+      const { ecdb, schema, ...keys } = setup;
       const hierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (
             parentNode &&
             HierarchyNode.isInstancesNode(parentNode) &&
-            parentNode.key.instanceKeys.some((ik) => InstanceKey.equals(ik, rootSubjectKey))
+            parentNode.key.instanceKeys.some((ik) => InstanceKey.equals(ik, keys.x1))
           ) {
             return [
               {
-                fullClassName: normalizeFullClassName(Subject.classFullName),
+                fullClassName: schema.items.Y.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
-                      nodeLabel: { selector: `p.CodeValue` },
+                      nodeLabel: { selector: `this.Label` },
                     })}
-                    FROM ${createClassECSqlSelector(Model.classFullName)} AS this
-                    JOIN ${createClassECSqlSelector(InformationPartitionElement.classFullName)} AS p ON p.ECInstanceId = this.ModeledElement.Id
-                    WHERE p.Parent.Id = ?
+                    FROM ${schema.items.Y.fullName} AS this
+                    JOIN ${schema.items.XY.fullName} AS rel ON rel.TargetECInstanceId = this.ECInstanceId
+                    WHERE rel.SourceECInstanceId = ?
                   `,
-                  bindings: [{ type: "id", value: rootSubjectKey.id }],
+                  bindings: [{ type: "id", value: keys.x1.id }],
                 },
               },
             ];
@@ -86,27 +122,41 @@ describe("Hierarchies", () => {
           return [];
         },
       };
-      const rootSubjectNode = {
-        key: { type: "instances" as const, instanceKeys: [rootSubjectKey] },
+      const xNode = {
+        key: { type: "instances" as const, instanceKeys: [keys.x1] },
         parentKeys: [],
-        label: "root subject",
+        label: "parent",
         children: true,
       };
-      const provider = createProvider({ imodel, hierarchy });
-      const keys = await collect(provider.getNodeInstanceKeys({ parentNode: rootSubjectNode }));
-      expect(keys).toMatchObject([
-        { className: normalizeFullClassName(LinkModel.classFullName), id: "0xe" },
-        { className: normalizeFullClassName(DictionaryModel.classFullName), id: "0x10" },
+      const provider = createProvider({ ecdb, hierarchy });
+      const instanceKeys = await collect(provider.getNodeInstanceKeys({ parentNode: xNode }));
+      expect(instanceKeys).toMatchObject([
+        { className: schema.items.Y.fullName, id: keys.y1.id },
+        { className: schema.items.Y.fullName, id: keys.y2.id },
       ]);
     });
 
     it("gets instance keys for generic node's child hierarchy level", async () => {
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="X">
+              <ECProperty propertyName="CodeValue" typeName="string" />
+            </ECEntityClass>
+          `,
+        );
+        const x1 = builder.insertInstance(s.items.X.fullName, { codeValue: "root" });
+        return { schema: s, x1 };
+      });
+      const { ecdb, schema, ...keys } = setup;
       const hierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (parentNode && HierarchyNode.isGeneric(parentNode) && parentNode.key.id === "test") {
             return [
               {
-                fullClassName: normalizeFullClassName(Subject.classFullName),
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
@@ -114,7 +164,7 @@ describe("Hierarchies", () => {
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.CodeValue` },
                     })}
-                    FROM ${createClassECSqlSelector(Subject.classFullName)} AS this
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                 },
               },
@@ -129,19 +179,47 @@ describe("Hierarchies", () => {
         label: "custom parent node",
         children: true,
       };
-      const provider = createProvider({ imodel, hierarchy });
-      const keys = await collect(provider.getNodeInstanceKeys({ parentNode: testCustomNode }));
-      expect(keys).toMatchObject([{ className: "BisCore.Subject", id: "0x1" }]);
+      const provider = createProvider({ ecdb, hierarchy });
+      const instanceKeys = await collect(provider.getNodeInstanceKeys({ parentNode: testCustomNode }));
+      expect(instanceKeys).toMatchObject([{ className: schema.items.X.fullName, id: keys.x1.id }]);
     });
 
     it("gets instance keys for hidden instance node's child hierarchy level", async () => {
-      const rootSubjectKey: InstanceKey = { className: normalizeFullClassName(Subject.classFullName), id: "0x1" };
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="X">
+              <ECProperty propertyName="CodeValue" typeName="string" />
+            </ECEntityClass>
+            <ECEntityClass typeName="Y">
+              <ECProperty propertyName="Label" typeName="string" />
+            </ECEntityClass>
+            <ECRelationshipClass typeName="XY" strength="referencing" strengthDirection="forward" modifier="None">
+              <Source multiplicity="(0..1)" roleLabel="owns" polymorphic="false">
+                <Class class="X" />
+              </Source>
+              <Target multiplicity="(0..*)" roleLabel="owned by" polymorphic="false">
+                <Class class="Y" />
+              </Target>
+            </ECRelationshipClass>
+          `,
+        );
+        const x1 = builder.insertInstance(s.items.X.fullName, { codeValue: "parent" });
+        const y1 = builder.insertInstance(s.items.Y.fullName, { label: "child1" });
+        const y2 = builder.insertInstance(s.items.Y.fullName, { label: "child2" });
+        builder.insertRelationship(s.items.XY.fullName, x1.id, y1.id);
+        builder.insertRelationship(s.items.XY.fullName, x1.id, y2.id);
+        return { schema: s, x1, y1, y2 };
+      });
+      const { ecdb, schema, ...keys } = setup;
       const hierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
-                fullClassName: normalizeFullClassName(Subject.classFullName),
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
@@ -150,7 +228,7 @@ describe("Hierarchies", () => {
                       nodeLabel: { selector: `this.CodeValue` },
                       hideNodeInHierarchy: true,
                     })}
-                    FROM ${createClassECSqlSelector(Subject.classFullName)} AS this
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                 },
               },
@@ -158,23 +236,23 @@ describe("Hierarchies", () => {
           }
           if (
             HierarchyNode.isInstancesNode(parentNode) &&
-            parentNode.key.instanceKeys.some((ik) => ik.id === rootSubjectKey.id)
+            parentNode.key.instanceKeys.some((ik) => ik.id === keys.x1.id)
           ) {
             return [
               {
-                fullClassName: normalizeFullClassName(Subject.classFullName),
+                fullClassName: schema.items.Y.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
-                      nodeLabel: { selector: `p.CodeValue` },
+                      nodeLabel: { selector: `this.Label` },
                     })}
-                    FROM ${createClassECSqlSelector(Model.classFullName)} AS this
-                    JOIN ${createClassECSqlSelector(InformationPartitionElement.classFullName)} AS p ON p.ECInstanceId = this.ModeledElement.Id
-                    WHERE p.Parent.Id = ?
+                    FROM ${schema.items.Y.fullName} AS this
+                    JOIN ${schema.items.XY.fullName} AS rel ON rel.TargetECInstanceId = this.ECInstanceId
+                    WHERE rel.SourceECInstanceId = ?
                   `,
-                  bindings: [{ type: "id", value: rootSubjectKey.id }],
+                  bindings: [{ type: "id", value: keys.x1.id }],
                 },
               },
             ];
@@ -182,15 +260,29 @@ describe("Hierarchies", () => {
           return [];
         },
       };
-      const provider = createProvider({ imodel, hierarchy });
-      const keys = await collect(provider.getNodeInstanceKeys({ parentNode: undefined }));
-      expect(keys).toMatchObject([
-        { className: normalizeFullClassName(LinkModel.classFullName), id: "0xe" },
-        { className: normalizeFullClassName(DictionaryModel.classFullName), id: "0x10" },
+      const provider = createProvider({ ecdb, hierarchy });
+      const instanceKeys = await collect(provider.getNodeInstanceKeys({ parentNode: undefined }));
+      expect(instanceKeys).toMatchObject([
+        { className: schema.items.Y.fullName, id: keys.y1.id },
+        { className: schema.items.Y.fullName, id: keys.y2.id },
       ]);
     });
 
     it("gets instance keys for hidden generic node's child hierarchy level", async () => {
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="X">
+              <ECProperty propertyName="CodeValue" typeName="string" />
+            </ECEntityClass>
+          `,
+        );
+        const x1 = builder.insertInstance(s.items.X.fullName, { codeValue: "root" });
+        return { schema: s, x1 };
+      });
+      const { ecdb, schema, ...keys } = setup;
       const hierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
@@ -201,7 +293,7 @@ describe("Hierarchies", () => {
           if (HierarchyNode.isGeneric(parentNode) && parentNode.key.id === "test") {
             return [
               {
-                fullClassName: normalizeFullClassName(Subject.classFullName),
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
@@ -209,7 +301,7 @@ describe("Hierarchies", () => {
                       ecInstanceId: { selector: `this.ECInstanceId` },
                       nodeLabel: { selector: `this.CodeValue` },
                     })}
-                    FROM ${createClassECSqlSelector(Subject.classFullName)} AS this
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                 },
               },
@@ -218,9 +310,9 @@ describe("Hierarchies", () => {
           return [];
         },
       };
-      const provider = createProvider({ imodel, hierarchy });
-      const keys = await collect(provider.getNodeInstanceKeys({ parentNode: undefined }));
-      expect(keys).toMatchObject([{ className: "BisCore.Subject", id: "0x1" }]);
+      const provider = createProvider({ ecdb, hierarchy });
+      const instanceKeys = await collect(provider.getNodeInstanceKeys({ parentNode: undefined }));
+      expect(instanceKeys).toMatchObject([{ className: schema.items.X.fullName, id: keys.x1.id }]);
     });
   });
 });

--- a/apps/full-stack-tests/src/hierarchies/HierarchySearch.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchySearch.test.ts
@@ -3,16 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-  createAsyncIterator,
-  insertPhysicalElement,
-  insertPhysicalModelWithPartition,
-  insertSpatialCategory,
-  insertSubject,
-} from "presentation-test-utilities";
+import { createAsyncIterator } from "presentation-test-utilities";
 import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
-import { Subject, withEditTxn } from "@itwin/core-backend";
-import { IModel } from "@itwin/core-common";
 import {
   createHierarchyProvider,
   createHierarchySearchHelper,
@@ -22,16 +14,12 @@ import {
   HierarchyNodeKey,
   mergeProviders,
 } from "@itwin/presentation-hierarchies";
-import { normalizeFullClassName } from "@itwin/presentation-shared";
 import { buildTestECDb } from "../ECDbUtils.js";
-import { buildTestIModel } from "../IModelUtils.js";
 import { initialize, terminate } from "../IntegrationTests.js";
 import { importSchema } from "../SchemaUtils.js";
 import { NodeValidators, validateHierarchy } from "./HierarchyValidation.js";
 import { createIModelAccess, createProvider } from "./Utils.js";
 
-import type { Id64String } from "@itwin/core-bentley";
-import type { IModelConnection } from "@itwin/core-frontend";
 import type {
   DefineHierarchyLevelProps,
   DefineInstanceNodeChildHierarchyLevelProps,
@@ -41,15 +29,12 @@ import type {
   HierarchySearchTree,
   IModelInstanceKey,
 } from "@itwin/presentation-hierarchies";
-import type { EC, ECSqlBinding, InstanceKey, Props } from "@itwin/presentation-shared";
+import type { Props } from "@itwin/presentation-shared";
 
 describe("Hierarchies", () => {
   describe("Hierarchy search", () => {
-    let subjectClassName: EC.FullClassName;
-
     beforeAll(async () => {
       await initialize();
-      subjectClassName = normalizeFullClassName(Subject.classFullName);
     });
 
     afterAll(async () => {
@@ -58,41 +43,59 @@ describe("Hierarchies", () => {
 
     describe("generic nodes", () => {
       it("searches through generic nodes", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-            const childSubject1 = insertSubject({ txn, codeValue: "test subject 1", parentId: rootSubject.id });
-            const childSubject2 = insertSubject({ txn, codeValue: "test subject 2", parentId: rootSubject.id });
-            return { rootSubject, childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="Label" typeName="string" />
+                <ECNavigationProperty propertyName="Parent" relationshipName="XX" direction="backward" />
+              </ECEntityClass>
+              <ECRelationshipClass typeName="XX" strength="referencing" strengthDirection="forward" modifier="None">
+                <Source multiplicity="(0..1)" roleLabel="owns" polymorphic="false">
+                  <Class class="X" />
+                </Source>
+                <Target multiplicity="(0..*)" roleLabel="owned by" polymorphic="false">
+                  <Class class="X" />
+                </Target>
+              </ECRelationshipClass>
+            `,
+          );
+          const rootX = builder.insertInstance(s.items.X.fullName, { label: "root x" });
+          const childX1 = builder.insertInstance(s.items.X.fullName, { label: "x 1", "Parent.Id": rootX.id });
+          const childX2 = builder.insertInstance(s.items.X.fullName, { label: "x 2", "Parent.Id": rootX.id });
+          return { schema: s, rootX, childX1, childX2 };
         });
+        const { ecdb, schema, ...keys } = setup;
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
-                  fullClassName: subjectClassName,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                       SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: "root subject",
+                        nodeLabel: "root x",
                       })}
-                      FROM ${subjectClassName} AS this
+                      FROM ${schema.items.X.fullName} AS this
+                      WHERE this.ECInstanceId = ${keys.rootX.id}
                     `,
                   },
                 },
               ];
             }
-            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "root subject") {
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "root x") {
               return [
                 {
                   node: {
                     key: "custom",
                     label: "custom",
                     children: undefined,
-                    extendedData: { parentSubjectIds: parentNode.key.instanceKeys.map((key) => key.id) },
+                    extendedData: { parentIds: parentNode.key.instanceKeys.map((key) => key.id) },
                   },
                 },
               ];
@@ -100,20 +103,17 @@ describe("Hierarchies", () => {
             if (HierarchyNode.isGeneric(parentNode)) {
               return [
                 {
-                  fullClassName: subjectClassName,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                       SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `this.CodeValue` },
+                        nodeLabel: { selector: `this.Label` },
                       })}
-                      FROM ${subjectClassName} AS this
-                      WHERE this.Parent.Id IN (${parentNode.extendedData!.parentSubjectIds.map(() => "?").join(",")})
+                      FROM ${schema.items.X.fullName} AS this
+                      WHERE this.Parent.Id IN (${parentNode.extendedData!.parentIds.join(",")})
                     `,
-                    bindings: parentNode.extendedData!.parentSubjectIds.map(
-                      (id: Id64String): ECSqlBinding => ({ type: "id", value: id }),
-                    ),
                   },
                 },
               ];
@@ -124,17 +124,17 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
             search: [
               {
-                identifier: keys.rootSubject,
+                identifier: keys.rootX,
                 options: { autoExpand: true },
                 children: [
                   {
                     identifier: { type: "generic", id: "custom" },
                     options: { autoExpand: true },
-                    children: [{ identifier: keys.childSubject2 }],
+                    children: [{ identifier: keys.childX2 }],
                   },
                 ],
               },
@@ -142,7 +142,7 @@ describe("Hierarchies", () => {
           }),
           expect: [
             NodeValidators.createForInstanceNode({
-              instanceKeys: [keys.rootSubject],
+              instanceKeys: [keys.rootX],
               autoExpand: true,
               isSearchTarget: false,
               children: [
@@ -152,7 +152,7 @@ describe("Hierarchies", () => {
                   isSearchTarget: false,
                   children: [
                     NodeValidators.createForInstanceNode({
-                      instanceKeys: [keys.childSubject2],
+                      instanceKeys: [keys.childX2],
                       isSearchTarget: true,
                       children: false,
                       autoExpand: false,
@@ -166,31 +166,40 @@ describe("Hierarchies", () => {
       });
 
       it("searches generic nodes", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async () => {
-          const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-          return { rootSubject };
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X" />
+            `,
+          );
+          const rootX = builder.insertInstance(s.items.X.fullName);
+          return { schema: s, rootX };
         });
+        const { ecdb, schema, ...keys } = setup;
 
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
-                  fullClassName: subjectClassName,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                       SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: "root subject",
+                        nodeLabel: "root x",
                       })}
-                      FROM ${subjectClassName} AS this
+                      FROM ${schema.items.X.fullName} AS this
+                      WHERE this.ECInstanceId = ${keys.rootX.id}
                     `,
                   },
                 },
               ];
             }
-            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "root subject") {
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "root x") {
               return [
                 { node: { key: "custom1", label: "custom1", children: undefined } },
                 { node: { key: "custom2", label: "custom2", children: undefined } },
@@ -202,11 +211,11 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
             search: [
               {
-                identifier: keys.rootSubject,
+                identifier: keys.rootX,
                 options: { autoExpand: true },
                 children: [{ identifier: { type: "generic", id: "custom2" } }],
               },
@@ -214,7 +223,7 @@ describe("Hierarchies", () => {
           }),
           expect: [
             NodeValidators.createForInstanceNode({
-              instanceKeys: [keys.rootSubject],
+              instanceKeys: [keys.rootX],
               autoExpand: true,
               isSearchTarget: false,
               children: [
@@ -226,7 +235,8 @@ describe("Hierarchies", () => {
       });
 
       it("searches generic nodes when targeting child and ancestor", async () => {
-        const { imodelConnection } = await buildTestIModel();
+        using setup = await buildTestECDb();
+        const { ecdb } = setup;
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {
@@ -249,7 +259,7 @@ describe("Hierarchies", () => {
         };
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
             search: [
               {
@@ -296,32 +306,39 @@ describe("Hierarchies", () => {
 
     describe("instance nodes", () => {
       it("sets auto-expand flag up to specific grouping level", async function () {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-            const childSubject1 = insertSubject({ txn, codeValue: "test subject 1", parentId: rootSubject.id });
-            const childSubject21 = insertSubject({ txn, codeValue: "test subject 2.1", parentId: rootSubject.id });
-            const childSubject22 = insertSubject({ txn, codeValue: "test subject 2.2", parentId: rootSubject.id });
-            const childSubject3 = insertSubject({ txn, codeValue: "test subject 3", parentId: rootSubject.id });
-            return { rootSubject, childSubject1, childSubject21, childSubject22, childSubject3 };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="Label" typeName="string" />
+              </ECEntityClass>
+            `,
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { label: "x 1" });
+          const x21 = builder.insertInstance(s.items.X.fullName, { label: "x 2.1" });
+          const x22 = builder.insertInstance(s.items.X.fullName, { label: "x 2.2" });
+          const x3 = builder.insertInstance(s.items.X.fullName, { label: "x 3" });
+          return { schema: s, x1, x21, x22, x3 };
         });
+        const { ecdb, schema, ...keys } = setup;
         const createHierarchyLevelDefinition = async (
           createSelectClause: DefineHierarchyLevelProps["createSelectClause"],
           whereClause: (alias: string) => string,
         ) => {
           return [
             {
-              fullClassName: subjectClassName,
+              fullClassName: schema.items.X.fullName,
               query: {
                 ecsql: `
                   SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
-                    nodeLabel: { selector: `this.CodeValue` },
+                    nodeLabel: { selector: `this.Label` },
                     grouping: { byClass: true, byLabel: true },
                   })}
-                  FROM ${subjectClassName} AS this
+                  FROM ${schema.items.X.fullName} AS this
                   ${whereClause("this")}
                 `,
               },
@@ -334,20 +351,19 @@ describe("Hierarchies", () => {
             if (!parentNode) {
               return createHierarchyLevelDefinition(
                 createSelectClause,
-                (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.childSubject1.id}`,
+                (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.x1.id}`,
               );
             }
-            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 1") {
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "x 1") {
               return createHierarchyLevelDefinition(
                 createSelectClause,
-                (alias: string) =>
-                  `WHERE ${alias}.ECInstanceId IN (${keys.childSubject21.id}, ${keys.childSubject22.id})`,
+                (alias: string) => `WHERE ${alias}.ECInstanceId IN (${keys.x21.id}, ${keys.x22.id})`,
               );
             }
-            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 2.1") {
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "x 2.1") {
               return createHierarchyLevelDefinition(
                 createSelectClause,
-                (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.childSubject3.id}`,
+                (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.x3.id}`,
               );
             }
             return [];
@@ -356,17 +372,17 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
             search: [
               {
-                identifier: keys.childSubject1,
+                identifier: keys.x1,
                 options: { autoExpand: true },
                 children: [
                   {
-                    identifier: keys.childSubject21,
+                    identifier: keys.x21,
                     options: { autoExpand: true },
-                    children: [{ identifier: keys.childSubject3, options: { autoExpand: { groupingLevel: 1 } } }],
+                    children: [{ identifier: keys.x3, options: { autoExpand: { groupingLevel: 1 } } }],
                   },
                 ],
               },
@@ -375,38 +391,38 @@ describe("Hierarchies", () => {
           expect: [
             NodeValidators.createForClassGroupingNode({
               autoExpand: true,
-              className: keys.childSubject1.className,
+              className: keys.x1.className,
               children: [
                 NodeValidators.createForLabelGroupingNode({
                   autoExpand: true,
-                  label: "test subject 1",
+                  label: "x 1",
                   children: [
                     NodeValidators.createForInstanceNode({
-                      instanceKeys: [keys.childSubject1],
+                      instanceKeys: [keys.x1],
                       autoExpand: true,
                       children: [
                         NodeValidators.createForClassGroupingNode({
                           autoExpand: true,
-                          className: keys.childSubject21.className,
+                          className: keys.x21.className,
                           children: [
                             NodeValidators.createForLabelGroupingNode({
                               autoExpand: true,
-                              label: "test subject 2.1",
+                              label: "x 2.1",
                               children: [
                                 NodeValidators.createForInstanceNode({
-                                  instanceKeys: [keys.childSubject21],
+                                  instanceKeys: [keys.x21],
                                   autoExpand: true,
                                   children: [
                                     NodeValidators.createForClassGroupingNode({
                                       autoExpand: true,
-                                      className: keys.childSubject21.className,
+                                      className: keys.x21.className,
                                       children: [
                                         NodeValidators.createForLabelGroupingNode({
                                           autoExpand: false,
-                                          label: "test subject 3",
+                                          label: "x 3",
                                           children: [
                                             NodeValidators.createForInstanceNode({
-                                              instanceKeys: [keys.childSubject3],
+                                              instanceKeys: [keys.x3],
                                               isSearchTarget: true,
                                               children: false,
                                               autoExpand: false,
@@ -432,31 +448,38 @@ describe("Hierarchies", () => {
       });
 
       it("searches through instance nodes that are in multiple paths", async function () {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-            const childSubject1 = insertSubject({ txn, codeValue: "test subject 1", parentId: rootSubject.id });
-            const childSubject2 = insertSubject({ txn, codeValue: "test subject 2", parentId: rootSubject.id });
-            const childSubject3 = insertSubject({ txn, codeValue: "test subject 3", parentId: rootSubject.id });
-            const childSubject4 = insertSubject({ txn, codeValue: "test subject 4", parentId: rootSubject.id });
-            return { rootSubject, childSubject1, childSubject2, childSubject3, childSubject4 };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="Label" typeName="string" />
+              </ECEntityClass>
+            `,
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { label: "x 1" });
+          const x2 = builder.insertInstance(s.items.X.fullName, { label: "x 2" });
+          const x3 = builder.insertInstance(s.items.X.fullName, { label: "x 3" });
+          const x4 = builder.insertInstance(s.items.X.fullName, { label: "x 4" });
+          return { schema: s, x1, x2, x3, x4 };
         });
+        const { ecdb, schema, ...keys } = setup;
         const createHierarchyLevelDefinition = async (
           createSelectClause: DefineHierarchyLevelProps["createSelectClause"],
           whereClause: (alias: string) => string,
         ) => {
           return [
             {
-              fullClassName: subjectClassName,
+              fullClassName: schema.items.X.fullName,
               query: {
                 ecsql: `
                   SELECT ${await createSelectClause({
                     ecClassId: { selector: `this.ECClassId` },
                     ecInstanceId: { selector: `this.ECInstanceId` },
-                    nodeLabel: { selector: `this.CodeValue` },
+                    nodeLabel: { selector: `this.Label` },
                   })}
-                  FROM ${subjectClassName} AS this
+                  FROM ${schema.items.X.fullName} AS this
                   ${whereClause("this")}
                 `,
               },
@@ -469,35 +492,33 @@ describe("Hierarchies", () => {
             if (!parentNode) {
               return createHierarchyLevelDefinition(
                 createSelectClause,
-                (alias: string) =>
-                  `WHERE ${alias}.ECInstanceId IN (${keys.childSubject1.id}, ${keys.childSubject4.id})`,
+                (alias: string) => `WHERE ${alias}.ECInstanceId IN (${keys.x1.id}, ${keys.x4.id})`,
               );
             }
             if (
               HierarchyNode.isInstancesNode(parentNode) &&
-              parentNode.label === "test subject 1" &&
+              parentNode.label === "x 1" &&
               parentNode.parentKeys.length === 0
             ) {
               return createHierarchyLevelDefinition(
                 createSelectClause,
-                (alias: string) =>
-                  `WHERE ${alias}.ECInstanceId IN (${keys.childSubject2.id}, ${keys.childSubject3.id})`,
+                (alias: string) => `WHERE ${alias}.ECInstanceId IN (${keys.x2.id}, ${keys.x3.id})`,
               );
             }
-            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 4") {
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "x 4") {
               return createHierarchyLevelDefinition(
                 createSelectClause,
-                (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.childSubject1.id}`,
+                (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.x1.id}`,
               );
             }
             if (
               HierarchyNode.isInstancesNode(parentNode) &&
-              parentNode.label === "test subject 1" &&
+              parentNode.label === "x 1" &&
               parentNode.parentKeys.length === 1
             ) {
               return createHierarchyLevelDefinition(
                 createSelectClause,
-                (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.childSubject2.id}`,
+                (alias: string) => `WHERE ${alias}.ECInstanceId = ${keys.x2.id}`,
               );
             }
             return [];
@@ -506,34 +527,24 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
             search: [
+              { identifier: keys.x1, options: { autoExpand: true }, children: [{ identifier: keys.x3 }] },
               {
-                identifier: keys.childSubject1,
+                identifier: keys.x4,
                 options: { autoExpand: true },
-                children: [{ identifier: keys.childSubject3 }],
-              },
-              {
-                identifier: keys.childSubject4,
-                options: { autoExpand: true },
-                children: [
-                  {
-                    identifier: keys.childSubject1,
-                    options: { autoExpand: true },
-                    children: [{ identifier: keys.childSubject2 }],
-                  },
-                ],
+                children: [{ identifier: keys.x1, options: { autoExpand: true }, children: [{ identifier: keys.x2 }] }],
               },
             ],
           }),
           expect: [
             NodeValidators.createForInstanceNode({
-              instanceKeys: [keys.childSubject1],
+              instanceKeys: [keys.x1],
               autoExpand: true,
               children: [
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.childSubject3],
+                  instanceKeys: [keys.x3],
                   isSearchTarget: true,
                   children: false,
                   autoExpand: false,
@@ -541,15 +552,15 @@ describe("Hierarchies", () => {
               ],
             }),
             NodeValidators.createForInstanceNode({
-              instanceKeys: [keys.childSubject4],
+              instanceKeys: [keys.x4],
               autoExpand: true,
               children: [
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.childSubject1],
+                  instanceKeys: [keys.x1],
                   autoExpand: true,
                   children: [
                     NodeValidators.createForInstanceNode({
-                      instanceKeys: [keys.childSubject2],
+                      instanceKeys: [keys.x2],
                       isSearchTarget: true,
                       children: false,
                       autoExpand: false,
@@ -563,40 +574,39 @@ describe("Hierarchies", () => {
       });
 
       it("searches instance nodes when targeting child and ancestor", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-            const childSubject1 = insertSubject({ txn, codeValue: "test subject 1", parentId: rootSubject.id });
-            const childSubject2 = insertSubject({ txn, codeValue: "test subject 2", parentId: rootSubject.id });
-            const childSubject21 = insertSubject({ txn, codeValue: "test subject 21", parentId: rootSubject.id });
-            const childSubject22 = insertSubject({ txn, codeValue: "test subject 22", parentId: rootSubject.id });
-            const childSubject221 = insertSubject({ txn, codeValue: "test subject 221", parentId: rootSubject.id });
-            const childSubject222 = insertSubject({ txn, codeValue: "test subject 222", parentId: rootSubject.id });
-            return {
-              rootSubject,
-              childSubject1,
-              childSubject2,
-              childSubject21,
-              childSubject22,
-              childSubject221,
-              childSubject222,
-            };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="Label" typeName="string" />
+              </ECEntityClass>
+            `,
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName, { label: "x 1" });
+          const x2 = builder.insertInstance(s.items.X.fullName, { label: "x 2" });
+          const x21 = builder.insertInstance(s.items.X.fullName, { label: "x 21" });
+          const x22 = builder.insertInstance(s.items.X.fullName, { label: "x 22" });
+          const x221 = builder.insertInstance(s.items.X.fullName, { label: "x 221" });
+          const x222 = builder.insertInstance(s.items.X.fullName, { label: "x 222" });
+          return { schema: s, x1, x2, x21, x22, x221, x222 };
         });
+        const { ecdb, schema, ...keys } = setup;
         const createHierarchyLevelDefinition = async (
           createSelectClause: DefineHierarchyLevelProps["createSelectClause"],
           whereClause: (alias: string) => string,
         ) => [
           {
-            fullClassName: subjectClassName,
+            fullClassName: schema.items.X.fullName,
             query: {
               ecsql: `
                 SELECT ${await createSelectClause({
                   ecClassId: { selector: `this.ECClassId` },
                   ecInstanceId: { selector: `this.ECInstanceId` },
-                  nodeLabel: { selector: `this.CodeValue` },
+                  nodeLabel: { selector: `this.Label` },
                 })}
-                FROM ${subjectClassName} AS this
+                FROM ${schema.items.X.fullName} AS this
                 ${whereClause("this")}
               `,
             },
@@ -607,22 +617,19 @@ describe("Hierarchies", () => {
             if (!parentNode) {
               return createHierarchyLevelDefinition(
                 createSelectClause,
-                (alias: string) =>
-                  `WHERE ${alias}.ECInstanceId IN (${keys.childSubject1.id}, ${keys.childSubject2.id})`,
+                (alias: string) => `WHERE ${alias}.ECInstanceId IN (${keys.x1.id}, ${keys.x2.id})`,
               );
             }
-            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 2") {
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "x 2") {
               return createHierarchyLevelDefinition(
                 createSelectClause,
-                (alias: string) =>
-                  `WHERE ${alias}.ECInstanceId IN (${keys.childSubject21.id}, ${keys.childSubject22.id})`,
+                (alias: string) => `WHERE ${alias}.ECInstanceId IN (${keys.x21.id}, ${keys.x22.id})`,
               );
             }
-            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 22") {
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "x 22") {
               return createHierarchyLevelDefinition(
                 createSelectClause,
-                (alias: string) =>
-                  `WHERE ${alias}.ECInstanceId IN (${keys.childSubject221.id}, ${keys.childSubject222.id})`,
+                (alias: string) => `WHERE ${alias}.ECInstanceId IN (${keys.x221.id}, ${keys.x222.id})`,
               );
             }
             return [];
@@ -631,48 +638,44 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
             search: [
               {
-                identifier: keys.childSubject2,
+                identifier: keys.x2,
                 isTarget: true,
                 options: { autoExpand: true },
                 children: [
-                  {
-                    identifier: keys.childSubject22,
-                    options: { autoExpand: true },
-                    children: [{ identifier: keys.childSubject222 }],
-                  },
+                  { identifier: keys.x22, options: { autoExpand: true }, children: [{ identifier: keys.x222 }] },
                 ],
               },
             ],
           }),
           expect: [
             NodeValidators.createForInstanceNode({
-              instanceKeys: [keys.childSubject2],
+              instanceKeys: [keys.x2],
               isSearchTarget: true,
               autoExpand: true,
               children: [
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.childSubject21],
+                  instanceKeys: [keys.x21],
                   isSearchTarget: false,
                   children: false,
                   autoExpand: false,
                 }),
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.childSubject22],
+                  instanceKeys: [keys.x22],
                   autoExpand: true,
                   isSearchTarget: false,
                   children: [
                     NodeValidators.createForInstanceNode({
-                      instanceKeys: [keys.childSubject221],
+                      instanceKeys: [keys.x221],
                       isSearchTarget: false,
                       children: false,
                       autoExpand: false,
                     }),
                     NodeValidators.createForInstanceNode({
-                      instanceKeys: [keys.childSubject222],
+                      instanceKeys: [keys.x222],
                       isSearchTarget: true,
                       children: false,
                       autoExpand: false,
@@ -688,35 +691,52 @@ describe("Hierarchies", () => {
 
     describe("when searching through hidden nodes", () => {
       it("searches through hidden generic nodes", async function () {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-            const childSubject1 = insertSubject({ txn, codeValue: "test subject 1", parentId: rootSubject.id });
-            const childSubject2 = insertSubject({ txn, codeValue: "test subject 2", parentId: rootSubject.id });
-            return { rootSubject, childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="Label" typeName="string" />
+                <ECNavigationProperty propertyName="Parent" relationshipName="XX" direction="backward" />
+              </ECEntityClass>
+              <ECRelationshipClass typeName="XX" strength="referencing" strengthDirection="forward" modifier="None">
+                <Source multiplicity="(0..1)" roleLabel="owns" polymorphic="false">
+                  <Class class="X" />
+                </Source>
+                <Target multiplicity="(0..*)" roleLabel="owned by" polymorphic="false">
+                  <Class class="X" />
+                </Target>
+              </ECRelationshipClass>
+            `,
+          );
+          const rootX = builder.insertInstance(s.items.X.fullName, { label: "root x" });
+          const childX2 = builder.insertInstance(s.items.X.fullName, { label: "x 2", "Parent.Id": rootX.id });
+          return { schema: s, rootX, childX2 };
         });
+        const { ecdb, schema, ...keys } = setup;
 
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
-                  fullClassName: subjectClassName,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                       SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: "root subject",
+                        nodeLabel: "root x",
                       })}
-                      FROM ${subjectClassName} AS this
+                      FROM ${schema.items.X.fullName} AS this
+                      WHERE this.ECInstanceId = ${keys.rootX.id}
                     `,
                   },
                 },
               ];
             }
-            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "root subject") {
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "root x") {
               return [
                 {
                   node: {
@@ -724,7 +744,7 @@ describe("Hierarchies", () => {
                     label: "custom",
                     children: undefined,
                     processingParams: { hideInHierarchy: true },
-                    extendedData: { parentSubjectIds: parentNode.key.instanceKeys.map((key) => key.id) },
+                    extendedData: { parentIds: parentNode.key.instanceKeys.map((key) => key.id) },
                   },
                 },
               ];
@@ -732,20 +752,17 @@ describe("Hierarchies", () => {
             if (HierarchyNode.isGeneric(parentNode)) {
               return [
                 {
-                  fullClassName: subjectClassName,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                       SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `this.CodeValue` },
+                        nodeLabel: { selector: `this.Label` },
                       })}
-                      FROM ${subjectClassName} AS this
-                      WHERE this.Parent.Id IN (${parentNode.extendedData!.parentSubjectIds.map(() => "?").join(",")})
+                      FROM ${schema.items.X.fullName} AS this
+                      WHERE this.Parent.Id IN (${parentNode.extendedData!.parentIds.join(",")})
                     `,
-                    bindings: parentNode.extendedData!.parentSubjectIds.map(
-                      (id: Id64String): ECSqlBinding => ({ type: "id", value: id }),
-                    ),
                   },
                 },
               ];
@@ -756,17 +773,17 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
             search: [
               {
-                identifier: keys.rootSubject,
+                identifier: keys.rootX,
                 options: { autoExpand: true },
                 children: [
                   {
                     identifier: { type: "generic", id: "custom" },
                     options: { autoExpand: true },
-                    children: [{ identifier: keys.childSubject2 }],
+                    children: [{ identifier: keys.childX2 }],
                   },
                 ],
               },
@@ -774,12 +791,12 @@ describe("Hierarchies", () => {
           }),
           expect: [
             NodeValidators.createForInstanceNode({
-              instanceKeys: [keys.rootSubject],
+              instanceKeys: [keys.rootX],
               autoExpand: true,
               isSearchTarget: false,
               children: [
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.childSubject2],
+                  instanceKeys: [keys.childX2],
                   isSearchTarget: true,
                   children: false,
                   autoExpand: false,
@@ -793,35 +810,56 @@ describe("Hierarchies", () => {
 
     describe("when targeting hidden nodes", () => {
       it("doesn't return matching hidden generic nodes or their children", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-            const childSubject1 = insertSubject({ txn, codeValue: "test subject 1", parentId: rootSubject.id });
-            const childSubject2 = insertSubject({ txn, codeValue: "test subject 2", parentId: rootSubject.id });
-            return { rootSubject, childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="Label" typeName="string" />
+              </ECEntityClass>
+              <ECEntityClass typeName="Y">
+                <ECProperty propertyName="Label" typeName="string" />
+                <ECNavigationProperty propertyName="Parent" relationshipName="XY" direction="backward" />
+              </ECEntityClass>
+              <ECRelationshipClass typeName="XY" strength="referencing" strengthDirection="forward" modifier="None">
+                <Source multiplicity="(0..1)" roleLabel="owns" polymorphic="false">
+                  <Class class="X" />
+                </Source>
+                <Target multiplicity="(0..*)" roleLabel="owned by" polymorphic="false">
+                  <Class class="Y" />
+                </Target>
+              </ECRelationshipClass>
+            `,
+          );
+          const x = builder.insertInstance(s.items.X.fullName, { label: "root x" });
+          const y1 = builder.insertInstance(s.items.Y.fullName, { label: "y 1", "Parent.Id": x.id });
+          const y2 = builder.insertInstance(s.items.Y.fullName, { label: "y 2", "Parent.Id": x.id });
+          return { schema: s, x, y1, y2 };
         });
+        const { ecdb, schema, ...keys } = setup;
 
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
-                  fullClassName: subjectClassName,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                       SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: "root subject",
+                        nodeLabel: "root x",
                       })}
-                      FROM ${subjectClassName} AS this
+                      FROM ${schema.items.X.fullName} AS this
+                      WHERE this.ECInstanceId = ${keys.x.id}
                     `,
                   },
                 },
               ];
             }
-            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "root subject") {
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "root x") {
               return [
                 {
                   node: {
@@ -829,7 +867,7 @@ describe("Hierarchies", () => {
                     label: "custom",
                     children: undefined,
                     processingParams: { hideInHierarchy: true },
-                    extendedData: { parentSubjectIds: parentNode.key.instanceKeys.map((key) => key.id) },
+                    extendedData: { parentIds: parentNode.key.instanceKeys.map((key) => key.id) },
                   },
                 },
               ];
@@ -837,20 +875,17 @@ describe("Hierarchies", () => {
             if (HierarchyNode.isGeneric(parentNode)) {
               return [
                 {
-                  fullClassName: subjectClassName,
+                  fullClassName: schema.items.Y.fullName,
                   query: {
                     ecsql: `
                       SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `this.CodeValue` },
+                        nodeLabel: { selector: `this.Label` },
                       })}
-                      FROM ${subjectClassName} AS this
-                      WHERE this.Parent.Id IN (${parentNode.extendedData!.parentSubjectIds.map(() => "?").join(",")})
+                      FROM ${schema.items.Y.fullName} AS this
+                      WHERE this.Parent.Id IN (${parentNode.extendedData!.parentIds.join(",")})
                     `,
-                    bindings: parentNode.extendedData!.parentSubjectIds.map(
-                      (id: Id64String): ECSqlBinding => ({ type: "id", value: id }),
-                    ),
                   },
                 },
               ];
@@ -861,85 +896,97 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
-            search: [{ identifier: keys.rootSubject, children: [{ identifier: { type: "generic", id: "custom" } }] }],
+            search: [{ identifier: keys.x, children: [{ identifier: { type: "generic", id: "custom" } }] }],
           }),
           expect: [
-            NodeValidators.createForInstanceNode({
-              instanceKeys: [keys.rootSubject],
-              isSearchTarget: false,
-              children: false,
-            }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [keys.x], isSearchTarget: false, children: false }),
           ],
         });
       });
 
       it("doesn't return matching hidden instance nodes", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-            const childSubject1 = insertSubject({ txn, codeValue: "test subject 1", parentId: rootSubject.id });
-            const childSubject2 = insertSubject({ txn, codeValue: "test subject 2", parentId: childSubject1.id });
-            const childSubject3 = insertSubject({ txn, codeValue: "test subject 3", parentId: childSubject1.id });
-            return { rootSubject, childSubject1, childSubject2, childSubject3 };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="Label" typeName="string" />
+                <ECNavigationProperty propertyName="Parent" relationshipName="XX" direction="backward" />
+              </ECEntityClass>
+              <ECRelationshipClass typeName="XX" strength="referencing" strengthDirection="forward" modifier="None">
+                <Source multiplicity="(0..1)" roleLabel="owns" polymorphic="false">
+                  <Class class="X" />
+                </Source>
+                <Target multiplicity="(0..*)" roleLabel="owned by" polymorphic="false">
+                  <Class class="X" />
+                </Target>
+              </ECRelationshipClass>
+            `,
+          );
+          const rootX = builder.insertInstance(s.items.X.fullName, { label: "root x" });
+          const childX1 = builder.insertInstance(s.items.X.fullName, { label: "x 1", "Parent.Id": rootX.id });
+          const childX2 = builder.insertInstance(s.items.X.fullName, { label: "x 2", "Parent.Id": childX1.id });
+          const childX3 = builder.insertInstance(s.items.X.fullName, { label: "x 3", "Parent.Id": childX1.id });
+          return { schema: s, rootX, childX1, childX2, childX3 };
         });
+        const { ecdb, schema, ...keys } = setup;
 
         const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
-                  fullClassName: subjectClassName,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                     SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
-                      nodeLabel: "root subject",
+                      nodeLabel: "root x",
                     })}
-                    FROM ${subjectClassName} AS this
+                    FROM ${schema.items.X.fullName} AS this
+                    WHERE this.ECInstanceId = ${keys.rootX.id}
                   `,
                   },
                 },
               ];
             }
-            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "root subject") {
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "root x") {
               return [
                 {
-                  fullClassName: subjectClassName,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                       SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `this.CodeValue` },
+                        nodeLabel: { selector: `this.Label` },
                         hideNodeInHierarchy: true,
                       })}
-                      FROM ${subjectClassName} AS this
-                      WHERE this.Parent.Id IN (${parentNode.key.instanceKeys.map(() => "?").join(",")})
+                      FROM ${schema.items.X.fullName} AS this
+                      WHERE this.Parent.Id IN (${parentNode.key.instanceKeys.map((key) => key.id).join(",")})
                     `,
-                    bindings: parentNode.key.instanceKeys.map((key): ECSqlBinding => ({ type: "id", value: key.id })),
                   },
                 },
               ];
             }
-            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "test subject 1") {
+            if (HierarchyNode.isInstancesNode(parentNode) && parentNode.label === "x 1") {
               return [
                 {
-                  fullClassName: subjectClassName,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                       SELECT ${await createSelectClause({
                         ecClassId: { selector: `this.ECClassId` },
                         ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `this.CodeValue` },
+                        nodeLabel: { selector: `this.Label` },
                       })}
-                      FROM ${subjectClassName} AS this
-                      WHERE this.Parent.Id IN (${parentNode.key.instanceKeys.map(() => "?").join(",")})
+                      FROM ${schema.items.X.fullName} AS this
+                      WHERE this.Parent.Id IN (${parentNode.key.instanceKeys.map((key) => key.id).join(",")})
                     `,
-                    bindings: parentNode.key.instanceKeys.map((key): ECSqlBinding => ({ type: "id", value: key.id })),
                   },
                 },
               ];
@@ -950,13 +997,13 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
-            search: [{ identifier: keys.rootSubject, children: [{ identifier: keys.childSubject1 }] }],
+            search: [{ identifier: keys.rootX, children: [{ identifier: keys.childX1 }] }],
           }),
           expect: [
             NodeValidators.createForInstanceNode({
-              instanceKeys: [keys.rootSubject],
+              instanceKeys: [keys.rootX],
               isSearchTarget: false,
               children: false,
             }),
@@ -1154,18 +1201,19 @@ describe("Hierarchies", () => {
 
     describe("when targeting grouped instance nodes", () => {
       it("sets auto-expand flag for parent nodes before the target grouping node", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-            const category = insertSpatialCategory({ txn, codeValue: "category" });
-            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
-            const elements = [
-              insertPhysicalElement({ txn, modelId: model.id, categoryId: category.id }),
-              insertPhysicalElement({ txn, modelId: model.id, categoryId: category.id }),
-            ];
-            return { rootSubject, model, category, elements };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X" />
+            `,
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName);
+          const x2 = builder.insertInstance(s.items.X.fullName);
+          return { schema: s, instances: [x1, x2] };
         });
+        const { ecdb, schema, instances } = setup;
 
         const rootNodeKey: GenericNodeKey = { type: "generic", id: "root-node" };
         const hierarchy: HierarchyDefinition = {
@@ -1176,7 +1224,7 @@ describe("Hierarchies", () => {
 
             return [
               {
-                fullClassName: "BisCore.PhysicalElement",
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
@@ -1185,7 +1233,7 @@ describe("Hierarchies", () => {
                       nodeLabel: { selector: "idToHex(this.ECInstanceId)" },
                       grouping: { byClass: true },
                     })}
-                    FROM BisCore.PhysicalElement this
+                    FROM ${schema.items.X.fullName} this
                   `,
                 },
               },
@@ -1195,13 +1243,13 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
             search: [
               {
                 identifier: rootNodeKey,
                 options: { autoExpand: true },
-                children: keys.elements.map((key) => ({ identifier: key })),
+                children: instances.map((key) => ({ identifier: key })),
               },
             ],
           }),
@@ -1211,9 +1259,9 @@ describe("Hierarchies", () => {
               autoExpand: true,
               children: [
                 NodeValidators.createForClassGroupingNode({
-                  className: keys.elements[0].className,
+                  className: instances[0].className,
                   autoExpand: false,
-                  children: keys.elements.map((key) => NodeValidators.createForInstanceNode({ instanceKeys: [key] })),
+                  children: instances.map((key) => NodeValidators.createForInstanceNode({ instanceKeys: [key] })),
                 }),
               ],
             }),
@@ -1222,27 +1270,30 @@ describe("Hierarchies", () => {
       });
 
       it("sets auto-expand flag for all deeply-nested grouping nodes before the target grouping node", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-            const category = insertSpatialCategory({ txn, codeValue: "category" });
-            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
-            const rootElement = insertPhysicalElement({ txn, modelId: model.id, categoryId: category.id });
-            const middleElement = insertPhysicalElement({
-              txn,
-              modelId: model.id,
-              categoryId: category.id,
-              parentId: rootElement.id,
-            });
-            const childElement = insertPhysicalElement({
-              txn,
-              modelId: model.id,
-              categoryId: category.id,
-              parentId: middleElement.id,
-            });
-            return { rootSubject, model, category, rootElement, middleElement, childElement };
-          });
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECNavigationProperty propertyName="Parent" relationshipName="XX" direction="backward" />
+              </ECEntityClass>
+              <ECRelationshipClass typeName="XX" strength="referencing" strengthDirection="forward" modifier="None">
+                <Source multiplicity="(0..1)" roleLabel="owns" polymorphic="false">
+                  <Class class="X" />
+                </Source>
+                <Target multiplicity="(0..*)" roleLabel="owned by" polymorphic="false">
+                  <Class class="X" />
+                </Target>
+              </ECRelationshipClass>
+            `,
+          );
+          const rootX = builder.insertInstance(s.items.X.fullName);
+          const middleX = builder.insertInstance(s.items.X.fullName, { "Parent.Id": rootX.id });
+          const childX = builder.insertInstance(s.items.X.fullName, { "Parent.Id": middleX.id });
+          return { schema: s, rootX, middleX, childX };
         });
+        const { ecdb, schema, ...keys } = setup;
 
         const rootNodeKey: GenericNodeKey = { type: "generic", id: "root-node" };
         const hierarchy: HierarchyDefinition = {
@@ -1252,7 +1303,7 @@ describe("Hierarchies", () => {
             }
             return [
               {
-                fullClassName: "BisCore.PhysicalElement",
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
@@ -1261,12 +1312,9 @@ describe("Hierarchies", () => {
                       nodeLabel: { selector: "idToHex(this.ECInstanceId)" },
                       grouping: { byClass: true },
                     })}
-                    FROM BisCore.PhysicalElement this
-                    WHERE this.Parent.Id ${HierarchyNodeKey.isGeneric(parentNode.key) ? "IS NULL" : "= ?"}
+                    FROM ${schema.items.X.fullName} this
+                    WHERE this.Parent.Id ${HierarchyNodeKey.isGeneric(parentNode.key) ? "IS NULL" : `= ${parentNode.key.instanceKeys[0].id}`}
                   `,
-                  bindings: HierarchyNodeKey.isGeneric(parentNode.key)
-                    ? undefined
-                    : [{ type: "id", value: parentNode.key.instanceKeys[0].id }],
                 },
               },
             ];
@@ -1275,7 +1323,7 @@ describe("Hierarchies", () => {
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
+            ecdb,
             hierarchy,
             search: [
               {
@@ -1283,13 +1331,13 @@ describe("Hierarchies", () => {
                 options: { autoExpand: true },
                 children: [
                   {
-                    identifier: keys.rootElement,
+                    identifier: keys.rootX,
                     options: { autoExpand: true },
                     children: [
                       {
-                        identifier: keys.middleElement,
+                        identifier: keys.middleX,
                         options: { autoExpand: true },
-                        children: [{ identifier: keys.childElement }],
+                        children: [{ identifier: keys.childX }],
                       },
                     ],
                   },
@@ -1306,21 +1354,19 @@ describe("Hierarchies", () => {
                   autoExpand: true,
                   children: [
                     NodeValidators.createForInstanceNode({
-                      instanceKeys: [keys.rootElement],
+                      instanceKeys: [keys.rootX],
                       autoExpand: true,
                       children: [
                         NodeValidators.createForClassGroupingNode({
                           autoExpand: true,
                           children: [
                             NodeValidators.createForInstanceNode({
-                              instanceKeys: [keys.middleElement],
+                              instanceKeys: [keys.middleX],
                               autoExpand: true,
                               children: [
                                 NodeValidators.createForClassGroupingNode({
                                   autoExpand: false,
-                                  children: [
-                                    NodeValidators.createForInstanceNode({ instanceKeys: [keys.childElement] }),
-                                  ],
+                                  children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childX] })],
                                 }),
                               ],
                             }),
@@ -1339,37 +1385,26 @@ describe("Hierarchies", () => {
       describe("nested grouping nodes of different types", async function () {
         const rootNodeKey: GenericNodeKey = { type: "generic", id: "root-node" };
         let hierarchy: HierarchyDefinition;
-        let imodelConnection: IModelConnection;
-        let elementKey: InstanceKey;
-        let circleClassName: EC.FullClassName;
+        let suiteSetup!: Awaited<ReturnType<typeof setupSuite>>;
+
+        async function setupSuite(fullTestName: string) {
+          return buildTestECDb(fullTestName, async (builder, testName) => {
+            const s = await importSchema(
+              testName,
+              builder,
+              `
+                <ECEntityClass typeName="Circle">
+                  <ECProperty propertyName="Color" typeName="string" />
+                </ECEntityClass>
+              `,
+            );
+            const circle = builder.insertInstance(s.items.Circle.fullName, { color: "Red" });
+            return { schema: s, circle };
+          });
+        }
 
         test.beforeAll(async (_, suite) => {
-          const result = await buildTestIModel(suite.fullTestName!, async (imodel, testName) => {
-            const schema = await importSchema(
-              testName,
-              imodel,
-              `
-                  <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
-                  <ECEntityClass typeName="Circle">
-                    <BaseClass>bis:PhysicalElement</BaseClass>
-                    <ECProperty propertyName="Color" typeName="string" />
-                  </ECEntityClass>
-                `,
-            );
-            return withEditTxn(imodel, (txn) => {
-              const category = insertSpatialCategory({ txn, codeValue: "category" });
-              const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
-              circleClassName = schema.items.Circle.fullName;
-              elementKey = insertPhysicalElement({
-                txn,
-                modelId: model.id,
-                categoryId: category.id,
-                classFullName: circleClassName,
-                ["Color"]: "Red",
-              });
-            });
-          });
-          imodelConnection = result.imodelConnection;
+          suiteSetup = await setupSuite(suite.fullTestName!);
 
           hierarchy = {
             defineHierarchyLevel: async ({ createSelectClause, ...props }) => {
@@ -1379,7 +1414,7 @@ describe("Hierarchies", () => {
 
               return [
                 {
-                  fullClassName: circleClassName,
+                  fullClassName: suiteSetup.schema.items.Circle.fullName,
                   query: {
                     ecsql: `
                       SELECT ${await createSelectClause({
@@ -1389,13 +1424,13 @@ describe("Hierarchies", () => {
                         grouping: {
                           byClass: true,
                           byProperties: {
-                            propertiesClassName: circleClassName,
+                            propertiesClassName: suiteSetup.schema.items.Circle.fullName,
                             propertyGroups: [{ propertyName: "Color", propertyClassAlias: "this" }],
                           },
                           byLabel: true,
                         },
                       })}
-                      FROM ${circleClassName} this
+                      FROM ${suiteSetup.schema.items.Circle.fullName} this
                     `,
                   },
                 },
@@ -1404,13 +1439,21 @@ describe("Hierarchies", () => {
           };
         });
 
+        test.afterAll(() => {
+          suiteSetup[Symbol.dispose]();
+        });
+
         it("sets auto-expand flag until the first grouping node", async () => {
           await validateHierarchy({
             provider: createProvider({
-              imodel: imodelConnection,
+              ecdb: suiteSetup.ecdb,
               hierarchy,
               search: [
-                { identifier: rootNodeKey, options: { autoExpand: true }, children: [{ identifier: elementKey }] },
+                {
+                  identifier: rootNodeKey,
+                  options: { autoExpand: true },
+                  children: [{ identifier: suiteSetup.circle }],
+                },
               ],
             }),
             expect: [
@@ -1419,7 +1462,7 @@ describe("Hierarchies", () => {
                 autoExpand: true,
                 children: [
                   NodeValidators.createForClassGroupingNode({
-                    className: circleClassName,
+                    className: suiteSetup.schema.items.Circle.fullName,
                     autoExpand: false,
                     children: [
                       NodeValidators.createForPropertyValueGroupingNode({
@@ -1431,7 +1474,7 @@ describe("Hierarchies", () => {
                             autoExpand: false,
                             children: [
                               NodeValidators.createForInstanceNode({
-                                instanceKeys: [elementKey],
+                                instanceKeys: [suiteSetup.circle],
                                 isSearchTarget: true,
                               }),
                             ],
@@ -1449,13 +1492,13 @@ describe("Hierarchies", () => {
         it("sets auto-expand flag until the second grouping node", async () => {
           await validateHierarchy({
             provider: createProvider({
-              imodel: imodelConnection,
+              ecdb: suiteSetup.ecdb,
               hierarchy,
               search: [
                 {
                   identifier: rootNodeKey,
                   options: { autoExpand: true },
-                  children: [{ identifier: elementKey, options: { autoExpand: { groupingLevel: 1 } } }],
+                  children: [{ identifier: suiteSetup.circle, options: { autoExpand: { groupingLevel: 1 } } }],
                 },
               ],
             }),
@@ -1465,7 +1508,7 @@ describe("Hierarchies", () => {
                 autoExpand: true,
                 children: [
                   NodeValidators.createForClassGroupingNode({
-                    className: circleClassName,
+                    className: suiteSetup.schema.items.Circle.fullName,
                     autoExpand: true,
                     children: [
                       NodeValidators.createForPropertyValueGroupingNode({
@@ -1477,7 +1520,7 @@ describe("Hierarchies", () => {
                             autoExpand: false,
                             children: [
                               NodeValidators.createForInstanceNode({
-                                instanceKeys: [elementKey],
+                                instanceKeys: [suiteSetup.circle],
                                 isSearchTarget: true,
                                 searchOptions: { autoExpand: { groupingLevel: 1 } },
                               }),
@@ -1496,13 +1539,13 @@ describe("Hierarchies", () => {
         it("sets auto-expand flag until the third grouping node", async () => {
           await validateHierarchy({
             provider: createProvider({
-              imodel: imodelConnection,
+              ecdb: suiteSetup.ecdb,
               hierarchy,
               search: [
                 {
                   identifier: rootNodeKey,
                   options: { autoExpand: true },
-                  children: [{ identifier: elementKey, options: { autoExpand: { groupingLevel: 2 } } }],
+                  children: [{ identifier: suiteSetup.circle, options: { autoExpand: { groupingLevel: 2 } } }],
                 },
               ],
             }),
@@ -1512,7 +1555,7 @@ describe("Hierarchies", () => {
                 autoExpand: true,
                 children: [
                   NodeValidators.createForClassGroupingNode({
-                    className: circleClassName,
+                    className: suiteSetup.schema.items.Circle.fullName,
                     autoExpand: true,
                     children: [
                       NodeValidators.createForPropertyValueGroupingNode({
@@ -1524,7 +1567,7 @@ describe("Hierarchies", () => {
                             autoExpand: false,
                             children: [
                               NodeValidators.createForInstanceNode({
-                                instanceKeys: [elementKey],
+                                instanceKeys: [suiteSetup.circle],
                                 isSearchTarget: true,
                                 searchOptions: { autoExpand: { groupingLevel: 2 } },
                               }),
@@ -1543,13 +1586,13 @@ describe("Hierarchies", () => {
         it("sets auto-expand flag until the instance node", async () => {
           await validateHierarchy({
             provider: createProvider({
-              imodel: imodelConnection,
+              ecdb: suiteSetup.ecdb,
               hierarchy,
               search: [
                 {
                   identifier: rootNodeKey,
                   options: { autoExpand: true },
-                  children: [{ identifier: elementKey, options: { autoExpand: true } }],
+                  children: [{ identifier: suiteSetup.circle, options: { autoExpand: true } }],
                 },
               ],
             }),
@@ -1559,7 +1602,7 @@ describe("Hierarchies", () => {
                 autoExpand: true,
                 children: [
                   NodeValidators.createForClassGroupingNode({
-                    className: circleClassName,
+                    className: suiteSetup.schema.items.Circle.fullName,
                     autoExpand: true,
                     children: [
                       NodeValidators.createForPropertyValueGroupingNode({
@@ -1571,7 +1614,7 @@ describe("Hierarchies", () => {
                             autoExpand: true,
                             children: [
                               NodeValidators.createForInstanceNode({
-                                instanceKeys: [elementKey],
+                                instanceKeys: [suiteSetup.circle],
                                 isSearchTarget: true,
                                 searchOptions: { autoExpand: true },
                               }),
@@ -1590,31 +1633,44 @@ describe("Hierarchies", () => {
     });
 
     describe("when searching merged hierarchy provider", () => {
+      const SCHEMA_XML = `
+        <ECEntityClass typeName="X">
+          <ECProperty propertyName="Label" typeName="string" />
+          <ECNavigationProperty propertyName="Parent" relationshipName="XX" direction="backward" />
+        </ECEntityClass>
+        <ECRelationshipClass typeName="XX" strength="referencing" strengthDirection="forward" modifier="None">
+          <Source multiplicity="(0..1)" roleLabel="owns" polymorphic="false">
+            <Class class="X" />
+          </Source>
+          <Target multiplicity="(0..*)" roleLabel="owned by" polymorphic="false">
+            <Class class="X" />
+          </Target>
+        </ECRelationshipClass>
+      `;
+
+      function createIModelAccessWithKey(ecdb: Parameters<typeof createIModelAccess>[0], imodelKey: string) {
+        const access = createIModelAccess(ecdb);
+        return { ...access, imodelKey };
+      }
+
       it("searches root nodes of individual provider", async function () {
-        const { imodelConnection: imodel1, ...keys1 } = await buildTestIModel(
-          `${expect.getState().currentTestName!} 1`,
-          async (imodel) => {
-            return withEditTxn(imodel, (txn) => {
-              const testSubject = insertSubject({ txn, codeValue: "A subject", parentId: IModel.rootSubjectId });
-              return { testSubject };
-            });
-          },
-        );
-        const { imodelConnection: imodel2, ...keys2 } = await buildTestIModel(
-          `${expect.getState().currentTestName!} 2`,
-          async (imodel) => {
-            return withEditTxn(imodel, (txn) => {
-              const testSubject = insertSubject({ txn, codeValue: "B subject", parentId: IModel.rootSubjectId });
-              return { testSubject };
-            });
-          },
-        );
-        expect(keys1.testSubject).toEqual(keys2.testSubject);
+        using setup1 = await buildTestECDb(`${expect.getState().currentTestName!} 1`, async (builder, testName) => {
+          const s = await importSchema(testName, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(s.items.X.fullName, { label: "A - x from ecdb 1" });
+          return { schema: s, x1 };
+        });
+        using setup2 = await buildTestECDb(`${expect.getState().currentTestName!} 2`, async (builder, testName) => {
+          const s = await importSchema(testName, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(s.items.X.fullName, { label: "B - x from ecdb 2" });
+          return { schema: s, x1 };
+        });
 
-        const testSubjectKey1 = { ...keys1.testSubject, imodelKey: imodel1.key };
-        const testSubjectKey2 = { ...keys1.testSubject, imodelKey: imodel2.key };
+        const imodelAccess1 = createIModelAccessWithKey(setup1.ecdb, "ecdb-1");
+        const instanceKey1: IModelInstanceKey = { ...setup1.x1, imodelKey: imodelAccess1.imodelKey };
 
-        const imodelAccess1 = createIModelAccess(imodel1);
+        const imodelAccess2 = createIModelAccessWithKey(setup2.ecdb, "ecdb-2");
+        const instanceKey2: IModelInstanceKey = { ...setup2.x1, imodelKey: imodelAccess2.imodelKey };
+
         const provider1 = createProvider({
           imodelAccess: imodelAccess1,
           hierarchy: {
@@ -1622,16 +1678,15 @@ describe("Hierarchies", () => {
               if (!parentNode) {
                 return [
                   {
-                    fullClassName: subjectClassName,
+                    fullClassName: instanceKey1.className,
                     query: {
                       ecsql: `
                         SELECT ${await createSelectClause({
                           ecClassId: { selector: `this.ECClassId` },
                           ecInstanceId: { selector: `this.ECInstanceId` },
-                          nodeLabel: { selector: `this.CodeValue` },
+                          nodeLabel: { selector: `this.Label` },
                         })}
-                        FROM ${subjectClassName} AS this
-                        WHERE Parent IS NOT NULL
+                        FROM ${instanceKey1.className} AS this
                       `,
                     },
                   },
@@ -1641,7 +1696,6 @@ describe("Hierarchies", () => {
             },
           },
         });
-        const imodelAccess2 = createIModelAccess(imodel2);
         const provider2 = createProvider({
           imodelAccess: imodelAccess2,
           hierarchy: {
@@ -1649,16 +1703,15 @@ describe("Hierarchies", () => {
               if (!parentNode) {
                 return [
                   {
-                    fullClassName: subjectClassName,
+                    fullClassName: instanceKey2.className,
                     query: {
                       ecsql: `
                         SELECT ${await createSelectClause({
                           ecClassId: { selector: `this.ECClassId` },
                           ecInstanceId: { selector: `this.ECInstanceId` },
-                          nodeLabel: { selector: `this.CodeValue` },
+                          nodeLabel: { selector: `this.Label` },
                         })}
-                        FROM ${subjectClassName} AS this
-                        WHERE Parent IS NOT NULL
+                        FROM ${instanceKey2.className} AS this
                       `,
                     },
                   },
@@ -1670,7 +1723,7 @@ describe("Hierarchies", () => {
         });
         const provider3 = createProvider({
           sourceName: "provider3",
-          imodel: imodel2,
+          imodelAccess: imodelAccess2,
           hierarchy: {
             async defineHierarchyLevel({ parentNode }) {
               if (!parentNode) {
@@ -1724,8 +1777,8 @@ describe("Hierarchies", () => {
         await validateHierarchy({
           provider: mergeProviders({ providers: [provider1, provider2, provider3, provider4] }),
           expect: [
-            NodeValidators.createForInstanceNode({ instanceKeys: [testSubjectKey1] }),
-            NodeValidators.createForInstanceNode({ instanceKeys: [testSubjectKey2] }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [instanceKey1] }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [instanceKey2] }),
             NodeValidators.createForGenericNode({ key: { type: "generic", id: "gen", source: "provider3" } }),
             NodeValidators.createForGenericNode({ key: { type: "generic", id: "gen", source: "custom-provider" } }),
           ],
@@ -1737,16 +1790,16 @@ describe("Hierarchies", () => {
             providers: [provider1, provider2, provider3, provider4],
             searchProps: {
               paths: [
-                { identifier: testSubjectKey1 },
-                { identifier: testSubjectKey2 },
+                { identifier: instanceKey1 },
+                { identifier: instanceKey2 },
                 { identifier: { type: "generic", id: "gen", source: "provider3" } },
                 { identifier: { type: "generic", id: "gen", source: "custom-provider" } },
               ],
             },
           }),
           expect: [
-            NodeValidators.createForInstanceNode({ instanceKeys: [testSubjectKey1] }),
-            NodeValidators.createForInstanceNode({ instanceKeys: [testSubjectKey2] }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [instanceKey1] }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [instanceKey2] }),
             NodeValidators.createForGenericNode({ key: { type: "generic", id: "gen", source: "provider3" } }),
             NodeValidators.createForGenericNode({ key: { type: "generic", id: "gen", source: "custom-provider" } }),
           ],
@@ -1756,16 +1809,16 @@ describe("Hierarchies", () => {
         await validateHierarchy({
           provider: mergeAndSearchProviders({
             providers: [provider1, provider2, provider3, provider4],
-            searchProps: { paths: [{ identifier: testSubjectKey1 }] },
+            searchProps: { paths: [{ identifier: instanceKey1 }] },
           }),
-          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [testSubjectKey1] })],
+          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [instanceKey1] })],
         });
         await validateHierarchy({
           provider: mergeAndSearchProviders({
             providers: [provider1, provider2, provider3, provider4],
-            searchProps: { paths: [{ identifier: testSubjectKey2 }] },
+            searchProps: { paths: [{ identifier: instanceKey2 }] },
           }),
-          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [testSubjectKey2] })],
+          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [instanceKey2] })],
         });
         await validateHierarchy({
           provider: mergeAndSearchProviders({
@@ -1786,31 +1839,38 @@ describe("Hierarchies", () => {
       });
 
       it("searches through multiple providers", async function () {
-        const rootSubjectKey = { className: subjectClassName, id: IModel.rootSubjectId };
-        const { imodelConnection: imodel1, ...keys1 } = await buildTestIModel(
-          `${expect.getState().currentTestName!} 1`,
-          async (imodel) => {
-            return withEditTxn(imodel, (txn) => {
-              const subject1 = insertSubject({ txn, codeValue: "A subject 1", parentId: rootSubjectKey.id });
-              const subject2 = insertSubject({ txn, codeValue: "A subject 2", parentId: subject1.id });
-              return { subject1, subject2 };
-            });
-          },
-        );
-        const { imodelConnection: imodel2, ...keys2 } = await buildTestIModel(
-          `${expect.getState().currentTestName!} 2`,
-          async (imodel) => {
-            return withEditTxn(imodel, (txn) => {
-              const subject1 = insertSubject({ txn, codeValue: "B subject 1", parentId: rootSubjectKey.id });
-              const subject2 = insertSubject({ txn, codeValue: "B subject 2", parentId: subject1.id });
-              return { subject1, subject2 };
-            });
-          },
-        );
+        const schemaProps = { schemaName: "TestSchema", schemaAlias: "TestSchema", schemaVersion: "1.0.0" as const };
+        const classNameX = `${schemaProps.schemaName}.X` as const;
+        using setup1 = await buildTestECDb(`${expect.getState().currentTestName!} 1`, async (builder) => {
+          const s = await importSchema(schemaProps, builder, SCHEMA_XML);
+          const rootX = builder.insertInstance(s.items.X.fullName, { label: "root x" });
+          const x1 = builder.insertInstance(s.items.X.fullName, { label: "A x 1", "Parent.Id": rootX.id });
+          const x2 = builder.insertInstance(s.items.X.fullName, { label: "A x 2", "Parent.Id": x1.id });
+          return { schema: s, rootX, x1, x2 };
+        });
+        using setup2 = await buildTestECDb(`${expect.getState().currentTestName!} 2`, async (builder) => {
+          const s = await importSchema(schemaProps, builder, SCHEMA_XML);
+          const rootX = builder.insertInstance(s.items.X.fullName, { label: "root x" });
+          const x1 = builder.insertInstance(s.items.X.fullName, { label: "B x 1", "Parent.Id": rootX.id });
+          const x2 = builder.insertInstance(s.items.X.fullName, { label: "B x 2", "Parent.Id": x1.id });
+          return { schema: s, rootX, x1, x2 };
+        });
 
-        function createSubjectsHierarchyProvider(
-          imodelAccess: ReturnType<typeof createIModelAccess>,
-        ): HierarchyProvider {
+        const imodelAccess1 = createIModelAccessWithKey(setup1.ecdb, "ecdb-1");
+        const keys1 = {
+          x0: { ...setup1.rootX, imodelKey: imodelAccess1.imodelKey } as IModelInstanceKey,
+          x1: { ...setup1.x1, imodelKey: imodelAccess1.imodelKey } as IModelInstanceKey,
+          x2: { ...setup1.x2, imodelKey: imodelAccess1.imodelKey } as IModelInstanceKey,
+        };
+
+        const imodelAccess2 = createIModelAccessWithKey(setup2.ecdb, "ecdb-2");
+        const keys2 = {
+          x0: { ...setup2.rootX, imodelKey: imodelAccess2.imodelKey } as IModelInstanceKey,
+          x1: { ...setup2.x1, imodelKey: imodelAccess2.imodelKey } as IModelInstanceKey,
+          x2: { ...setup2.x2, imodelKey: imodelAccess2.imodelKey } as IModelInstanceKey,
+        };
+
+        function createXHierarchyProvider(imodelAccess: ReturnType<typeof createIModelAccess>): HierarchyProvider {
           return createProvider({
             imodelAccess,
             hierarchy: createPredicateBasedHierarchyDefinition({
@@ -1818,39 +1878,39 @@ describe("Hierarchies", () => {
               hierarchy: {
                 rootNodes: async ({ createSelectClause }) => [
                   {
-                    fullClassName: subjectClassName,
+                    fullClassName: classNameX,
                     query: {
                       ecsql: `
                         SELECT ${await createSelectClause({
                           ecClassId: { selector: `this.ECClassId` },
                           ecInstanceId: { selector: `this.ECInstanceId` },
-                          nodeLabel: { selector: `this.CodeValue` },
+                          nodeLabel: { selector: `this.Label` },
                           hideNodeInHierarchy: true,
                         })}
-                        FROM ${subjectClassName} AS this
-                        WHERE Parent IS NULL
+                        FROM ${classNameX} AS this
+                        WHERE this.Parent IS NULL
                       `,
                     },
                   },
                 ],
                 childNodes: [
                   {
-                    parentInstancesNodePredicate: subjectClassName,
+                    parentInstancesNodePredicate: classNameX,
                     definitions: async ({
                       parentNodeInstanceIds,
                       createSelectClause,
                     }: DefineInstanceNodeChildHierarchyLevelProps) => [
                       {
-                        fullClassName: subjectClassName,
+                        fullClassName: classNameX,
                         query: {
                           ecsql: `
                             SELECT ${await createSelectClause({
                               ecClassId: { selector: `this.ECClassId` },
                               ecInstanceId: { selector: `this.ECInstanceId` },
-                              nodeLabel: { selector: `this.CodeValue` },
+                              nodeLabel: { selector: `this.Label` },
                             })}
-                            FROM ${subjectClassName} AS this
-                            WHERE Parent.Id IN (${parentNodeInstanceIds.join(",")})
+                            FROM ${classNameX} AS this
+                            WHERE this.Parent.Id IN (${parentNodeInstanceIds.join(",")})
                           `,
                         },
                       },
@@ -1861,14 +1921,9 @@ describe("Hierarchies", () => {
             }),
           });
         }
-
-        Object.values(keys1).forEach((value: IModelInstanceKey) => (value.imodelKey = imodel1.key));
-        Object.values(keys2).forEach((value: IModelInstanceKey) => (value.imodelKey = imodel2.key));
-
-        // create subject hierarchy providers for two iModels
-        const provider1 = createSubjectsHierarchyProvider(createIModelAccess(imodel1));
-        const provider2 = createSubjectsHierarchyProvider(createIModelAccess(imodel2));
-        // create generic node provider that creates a node for every bis.Subject node of any iModel
+        const provider1 = createXHierarchyProvider(imodelAccess1);
+        const provider2 = createXHierarchyProvider(imodelAccess2);
+        // create generic node provider that creates a node for every X node of any source
         const provider3 = createHierarchyProvider(
           () =>
             new (class implements Pick<HierarchyProvider, "getNodes" | "setHierarchySearch"> {
@@ -1876,7 +1931,7 @@ describe("Hierarchies", () => {
                 if (
                   parentNode &&
                   HierarchyNode.isInstancesNode(parentNode) &&
-                  parentNode.key.instanceKeys.some(({ className }) => className === subjectClassName)
+                  parentNode.key.instanceKeys.some(({ className }) => className === classNameX)
                 ) {
                   const myNode = {
                     key: { type: "generic", id: "gen", source: "custom-provider" } satisfies GenericNodeKey,
@@ -1911,10 +1966,10 @@ describe("Hierarchies", () => {
           provider: mergeProviders({ providers: [provider1, provider2, provider3] }),
           expect: [
             NodeValidators.createForInstanceNode({
-              instanceKeys: [keys1.subject1],
+              instanceKeys: [keys1.x1],
               children: [
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys1.subject2],
+                  instanceKeys: [keys1.x2],
                   children: [
                     NodeValidators.createForGenericNode({
                       key: { type: "generic", id: "gen", source: "custom-provider" },
@@ -1925,10 +1980,10 @@ describe("Hierarchies", () => {
               ],
             }),
             NodeValidators.createForInstanceNode({
-              instanceKeys: [keys2.subject1],
+              instanceKeys: [keys2.x1],
               children: [
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys2.subject2],
+                  instanceKeys: [keys2.x2],
                   children: [
                     NodeValidators.createForGenericNode({
                       key: { type: "generic", id: "gen", source: "custom-provider" },
@@ -1942,25 +1997,26 @@ describe("Hierarchies", () => {
         });
 
         // ensure we can search through different providers
+        const rootXKey = { className: classNameX, id: setup1.rootX.id };
         await validateHierarchy({
           provider: mergeAndSearchProviders({
             providers: [provider1, provider2, provider3],
             searchProps: {
               paths: [
                 {
-                  identifier: rootSubjectKey,
+                  identifier: rootXKey,
                   children: [
                     {
-                      identifier: keys1.subject1,
+                      identifier: keys1.x1,
                       children: [
                         {
-                          identifier: keys1.subject2,
+                          identifier: keys1.x2,
                           children: [{ identifier: { type: "generic", id: "gen", source: "custom-provider" } }],
                         },
                       ],
                     },
                     {
-                      identifier: keys2.subject1,
+                      identifier: keys2.x1,
                       children: [{ identifier: { type: "generic", id: "gen", source: "custom-provider" } }],
                     },
                   ],
@@ -1970,16 +2026,16 @@ describe("Hierarchies", () => {
           }),
           expect: [
             NodeValidators.createForInstanceNode({
-              instanceKeys: [keys1.subject1],
+              instanceKeys: [keys1.x1],
               children: [
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys1.subject2],
+                  instanceKeys: [keys1.x2],
                   children: [NodeValidators.createForGenericNode({ key: "gen" })],
                 }),
               ],
             }),
             NodeValidators.createForInstanceNode({
-              instanceKeys: [keys2.subject1],
+              instanceKeys: [keys2.x1],
               children: [NodeValidators.createForGenericNode({ key: "gen" })],
             }),
           ],

--- a/apps/full-stack-tests/src/hierarchies/Update.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/Update.test.ts
@@ -82,7 +82,7 @@ describe("Hierarchies", () => {
     });
 
     beforeEach(async (ctx) => {
-      const fileName = createFileNameFromString(ctx.task.name);
+      const fileName = createFileNameFromString(`${ctx.task.suite!.fullTestName!}`);
       const filePath = setupOutputFileLocation(fileName);
 
       if (fs.existsSync(filePath)) {

--- a/apps/full-stack-tests/src/hierarchies/grouping/AutoExpand.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/AutoExpand.test.ts
@@ -3,39 +3,55 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { insertSubject } from "presentation-test-utilities";
 import { afterAll, describe, it, test } from "vitest";
-import { Subject, withEditTxn } from "@itwin/core-backend";
-import { IModel } from "@itwin/core-common";
-import { buildTestIModel } from "../../IModelUtils.js";
+import { buildTestECDb } from "../../ECDbUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
+import { importSchema } from "../../SchemaUtils.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
 import { createProvider } from "../Utils.js";
 
-import type { IModelConnection } from "@itwin/core-frontend";
 import type { DefineHierarchyLevelProps, HierarchyDefinition } from "@itwin/presentation-hierarchies";
 import type { Props } from "@itwin/presentation-shared";
+
+const SCHEMA_PROPS = { schemaName: "AutoExpandTest", schemaAlias: "aet" };
+const SCHEMA_XML = `
+  <ECEntityClass typeName="B">
+    <ECProperty propertyName="CodeValue" typeName="string" />
+    <ECProperty propertyName="UserLabel" typeName="string" />
+  </ECEntityClass>
+  <ECEntityClass typeName="X">
+    <BaseClass>B</BaseClass>
+  </ECEntityClass>
+`;
+const X_FULL_NAME = "AutoExpandTest.X";
+const B_FULL_NAME = "AutoExpandTest.B";
 
 describe("Hierarchies", () => {
   describe("Grouping nodes' autoExpand setting", () => {
     type ECSqlSelectClauseGroupingParams = NonNullable<
       Props<DefineHierarchyLevelProps["createSelectClause"]>["grouping"]
     >;
-    let subjectClassName: string;
-    let emptyIModel: IModelConnection;
+    let suiteSetup!: Awaited<ReturnType<typeof setupSuite>>;
+
+    async function setupSuite(fullTestName: string) {
+      return buildTestECDb(fullTestName, async (builder) => {
+        await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+        const x0 = builder.insertInstance(X_FULL_NAME, { userLabel: "Test label" });
+        return { x0 };
+      });
+    }
 
     test.beforeAll(async (_, suite) => {
       await initialize();
-      emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodelConnection;
-      subjectClassName = Subject.classFullName.replace(":", ".");
+      suiteSetup = await setupSuite(suite.fullTestName!);
     });
 
     afterAll(async () => {
+      suiteSetup[Symbol.dispose]();
       await terminate();
     });
 
     function createHierarchyWithSpecifiedGrouping(
-      _imodel: IModelConnection,
       specifiedGrouping: ECSqlSelectClauseGroupingParams,
       labelProperty?: string,
     ): HierarchyDefinition {
@@ -44,17 +60,17 @@ describe("Hierarchies", () => {
           if (!parentNode) {
             return [
               {
-                fullClassName: `BisCore.InformationContentElement`,
+                fullClassName: X_FULL_NAME,
                 query: {
                   ecsql: `
-                  SELECT ${await createSelectClause({
-                    ecClassId: { selector: `this.ECClassId` },
-                    ecInstanceId: { selector: `this.ECInstanceId` },
-                    nodeLabel: { selector: `this.${labelProperty ?? "CodeValue"}` },
-                    grouping: specifiedGrouping,
-                  })}
-                  FROM ${subjectClassName} this
-                `,
+                    SELECT ${await createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: { selector: `this.${labelProperty ?? "CodeValue"}` },
+                      grouping: specifiedGrouping,
+                    })}
+                    FROM ${X_FULL_NAME} AS this
+                  `,
                 },
               },
             ];
@@ -66,30 +82,23 @@ describe("Hierarchies", () => {
 
     describe("Base class grouping", () => {
       const baseClassAutoExpandAlways: ECSqlSelectClauseGroupingParams = {
-        byBaseClasses: { fullClassNames: ["BisCore.InformationReferenceElement"], autoExpand: "always" },
+        byBaseClasses: { fullClassNames: [B_FULL_NAME], autoExpand: "always" },
       };
-
       const baseClassAutoExpandSingleChild: ECSqlSelectClauseGroupingParams = {
-        byBaseClasses: { fullClassNames: ["BisCore.InformationReferenceElement"], autoExpand: "single-child" },
+        byBaseClasses: { fullClassNames: [B_FULL_NAME], autoExpand: "single-child" },
       };
 
       it("grouping nodes' autoExpand option is true when some child has autoExpand set to 'always'", async () => {
         await validateHierarchy({
           provider: createProvider({
-            imodel: emptyIModel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(emptyIModel, baseClassAutoExpandAlways),
+            ecdb: suiteSetup.ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(baseClassAutoExpandAlways),
           }),
           expect: [
             NodeValidators.createForClassGroupingNode({
-              label: "Information Reference",
-              className: "BisCore.InformationReferenceElement",
+              className: B_FULL_NAME,
               autoExpand: true,
-              children: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-                  children: false,
-                }),
-              ],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [suiteSetup.x0], children: false })],
             }),
           ],
         });
@@ -98,55 +107,42 @@ describe("Hierarchies", () => {
       it("grouping nodes' autoExpand option is true when it has one child with autoExpand set to 'single-child'", async () => {
         await validateHierarchy({
           provider: createProvider({
-            imodel: emptyIModel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(emptyIModel, baseClassAutoExpandSingleChild),
+            ecdb: suiteSetup.ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(baseClassAutoExpandSingleChild),
           }),
           expect: [
             NodeValidators.createForClassGroupingNode({
-              label: "Information Reference",
-              className: "BisCore.InformationReferenceElement",
+              className: B_FULL_NAME,
               autoExpand: true,
-              children: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-                  children: false,
-                }),
-              ],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [suiteSetup.x0], children: false })],
             }),
           ],
         });
       });
 
       it("grouping nodes' autoExpand option is undefined when none of the child nodes have autoExpand set to 'always'", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({ txn, codeValue: "A1", parentId: IModel.rootSubjectId });
-            const childSubject2 = insertSubject({ txn, codeValue: "A2", parentId: IModel.rootSubjectId });
-            return { childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x0 = builder.insertInstance(X_FULL_NAME, { codeValue: "a" });
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "b" });
+          const x2 = builder.insertInstance(X_FULL_NAME, { codeValue: "c" });
+          return { x0, x1, x2 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(
-              imodelConnection,
-              baseClassAutoExpandSingleChild,
-              `ECInstanceId`,
-            ),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(baseClassAutoExpandSingleChild),
           }),
           expect: [
             NodeValidators.createForClassGroupingNode({
-              label: "Information Reference",
-              className: "BisCore.InformationReferenceElement",
+              className: B_FULL_NAME,
               autoExpand: false,
               children: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-                  children: false,
-                }),
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x0], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
               ],
             }),
           ],
@@ -156,25 +152,19 @@ describe("Hierarchies", () => {
 
     describe("Class grouping", () => {
       const classAutoExpandAlways: ECSqlSelectClauseGroupingParams = { byClass: { autoExpand: "always" } };
-
       const classAutoExpandSingleChild: ECSqlSelectClauseGroupingParams = { byClass: { autoExpand: "single-child" } };
 
       it("grouping nodes' autoExpand option is true when some child has autoExpand set to 'always'", async () => {
         await validateHierarchy({
           provider: createProvider({
-            imodel: emptyIModel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(emptyIModel, classAutoExpandAlways),
+            ecdb: suiteSetup.ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(classAutoExpandAlways),
           }),
           expect: [
             NodeValidators.createForClassGroupingNode({
-              className: "BisCore.Subject",
+              className: X_FULL_NAME,
               autoExpand: true,
-              children: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-                  children: false,
-                }),
-              ],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [suiteSetup.x0], children: false })],
             }),
           ],
         });
@@ -183,53 +173,42 @@ describe("Hierarchies", () => {
       it("grouping nodes' autoExpand option is true when it has one child with autoExpand set to 'single-child'", async () => {
         await validateHierarchy({
           provider: createProvider({
-            imodel: emptyIModel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(emptyIModel, classAutoExpandSingleChild),
+            ecdb: suiteSetup.ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(classAutoExpandSingleChild),
           }),
           expect: [
             NodeValidators.createForClassGroupingNode({
-              className: "BisCore.Subject",
+              className: X_FULL_NAME,
               autoExpand: true,
-              children: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-                  children: false,
-                }),
-              ],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [suiteSetup.x0], children: false })],
             }),
           ],
         });
       });
 
       it("grouping nodes' autoExpand option is undefined when none of the child nodes have autoExpand set to 'always'", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({ txn, codeValue: "A1", parentId: IModel.rootSubjectId });
-            const childSubject2 = insertSubject({ txn, codeValue: "A2", parentId: IModel.rootSubjectId });
-            return { childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x0 = builder.insertInstance(X_FULL_NAME, { codeValue: "a" });
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "b" });
+          const x2 = builder.insertInstance(X_FULL_NAME, { codeValue: "c" });
+          return { x0, x1, x2 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(
-              imodelConnection,
-              classAutoExpandSingleChild,
-              `ECInstanceId`,
-            ),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(classAutoExpandSingleChild),
           }),
           expect: [
             NodeValidators.createForClassGroupingNode({
-              className: "BisCore.Subject",
+              className: X_FULL_NAME,
               autoExpand: false,
               children: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-                  children: false,
-                }),
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x0], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
               ],
             }),
           ],
@@ -239,24 +218,18 @@ describe("Hierarchies", () => {
 
     describe("Label grouping", () => {
       const labelAutoExpandAlways: ECSqlSelectClauseGroupingParams = { byLabel: { autoExpand: "always" } };
-
       const labelAutoExpandSingleChild: ECSqlSelectClauseGroupingParams = { byLabel: { autoExpand: "single-child" } };
 
       it("grouping nodes' autoExpand option is true when some child has autoExpand set to 'always'", async () => {
         await validateHierarchy({
           provider: createProvider({
-            imodel: emptyIModel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(emptyIModel, labelAutoExpandAlways),
+            ecdb: suiteSetup.ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(labelAutoExpandAlways, "UserLabel"),
           }),
           expect: [
             NodeValidators.createForLabelGroupingNode({
               autoExpand: true,
-              children: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-                  children: false,
-                }),
-              ],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [suiteSetup.x0], children: false })],
             }),
           ],
         });
@@ -265,18 +238,13 @@ describe("Hierarchies", () => {
       it("grouping nodes' autoExpand option is true when it has one child with autoExpand set to 'single-child'", async () => {
         await validateHierarchy({
           provider: createProvider({
-            imodel: emptyIModel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(emptyIModel, labelAutoExpandSingleChild),
+            ecdb: suiteSetup.ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(labelAutoExpandSingleChild, "UserLabel"),
           }),
           expect: [
             NodeValidators.createForLabelGroupingNode({
               autoExpand: true,
-              children: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-                  children: false,
-                }),
-              ],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [suiteSetup.x0], children: false })],
             }),
           ],
         });
@@ -284,46 +252,32 @@ describe("Hierarchies", () => {
 
       it("grouping nodes' autoExpand option is undefined when none of the child nodes have autoExpand set to 'always'", async () => {
         const groupName = "test1";
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({
-              txn,
-              codeValue: "A1",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            const childSubject2 = insertSubject({
-              txn,
-              codeValue: "A2",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            return { childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x0 = builder.insertInstance(X_FULL_NAME, { userLabel: groupName });
+          const x1 = builder.insertInstance(X_FULL_NAME, { userLabel: "test2" });
+          const x2 = builder.insertInstance(X_FULL_NAME, { userLabel: groupName });
+          return { x0, x1, x2 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, labelAutoExpandSingleChild, "UserLabel"),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(labelAutoExpandSingleChild, "UserLabel"),
           }),
           expect: [
             NodeValidators.createForLabelGroupingNode({
-              autoExpand: true,
-              children: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-                  children: false,
-                }),
+              label: groupName,
+              autoExpand: false,
+              childrenUnordered: [
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x0], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
               ],
             }),
             NodeValidators.createForLabelGroupingNode({
-              label: groupName,
-              autoExpand: false,
-              children: [
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
-              ],
+              autoExpand: true,
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
             }),
           ],
         });
@@ -333,7 +287,7 @@ describe("Hierarchies", () => {
     describe("Properties grouping", () => {
       const propertiesAutoExpandAlways: ECSqlSelectClauseGroupingParams = {
         byProperties: {
-          propertiesClassName: "BisCore.Element",
+          propertiesClassName: B_FULL_NAME,
           createGroupForUnspecifiedValues: true,
           propertyGroups: [{ propertyName: "UserLabel", propertyClassAlias: "this" }],
           autoExpand: "always",
@@ -342,7 +296,7 @@ describe("Hierarchies", () => {
 
       const propertiesAutoExpandSingleChild: ECSqlSelectClauseGroupingParams = {
         byProperties: {
-          propertiesClassName: "BisCore.Element",
+          propertiesClassName: B_FULL_NAME,
           createGroupForUnspecifiedValues: true,
           propertyGroups: [{ propertyName: "UserLabel", propertyClassAlias: "this" }],
           autoExpand: "single-child",
@@ -352,18 +306,13 @@ describe("Hierarchies", () => {
       it("grouping nodes' autoExpand option is true when some child has autoExpand set to 'always'", async () => {
         await validateHierarchy({
           provider: createProvider({
-            imodel: emptyIModel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(emptyIModel, propertiesAutoExpandAlways),
+            ecdb: suiteSetup.ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(propertiesAutoExpandAlways),
           }),
           expect: [
             NodeValidators.createForPropertyValueGroupingNode({
               autoExpand: true,
-              children: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-                  children: false,
-                }),
-              ],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [suiteSetup.x0], children: false })],
             }),
           ],
         });
@@ -372,51 +321,40 @@ describe("Hierarchies", () => {
       it("grouping nodes' autoExpand option is true when it has one child with autoExpand set to 'single-child'", async () => {
         await validateHierarchy({
           provider: createProvider({
-            imodel: emptyIModel,
-            hierarchy: createHierarchyWithSpecifiedGrouping(emptyIModel, propertiesAutoExpandSingleChild),
+            ecdb: suiteSetup.ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(propertiesAutoExpandSingleChild),
           }),
           expect: [
             NodeValidators.createForPropertyValueGroupingNode({
               autoExpand: true,
-              children: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-                  children: false,
-                }),
-              ],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [suiteSetup.x0], children: false })],
             }),
           ],
         });
       });
 
       it("grouping nodes' autoExpand option is undefined when none of the child nodes have autoExpand set to 'always'", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({ txn, codeValue: "A1", parentId: IModel.rootSubjectId });
-            const childSubject2 = insertSubject({ txn, codeValue: "A2", parentId: IModel.rootSubjectId });
-            return { childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x0 = builder.insertInstance(X_FULL_NAME);
+          const x1 = builder.insertInstance(X_FULL_NAME);
+          const x2 = builder.insertInstance(X_FULL_NAME);
+          return { x0, x1, x2 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(
-              imodelConnection,
-              propertiesAutoExpandSingleChild,
-              "ECInstanceId",
-            ),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(propertiesAutoExpandSingleChild, "ECInstanceId"),
           }),
           expect: [
             NodeValidators.createForPropertyValueGroupingNode({
               autoExpand: false,
               children: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-                  children: false,
-                }),
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x0], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
               ],
             }),
           ],

--- a/apps/full-stack-tests/src/hierarchies/grouping/BaseClassGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/BaseClassGrouping.test.ts
@@ -3,57 +3,57 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { insertPhysicalPartition, insertSubject } from "presentation-test-utilities";
-import { afterAll, describe, it, test } from "vitest";
-import { PhysicalPartition, Subject, withEditTxn } from "@itwin/core-backend";
-import { IModel } from "@itwin/core-common";
-import { normalizeFullClassName } from "@itwin/presentation-shared";
-import { buildTestIModel } from "../../IModelUtils.js";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { buildTestECDb } from "../../ECDbUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
+import { importSchema } from "../../SchemaUtils.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
 import { createProvider } from "../Utils.js";
 
-import type { IModelConnection } from "@itwin/core-frontend";
 import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
-import type { EC } from "@itwin/presentation-shared";
 
 describe("Hierarchies", () => {
   describe("Base class grouping", () => {
-    let subjectClassName: EC.FullClassName;
-    let physicalPartitionClassName: EC.FullClassName;
-    let emptyIModel: IModelConnection;
-
-    test.beforeAll(async (_, suite) => {
+    beforeAll(async () => {
       await initialize();
-      emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodelConnection;
-      subjectClassName = normalizeFullClassName(Subject.classFullName);
-      physicalPartitionClassName = normalizeFullClassName(PhysicalPartition.classFullName);
     });
 
     afterAll(async () => {
       await terminate();
     });
+
     it("doesn't create grouping nodes if provided classes aren't base for node class", async () => {
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+          <ECEntityClass typeName="X">
+            <ECProperty propertyName="Label" typeName="string" />
+          </ECEntityClass>
+          <ECEntityClass typeName="C" />
+        `,
+        );
+        const x1 = builder.insertInstance(s.items.X.fullName, { label: "x1" });
+        return { schema: s, x1 };
+      });
+      const { ecdb, schema, ...keys } = setup;
+
       const customHierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
-                fullClassName: `BisCore.InformationContentElement`,
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
-                      nodeLabel: { selector: `this.UserLabel` },
-                      grouping: {
-                        byBaseClasses: { fullClassNames: ["BisCore.GraphicalPartition3d", "BisCore.LinkElement"] },
-                      },
+                      nodeLabel: { selector: `this.Label` },
+                      grouping: { byBaseClasses: { fullClassNames: [schema.items.C.fullName] } },
                     })}
-                    FROM (
-                      SELECT ECClassId, ECInstanceId, UserLabel, Parent
-                      FROM ${subjectClassName}
-                    ) AS this
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                 },
               },
@@ -64,37 +64,50 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel: emptyIModel, hierarchy: customHierarchy }),
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-            children: false,
-          }),
-        ],
+        provider: createProvider({ ecdb, hierarchy: customHierarchy }),
+        expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
       });
     });
 
     it("doesn't create grouping nodes if provided classes aren't of entity or relationship type", async () => {
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+          <ECEntityClass typeName="M">
+            <ECCustomAttributes>
+              <IsMixin xmlns="CoreCustomAttributes.01.00.03">
+                <AppliesToEntityClass>X</AppliesToEntityClass>
+              </IsMixin>
+            </ECCustomAttributes>
+          </ECEntityClass>
+          <ECEntityClass typeName="X">
+            <BaseClass>M</BaseClass>
+            <ECProperty propertyName="Label" typeName="string" />
+          </ECEntityClass>
+        `,
+        );
+        const x1 = builder.insertInstance(s.items.X.fullName, { label: "x1" });
+        return { schema: s, x1 };
+      });
+      const { ecdb, schema, ...keys } = setup;
+
       const customHierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
-                fullClassName: `BisCore.InformationContentElement`,
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
                       ecClassId: { selector: `this.ECClassId` },
                       ecInstanceId: { selector: `this.ECInstanceId` },
-                      nodeLabel: { selector: `this.UserLabel` },
-                      grouping: {
-                        byBaseClasses: { fullClassNames: ["BisCore.IParentElement", "BisCore.ISubModeledElement"] },
-                      },
+                      nodeLabel: { selector: `this.Label` },
+                      grouping: { byBaseClasses: { fullClassNames: [schema.items.M.fullName] } },
                     })}
-                    FROM (
-                      SELECT ECClassId, ECInstanceId, UserLabel, Parent
-                      FROM ${subjectClassName}
-                    ) AS this
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                 },
               },
@@ -105,37 +118,46 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel: emptyIModel, hierarchy: customHierarchy }),
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-            children: false,
-          }),
-        ],
+        provider: createProvider({ ecdb, hierarchy: customHierarchy }),
+        expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
       });
     });
 
     it("creates grouping nodes if provided class is base for node class", async () => {
-      const baseClassName = "BisCore.InformationContentElement";
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+          <ECEntityClass typeName="B">
+            <ECProperty propertyName="Label" typeName="string" />
+          </ECEntityClass>
+          <ECEntityClass typeName="X">
+            <BaseClass>B</BaseClass>
+          </ECEntityClass>
+        `,
+        );
+        const x1 = builder.insertInstance(s.items.X.fullName, { label: "x1" });
+        return { schema: s, x1 };
+      });
+      const { ecdb, schema, ...keys } = setup;
+
       const customHierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
-                fullClassName: `BisCore.InformationContentElement`,
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
-                      SELECT ${await createSelectClause({
-                        ecClassId: { selector: `this.ECClassId` },
-                        ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `this.UserLabel` },
-                        grouping: { byBaseClasses: { fullClassNames: [baseClassName] } },
-                      })}
-                      FROM (
-                        SELECT ECClassId, ECInstanceId, UserLabel, Parent
-                        FROM ${subjectClassName}
-                      ) AS this
-                    `,
+                    SELECT ${await createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: { selector: `this.Label` },
+                      grouping: { byBaseClasses: { fullClassNames: [schema.items.B.fullName] } },
+                    })}
+                    FROM ${schema.items.X.fullName} AS this
+                  `,
                 },
               },
             ];
@@ -145,62 +167,60 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel: emptyIModel, hierarchy: customHierarchy }),
+        provider: createProvider({ ecdb, hierarchy: customHierarchy }),
         expect: [
           NodeValidators.createForClassGroupingNode({
-            label: "Information Content Element",
-            className: baseClassName,
-            children: [
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [{ className: "BisCore.Subject", id: IModel.rootSubjectId }],
-                children: false,
-              }),
-            ],
+            className: schema.items.B.fullName,
+            children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
           }),
         ],
       });
     });
 
     it("creates multiple grouping nodes if provided base classes are base for node and for provided other base class", async () => {
-      const baseClassName1 = "Element";
-      const baseClassName2 = "InformationContentElement";
-      const baseClassName3 = "InformationPartitionElement";
-      const baseSchemaName = "BisCore";
-      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-        return withEditTxn(imodel, (txn) => {
-          const childPartition1 = insertPhysicalPartition({ txn, codeValue: "B1", parentId: IModel.rootSubjectId });
-          return { childPartition1 };
-        });
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+          <ECEntityClass typeName="A" />
+          <ECEntityClass typeName="B">
+            <BaseClass>A</BaseClass>
+          </ECEntityClass>
+          <ECEntityClass typeName="C">
+            <BaseClass>B</BaseClass>
+          </ECEntityClass>
+          <ECEntityClass typeName="Z">
+            <BaseClass>C</BaseClass>
+            <ECProperty propertyName="Label" typeName="string" />
+          </ECEntityClass>
+        `,
+        );
+        const z1 = builder.insertInstance(s.items.Z.fullName, { label: "z1" });
+        return { schema: s, z1 };
       });
+      const { ecdb, schema, ...keys } = setup;
 
       const customHierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
-                fullClassName: `BisCore.InformationContentElement`,
+                fullClassName: schema.items.Z.fullName,
                 query: {
                   ecsql: `
-                      SELECT ${await createSelectClause({
-                        ecClassId: { selector: `this.ECClassId` },
-                        ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `this.UserLabel` },
-                        grouping: {
-                          byBaseClasses: {
-                            fullClassNames: [
-                              `${baseSchemaName}.${baseClassName1}`,
-                              `${baseSchemaName}.${baseClassName2}`,
-                              `${baseSchemaName}.${baseClassName3}`,
-                            ],
-                          },
+                    SELECT ${await createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: { selector: `this.Label` },
+                      grouping: {
+                        byBaseClasses: {
+                          fullClassNames: [schema.items.A.fullName, schema.items.B.fullName, schema.items.C.fullName],
                         },
-                      })}
-                      FROM (
-                        SELECT ECClassId, ECInstanceId, UserLabel, Parent
-                        FROM ${physicalPartitionClassName}
-                      ) AS this
-                      WHERE this.Parent.Id = (${IModel.rootSubjectId})
-                    `,
+                      },
+                    })}
+                    FROM ${schema.items.Z.fullName} AS this
+                  `,
                 },
               },
             ];
@@ -210,22 +230,17 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel: imodelConnection, hierarchy: customHierarchy }),
+        provider: createProvider({ ecdb, hierarchy: customHierarchy }),
         expect: [
           NodeValidators.createForClassGroupingNode({
-            label: "Element",
-            className: `${baseSchemaName}.${baseClassName1}`,
+            className: schema.items.A.fullName,
             children: [
               NodeValidators.createForClassGroupingNode({
-                label: "Information Content Element",
-                className: `${baseSchemaName}.${baseClassName2}`,
+                className: schema.items.B.fullName,
                 children: [
                   NodeValidators.createForClassGroupingNode({
-                    label: "Information Partition",
-                    className: `${baseSchemaName}.${baseClassName3}`,
-                    children: [
-                      NodeValidators.createForInstanceNode({ instanceKeys: [keys.childPartition1], children: false }),
-                    ],
+                    className: schema.items.C.fullName,
+                    children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.z1], children: false })],
                   }),
                 ],
               }),
@@ -236,70 +251,68 @@ describe("Hierarchies", () => {
     });
 
     it("creates different grouping nodes if nodes of the same class have different base classes provided", async () => {
-      const baseClassName1 = "Element";
-      const baseClassName2 = "InformationContentElement";
-      const baseClassName3 = "InformationPartitionElement";
-      const baseSchemaName = "BisCore";
-      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-        return withEditTxn(imodel, (txn) => {
-          const childPartition1 = insertPhysicalPartition({ txn, codeValue: "B1", parentId: IModel.rootSubjectId });
-          const childPartition2 = insertPhysicalPartition({ txn, codeValue: "B2", parentId: IModel.rootSubjectId });
-          return { childPartition1, childPartition2 };
-        });
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+          <ECEntityClass typeName="A" />
+          <ECEntityClass typeName="B">
+            <BaseClass>A</BaseClass>
+          </ECEntityClass>
+          <ECEntityClass typeName="C">
+            <BaseClass>B</BaseClass>
+          </ECEntityClass>
+          <ECEntityClass typeName="Z">
+            <BaseClass>C</BaseClass>
+            <ECProperty propertyName="CodeValue" typeName="string" />
+          </ECEntityClass>
+        `,
+        );
+        const z1 = builder.insertInstance(s.items.Z.fullName, { codeValue: "z1" });
+        const z2 = builder.insertInstance(s.items.Z.fullName, { codeValue: "z2" });
+        return { schema: s, z1, z2 };
       });
+      const { ecdb, schema, ...keys } = setup;
 
       const customHierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
-                fullClassName: `BisCore.InformationContentElement`,
+                fullClassName: schema.items.Z.fullName,
                 query: {
                   ecsql: `
-                      SELECT ${await createSelectClause({
-                        ecClassId: { selector: `this.ECClassId` },
-                        ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `this.UserLabel` },
-                        grouping: {
-                          byBaseClasses: {
-                            fullClassNames: [
-                              `${baseSchemaName}.${baseClassName1}`,
-                              `${baseSchemaName}.${baseClassName2}`,
-                              `${baseSchemaName}.${baseClassName3}`,
-                            ],
-                          },
+                    SELECT ${await createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: { selector: `this.CodeValue` },
+                      grouping: {
+                        byBaseClasses: {
+                          fullClassNames: [schema.items.A.fullName, schema.items.B.fullName, schema.items.C.fullName],
                         },
-                      })}
-                      FROM (
-                        SELECT ECClassId, ECInstanceId, UserLabel, Parent, CodeValue
-                        FROM ${physicalPartitionClassName}
-                      ) AS this
-                      WHERE this.Parent.Id = (${IModel.rootSubjectId})
-                        AND NOT this.CodeValue = 'B2'
-                    `,
+                      },
+                    })}
+                    FROM ${schema.items.Z.fullName} AS this
+                    WHERE this.CodeValue <> 'z2'
+                  `,
                 },
               },
               {
-                fullClassName: physicalPartitionClassName,
+                fullClassName: schema.items.Z.fullName,
                 query: {
                   ecsql: `
-                      SELECT ${await createSelectClause({
-                        ecClassId: { selector: `this.ECClassId` },
-                        ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `this.UserLabel` },
-                        grouping: {
-                          byBaseClasses: {
-                            fullClassNames: [
-                              `${baseSchemaName}.${baseClassName2}`,
-                              `${baseSchemaName}.${baseClassName3}`,
-                            ],
-                          },
-                        },
-                      })}
-                      FROM ${physicalPartitionClassName} AS this
-                      WHERE this.Parent.Id = (${IModel.rootSubjectId})
-                        AND this.CodeValue = 'B2'
-                    `,
+                    SELECT ${await createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: { selector: `this.CodeValue` },
+                      grouping: {
+                        byBaseClasses: { fullClassNames: [schema.items.B.fullName, schema.items.C.fullName] },
+                      },
+                    })}
+                    FROM ${schema.items.Z.fullName} AS this
+                    WHERE this.CodeValue = 'z2'
+                  `,
                 },
               },
             ];
@@ -309,37 +322,28 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel: imodelConnection, hierarchy: customHierarchy }),
+        provider: createProvider({ ecdb, hierarchy: customHierarchy }),
         expect: [
           NodeValidators.createForClassGroupingNode({
-            label: "Element",
-            className: `${baseSchemaName}.${baseClassName1}`,
+            className: schema.items.A.fullName,
             children: [
               NodeValidators.createForClassGroupingNode({
-                label: "Information Content Element",
-                className: `${baseSchemaName}.${baseClassName2}`,
+                className: schema.items.B.fullName,
                 children: [
                   NodeValidators.createForClassGroupingNode({
-                    label: "Information Partition",
-                    className: `${baseSchemaName}.${baseClassName3}`,
-                    children: [
-                      NodeValidators.createForInstanceNode({ instanceKeys: [keys.childPartition1], children: false }),
-                    ],
+                    className: schema.items.C.fullName,
+                    children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.z1], children: false })],
                   }),
                 ],
               }),
             ],
           }),
           NodeValidators.createForClassGroupingNode({
-            label: "Information Content Element",
-            className: `${baseSchemaName}.${baseClassName2}`,
+            className: schema.items.B.fullName,
             children: [
               NodeValidators.createForClassGroupingNode({
-                label: "Information Partition",
-                className: `${baseSchemaName}.${baseClassName3}`,
-                children: [
-                  NodeValidators.createForInstanceNode({ instanceKeys: [keys.childPartition2], children: false }),
-                ],
+                className: schema.items.C.fullName,
+                children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.z2], children: false })],
               }),
             ],
           }),
@@ -348,37 +352,58 @@ describe("Hierarchies", () => {
     });
 
     it("groups nodes of different classes if they share the same base class", async () => {
-      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-        return withEditTxn(imodel, (txn) => {
-          const childSubject1 = insertSubject({ txn, codeValue: "A1", parentId: IModel.rootSubjectId });
-          const childPartition2 = insertPhysicalPartition({ txn, codeValue: "B2", parentId: IModel.rootSubjectId });
-          return { childSubject1, childPartition2 };
-        });
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+          <ECEntityClass typeName="E">
+            <ECProperty propertyName="Label" typeName="string" />
+          </ECEntityClass>
+          <ECEntityClass typeName="S">
+            <BaseClass>E</BaseClass>
+          </ECEntityClass>
+          <ECEntityClass typeName="P">
+            <BaseClass>E</BaseClass>
+          </ECEntityClass>
+        `,
+        );
+        const s1 = builder.insertInstance(s.items.S.fullName, { label: "a s1" });
+        const p1 = builder.insertInstance(s.items.P.fullName, { label: "b p1" });
+        return { schema: s, s1, p1 };
       });
+      const { ecdb, schema, ...keys } = setup;
 
       const customHierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
-                fullClassName: `BisCore.InformationContentElement`,
+                fullClassName: schema.items.S.fullName,
                 query: {
                   ecsql: `
-                      SELECT ${await createSelectClause({
-                        ecClassId: { selector: `this.ECClassId` },
-                        ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `this.CodeValue` },
-                        grouping: { byBaseClasses: { fullClassNames: ["BisCore.Element"] } },
-                      })}
-                      FROM (
-                        SELECT ECClassId, ECInstanceId, Parent, CodeValue
-                        FROM ${subjectClassName}
-                        UNION ALL
-                        SELECT ECClassId, ECInstanceId, Parent, CodeValue
-                        FROM ${physicalPartitionClassName}
-                      ) AS this
-                      WHERE this.Parent.Id = (${IModel.rootSubjectId})
-                    `,
+                    SELECT ${await createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: { selector: `this.Label` },
+                      grouping: { byBaseClasses: { fullClassNames: [schema.items.E.fullName] } },
+                    })}
+                    FROM ${schema.items.S.fullName} AS this
+                  `,
+                },
+              },
+              {
+                fullClassName: schema.items.P.fullName,
+                query: {
+                  ecsql: `
+                    SELECT ${await createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: { selector: `this.Label` },
+                      grouping: { byBaseClasses: { fullClassNames: [schema.items.E.fullName] } },
+                    })}
+                    FROM ${schema.items.P.fullName} AS this
+                  `,
                 },
               },
             ];
@@ -388,14 +413,13 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel: imodelConnection, hierarchy: customHierarchy }),
+        provider: createProvider({ ecdb, hierarchy: customHierarchy }),
         expect: [
           NodeValidators.createForClassGroupingNode({
-            label: "Element",
-            className: "BisCore.Element",
+            className: schema.items.E.fullName,
             children: [
-              NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
-              NodeValidators.createForInstanceNode({ instanceKeys: [keys.childPartition2], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.s1], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.p1], children: false }),
             ],
           }),
         ],

--- a/apps/full-stack-tests/src/hierarchies/grouping/ClassGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/ClassGrouping.test.ts
@@ -3,12 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { insertPhysicalPartition, insertSubject } from "presentation-test-utilities";
 import { afterAll, beforeAll, describe, it } from "vitest";
-import { PhysicalPartition, Subject, withEditTxn } from "@itwin/core-backend";
-import { IModel } from "@itwin/core-common";
-import { buildTestIModel } from "../../IModelUtils.js";
+import { buildTestECDb } from "../../ECDbUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
+import { importSchema } from "../../SchemaUtils.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
 import { createProvider } from "../Utils.js";
 
@@ -16,13 +14,8 @@ import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
 
 describe("Hierarchies", () => {
   describe("Class grouping", () => {
-    let subjectClassName: string;
-    let physicalPartitionClassName: string;
-
     beforeAll(async () => {
       await initialize();
-      subjectClassName = Subject.classFullName.replace(":", ".");
-      physicalPartitionClassName = PhysicalPartition.classFullName.replace(":", ".");
     });
 
     afterAll(async () => {
@@ -30,22 +23,36 @@ describe("Hierarchies", () => {
     });
 
     it("creates different groups for different classes", async () => {
-      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-        return withEditTxn(imodel, (txn) => {
-          const childSubject1 = insertSubject({ txn, codeValue: "1", parentId: IModel.rootSubjectId });
-          const childPartition2 = insertPhysicalPartition({ txn, codeValue: "2", parentId: IModel.rootSubjectId });
-          const childSubject3 = insertSubject({ txn, codeValue: "3", parentId: IModel.rootSubjectId });
-          const childPartition4 = insertPhysicalPartition({ txn, codeValue: "4", parentId: IModel.rootSubjectId });
-          return { childSubject1, childPartition2, childSubject3, childPartition4 };
-        });
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="B">
+              <ECProperty propertyName="CodeValue" typeName="string" />
+            </ECEntityClass>
+            <ECEntityClass typeName="X">
+              <BaseClass>B</BaseClass>
+            </ECEntityClass>
+            <ECEntityClass typeName="Y">
+              <BaseClass>B</BaseClass>
+            </ECEntityClass>
+          `,
+        );
+        const x1 = builder.insertInstance(s.items.X.fullName, { codeValue: "1" });
+        const y2 = builder.insertInstance(s.items.Y.fullName, { codeValue: "2" });
+        const x3 = builder.insertInstance(s.items.X.fullName, { codeValue: "3" });
+        const y4 = builder.insertInstance(s.items.Y.fullName, { codeValue: "4" });
+        return { schema: s, x1, y2, x3, y4 };
       });
+      const { ecdb, schema, ...keys } = setup;
 
       const hierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
-                fullClassName: `BisCore.InformationContentElement`,
+                fullClassName: schema.items.B.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
@@ -55,13 +62,12 @@ describe("Hierarchies", () => {
                       grouping: { byClass: true },
                     })}
                     FROM (
-                      SELECT ECClassId, ECInstanceId, CodeValue, Parent
-                      FROM ${subjectClassName}
+                      SELECT ECClassId, ECInstanceId, CodeValue
+                      FROM ${schema.items.X.fullName}
                       UNION ALL
-                      SELECT ECClassId, ECInstanceId, CodeValue, Parent
-                      FROM ${physicalPartitionClassName}
+                      SELECT ECClassId, ECInstanceId, CodeValue
+                      FROM ${schema.items.Y.fullName}
                     ) AS this
-                    WHERE this.Parent.Id = (${IModel.rootSubjectId})
                   `,
                 },
               },
@@ -72,18 +78,20 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel: imodelConnection, hierarchy }),
+        provider: createProvider({ ecdb, hierarchy }),
         expect: [
           NodeValidators.createForClassGroupingNode({
+            className: schema.items.X.fullName,
             children: [
-              NodeValidators.createForInstanceNode({ instanceKeys: [keys.childPartition2], children: false }),
-              NodeValidators.createForInstanceNode({ instanceKeys: [keys.childPartition4], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.x3], children: false }),
             ],
           }),
           NodeValidators.createForClassGroupingNode({
+            className: schema.items.Y.fullName,
             children: [
-              NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
-              NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject3], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.y2], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.y4], children: false }),
             ],
           }),
         ],

--- a/apps/full-stack-tests/src/hierarchies/grouping/GroupHiding.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/GroupHiding.test.ts
@@ -3,32 +3,42 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { insertPhysicalPartition, insertSubject } from "presentation-test-utilities";
 import { afterAll, beforeAll, describe, it } from "vitest";
-import { PhysicalPartition, Subject, withEditTxn } from "@itwin/core-backend";
-import { IModel } from "@itwin/core-common";
-import { buildTestIModel } from "../../IModelUtils.js";
+import { buildTestECDb } from "../../ECDbUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
+import { importSchema } from "../../SchemaUtils.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
 import { createProvider } from "../Utils.js";
 
-import type { IModelConnection } from "@itwin/core-frontend";
 import type { DefineHierarchyLevelProps, HierarchyDefinition } from "@itwin/presentation-hierarchies";
 import type { Props } from "@itwin/presentation-shared";
+
+const SCHEMA_PROPS = { schemaName: "GroupHidingTest", schemaAlias: "ght" };
+const SCHEMA_XML = `
+  <ECEntityClass typeName="B">
+    <ECProperty propertyName="CodeValue" typeName="string" />
+    <ECProperty propertyName="UserLabel" typeName="string" />
+  </ECEntityClass>
+  <ECEntityClass typeName="X">
+    <BaseClass>B</BaseClass>
+  </ECEntityClass>
+  <ECEntityClass typeName="Y">
+    <ECProperty propertyName="CodeValue" typeName="string" />
+    <ECProperty propertyName="UserLabel" typeName="string" />
+  </ECEntityClass>
+`;
+const X_FULL_NAME = "GroupHidingTest.X";
+const Y_FULL_NAME = "GroupHidingTest.Y";
+const B_FULL_NAME = "GroupHidingTest.B";
 
 describe("Hierarchies", () => {
   describe("Grouping nodes' hiding", () => {
     type ECSqlSelectClauseGroupingParams = NonNullable<
       Props<DefineHierarchyLevelProps["createSelectClause"]>["grouping"]
     >;
-    let subjectClassName: string;
-    let physicalPartitionClassName: string;
-    const groupName = "test1";
 
     beforeAll(async () => {
       await initialize();
-      subjectClassName = Subject.classFullName.replace(":", ".");
-      physicalPartitionClassName = PhysicalPartition.classFullName.replace(":", ".");
     });
 
     afterAll(async () => {
@@ -36,7 +46,6 @@ describe("Hierarchies", () => {
     });
 
     function createHierarchyWithSpecifiedGrouping(
-      _imodel: IModelConnection,
       specifiedGrouping: ECSqlSelectClauseGroupingParams,
       labelProperty?: string,
     ): HierarchyDefinition {
@@ -45,7 +54,7 @@ describe("Hierarchies", () => {
           if (!parentNode) {
             return [
               {
-                fullClassName: `BisCore.InformationContentElement`,
+                fullClassName: X_FULL_NAME,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
@@ -54,14 +63,21 @@ describe("Hierarchies", () => {
                       nodeLabel: { selector: `this.${labelProperty ?? "CodeValue"}` },
                       grouping: specifiedGrouping,
                     })}
-                    FROM (
-                      SELECT ECClassId, ECInstanceId, CodeValue, Parent, UserLabel
-                      FROM ${subjectClassName}
-                      UNION ALL
-                      SELECT ECClassId, ECInstanceId, CodeValue, Parent, UserLabel
-                      FROM ${physicalPartitionClassName}
-                    ) AS this
-                    WHERE this.Parent.Id = (${IModel.rootSubjectId})
+                    FROM ${X_FULL_NAME} AS this
+                  `,
+                },
+              },
+              {
+                fullClassName: Y_FULL_NAME,
+                query: {
+                  ecsql: `
+                    SELECT ${await createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: { selector: `this.${labelProperty ?? "CodeValue"}` },
+                      grouping: specifiedGrouping,
+                    })}
+                    FROM ${Y_FULL_NAME} AS this
                   `,
                 },
               },
@@ -74,102 +90,94 @@ describe("Hierarchies", () => {
 
     describe("Base class grouping", () => {
       const baseClassHideIfNoSiblingsGrouping: ECSqlSelectClauseGroupingParams = {
-        byBaseClasses: { fullClassNames: ["BisCore.InformationReferenceElement"], hideIfNoSiblings: true },
+        byBaseClasses: { fullClassNames: [B_FULL_NAME], hideIfNoSiblings: true },
       };
-
       const baseClassHideIfOneGroupedNodeGrouping: ECSqlSelectClauseGroupingParams = {
-        byBaseClasses: { fullClassNames: ["BisCore.InformationReferenceElement"], hideIfOneGroupedNode: true },
+        byBaseClasses: { fullClassNames: [B_FULL_NAME], hideIfOneGroupedNode: true },
       };
 
       it("hides base class groups when there're no siblings", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({ txn, codeValue: "A1", parentId: IModel.rootSubjectId });
-            const childSubject2 = insertSubject({ txn, codeValue: "A2", parentId: IModel.rootSubjectId });
-            return { childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1" });
+          const x2 = builder.insertInstance(X_FULL_NAME, { codeValue: "A2" });
+          return { x1, x2 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, baseClassHideIfNoSiblingsGrouping),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(baseClassHideIfNoSiblingsGrouping),
           }),
           expect: [
-            NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
-            NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
           ],
         });
       });
 
       it("hides base class groups when there's only 1 grouped node", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({ txn, codeValue: "A1", parentId: IModel.rootSubjectId });
-            return { childSubject1 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1" });
+          return { x1 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, baseClassHideIfOneGroupedNodeGrouping),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(baseClassHideIfOneGroupedNodeGrouping),
           }),
-          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
+          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
         });
       });
 
       it("doesn't hide base class groups when there are siblings", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({
-              txn,
-              codeValue: "A1",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            const childPartition2 = insertPhysicalPartition({ txn, codeValue: "B1", parentId: IModel.rootSubjectId });
-            return { childSubject1, childPartition2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1" });
+          const y1 = builder.insertInstance(Y_FULL_NAME, { codeValue: "B1" });
+          return { x1, y1 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, baseClassHideIfNoSiblingsGrouping),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(baseClassHideIfNoSiblingsGrouping),
           }),
           expect: [
-            NodeValidators.createForInstanceNode({ instanceKeys: [keys.childPartition2], children: false }),
             NodeValidators.createForClassGroupingNode({
-              label: "Information Reference",
-              className: "BisCore.InformationReferenceElement",
-              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
+              className: B_FULL_NAME,
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
             }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [keys.y1], children: false }),
           ],
         });
       });
 
       it("doesn't hide base class groups when there's more than 1 grouped node", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({ txn, codeValue: "A1", parentId: IModel.rootSubjectId });
-            const childSubject2 = insertSubject({ txn, codeValue: "A2", parentId: IModel.rootSubjectId });
-            return { childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1" });
+          const x2 = builder.insertInstance(X_FULL_NAME, { codeValue: "A2" });
+          return { x1, x2 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, baseClassHideIfOneGroupedNodeGrouping),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(baseClassHideIfOneGroupedNodeGrouping),
           }),
           expect: [
             NodeValidators.createForClassGroupingNode({
-              label: "Information Reference",
-              className: "BisCore.InformationReferenceElement",
+              className: B_FULL_NAME,
               children: [
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
               ],
             }),
           ],
@@ -179,98 +187,95 @@ describe("Hierarchies", () => {
 
     describe("Class grouping", () => {
       const classHideIfNoSiblingsGrouping: ECSqlSelectClauseGroupingParams = { byClass: { hideIfNoSiblings: true } };
-
       const classHideIfOneGroupedNodeGrouping: ECSqlSelectClauseGroupingParams = {
         byClass: { hideIfOneGroupedNode: true },
       };
 
       it("hides class groups when there're no siblings", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({ txn, codeValue: "A1", parentId: IModel.rootSubjectId });
-            const childSubject2 = insertSubject({ txn, codeValue: "A2", parentId: IModel.rootSubjectId });
-            return { childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1" });
+          const x2 = builder.insertInstance(X_FULL_NAME, { codeValue: "A2" });
+          return { x1, x2 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, classHideIfNoSiblingsGrouping),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(classHideIfNoSiblingsGrouping),
           }),
           expect: [
-            NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
-            NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
           ],
         });
       });
 
       it("hides class groups when there's only 1 grouped node", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({ txn, codeValue: "A1", parentId: IModel.rootSubjectId });
-            return { childSubject1 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1" });
+          return { x1 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, classHideIfOneGroupedNodeGrouping),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(classHideIfOneGroupedNodeGrouping),
           }),
-          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
+          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
         });
       });
 
       it("doesn't hide class groups when there are siblings", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({ txn, codeValue: "A1", parentId: IModel.rootSubjectId });
-            const childPartition2 = insertPhysicalPartition({ txn, codeValue: "B1", parentId: IModel.rootSubjectId });
-            return { childSubject1, childPartition2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1" });
+          const y1 = builder.insertInstance(Y_FULL_NAME, { codeValue: "B1" });
+          return { x1, y1 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, classHideIfNoSiblingsGrouping),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(classHideIfNoSiblingsGrouping),
           }),
           expect: [
             NodeValidators.createForClassGroupingNode({
-              className: "BisCore.PhysicalPartition",
-              children: [
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childPartition2], children: false }),
-              ],
+              className: X_FULL_NAME,
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
             }),
             NodeValidators.createForClassGroupingNode({
-              className: "BisCore.Subject",
-              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
+              className: Y_FULL_NAME,
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.y1], children: false })],
             }),
           ],
         });
       });
 
       it("doesn't hide class groups when there's more than 1 grouped node", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({ txn, codeValue: "A1", parentId: IModel.rootSubjectId });
-            const childSubject2 = insertSubject({ txn, codeValue: "A2", parentId: IModel.rootSubjectId });
-            return { childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1" });
+          const x2 = builder.insertInstance(X_FULL_NAME, { codeValue: "A2" });
+          return { x1, x2 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, classHideIfOneGroupedNodeGrouping),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(classHideIfOneGroupedNodeGrouping),
           }),
           expect: [
             NodeValidators.createForClassGroupingNode({
-              className: "BisCore.Subject",
+              className: X_FULL_NAME,
               children: [
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
               ],
             }),
           ],
@@ -279,148 +284,98 @@ describe("Hierarchies", () => {
     });
 
     describe("Label grouping", () => {
+      const groupName = "test1";
+
       const labelHideIfOneGroupedNodeGrouping: ECSqlSelectClauseGroupingParams = {
         byLabel: { hideIfOneGroupedNode: true },
       };
-
       const labelHideIfNoSiblingsGrouping: ECSqlSelectClauseGroupingParams = { byLabel: { hideIfNoSiblings: true } };
 
       it("hides label groups when there're no siblings", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({
-              txn,
-              codeValue: "A1",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            const childSubject2 = insertSubject({
-              txn,
-              codeValue: "A2",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            return { childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1", userLabel: groupName });
+          const x2 = builder.insertInstance(X_FULL_NAME, { codeValue: "A2", userLabel: groupName });
+          return { x1, x2 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(
-              imodelConnection,
-              labelHideIfNoSiblingsGrouping,
-              "UserLabel",
-            ),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(labelHideIfNoSiblingsGrouping, "UserLabel"),
           }),
           expect: [
-            NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
-            NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
           ],
         });
       });
 
       it("hides label groups when there's only 1 grouped node", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({
-              txn,
-              codeValue: "A1",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            return { childSubject1 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1", userLabel: groupName });
+          return { x1 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(
-              imodelConnection,
-              labelHideIfOneGroupedNodeGrouping,
-              "UserLabel",
-            ),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(labelHideIfOneGroupedNodeGrouping, "UserLabel"),
           }),
-          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
+          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
         });
       });
 
       it("doesn't hide label groups when there are siblings", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({
-              txn,
-              codeValue: "A1",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            const childSubject2 = insertSubject({
-              txn,
-              codeValue: "A2",
-              parentId: IModel.rootSubjectId,
-              userLabel: "test2",
-            });
-            return { childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1", userLabel: groupName });
+          const x2 = builder.insertInstance(X_FULL_NAME, { codeValue: "A2", userLabel: "test2" });
+          return { x1, x2 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(
-              imodelConnection,
-              labelHideIfNoSiblingsGrouping,
-              "UserLabel",
-            ),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(labelHideIfNoSiblingsGrouping, "UserLabel"),
           }),
           expect: [
             NodeValidators.createForLabelGroupingNode({
               label: groupName,
-              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
             }),
             NodeValidators.createForLabelGroupingNode({
               label: "test2",
-              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false })],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false })],
             }),
           ],
         });
       });
 
       it("doesn't hide label groups when there's more than 1 grouped node", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({
-              txn,
-              codeValue: "A1",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            const childSubject2 = insertSubject({
-              txn,
-              codeValue: "A2",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            return { childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1", userLabel: groupName });
+          const x2 = builder.insertInstance(X_FULL_NAME, { codeValue: "A2", userLabel: groupName });
+          return { x1, x2 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(
-              imodelConnection,
-              labelHideIfOneGroupedNodeGrouping,
-              "UserLabel",
-            ),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(labelHideIfOneGroupedNodeGrouping, "userLabel"),
           }),
           expect: [
             NodeValidators.createForLabelGroupingNode({
               label: groupName,
               children: [
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
               ],
             }),
           ],
@@ -429,148 +384,113 @@ describe("Hierarchies", () => {
     });
 
     describe("Properties grouping", () => {
+      const groupName = "test1";
       const propertiesHideIfNoSiblingsGrouping: ECSqlSelectClauseGroupingParams = {
         byProperties: {
-          propertiesClassName: "BisCore.Element",
+          propertiesClassName: B_FULL_NAME,
           propertyGroups: [{ propertyName: "UserLabel", propertyClassAlias: "this" }],
           hideIfNoSiblings: true,
         },
       };
-
       const propertiesHideIfOneGroupedNodeGrouping: ECSqlSelectClauseGroupingParams = {
         byProperties: {
-          propertiesClassName: "BisCore.Element",
+          propertiesClassName: B_FULL_NAME,
           propertyGroups: [{ propertyName: "UserLabel", propertyClassAlias: "this" }],
           hideIfOneGroupedNode: true,
         },
       };
 
       it("hides property groups when there're no siblings", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({
-              txn,
-              codeValue: "A1",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            const childSubject2 = insertSubject({
-              txn,
-              codeValue: "A2",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            return { childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1", userLabel: groupName });
+          const x2 = builder.insertInstance(X_FULL_NAME, { codeValue: "A2", userLabel: groupName });
+          return { x1, x2 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, propertiesHideIfNoSiblingsGrouping),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(propertiesHideIfNoSiblingsGrouping),
           }),
           expect: [
-            NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
-            NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
+            NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
           ],
         });
       });
 
       it("hides property groups when there's only 1 grouped node", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({
-              txn,
-              codeValue: "A1",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            return { childSubject1 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1", userLabel: groupName });
+          return { x1 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, propertiesHideIfOneGroupedNodeGrouping),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(propertiesHideIfOneGroupedNodeGrouping),
           }),
-          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
+          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
         });
       });
 
       it("doesn't hide property groups when there are siblings", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({
-              txn,
-              codeValue: "A1",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            const childSubject2 = insertSubject({
-              txn,
-              codeValue: "A2",
-              parentId: IModel.rootSubjectId,
-              userLabel: `${groupName}2`,
-            });
-            return { childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1", userLabel: groupName });
+          const x2 = builder.insertInstance(X_FULL_NAME, { codeValue: "A2", userLabel: `${groupName}2` });
+          return { x1, x2 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, propertiesHideIfNoSiblingsGrouping),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(propertiesHideIfNoSiblingsGrouping),
           }),
           expect: [
             NodeValidators.createForPropertyValueGroupingNode({
               label: groupName,
-              propertyClassName: "BisCore.Element",
+              propertyClassName: B_FULL_NAME,
               formattedPropertyValue: groupName,
-              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
             }),
             NodeValidators.createForPropertyValueGroupingNode({
               label: `${groupName}2`,
-              propertyClassName: "BisCore.Element",
+              propertyClassName: B_FULL_NAME,
               formattedPropertyValue: `${groupName}2`,
-              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false })],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false })],
             }),
           ],
         });
       });
 
       it("doesn't hide base class groups when there's more than 1 grouped node", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({
-              txn,
-              codeValue: "A1",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            const childSubject2 = insertSubject({
-              txn,
-              codeValue: "A2",
-              parentId: IModel.rootSubjectId,
-              userLabel: groupName,
-            });
-            return { childSubject1, childSubject2 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1", userLabel: groupName });
+          const x2 = builder.insertInstance(X_FULL_NAME, { codeValue: "A2", userLabel: groupName });
+          return { x1, x2 };
         });
+        const { ecdb, ...keys } = setup;
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, propertiesHideIfOneGroupedNodeGrouping),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(propertiesHideIfOneGroupedNodeGrouping),
           }),
           expect: [
             NodeValidators.createForPropertyValueGroupingNode({
               label: groupName,
-              propertyClassName: "BisCore.Element",
+              propertyClassName: B_FULL_NAME,
               formattedPropertyValue: groupName,
               children: [
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
-                NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
+                NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
               ],
             }),
           ],

--- a/apps/full-stack-tests/src/hierarchies/grouping/LabelGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/LabelGrouping.test.ts
@@ -3,26 +3,28 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { insertSubject } from "presentation-test-utilities";
 import { afterAll, beforeAll, describe, it } from "vitest";
-import { Subject, withEditTxn } from "@itwin/core-backend";
-import { IModel } from "@itwin/core-common";
 import { HierarchyNode } from "@itwin/presentation-hierarchies";
-import { normalizeFullClassName } from "@itwin/presentation-shared";
-import { buildTestIModel } from "../../IModelUtils.js";
+import { buildTestECDb } from "../../ECDbUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
+import { importSchema } from "../../SchemaUtils.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
 import { createProvider } from "../Utils.js";
 
 import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
-import type { EC } from "@itwin/presentation-shared";
+
+const SCHEMA_XML = `
+  <ECEntityClass typeName="X">
+    <ECProperty propertyName="UserLabel" typeName="string" />
+    <ECProperty propertyName="Description" typeName="string" />
+    <ECProperty propertyName="CodeValue" typeName="string" />
+    <ECProperty propertyName="ParentId" typeName="long" />
+  </ECEntityClass>
+`;
 
 describe("Hierarchies", () => {
-  let subjectClassName: EC.FullClassName;
-
   beforeAll(async () => {
     await initialize();
-    subjectClassName = normalizeFullClassName(Subject.classFullName);
   });
 
   afterAll(async () => {
@@ -33,53 +35,32 @@ describe("Hierarchies", () => {
     it("creates different groups for different labels", async () => {
       const labelGroupName1 = "test1";
       const labelGroupName2 = "test2";
-      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-        return withEditTxn(imodel, (txn) => {
-          const childSubject1 = insertSubject({
-            txn,
-            codeValue: "1",
-            parentId: IModel.rootSubjectId,
-            userLabel: labelGroupName1,
-          });
-          const childSubject2 = insertSubject({
-            txn,
-            codeValue: "2",
-            parentId: IModel.rootSubjectId,
-            userLabel: labelGroupName2,
-          });
-          const childSubject3 = insertSubject({
-            txn,
-            codeValue: "3",
-            parentId: IModel.rootSubjectId,
-            userLabel: labelGroupName1,
-          });
-          const childSubject4 = insertSubject({
-            txn,
-            codeValue: "4",
-            parentId: IModel.rootSubjectId,
-            userLabel: labelGroupName2,
-          });
-          return { childSubject1, childSubject2, childSubject3, childSubject4 };
-        });
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(testName, builder, SCHEMA_XML);
+        const x1 = builder.insertInstance(s.items.X.fullName, { userLabel: labelGroupName1 });
+        const x2 = builder.insertInstance(s.items.X.fullName, { userLabel: labelGroupName2 });
+        const x3 = builder.insertInstance(s.items.X.fullName, { userLabel: labelGroupName1 });
+        const x4 = builder.insertInstance(s.items.X.fullName, { userLabel: labelGroupName2 });
+        return { schema: s, x1, x2, x3, x4 };
       });
+      const { ecdb, schema, ...keys } = setup;
 
       const hierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ createSelectClause, ...props }) {
           if (!props.parentNode) {
             return [
               {
-                fullClassName: subjectClassName,
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
-                  SELECT ${await createSelectClause({
-                    ecClassId: { selector: `this.ECClassId` },
-                    ecInstanceId: { selector: `this.ECInstanceId` },
-                    nodeLabel: { selector: `this.UserLabel` },
-                    grouping: { byLabel: true },
-                  })}
-                  FROM ${subjectClassName} AS this
-                  WHERE this.Parent.Id = (${IModel.rootSubjectId})
-                `,
+                    SELECT ${await createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: { selector: `this.UserLabel` },
+                      grouping: { byLabel: true },
+                    })}
+                    FROM ${schema.items.X.fullName} AS this
+                  `,
                 },
               },
             ];
@@ -89,20 +70,20 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel: imodelConnection, hierarchy }),
+        provider: createProvider({ ecdb, hierarchy }),
         expect: [
           NodeValidators.createForLabelGroupingNode({
             label: labelGroupName1,
             children: [
-              NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject3], children: false }),
-              NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.x3], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
             ],
           }),
           NodeValidators.createForLabelGroupingNode({
             label: labelGroupName2,
             children: [
-              NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject4], children: false }),
-              NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.x4], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
             ],
           }),
         ],
@@ -112,57 +93,44 @@ describe("Hierarchies", () => {
     it("creates different groups for same labels and different groupIds", async () => {
       const descriptionGroupName1 = "test1";
       const descriptionGroupName2 = "test2";
-      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-        return withEditTxn(imodel, (txn) => {
-          const childSubject1 = insertSubject({
-            txn,
-            codeValue: "1",
-            parentId: IModel.rootSubjectId,
-            userLabel: "test",
-            description: descriptionGroupName1,
-          });
-          const childSubject2 = insertSubject({
-            txn,
-            codeValue: "2",
-            parentId: IModel.rootSubjectId,
-            userLabel: "test",
-            description: descriptionGroupName2,
-          });
-          const childSubject3 = insertSubject({
-            txn,
-            codeValue: "3",
-            parentId: IModel.rootSubjectId,
-            userLabel: "test",
-            description: descriptionGroupName1,
-          });
-          const childSubject4 = insertSubject({
-            txn,
-            codeValue: "4",
-            parentId: IModel.rootSubjectId,
-            userLabel: "test",
-            description: descriptionGroupName2,
-          });
-          return { childSubject1, childSubject2, childSubject3, childSubject4 };
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(testName, builder, SCHEMA_XML);
+        const x1 = builder.insertInstance(s.items.X.fullName, {
+          userLabel: "test",
+          description: descriptionGroupName1,
         });
+        const x2 = builder.insertInstance(s.items.X.fullName, {
+          userLabel: "test",
+          description: descriptionGroupName2,
+        });
+        const x3 = builder.insertInstance(s.items.X.fullName, {
+          userLabel: "test",
+          description: descriptionGroupName1,
+        });
+        const x4 = builder.insertInstance(s.items.X.fullName, {
+          userLabel: "test",
+          description: descriptionGroupName2,
+        });
+        return { schema: s, x1, x2, x3, x4 };
       });
+      const { ecdb, schema, ...keys } = setup;
 
       const hierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ createSelectClause, ...props }) {
           if (!props.parentNode) {
             return [
               {
-                fullClassName: subjectClassName,
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
-                  SELECT ${await createSelectClause({
-                    ecClassId: { selector: `this.ECClassId` },
-                    ecInstanceId: { selector: `this.ECInstanceId` },
-                    nodeLabel: { selector: `this.UserLabel` },
-                    grouping: { byLabel: { groupId: { selector: `this.Description` } } },
-                  })}
-                  FROM ${subjectClassName} AS this
-                  WHERE this.Parent.Id = (${IModel.rootSubjectId})
-                `,
+                    SELECT ${await createSelectClause({
+                      ecClassId: { selector: `this.ECClassId` },
+                      ecInstanceId: { selector: `this.ECInstanceId` },
+                      nodeLabel: { selector: `this.UserLabel` },
+                      grouping: { byLabel: { groupId: { selector: `this.Description` } } },
+                    })}
+                    FROM ${schema.items.X.fullName} AS this
+                  `,
                 },
               },
             ];
@@ -172,22 +140,22 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel: imodelConnection, hierarchy }),
+        provider: createProvider({ ecdb, hierarchy }),
         expect: [
           NodeValidators.createForLabelGroupingNode({
             label: "test",
             groupId: descriptionGroupName2,
             children: [
-              NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject4], children: false }),
-              NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.x4], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
             ],
           }),
           NodeValidators.createForLabelGroupingNode({
             label: "test",
             groupId: descriptionGroupName1,
             children: [
-              NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject3], children: false }),
-              NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.x3], children: false }),
+              NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
             ],
           }),
         ],
@@ -197,40 +165,21 @@ describe("Hierarchies", () => {
 
   describe("Label merging", () => {
     it("doesn't merge when different groupIds or labels are provided", async () => {
-      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-        return withEditTxn(imodel, (txn) => {
-          const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-          const childSubject1 = insertSubject({
-            txn,
-            codeValue: "1",
-            parentId: rootSubject.id,
-            userLabel: "label1",
-            description: "description1",
-          });
-          const childSubject2 = insertSubject({
-            txn,
-            codeValue: "2",
-            parentId: rootSubject.id,
-            userLabel: "label1",
-            description: "description2",
-          });
-          const childSubject3 = insertSubject({
-            txn,
-            codeValue: "3",
-            parentId: rootSubject.id,
-            userLabel: "label2",
-            description: "description1",
-          });
-          return { rootSubject, childSubject1, childSubject2, childSubject3 };
-        });
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(testName, builder, SCHEMA_XML);
+        const x1 = builder.insertInstance(s.items.X.fullName, { userLabel: "label1", description: "description1" });
+        const x2 = builder.insertInstance(s.items.X.fullName, { userLabel: "label1", description: "description2" });
+        const x3 = builder.insertInstance(s.items.X.fullName, { userLabel: "label2", description: "description1" });
+        return { schema: s, x1, x2, x3 };
       });
+      const { ecdb, schema, ...keys } = setup;
 
       const hierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ createSelectClause, ...props }) {
           if (!props.parentNode) {
             return [
               {
-                fullClassName: subjectClassName,
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
@@ -239,8 +188,7 @@ describe("Hierarchies", () => {
                       nodeLabel: { selector: `this.UserLabel` },
                       grouping: { byLabel: { action: "merge", groupId: { selector: `this.Description` } } },
                     })}
-                    FROM ${subjectClassName} AS this
-                    WHERE this.Parent.Id = (${IModel.rootSubjectId})
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                 },
               },
@@ -251,31 +199,30 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel: imodelConnection, hierarchy }),
+        provider: createProvider({ ecdb, hierarchy }),
         expect: [
-          NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
-          NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
-          NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject3], children: false }),
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
+          NodeValidators.createForInstanceNode({ instanceKeys: [keys.x3], children: false }),
         ],
       });
     });
 
     it("merges instance nodes with same merge id", async () => {
-      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-        return withEditTxn(imodel, (txn) => {
-          const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-          const childSubject1 = insertSubject({ txn, codeValue: "1", parentId: rootSubject.id });
-          const childSubject2 = insertSubject({ txn, codeValue: "2", parentId: rootSubject.id });
-          return { rootSubject, childSubject1, childSubject2 };
-        });
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(testName, builder, SCHEMA_XML);
+        const x1 = builder.insertInstance(s.items.X.fullName);
+        const x2 = builder.insertInstance(s.items.X.fullName);
+        return { schema: s, x1, x2 };
       });
+      const { ecdb, schema, ...keys } = setup;
 
       const hierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ createSelectClause, ...props }) {
           if (!props.parentNode) {
             return [
               {
-                fullClassName: subjectClassName,
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
@@ -284,8 +231,7 @@ describe("Hierarchies", () => {
                       nodeLabel: "merge this",
                       grouping: { byLabel: { action: "merge", groupId: "merge" } },
                     })}
-                    FROM ${subjectClassName} AS this
-                    WHERE this.Parent.Id = (${IModel.rootSubjectId})
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                 },
               },
@@ -296,10 +242,10 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel: imodelConnection, hierarchy }),
+        provider: createProvider({ ecdb, hierarchy }),
         expect: [
           NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.childSubject1, keys.childSubject2],
+            instanceKeys: [keys.x1, keys.x2],
             label: "merge this",
             children: false,
           }),
@@ -308,22 +254,24 @@ describe("Hierarchies", () => {
     });
 
     it("merges instance nodes from different hidden parent hierarchy levels ", async () => {
-      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-        return withEditTxn(imodel, (txn) => {
-          const rootSubject = { className: subjectClassName, id: IModel.rootSubjectId };
-          const visibleSubject1 = insertSubject({ txn, codeValue: "merged", parentId: rootSubject.id });
-          const hiddenSubject = insertSubject({ txn, codeValue: "hide", parentId: rootSubject.id });
-          const visibleSubject2 = insertSubject({ txn, codeValue: "merged", parentId: hiddenSubject.id });
-          return { rootSubject, visibleSubject1, visibleSubject2 };
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(testName, builder, SCHEMA_XML);
+        const visibleX1 = builder.insertInstance(s.items.X.fullName, { codeValue: "merged" });
+        const hiddenX = builder.insertInstance(s.items.X.fullName, { codeValue: "hide" });
+        const visibleX2 = builder.insertInstance(s.items.X.fullName, {
+          codeValue: "merged",
+          parentId: parseInt(hiddenX.id, 16),
         });
+        return { schema: s, visibleX1, hiddenX, visibleX2 };
       });
+      const { ecdb, schema, ...keys } = setup;
 
       const hierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ createSelectClause, ...props }) {
           if (!props.parentNode) {
             return [
               {
-                fullClassName: subjectClassName,
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
@@ -333,8 +281,8 @@ describe("Hierarchies", () => {
                       grouping: { byLabel: { action: "merge", groupId: "merge" } },
                       hideNodeInHierarchy: { selector: `IIF(this.CodeValue = 'hide', 1, 0)` },
                     })}
-                    FROM ${subjectClassName} AS this
-                    WHERE this.Parent.Id = (${IModel.rootSubjectId})
+                    FROM ${schema.items.X.fullName} AS this
+                    WHERE this.ParentId IS NULL
                   `,
                 },
               },
@@ -343,7 +291,7 @@ describe("Hierarchies", () => {
           if (HierarchyNode.isInstancesNode(props.parentNode) && props.parentNode.label === "hide") {
             return [
               {
-                fullClassName: subjectClassName,
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
@@ -352,8 +300,8 @@ describe("Hierarchies", () => {
                       nodeLabel: { selector: `this.CodeValue` },
                       grouping: { byLabel: { action: "merge", groupId: "merge" } },
                     })}
-                    FROM ${subjectClassName} AS this
-                    WHERE this.Parent.Id = ?
+                    FROM ${schema.items.X.fullName} AS this
+                    WHERE this.ParentId = ?
                   `,
                   bindings: props.parentNode.key.instanceKeys.map((k) => ({ type: "id", value: k.id })),
                 },
@@ -365,10 +313,10 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel: imodelConnection, hierarchy }),
+        provider: createProvider({ ecdb, hierarchy }),
         expect: [
           NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.visibleSubject1, keys.visibleSubject2],
+            instanceKeys: [keys.visibleX1, keys.visibleX2],
             label: "merged",
             children: false,
           }),

--- a/apps/full-stack-tests/src/hierarchies/grouping/MultiLevelGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/MultiLevelGrouping.test.ts
@@ -3,12 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { insertPhysicalPartition, insertSubject } from "presentation-test-utilities";
 import { afterAll, beforeAll, describe, it } from "vitest";
-import { PhysicalPartition, Subject, withEditTxn } from "@itwin/core-backend";
-import { IModel } from "@itwin/core-common";
-import { buildTestIModel } from "../../IModelUtils.js";
+import { buildTestECDb } from "../../ECDbUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
+import { importSchema } from "../../SchemaUtils.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
 import { createProvider } from "../Utils.js";
 
@@ -16,13 +14,8 @@ import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
 
 describe("Hierarchies", () => {
   describe("Multi level grouping", () => {
-    let subjectClassName: string;
-    let physicalPartitionClassName: string;
-
     beforeAll(async () => {
       await initialize();
-      subjectClassName = Subject.classFullName.replace(":", ".");
-      physicalPartitionClassName = PhysicalPartition.classFullName.replace(":", ".");
     });
 
     afterAll(async () => {
@@ -33,50 +26,47 @@ describe("Hierarchies", () => {
       const labelGroupName1 = "test1";
       const labelGroupName2 = "test2";
       const description1 = "test description1";
-      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-        return withEditTxn(imodel, (txn) => {
-          const childSubject1 = insertSubject({
-            txn,
-            codeValue: "A1",
-            parentId: IModel.rootSubjectId,
-            userLabel: labelGroupName1,
-            description: description1,
-          });
-          const childSubject2 = insertSubject({
-            txn,
-            codeValue: "A2",
-            parentId: IModel.rootSubjectId,
-            userLabel: labelGroupName1,
-            description: description1,
-          });
-          const childPartition3 = insertPhysicalPartition({
-            txn,
-            codeValue: "B3",
-            parentId: IModel.rootSubjectId,
-            userLabel: labelGroupName1,
-          });
-          const childPartition4 = insertPhysicalPartition({
-            txn,
-            codeValue: "B4",
-            parentId: IModel.rootSubjectId,
-            userLabel: labelGroupName2,
-          });
-          const childPartition5 = insertPhysicalPartition({
-            txn,
-            codeValue: "B5",
-            parentId: IModel.rootSubjectId,
-            userLabel: labelGroupName2,
-          });
-          return { childSubject1, childSubject2, childPartition3, childPartition4, childPartition5 };
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const s = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="A">
+              <ECProperty propertyName="UserLabel" typeName="string" />
+            </ECEntityClass>
+            <ECEntityClass typeName="B">
+              <BaseClass>A</BaseClass>
+            </ECEntityClass>
+            <ECEntityClass typeName="X">
+              <BaseClass>A</BaseClass>
+              <ECProperty propertyName="Description" typeName="string" />
+            </ECEntityClass>
+            <ECEntityClass typeName="Y">
+              <BaseClass>B</BaseClass>
+            </ECEntityClass>
+          `,
+        );
+        const x1 = builder.insertInstance(s.items.X.fullName, {
+          userLabel: labelGroupName1,
+          description: description1,
         });
+        const x2 = builder.insertInstance(s.items.X.fullName, {
+          userLabel: labelGroupName1,
+          description: description1,
+        });
+        const y3 = builder.insertInstance(s.items.Y.fullName, { userLabel: labelGroupName1 });
+        const y4 = builder.insertInstance(s.items.Y.fullName, { userLabel: labelGroupName2 });
+        const y5 = builder.insertInstance(s.items.Y.fullName, { userLabel: labelGroupName2 });
+        return { schema: s, x1, x2, y3, y4, y5 };
       });
+      const { ecdb, schema, ...keys } = setup;
 
       const customHierarchy: HierarchyDefinition = {
         async defineHierarchyLevel({ parentNode, createSelectClause }) {
           if (!parentNode) {
             return [
               {
-                fullClassName: `BisCore.InformationContentElement`,
+                fullClassName: schema.items.X.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
@@ -86,11 +76,9 @@ describe("Hierarchies", () => {
                       grouping: {
                         byClass: true,
                         byLabel: true,
-                        byBaseClasses: {
-                          fullClassNames: ["BisCore.InformationContentElement", "BisCore.InformationPartitionElement"],
-                        },
+                        byBaseClasses: { fullClassNames: [schema.items.A.fullName, schema.items.B.fullName] },
                         byProperties: {
-                          propertiesClassName: "BisCore.Subject",
+                          propertiesClassName: schema.items.X.fullName,
                           propertyGroups: [
                             { propertyName: "Description", propertyClassAlias: "this" },
                             { propertyName: "UserLabel", propertyClassAlias: "this" },
@@ -98,13 +86,12 @@ describe("Hierarchies", () => {
                         },
                       },
                     })}
-                    FROM ${subjectClassName} AS this
-                    WHERE this.Parent.Id = (${IModel.rootSubjectId})
+                    FROM ${schema.items.X.fullName} AS this
                   `,
                 },
               },
               {
-                fullClassName: `BisCore.InformationContentElement`,
+                fullClassName: schema.items.Y.fullName,
                 query: {
                   ecsql: `
                     SELECT ${await createSelectClause({
@@ -114,13 +101,10 @@ describe("Hierarchies", () => {
                       grouping: {
                         byClass: true,
                         byLabel: true,
-                        byBaseClasses: {
-                          fullClassNames: ["BisCore.InformationContentElement", "BisCore.InformationPartitionElement"],
-                        },
+                        byBaseClasses: { fullClassNames: [schema.items.A.fullName, schema.items.B.fullName] },
                       },
                     })}
-                    FROM ${physicalPartitionClassName} AS this
-                    WHERE this.Parent.Id = (${IModel.rootSubjectId})
+                    FROM ${schema.items.Y.fullName} AS this
                   `,
                 },
               },
@@ -131,39 +115,26 @@ describe("Hierarchies", () => {
       };
 
       await validateHierarchy({
-        provider: createProvider({ imodel: imodelConnection, hierarchy: customHierarchy }),
+        provider: createProvider({ ecdb, hierarchy: customHierarchy }),
         expect: [
           NodeValidators.createForClassGroupingNode({
-            label: "Information Content Element",
-            className: "BisCore.InformationContentElement",
+            className: schema.items.A.fullName,
             children: [
               NodeValidators.createForClassGroupingNode({
-                label: "Information Partition",
-                className: "BisCore.InformationPartitionElement",
+                className: schema.items.B.fullName,
                 children: [
                   NodeValidators.createForClassGroupingNode({
-                    className: physicalPartitionClassName,
+                    className: schema.items.Y.fullName,
                     children: [
                       NodeValidators.createForLabelGroupingNode({
                         label: labelGroupName1,
-                        children: [
-                          NodeValidators.createForInstanceNode({
-                            instanceKeys: [keys.childPartition3],
-                            children: false,
-                          }),
-                        ],
+                        children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.y3], children: false })],
                       }),
                       NodeValidators.createForLabelGroupingNode({
                         label: labelGroupName2,
                         children: [
-                          NodeValidators.createForInstanceNode({
-                            instanceKeys: [keys.childPartition5],
-                            children: false,
-                          }),
-                          NodeValidators.createForInstanceNode({
-                            instanceKeys: [keys.childPartition4],
-                            children: false,
-                          }),
+                          NodeValidators.createForInstanceNode({ instanceKeys: [keys.y5], children: false }),
+                          NodeValidators.createForInstanceNode({ instanceKeys: [keys.y4], children: false }),
                         ],
                       }),
                     ],
@@ -171,31 +142,25 @@ describe("Hierarchies", () => {
                 ],
               }),
               NodeValidators.createForClassGroupingNode({
-                className: subjectClassName,
+                className: schema.items.X.fullName,
                 children: [
                   NodeValidators.createForPropertyValueGroupingNode({
                     label: description1,
-                    propertyClassName: "BisCore.Subject",
+                    propertyClassName: schema.items.X.fullName,
                     formattedPropertyValue: description1,
                     propertyName: "Description",
                     children: [
                       NodeValidators.createForPropertyValueGroupingNode({
                         label: labelGroupName1,
-                        propertyClassName: "BisCore.Subject",
+                        propertyClassName: schema.items.X.fullName,
                         formattedPropertyValue: labelGroupName1,
                         propertyName: "UserLabel",
                         children: [
                           NodeValidators.createForLabelGroupingNode({
                             label: labelGroupName1,
                             children: [
-                              NodeValidators.createForInstanceNode({
-                                instanceKeys: [keys.childSubject2],
-                                children: false,
-                              }),
-                              NodeValidators.createForInstanceNode({
-                                instanceKeys: [keys.childSubject1],
-                                children: false,
-                              }),
+                              NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
+                              NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false }),
                             ],
                           }),
                         ],

--- a/apps/full-stack-tests/src/hierarchies/grouping/PropertiesGrouping.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/grouping/PropertiesGrouping.test.ts
@@ -3,39 +3,40 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-  insertPhysicalElement,
-  insertPhysicalModelWithPartition,
-  insertSpatialCategory,
-  insertSubject,
-} from "presentation-test-utilities";
 import { afterAll, describe, it, test } from "vitest";
-import { Subject, withEditTxn } from "@itwin/core-backend";
-import { IModel } from "@itwin/core-common";
 import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
+import { createDefaultInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 import { buildTestECDb } from "../../ECDbUtils.js";
-import { buildTestIModel } from "../../IModelUtils.js";
 import { initialize, terminate } from "../../IntegrationTests.js";
 import { importSchema } from "../../SchemaUtils.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
 import { createIModelAccess, createProvider } from "../Utils.js";
 
-import type { IModelConnection } from "@itwin/core-frontend";
 import type { DefineHierarchyLevelProps, HierarchyDefinition } from "@itwin/presentation-hierarchies";
 import type { Props } from "@itwin/presentation-shared";
+
+const SCHEMA_PROPS = { schemaName: "PropGroupingTest", schemaAlias: "pgt" };
+const SCHEMA_XML = `
+  <ECEntityClass typeName="X">
+    <ECProperty propertyName="UserLabel" typeName="string" />
+    <ECProperty propertyName="Description" typeName="string" />
+    <ECProperty propertyName="CodeValue" typeName="string" />
+  </ECEntityClass>
+  <ECEntityClass typeName="Y">
+    <ECProperty propertyName="Description" typeName="string" />
+  </ECEntityClass>
+`;
+const X_FULL_NAME = "PropGroupingTest.X";
+const Y_FULL_NAME = "PropGroupingTest.Y";
 
 describe("Hierarchies", () => {
   describe("Properties grouping", () => {
     type ECSqlSelectClausePropertiesGroupingParams = NonNullable<
       NonNullable<Props<DefineHierarchyLevelProps["createSelectClause"]>["grouping"]>["byProperties"]
     >;
-    let subjectClassName: string;
-    let emptyIModel: IModelConnection;
 
-    test.beforeAll(async (_, suite) => {
+    test.beforeAll(async () => {
       await initialize();
-      subjectClassName = Subject.classFullName.replace(":", ".");
-      emptyIModel = (await buildTestIModel(suite.fullTestName!)).imodelConnection;
     });
 
     afterAll(async () => {
@@ -43,7 +44,6 @@ describe("Hierarchies", () => {
     });
 
     function createHierarchyWithSpecifiedGrouping(
-      _imodel: IModelConnection,
       specifiedGrouping: ECSqlSelectClausePropertiesGroupingParams,
     ): HierarchyDefinition {
       return {
@@ -51,7 +51,7 @@ describe("Hierarchies", () => {
           if (!parentNode) {
             return [
               {
-                fullClassName: `BisCore.InformationContentElement`,
+                fullClassName: X_FULL_NAME,
                 query: {
                   ecsql: `
                   SELECT ${await createSelectClause({
@@ -60,8 +60,7 @@ describe("Hierarchies", () => {
                     nodeLabel: { selector: `this.UserLabel` },
                     grouping: { byProperties: specifiedGrouping },
                   })}
-                  FROM ${subjectClassName} AS this
-                  WHERE this.Parent.Id = (${IModel.rootSubjectId})
+                  FROM ${X_FULL_NAME} AS this
                 `,
                 },
               },
@@ -73,210 +72,122 @@ describe("Hierarchies", () => {
     }
 
     it("doesn't group if provided properties class isn't base of nodes class", async () => {
-      const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-        return withEditTxn(imodel, (txn) => {
-          const childSubject1 = insertSubject({
-            txn,
-            codeValue: "A1",
-            parentId: IModel.rootSubjectId,
-            description: "TestDescription",
-          });
-          return { childSubject1 };
-        });
+      using setup = await buildTestECDb(async (builder) => {
+        await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+        const x1 = builder.insertInstance(X_FULL_NAME, { description: "Test description" });
+        return { x1 };
       });
+      const { ecdb, ...keys } = setup;
 
       const groupingParams: ECSqlSelectClausePropertiesGroupingParams = {
-        propertiesClassName: "BisCore.PhysicalPartition",
+        propertiesClassName: Y_FULL_NAME,
         propertyGroups: [{ propertyName: "Description", propertyClassAlias: "this" }],
         createGroupForUnspecifiedValues: true,
       };
       await validateHierarchy({
-        provider: createProvider({
-          imodel: imodelConnection,
-          hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, groupingParams),
-        }),
-        expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
+        provider: createProvider({ ecdb, hierarchy: createHierarchyWithSpecifiedGrouping(groupingParams) }),
+        expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
       });
     });
 
     describe("unspecified values grouping", () => {
       it("doesn't create grouping nodes if provided property values are not defined and `createGroupForUnspecifiedValues` isn't set", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({ txn, codeValue: "A1", parentId: IModel.rootSubjectId });
-            return { childSubject1 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1" });
+          return { x1 };
         });
+        const { ecdb, ...keys } = setup;
 
         const groupingParams: ECSqlSelectClausePropertiesGroupingParams = {
-          propertiesClassName: "BisCore.Subject",
+          propertiesClassName: X_FULL_NAME,
           propertyGroups: [{ propertyName: "Description", propertyClassAlias: "this" }],
         };
 
         await validateHierarchy({
-          provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, groupingParams),
-          }),
-          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
+          provider: createProvider({ ecdb, hierarchy: createHierarchyWithSpecifiedGrouping(groupingParams) }),
+          expect: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
         });
       });
 
       it("creates property value grouping node if provided property values are not defined and `createGroupForOutOfRangeValues` is `true`", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({ txn, codeValue: "A1", parentId: IModel.rootSubjectId });
-            return { childSubject1 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { codeValue: "A1" });
+          return { x1 };
         });
+        const { ecdb, ...keys } = setup;
 
         const groupingParams: ECSqlSelectClausePropertiesGroupingParams = {
-          propertiesClassName: "BisCore.Subject",
+          propertiesClassName: X_FULL_NAME,
           createGroupForUnspecifiedValues: true,
           propertyGroups: [{ propertyName: "Description", propertyClassAlias: "this" }],
         };
 
         await validateHierarchy({
           provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, groupingParams),
+            ecdb,
+            hierarchy: createHierarchyWithSpecifiedGrouping(groupingParams),
             localizedStrings: { other: "", unspecified: "NOT SPECIFIED" },
           }),
           expect: [
             NodeValidators.createForPropertyValueGroupingNode({
-              propertyClassName: "BisCore.Subject",
+              propertyClassName: X_FULL_NAME,
               propertyName: "Description",
               formattedPropertyValue: "",
               label: "NOT SPECIFIED",
-              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
             }),
           ],
         });
       });
 
       it("groups by navigation property", async () => {
-        const imodelAccess = createIModelAccess(emptyIModel);
-        const provider = createIModelHierarchyProvider({
-          imodelAccess,
-          hierarchyDefinition: {
-            defineHierarchyLevel: async ({ parentNode, createSelectClause }) =>
-              parentNode
-                ? []
-                : [
-                    {
-                      fullClassName: "BisCore.Subject",
-                      query: {
-                        ecsql: `
-                          SELECT ${await createSelectClause({
-                            ecClassId: { selector: "this.ECClassId" },
-                            ecInstanceId: { selector: "this.ECInstanceId" },
-                            nodeLabel: { selector: "this.CodeValue" },
-                            grouping: {
-                              byProperties: {
-                                createGroupForUnspecifiedValues: true,
-                                propertiesClassName: "BisCore.Subject",
-                                propertyGroups: [{ propertyClassAlias: "this", propertyName: "Parent" }],
-                              },
-                            },
-                          })}
-                          FROM BisCore.Subject [this]
-                        `,
-                      },
-                    },
-                  ],
-          },
-          localizedStrings: { other: "", unspecified: "NOT SPECIFIED" },
+        using setup = await buildTestECDb(async (builder, testName) => {
+          const s = await importSchema(
+            testName,
+            builder,
+            `
+              <ECEntityClass typeName="X">
+                <ECProperty propertyName="CodeValue" typeName="string" />
+                <ECNavigationProperty propertyName="Parent" relationshipName="XX" direction="backward" />
+              </ECEntityClass>
+              <ECRelationshipClass typeName="XX" strength="referencing" strengthDirection="forward" modifier="None">
+                <Source multiplicity="(0..1)" roleLabel="owns" polymorphic="false">
+                  <Class class="X" />
+                </Source>
+                <Target multiplicity="(0..*)" roleLabel="owned by" polymorphic="false">
+                  <Class class="X" />
+                </Target>
+              </ECRelationshipClass>
+            `,
+          );
+          const x1 = builder.insertInstance(s.items.X.fullName);
+          return { schema: s, x1 };
         });
+        const { ecdb, schema, ...keys } = setup;
 
-        await validateHierarchy({
-          provider,
-          expect: [
-            NodeValidators.createForPropertyValueGroupingNode({
-              label: "NOT SPECIFIED",
-              propertyName: "Parent",
-              children: [NodeValidators.createForInstanceNode({ children: false })],
-            }),
-          ],
-        });
-      });
-    });
-
-    describe("value grouping", () => {
-      it("creates property value grouping nodes", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({
-              txn,
-              codeValue: "A1",
-              parentId: IModel.rootSubjectId,
-              description: "TestDescription",
-            });
-            return { childSubject1 };
-          });
-        });
-
-        const groupingParams: ECSqlSelectClausePropertiesGroupingParams = {
-          propertiesClassName: "BisCore.Subject",
-          propertyGroups: [{ propertyName: "Description", propertyClassAlias: "this" }],
-        };
-
-        await validateHierarchy({
-          provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, groupingParams),
-          }),
-          expect: [
-            NodeValidators.createForPropertyValueGroupingNode({
-              label: "TestDescription",
-              propertyClassName: "BisCore.Subject",
-              propertyName: "Description",
-              formattedPropertyValue: "TestDescription",
-              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
-            }),
-          ],
-        });
-      });
-
-      it("creates multiple grouping nodes if nodes have different property values", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({
-              txn,
-              codeValue: "A1",
-              parentId: IModel.rootSubjectId,
-              userLabel: "Test1",
-            });
-            const childSubject2 = insertSubject({
-              txn,
-              codeValue: "A2",
-              parentId: IModel.rootSubjectId,
-              userLabel: "Test2",
-            });
-            return { childSubject1, childSubject2 };
-          });
-        });
-
-        const customHierarchy: HierarchyDefinition = {
+        const hierarchy: HierarchyDefinition = {
           async defineHierarchyLevel({ parentNode, createSelectClause }) {
             if (!parentNode) {
               return [
                 {
-                  fullClassName: `BisCore.InformationContentElement`,
+                  fullClassName: schema.items.X.fullName,
                   query: {
                     ecsql: `
                       SELECT ${await createSelectClause({
-                        ecClassId: { selector: `this.ECClassId` },
-                        ecInstanceId: { selector: `this.ECInstanceId` },
-                        nodeLabel: { selector: `this.UserLabel` },
+                        ecClassId: { selector: "this.ECClassId" },
+                        ecInstanceId: { selector: "this.ECInstanceId" },
+                        nodeLabel: { selector: "this.CodeValue" },
                         grouping: {
                           byProperties: {
-                            propertiesClassName: "BisCore.Subject",
-                            propertyGroups: [{ propertyName: "UserLabel", propertyClassAlias: "this" }],
+                            createGroupForUnspecifiedValues: true,
+                            propertiesClassName: schema.items.X.fullName,
+                            propertyGroups: [{ propertyClassAlias: "this", propertyName: "Parent" }],
                           },
                         },
                       })}
-                      FROM ${subjectClassName} AS this
-                      WHERE this.Parent.Id = (${IModel.rootSubjectId})
+                      FROM ${schema.items.X.fullName} [this]
                     `,
                   },
                 },
@@ -287,41 +198,119 @@ describe("Hierarchies", () => {
         };
 
         await validateHierarchy({
-          provider: createProvider({ imodel: imodelConnection, hierarchy: customHierarchy }),
+          provider: createIModelHierarchyProvider({
+            imodelAccess: createIModelAccess(ecdb),
+            hierarchyDefinition: hierarchy,
+            instanceLabelSelectClauseFactory: createDefaultInstanceLabelSelectClauseFactory(),
+            localizedStrings: { other: "", unspecified: "NOT SPECIFIED" },
+          }),
+          expect: [
+            NodeValidators.createForPropertyValueGroupingNode({
+              label: "NOT SPECIFIED",
+              propertyName: "Parent",
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
+            }),
+          ],
+        });
+      });
+    });
+
+    describe("value grouping", () => {
+      it("creates property value grouping nodes", async () => {
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { description: "Test description" });
+          return { x1 };
+        });
+        const { ecdb, ...keys } = setup;
+
+        const groupingParams: ECSqlSelectClausePropertiesGroupingParams = {
+          propertiesClassName: X_FULL_NAME,
+          propertyGroups: [{ propertyName: "Description", propertyClassAlias: "this" }],
+        };
+
+        await validateHierarchy({
+          provider: createProvider({ ecdb, hierarchy: createHierarchyWithSpecifiedGrouping(groupingParams) }),
+          expect: [
+            NodeValidators.createForPropertyValueGroupingNode({
+              label: "Test description",
+              propertyClassName: X_FULL_NAME,
+              propertyName: "Description",
+              formattedPropertyValue: "Test description",
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
+            }),
+          ],
+        });
+      });
+
+      it("creates multiple grouping nodes if nodes have different property values", async () => {
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { userLabel: "Test1" });
+          const x2 = builder.insertInstance(X_FULL_NAME, { userLabel: "Test2" });
+          return { x1, x2 };
+        });
+        const { ecdb, ...keys } = setup;
+
+        const customHierarchy: HierarchyDefinition = {
+          async defineHierarchyLevel({ parentNode, createSelectClause }) {
+            if (!parentNode) {
+              return [
+                {
+                  fullClassName: X_FULL_NAME,
+                  query: {
+                    ecsql: `
+                      SELECT ${await createSelectClause({
+                        ecClassId: { selector: `this.ECClassId` },
+                        ecInstanceId: { selector: `this.ECInstanceId` },
+                        nodeLabel: { selector: `this.UserLabel` },
+                        grouping: {
+                          byProperties: {
+                            propertiesClassName: X_FULL_NAME,
+                            propertyGroups: [{ propertyName: "UserLabel", propertyClassAlias: "this" }],
+                          },
+                        },
+                      })}
+                      FROM ${X_FULL_NAME} AS this
+                    `,
+                  },
+                },
+              ];
+            }
+            return [];
+          },
+        };
+
+        await validateHierarchy({
+          provider: createProvider({ ecdb, hierarchy: customHierarchy }),
           expect: [
             NodeValidators.createForPropertyValueGroupingNode({
               label: "Test1",
-              propertyClassName: "BisCore.Subject",
+              propertyClassName: X_FULL_NAME,
               propertyName: "UserLabel",
               formattedPropertyValue: "Test1",
-              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false })],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
             }),
             NodeValidators.createForPropertyValueGroupingNode({
               label: "Test2",
-              propertyClassName: "BisCore.Subject",
+              propertyClassName: X_FULL_NAME,
               propertyName: "UserLabel",
               formattedPropertyValue: "Test2",
-              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false })],
+              children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false })],
             }),
           ],
         });
       });
 
       it("creates multiple levels of grouping if node has multiple property groupings", async () => {
-        const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-          return withEditTxn(imodel, (txn) => {
-            const childSubject1 = insertSubject({
-              txn,
-              codeValue: "A1",
-              parentId: IModel.rootSubjectId,
-              userLabel: "TestLabel",
-              description: "TestDescription",
-            });
-            return { childSubject1 };
-          });
+        using setup = await buildTestECDb(async (builder) => {
+          await importSchema(SCHEMA_PROPS, builder, SCHEMA_XML);
+          const x1 = builder.insertInstance(X_FULL_NAME, { userLabel: "Test label", description: "Test description" });
+          return { x1 };
         });
+        const { ecdb, ...keys } = setup;
         const groupingParams: ECSqlSelectClausePropertiesGroupingParams = {
-          propertiesClassName: "BisCore.Subject",
+          propertiesClassName: X_FULL_NAME,
           propertyGroups: [
             { propertyName: "UserLabel", propertyClassAlias: "this" },
             { propertyName: "Description", propertyClassAlias: "this" },
@@ -329,25 +318,20 @@ describe("Hierarchies", () => {
         };
 
         await validateHierarchy({
-          provider: createProvider({
-            imodel: imodelConnection,
-            hierarchy: createHierarchyWithSpecifiedGrouping(imodelConnection, groupingParams),
-          }),
+          provider: createProvider({ ecdb, hierarchy: createHierarchyWithSpecifiedGrouping(groupingParams) }),
           expect: [
             NodeValidators.createForPropertyValueGroupingNode({
-              label: "TestLabel",
-              propertyClassName: "BisCore.Subject",
+              label: "Test label",
+              propertyClassName: X_FULL_NAME,
               propertyName: "UserLabel",
-              formattedPropertyValue: "TestLabel",
+              formattedPropertyValue: "Test label",
               children: [
                 NodeValidators.createForPropertyValueGroupingNode({
-                  label: "TestDescription",
-                  propertyClassName: "BisCore.Subject",
+                  label: "Test description",
+                  propertyClassName: X_FULL_NAME,
                   propertyName: "Description",
-                  formattedPropertyValue: "TestDescription",
-                  children: [
-                    NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject1], children: false }),
-                  ],
+                  formattedPropertyValue: "Test description",
+                  children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
                 }),
               ],
             }),
@@ -356,30 +340,48 @@ describe("Hierarchies", () => {
       });
 
       describe("navigation property", () => {
+        const labelSelectClauseFactory = {
+          createSelectClause: async ({ classAlias }: { classAlias: string }) => `${classAlias}.UserLabel`,
+        };
+
         it("groups by navigation property with forward direction", async () => {
-          const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-            return withEditTxn(imodel, (txn) => {
-              const model = insertPhysicalModelWithPartition({ txn, codeValue: "Physical model" });
-              const category = insertSpatialCategory({ txn, codeValue: "Spatial category" });
-              const physicalElement = insertPhysicalElement({
-                txn,
-                modelId: model.id,
-                categoryId: category.id,
-                codeValue: "Physical element",
-              });
-              return { physicalElement };
-            });
+          using setup = await buildTestECDb(async (builder, testName) => {
+            const s = await importSchema(
+              testName,
+              builder,
+              `
+                <ECEntityClass typeName="C">
+                  <ECProperty propertyName="UserLabel" typeName="string" />
+                </ECEntityClass>
+                <ECEntityClass typeName="X">
+                  <ECProperty propertyName="CodeValue" typeName="string" />
+                  <ECNavigationProperty propertyName="Category" relationshipName="XC" direction="forward" />
+                </ECEntityClass>
+                <ECRelationshipClass typeName="XC" strength="referencing" strengthDirection="forward" modifier="None">
+                  <Source multiplicity="(0..*)" roleLabel="belongs to" polymorphic="false">
+                    <Class class="X" />
+                  </Source>
+                  <Target multiplicity="(0..1)" roleLabel="is category for" polymorphic="false">
+                    <Class class="C" />
+                  </Target>
+                </ECRelationshipClass>
+              `,
+            );
+            const c1 = builder.insertInstance(s.items.C.fullName, { userLabel: "c 1" });
+            const x1 = builder.insertInstance(s.items.X.fullName, { codeValue: "x 1", "Category.Id": c1.id });
+            return { schema: s, x1 };
           });
+          const { ecdb, schema, ...keys } = setup;
 
           const provider = createIModelHierarchyProvider({
-            imodelAccess: createIModelAccess(imodelConnection),
+            imodelAccess: createIModelAccess(ecdb),
             hierarchyDefinition: {
               defineHierarchyLevel: async ({ parentNode, createSelectClause }) =>
                 parentNode
                   ? []
                   : [
                       {
-                        fullClassName: "BisCore.GeometricElement3d",
+                        fullClassName: schema.items.X.fullName,
                         query: {
                           ecsql: `
                             SELECT ${await createSelectClause({
@@ -388,57 +390,69 @@ describe("Hierarchies", () => {
                               nodeLabel: { selector: "this.CodeValue" },
                               grouping: {
                                 byProperties: {
-                                  propertiesClassName: "BisCore.GeometricElement3d",
+                                  propertiesClassName: schema.items.X.fullName,
                                   propertyGroups: [{ propertyName: "Category", propertyClassAlias: "this" }],
                                 },
                               },
                             })}
-                            FROM BisCore.GeometricElement3d [this]
+                            FROM ${schema.items.X.fullName} [this]
                           `,
                         },
                       },
                     ],
             },
+            instanceLabelSelectClauseFactory: labelSelectClauseFactory,
           });
 
           await validateHierarchy({
             provider,
             expect: [
               NodeValidators.createForPropertyValueGroupingNode({
-                propertyClassName: "BisCore.GeometricElement3d",
+                propertyClassName: schema.items.X.fullName,
                 propertyName: "Category",
-                label: "Spatial category",
-                children: [
-                  NodeValidators.createForInstanceNode({ instanceKeys: [keys.physicalElement], children: false }),
-                ],
+                label: "c 1",
+                children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x1], children: false })],
               }),
             ],
           });
         });
 
         it("groups by navigation property with backward direction", async () => {
-          const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-            return withEditTxn(imodel, (txn) => {
-              const childSubject1 = insertSubject({
-                txn,
-                codeValue: "A1",
-                parentId: IModel.rootSubjectId,
-                userLabel: "custom label",
-              });
-              const childSubject2 = insertSubject({ txn, codeValue: "A2", parentId: childSubject1.id });
-              return { childSubject1, childSubject2 };
-            });
+          using setup = await buildTestECDb(async (builder, testName) => {
+            const s = await importSchema(
+              testName,
+              builder,
+              `
+                <ECEntityClass typeName="X">
+                  <ECProperty propertyName="UserLabel" typeName="string" />
+                  <ECProperty propertyName="CodeValue" typeName="string" />
+                  <ECNavigationProperty propertyName="Parent" relationshipName="XX" direction="backward" />
+                </ECEntityClass>
+                <ECRelationshipClass typeName="XX" strength="referencing" strengthDirection="forward" modifier="None">
+                  <Source multiplicity="(0..1)" roleLabel="owns" polymorphic="false">
+                    <Class class="X" />
+                  </Source>
+                  <Target multiplicity="(0..*)" roleLabel="owned by" polymorphic="false">
+                    <Class class="X" />
+                  </Target>
+                </ECRelationshipClass>
+              `,
+            );
+            const x1 = builder.insertInstance(s.items.X.fullName, { codeValue: "A1", userLabel: "x 1" });
+            const x2 = builder.insertInstance(s.items.X.fullName, { codeValue: "A2", "Parent.Id": x1.id });
+            return { schema: s, x1, x2 };
           });
+          const { ecdb, schema, ...keys } = setup;
 
           const provider = createIModelHierarchyProvider({
-            imodelAccess: createIModelAccess(imodelConnection),
+            imodelAccess: createIModelAccess(ecdb),
             hierarchyDefinition: {
               defineHierarchyLevel: async ({ parentNode, createSelectClause }) =>
                 parentNode
                   ? []
                   : [
                       {
-                        fullClassName: "BisCore.InformationContentElement",
+                        fullClassName: schema.items.X.fullName,
                         query: {
                           ecsql: `
                             SELECT ${await createSelectClause({
@@ -447,76 +461,71 @@ describe("Hierarchies", () => {
                               nodeLabel: { selector: "this.CodeValue" },
                               grouping: {
                                 byProperties: {
-                                  propertiesClassName: "BisCore.Subject",
+                                  propertiesClassName: schema.items.X.fullName,
                                   propertyGroups: [{ propertyName: "Parent", propertyClassAlias: "this" }],
                                 },
                               },
                             })}
-                            FROM ${subjectClassName} [this]
-                            WHERE [this].[Parent].[Id] = ${keys.childSubject1.id}
-
+                            FROM ${schema.items.X.fullName} [this]
+                            WHERE [this].[Parent].[Id] = ${keys.x1.id}
                           `,
                         },
                       },
                     ],
             },
+            instanceLabelSelectClauseFactory: labelSelectClauseFactory,
           });
           await validateHierarchy({
             provider,
             expect: [
               NodeValidators.createForPropertyValueGroupingNode({
-                propertyClassName: "BisCore.Subject",
+                propertyClassName: schema.items.X.fullName,
                 propertyName: "Parent",
-                label: "custom label",
-                children: [
-                  NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
-                ],
+                label: "x 1",
+                children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false })],
               }),
             ],
           });
         });
 
         it("creates one grouping node when navigation properties point to different nodes with same labels", async () => {
-          const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-            return withEditTxn(imodel, (txn) => {
-              const childSubject1 = insertSubject({
-                txn,
-                codeValue: "A1",
-                parentId: IModel.rootSubjectId,
-                description: "TestDescription",
-                userLabel: "sameLabel",
-              });
-              const childSubject2 = insertSubject({
-                txn,
-                codeValue: "A2",
-                parentId: childSubject1.id,
-                description: "TestDescription",
-              });
-              const childSubject3 = insertSubject({
-                txn,
-                codeValue: "A3",
-                parentId: IModel.rootSubjectId,
-                description: "TestDescription",
-                userLabel: "sameLabel",
-              });
-              const childSubject4 = insertSubject({
-                txn,
-                codeValue: "A4",
-                parentId: childSubject3.id,
-                description: "TestDescription",
-              });
-              return { childSubject1, childSubject2, childSubject3, childSubject4 };
-            });
+          using setup = await buildTestECDb(async (builder, testName) => {
+            const s = await importSchema(
+              testName,
+              builder,
+              `
+                <ECEntityClass typeName="X">
+                  <ECProperty propertyName="UserLabel" typeName="string" />
+                  <ECProperty propertyName="CodeValue" typeName="string" />
+                  <ECNavigationProperty propertyName="Parent" relationshipName="XX" direction="backward" />
+                </ECEntityClass>
+                <ECRelationshipClass typeName="XX" strength="referencing" strengthDirection="forward" modifier="None">
+                  <Source multiplicity="(0..1)" roleLabel="owns" polymorphic="false">
+                    <Class class="X" />
+                  </Source>
+                  <Target multiplicity="(0..*)" roleLabel="owned by" polymorphic="false">
+                    <Class class="X" />
+                  </Target>
+                </ECRelationshipClass>
+              `,
+            );
+            const x1 = builder.insertInstance(s.items.X.fullName, { codeValue: "A1", userLabel: "sameLabel" });
+            const x2 = builder.insertInstance(s.items.X.fullName, { codeValue: "A2", "Parent.Id": x1.id });
+            const x3 = builder.insertInstance(s.items.X.fullName, { codeValue: "A3", userLabel: "sameLabel" });
+            const x4 = builder.insertInstance(s.items.X.fullName, { codeValue: "A4", "Parent.Id": x3.id });
+            return { schema: s, x1, x2, x3, x4 };
           });
+          const { ecdb, schema, ...keys } = setup;
+
           const provider = createIModelHierarchyProvider({
-            imodelAccess: createIModelAccess(imodelConnection),
+            imodelAccess: createIModelAccess(ecdb),
             hierarchyDefinition: {
               defineHierarchyLevel: async ({ parentNode, createSelectClause }) =>
                 parentNode
                   ? []
                   : [
                       {
-                        fullClassName: "BisCore.Subject",
+                        fullClassName: schema.items.X.fullName,
                         query: {
                           ecsql: `
                             SELECT ${await createSelectClause({
@@ -525,30 +534,31 @@ describe("Hierarchies", () => {
                               nodeLabel: { selector: "this.CodeValue" },
                               grouping: {
                                 byProperties: {
-                                  propertiesClassName: "BisCore.Subject",
+                                  propertiesClassName: schema.items.X.fullName,
                                   propertyGroups: [{ propertyName: "Parent", propertyClassAlias: "this" }],
                                 },
                               },
                             })}
-                            FROM BisCore.Subject [this]
-                            WHERE [this].[Parent].[Id] = ${keys.childSubject1.id} or [this].[Parent].[Id] = ${keys.childSubject3.id}
+                            FROM ${schema.items.X.fullName} [this]
+                            WHERE [this].[Parent].[Id] IS NOT NULL
                           `,
                         },
                       },
                     ],
             },
+            instanceLabelSelectClauseFactory: labelSelectClauseFactory,
           });
 
           await validateHierarchy({
             provider,
             expect: [
               NodeValidators.createForPropertyValueGroupingNode({
-                propertyClassName: "BisCore.Subject",
+                propertyClassName: schema.items.X.fullName,
                 propertyName: "Parent",
                 label: "sameLabel",
                 children: [
-                  NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
-                  NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject4], children: false }),
+                  NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false }),
+                  NodeValidators.createForInstanceNode({ instanceKeys: [keys.x4], children: false }),
                 ],
               }),
             ],
@@ -556,47 +566,43 @@ describe("Hierarchies", () => {
         });
 
         it("creates different grouping nodes when navigation properties point to different nodes with different labels", async () => {
-          const { imodelConnection, ...keys } = await buildTestIModel(async (imodel) => {
-            return withEditTxn(imodel, (txn) => {
-              const childSubject1 = insertSubject({
-                txn,
-                codeValue: "A1",
-                parentId: IModel.rootSubjectId,
-                description: "TestDescription",
-                userLabel: "differentLabel1",
-              });
-              const childSubject2 = insertSubject({
-                txn,
-                codeValue: "A2",
-                parentId: childSubject1.id,
-                description: "TestDescription",
-              });
-              const childSubject3 = insertSubject({
-                txn,
-                codeValue: "A3",
-                parentId: IModel.rootSubjectId,
-                description: "TestDescription",
-                userLabel: "differentLabel2",
-              });
-              const childSubject4 = insertSubject({
-                txn,
-                codeValue: "A4",
-                parentId: childSubject3.id,
-                description: "TestDescription",
-              });
-              return { childSubject1, childSubject2, childSubject3, childSubject4 };
-            });
+          using setup = await buildTestECDb(async (builder, testName) => {
+            const s = await importSchema(
+              testName,
+              builder,
+              `
+                <ECEntityClass typeName="X">
+                  <ECProperty propertyName="UserLabel" typeName="string" />
+                  <ECProperty propertyName="CodeValue" typeName="string" />
+                  <ECNavigationProperty propertyName="Parent" relationshipName="XX" direction="backward" />
+                </ECEntityClass>
+                <ECRelationshipClass typeName="XX" strength="referencing" strengthDirection="forward" modifier="None">
+                  <Source multiplicity="(0..1)" roleLabel="owns" polymorphic="false">
+                    <Class class="X" />
+                  </Source>
+                  <Target multiplicity="(0..*)" roleLabel="owned by" polymorphic="false">
+                    <Class class="X" />
+                  </Target>
+                </ECRelationshipClass>
+              `,
+            );
+            const x1 = builder.insertInstance(s.items.X.fullName, { codeValue: "A1", userLabel: "differentLabel1" });
+            const x2 = builder.insertInstance(s.items.X.fullName, { codeValue: "A2", "Parent.Id": x1.id });
+            const x3 = builder.insertInstance(s.items.X.fullName, { codeValue: "A3", userLabel: "differentLabel2" });
+            const x4 = builder.insertInstance(s.items.X.fullName, { codeValue: "A4", "Parent.Id": x3.id });
+            return { schema: s, x1, x2, x3, x4 };
           });
+          const { ecdb, schema, ...keys } = setup;
 
           const provider = createIModelHierarchyProvider({
-            imodelAccess: createIModelAccess(imodelConnection),
+            imodelAccess: createIModelAccess(ecdb),
             hierarchyDefinition: {
               defineHierarchyLevel: async ({ parentNode, createSelectClause }) =>
                 parentNode
                   ? []
                   : [
                       {
-                        fullClassName: "BisCore.Subject",
+                        fullClassName: schema.items.X.fullName,
                         query: {
                           ecsql: `
                             SELECT ${await createSelectClause({
@@ -605,38 +611,35 @@ describe("Hierarchies", () => {
                               nodeLabel: { selector: "this.CodeValue" },
                               grouping: {
                                 byProperties: {
-                                  propertiesClassName: "BisCore.Subject",
+                                  propertiesClassName: schema.items.X.fullName,
                                   propertyGroups: [{ propertyName: "Parent", propertyClassAlias: "this" }],
                                 },
                               },
                             })}
-                            FROM BisCore.Subject [this]
-                            WHERE [this].[Parent].[Id] = ${keys.childSubject1.id} or [this].[Parent].[Id] = ${keys.childSubject3.id}
+                            FROM ${schema.items.X.fullName} [this]
+                            WHERE [this].[Parent].[Id] IS NOT NULL
                           `,
                         },
                       },
                     ],
             },
+            instanceLabelSelectClauseFactory: labelSelectClauseFactory,
           });
 
           await validateHierarchy({
             provider,
             expect: [
               NodeValidators.createForPropertyValueGroupingNode({
-                propertyClassName: "BisCore.Subject",
+                propertyClassName: schema.items.X.fullName,
                 propertyName: "Parent",
                 label: "differentLabel1",
-                children: [
-                  NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject2], children: false }),
-                ],
+                children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x2], children: false })],
               }),
               NodeValidators.createForPropertyValueGroupingNode({
-                propertyClassName: "BisCore.Subject",
+                propertyClassName: schema.items.X.fullName,
                 propertyName: "Parent",
                 label: "differentLabel2",
-                children: [
-                  NodeValidators.createForInstanceNode({ instanceKeys: [keys.childSubject4], children: false }),
-                ],
+                children: [NodeValidators.createForInstanceNode({ instanceKeys: [keys.x4], children: false })],
               }),
             ],
           });


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/1337.

Some tests were left to use iModels:
- The ones that rely on BIS (e.g. `createBisInstanceLabelSelectClauseFactory`),
- Learning snippets - for clarity (we expect consumers to use iModels, not ECDbs)