### PR TITLE
Add support for named query bindings

### DIFF
--- a/.changeset/named-ecsql-bindings-core-interop.md
+++ b/.changeset/named-ecsql-bindings-core-interop.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-core-interop": minor
+---
+
+`createECSqlQueryExecutor`: Updated to handle both positional and named bindings when creating query readers.

--- a/.changeset/named-ecsql-bindings-hierarchies.md
+++ b/.changeset/named-ecsql-bindings-hierarchies.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies": patch
+---
+
+`createInstanceKeysFilteredQuery`: Updated to correctly append `IdSet` bindings in both positional and named binding formats, using the `IdSet` virtual table instead of `InVirtualSet`.

--- a/.changeset/named-ecsql-bindings-hierarchies.md
+++ b/.changeset/named-ecsql-bindings-hierarchies.md
@@ -1,5 +1,11 @@
 ---
-"@itwin/presentation-hierarchies": patch
+"@itwin/presentation-hierarchies": major
 ---
 
 `createInstanceKeysFilteredQuery`: Updated to correctly append `IdSet` bindings in both positional and named binding formats, using the `IdSet` virtual table instead of `InVirtualSet`.
+
+ **Breaking:** `createInstanceKeysFilteredQuery` now correctly appends `IdSet` bindings in both positional and named binding formats, using the `IdSet` virtual table instead of `InVirtualSet`.
+
+ Consumers that provide their own `LimitingECSqlQueryExecutor` or `imodelAccess` may now receive named bindings (`Record<string, ECSqlBinding>`) through the public `createQueryReader` path.
+
+ To migrate, update custom query reader / executor implementations to handle both positional bindings (`ECSqlBinding[]`) and named bindings (`Record<string, ECSqlBinding>`), or use the default implementation provided by the `@itwin/presentation-core-interop` package, `createECSqlQueryExecutor` function.

--- a/.changeset/named-ecsql-bindings-shared.md
+++ b/.changeset/named-ecsql-bindings-shared.md
@@ -1,0 +1,7 @@
+---
+"@itwin/presentation-shared": major
+---
+
+`ECSqlQueryDef.bindings`: Added support for named bindings via `Record<string, ECSqlBinding>` in addition to the existing positional `ECSqlBinding[]` format.
+
+This change is non-breaking for consumers who define queries (the type is widened). However, it is **breaking** for code that handles `ECSqlQueryDef` bindings directly (e.g., custom `ECSqlQueryExecutor` implementations), since `bindings` is now a union type. Consumers should update to the latest `@itwin/presentation-core-interop` version, which handles both binding formats.

--- a/.changeset/named-ecsql-bindings-shared.md
+++ b/.changeset/named-ecsql-bindings-shared.md
@@ -2,6 +2,25 @@
 "@itwin/presentation-shared": major
 ---
 
-`ECSqlQueryDef.bindings`: Added support for named bindings via `Record<string, ECSqlBinding>` in addition to the existing positional `ECSqlBinding[]` format.
+**Breaking:** `ECSqlQueryDef.bindings` is now `ECSqlBinding[] | Record<string, ECSqlBinding>` (previously `ECSqlBinding[]`). This is non-breaking for consumers who only define queries, but breaking for code that reads or forwards bindings (e.g., custom `ECSqlQueryExecutor` implementations) because it must now handle both formats.
 
-This change is non-breaking for consumers who define queries (the type is widened). However, it is **breaking** for code that handles `ECSqlQueryDef` bindings directly (e.g., custom `ECSqlQueryExecutor` implementations), since `bindings` is now a union type. Consumers should update to the latest `@itwin/presentation-core-interop` version, which handles both binding formats.
+Migration example:
+
+```ts
+// Before
+function handleBindings(bindings: ECSqlBinding[]) {
+  bindings.forEach((b, i) => bind(i + 1, b));
+}
+
+// After
+function handleBindings(bindings: ECSqlBinding[] | Record<string, ECSqlBinding>) {
+  const entries: Array<[string | number, ECSqlBinding]> = Array.isArray(bindings)
+    ? bindings.map((b, i) => [i + 1, b])
+    : Object.entries(bindings);
+  for (const [key, b] of entries) {
+    bind(key, b);
+  }
+}
+```
+
+Alternatively, update to the latest `@itwin/presentation-core-interop` which handles both binding formats out of the box.

--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,7 @@
     "ctes",
     "ecdb",
     "ecsql",
+    "ecsqloptions",
     "favorited",
     "favoriting",
     "filterables",

--- a/packages/core-interop/src/core-interop/QueryExecutor.ts
+++ b/packages/core-interop/src/core-interop/QueryExecutor.ts
@@ -62,7 +62,11 @@ export function createECSqlQueryExecutor(imodel: CoreECSqlReaderFactory): ECSqlQ
         opts.setRestartToken(config.restartToken);
       }
       return new ECSqlQueryReaderImpl(
-        imodel.createQueryReader(trimWhitespace(addCTEs(ecsql, ctes)), bind(bindings ?? []), opts.getOptions()),
+        imodel.createQueryReader(
+          trimWhitespace(addCTEs(ecsql, ctes)),
+          bindings ? bind(bindings) : undefined,
+          opts.getOptions(),
+        ),
         config?.rowFormat === "Indexes" ? "array" : "object",
       );
     },
@@ -86,43 +90,46 @@ class ECSqlQueryReaderImpl implements ReturnType<ECSqlQueryExecutor["createQuery
   }
 }
 
-function bind(bindings: ECSqlBinding[]): QueryBinder {
+function bind(bindings: ECSqlBinding[] | Record<string, ECSqlBinding>): QueryBinder {
   const binder = new QueryBinder();
-  bindings.forEach((b, i) => {
+  const entries: Array<[string | number, ECSqlBinding]> = Array.isArray(bindings)
+    ? bindings.map((b, i) => [i + 1, b])
+    : Object.entries(bindings);
+  for (const [key, b] of entries) {
     if (b.value === undefined) {
-      binder.bindNull(i + 1);
-      return;
+      binder.bindNull(key);
+      continue;
     }
     switch (b.type) {
       case "boolean":
-        binder.bindBoolean(i + 1, b.value);
+        binder.bindBoolean(key, b.value);
         break;
       case "double":
-        binder.bindDouble(i + 1, b.value);
+        binder.bindDouble(key, b.value);
         break;
       case "id":
-        binder.bindId(i + 1, b.value);
+        binder.bindId(key, b.value);
         break;
       case "idset":
-        binder.bindIdSet(i + 1, OrderedId64Iterable.sortArray(b.value));
+        binder.bindIdSet(key, OrderedId64Iterable.sortArray(b.value));
         break;
       case "int":
-        binder.bindInt(i + 1, b.value);
+        binder.bindInt(key, b.value);
         break;
       case "long":
-        binder.bindLong(i + 1, b.value);
+        binder.bindLong(key, b.value);
         break;
       case "point2d":
-        binder.bindPoint2d(i + 1, Point2d.fromJSON(b.value));
+        binder.bindPoint2d(key, Point2d.fromJSON(b.value));
         break;
       case "point3d":
-        binder.bindPoint3d(i + 1, Point3d.fromJSON(b.value));
+        binder.bindPoint3d(key, Point3d.fromJSON(b.value));
         break;
       case "string":
-        binder.bindString(i + 1, b.value);
+        binder.bindString(key, b.value);
         break;
     }
-  });
+  }
   return binder;
 }
 

--- a/packages/core-interop/src/test/QueryExecutor.test.ts
+++ b/packages/core-interop/src/test/QueryExecutor.test.ts
@@ -23,7 +23,7 @@ describe("createECSqlQueryExecutor", () => {
       expect(imodel.createQueryReader).toHaveBeenCalledOnce();
       const [ecsql, binder, options] = imodel.createQueryReader.mock.calls[0];
       expect(ecsql).toBe("ecsql");
-      expect(Object.keys(binder.serialize()).length).toBe(0);
+      expect(binder).toBeUndefined();
       expect(Object.keys(options).length).toBe(0);
     });
 
@@ -67,7 +67,7 @@ describe("createECSqlQueryExecutor", () => {
       expect(imodel.createQueryReader).toHaveBeenCalledOnce();
       const [ecsql, binder, options] = imodel.createQueryReader.mock.calls[0];
       expect(ecsql).toBe("ecsql");
-      expect(Object.keys(binder.serialize()).length).toBe(0);
+      expect(binder).toBeUndefined();
       expect(options.rowFormat).toBe(QueryRowFormat.UseECSqlPropertyNames);
     });
 
@@ -82,7 +82,7 @@ describe("createECSqlQueryExecutor", () => {
       expect(imodel.createQueryReader).toHaveBeenCalledOnce();
       const [ecsql, binder, options] = imodel.createQueryReader.mock.calls[0];
       expect(ecsql).toBe("ecsql");
-      expect(Object.keys(binder.serialize()).length).toBe(0);
+      expect(binder).toBeUndefined();
       expect(options.rowFormat).toBe(QueryRowFormat.UseECSqlPropertyIndexes);
     });
 
@@ -97,7 +97,7 @@ describe("createECSqlQueryExecutor", () => {
       expect(imodel.createQueryReader).toHaveBeenCalledOnce();
       const [ecsql, binder, options] = imodel.createQueryReader.mock.calls[0];
       expect(ecsql).toBe("ecsql");
-      expect(Object.keys(binder.serialize()).length).toBe(0);
+      expect(binder).toBeUndefined();
       expect(options.restartToken).toBe("TestToken");
     });
 
@@ -128,6 +128,32 @@ describe("createECSqlQueryExecutor", () => {
       expectedBinder.bindPoint3d(8, Point3d.create(1.23, 4.56, 7.89));
       expectedBinder.bindString(9, "xxx");
       expectedBinder.bindNull(10);
+
+      const executor = createECSqlQueryExecutor(imodel);
+      const reader = executor.createQueryReader({ ecsql: "ecsql", bindings }, undefined);
+      for await (const _ of reader) {
+      }
+
+      expect(imodel.createQueryReader).toHaveBeenCalledOnce();
+      const [ecsql, binder, options] = imodel.createQueryReader.mock.calls[0];
+      expect(ecsql).toBe("ecsql");
+      expect(JSON.stringify(binder.serialize())).toBe(JSON.stringify(expectedBinder.serialize()));
+      expect(Object.keys(options).length).toBe(0);
+    });
+
+    it("calls IModel's `createQueryReader` with named bindings", async () => {
+      const imodel = { createQueryReader: vi.fn().mockReturnValue(createCoreECSqlReaderStub([])) };
+
+      const bindings: Record<string, ECSqlBinding> = {
+        boolParam: { type: "boolean", value: true },
+        idParam: { type: "id", value: "0x123" },
+        nullParam: { type: "string", value: undefined },
+      };
+
+      const expectedBinder = new QueryBinder();
+      expectedBinder.bindBoolean("boolParam", true);
+      expectedBinder.bindId("idParam", "0x123");
+      expectedBinder.bindNull("nullParam");
 
       const executor = createECSqlQueryExecutor(imodel);
       const reader = executor.createQueryReader({ ecsql: "ecsql", bindings }, undefined);

--- a/packages/core-interop/src/test/QueryExecutor.test.ts
+++ b/packages/core-interop/src/test/QueryExecutor.test.ts
@@ -147,12 +147,14 @@ describe("createECSqlQueryExecutor", () => {
       const bindings: Record<string, ECSqlBinding> = {
         boolParam: { type: "boolean", value: true },
         idParam: { type: "id", value: "0x123" },
+        idsetParam: { type: "idset", value: ["0x456", "0x789"] },
         nullParam: { type: "string", value: undefined },
       };
 
       const expectedBinder = new QueryBinder();
       expectedBinder.bindBoolean("boolParam", true);
       expectedBinder.bindId("idParam", "0x123");
+      expectedBinder.bindIdSet("idsetParam", ["0x456", "0x789"]);
       expectedBinder.bindNull("nullParam");
 
       const executor = createECSqlQueryExecutor(imodel);

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
@@ -62,6 +62,7 @@ import { createHideIfNoChildrenOperator } from "./operators/HideIfNoChildren.js"
 import { createHideNodesInHierarchyOperator } from "./operators/HideNodesInHierarchy.js";
 import { SearchHierarchyDefinition } from "./SearchHierarchyDefinition.js";
 import { readNodes } from "./TreeNodesReader.js";
+import { ECSQL_PREFIX } from "./Utils.js";
 
 import type { Observable, ObservableInput, ObservedValueOf } from "rxjs";
 import type { GuidString } from "@itwin/core-bentley";
@@ -993,15 +994,19 @@ function createInstanceKeysFilteredQuery(
       bindings: [...query.bindings, { type: "idset", value: targetInstanceKeys.map((k) => k.id) }],
     };
   }
+  const ecsqlVarTargetInstanceKeys = `${ECSQL_PREFIX}targetInstanceKeys`;
   return {
     ...query,
     ecsql: `
       SELECT *
       FROM (${query.ecsql}) q
-      JOIN IdSet(:targetInstanceKeys) targetInstanceKeys ON targetInstanceKeys.id = q.ECInstanceId
+      JOIN IdSet(:${ecsqlVarTargetInstanceKeys}) targetInstanceKeys ON targetInstanceKeys.id = q.ECInstanceId
       ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
     `,
-    bindings: { ...query.bindings, targetInstanceKeys: { type: "idset", value: targetInstanceKeys.map((k) => k.id) } },
+    bindings: {
+      ...query.bindings,
+      [ecsqlVarTargetInstanceKeys]: { type: "idset", value: targetInstanceKeys.map((k) => k.id) },
+    },
   };
 }
 

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
@@ -69,7 +69,6 @@ import type {
   ConcatenatedValue,
   ECClassHierarchyInspector,
   ECSchemaProvider,
-  ECSqlBinding,
   ECSqlQueryDef,
   Event,
   EventArgs,
@@ -981,34 +980,29 @@ function createInstanceKeysFilteredQuery(
   if (!targetInstanceKeys || !targetInstanceKeys.length) {
     return query;
   }
-  const MAX_ALLOWED_BINDINGS = 1000;
-  // TODO: MISSING_COVERAGE
-  /* v8 ignore else -- @preserve */
-  if (targetInstanceKeys.length < MAX_ALLOWED_BINDINGS) {
+
+  if (Array.isArray(query.bindings)) {
     return {
       ...query,
       ecsql: `
         SELECT *
         FROM (${query.ecsql}) q
-        WHERE q.ECInstanceId IN (${targetInstanceKeys.map(() => "?").join(",")})
+        JOIN IdSet(?) targetInstanceKeys ON targetInstanceKeys.id = q.ECInstanceId
+        ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
       `,
-      bindings: [
-        ...(query.bindings ?? []),
-        ...targetInstanceKeys.map((k): ECSqlBinding => ({ type: "id", value: k.id })),
-      ],
+      bindings: [...query.bindings, { type: "idset", value: targetInstanceKeys.map((k) => k.id) }],
     };
   }
-  /* v8 ignore start */
   return {
     ...query,
     ecsql: `
       SELECT *
       FROM (${query.ecsql}) q
-      WHERE InVirtualSet(?, q.ECInstanceId)
+      JOIN IdSet(:targetInstanceKeys) targetInstanceKeys ON targetInstanceKeys.id = q.ECInstanceId
+      ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
     `,
-    bindings: [...(query.bindings ?? []), { type: "idset", value: targetInstanceKeys.map((k) => k.id) }],
+    bindings: { ...query.bindings, targetInstanceKeys: { type: "idset", value: targetInstanceKeys.map((k) => k.id) } },
   };
-  /* v8 ignore stop */
 }
 
 interface MergeNodesInput {

--- a/packages/hierarchies/src/hierarchies/imodel/LimitingECSqlQueryExecutor.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/LimitingECSqlQueryExecutor.ts
@@ -142,14 +142,18 @@ function createQueryLogger(query: ECSqlQueryDef, firstStepWarningThreshold = 300
 /* v8 ignore start */
 function createQueryLogMessage(query: ECSqlQueryDef): string {
   const ctes = query.ctes?.map((cte) => `    ${trimWhitespace(cte)}`).join(", \n");
-  const bindings = query.bindings?.map((b) => JSON.stringify(b.value)).join(", ");
+  const bindings = query.bindings
+    ? Array.isArray(query.bindings)
+      ? `[${query.bindings.map((b) => JSON.stringify(b.value)).join(", ")}]`
+      : JSON.stringify(query.bindings)
+    : undefined;
   let output = "{\n";
   if (ctes) {
     output += `  ctes: [ \n${ctes} \n], \n`;
   }
   output += `  ecsql: ${trimWhitespace(query.ecsql)}, \n`;
   if (bindings) {
-    output += `  bindings: [${bindings}], \n`;
+    output += `  bindings: ${bindings}, \n`;
   }
   output += "}";
   return output;

--- a/packages/hierarchies/src/hierarchies/imodel/Utils.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/Utils.ts
@@ -12,6 +12,8 @@ import type {
   ProcessedInstanceHierarchyNode,
 } from "./IModelHierarchyNode.js";
 
+export const ECSQL_PREFIX = "pres_";
+
 function mergeNodeHandlingParams(
   lhs: InstanceHierarchyNodeProcessingParams | undefined,
   rhs: InstanceHierarchyNodeProcessingParams | undefined,

--- a/packages/hierarchies/src/test/imodel/IModelHierarchyProvider.test.ts
+++ b/packages/hierarchies/src/test/imodel/IModelHierarchyProvider.test.ts
@@ -18,6 +18,7 @@ import {
   ECSQL_COLUMN_NAME_SearchClassName,
   ECSQL_COLUMN_NAME_SearchECInstanceId,
 } from "../../hierarchies/imodel/SearchHierarchyDefinition.js";
+import { ECSQL_PREFIX } from "../../hierarchies/imodel/Utils.js";
 import {
   createIModelAccessStub,
   createInstanceLabelSelectClauseFactoryStub,
@@ -1688,10 +1689,10 @@ describe("createIModelHierarchyProvider", () => {
       {
         const cachedQueryArg = imodelAccess.createQueryReader.mock.calls[0][0];
         expect(cachedQueryArg.ecsql).toContain("FROM (ROOT)");
-        expect(cachedQueryArg.ecsql).toContain("IdSet(:targetInstanceKeys)");
+        expect(cachedQueryArg.ecsql).toContain(`IdSet(:${ECSQL_PREFIX}targetInstanceKeys)`);
         expect(cachedQueryArg.bindings).to.deep.eq({
           param1: { type: "string", value: "test" },
-          targetInstanceKeys: { type: "idset", value: ["0x1"] },
+          [`${ECSQL_PREFIX}targetInstanceKeys`]: { type: "idset", value: ["0x1"] },
         });
       }
       expect(rootInstanceNodes2).toEqual(rootInstanceNodes);

--- a/packages/hierarchies/src/test/imodel/IModelHierarchyProvider.test.ts
+++ b/packages/hierarchies/src/test/imodel/IModelHierarchyProvider.test.ts
@@ -1548,7 +1548,9 @@ describe("createIModelHierarchyProvider", () => {
         hierarchyDefinition: {
           async defineHierarchyLevel({ parentNode }) {
             if (!parentNode) {
-              return [{ fullClassName: "x.y", query: { ecsql: "ROOT" } }];
+              return [
+                { fullClassName: "x.y", query: { ecsql: "ROOT", bindings: [{ type: "string", value: "test" }] } },
+              ];
             }
             if (parentNode.label === "one") {
               return [{ fullClassName: "x.y", query: { ecsql: "CHILD" } }];
@@ -1609,8 +1611,11 @@ describe("createIModelHierarchyProvider", () => {
       {
         const cachedQueryArg = imodelAccess.createQueryReader.mock.calls[0][0];
         expect(cachedQueryArg.ecsql).toContain("FROM (ROOT)");
-        expect(cachedQueryArg.bindings).toHaveLength(1);
-        expect(cachedQueryArg.bindings?.[0].value).toBe("0x1");
+        expect(cachedQueryArg.ecsql).toContain("IdSet(?)");
+        expect(cachedQueryArg.bindings).to.deep.eq([
+          { type: "string", value: "test" },
+          { type: "idset", value: ["0x1"] },
+        ]);
       }
       expect(rootInstanceNodes2).toEqual(rootInstanceNodes);
       imodelAccess.createQueryReader.mockClear();
@@ -1621,9 +1626,75 @@ describe("createIModelHierarchyProvider", () => {
       {
         const rootQueryArg = imodelAccess.createQueryReader.mock.calls[0][0];
         expect(rootQueryArg.ecsql).toBe("ROOT");
-        expect(rootQueryArg.bindings).toBeUndefined();
+        expect(rootQueryArg.bindings).to.deep.eq([{ type: "string", value: "test" }]);
       }
       expect(groupingNodes2).toEqual(groupingNodes);
+    });
+
+    it("queries grouped instance nodes with named bindings when requesting grouped children if the query is pushed-out of cache", async () => {
+      imodelAccess.stubEntityClass({ schemaName: "x", className: "y", classLabel: "Class Y" });
+      imodelAccess.createQueryReader.mockImplementation((query) => {
+        if (query.ecsql.includes("ROOT")) {
+          return createAsyncIterator<RowDef>([
+            {
+              [NodeSelectClauseColumnNames.FullClassName]: `x.y`,
+              [NodeSelectClauseColumnNames.ECInstanceId]: "0x1",
+              [NodeSelectClauseColumnNames.DisplayLabel]: "one",
+              [NodeSelectClauseColumnNames.HasChildren]: true,
+              [NodeSelectClauseColumnNames.Grouping]: JSON.stringify({ byClass: true }),
+            },
+          ]);
+        }
+        return createAsyncIterator<RowDef>([
+          {
+            [NodeSelectClauseColumnNames.FullClassName]: `x.y`,
+            [NodeSelectClauseColumnNames.ECInstanceId]: "0x2",
+            [NodeSelectClauseColumnNames.DisplayLabel]: "two",
+            [NodeSelectClauseColumnNames.HasChildren]: false,
+          },
+        ]);
+      });
+      using provider = createIModelHierarchyProvider({
+        imodelAccess,
+        hierarchyDefinition: {
+          async defineHierarchyLevel({ parentNode }) {
+            if (!parentNode) {
+              return [
+                {
+                  fullClassName: "x.y",
+                  query: { ecsql: "ROOT", bindings: { param1: { type: "string", value: "test" } } },
+                },
+              ];
+            }
+            return [{ fullClassName: "x.y", query: { ecsql: "CHILD" } }];
+          },
+        },
+        queryCacheSize: 1,
+      });
+
+      const groupingNodes = await collect(provider.getNodes({ parentNode: undefined }));
+      imodelAccess.createQueryReader.mockClear();
+
+      const rootInstanceNodes = await collect(provider.getNodes({ parentNode: groupingNodes[0] }));
+      imodelAccess.createQueryReader.mockClear();
+
+      // push root query out of cache
+      await collect(provider.getNodes({ parentNode: rootInstanceNodes[0] }));
+      imodelAccess.createQueryReader.mockClear();
+
+      // requesting children for the class grouping node again should re-execute the root query with named bindings
+      const rootInstanceNodes2 = await collect(provider.getNodes({ parentNode: groupingNodes[0] }));
+      expect(imodelAccess.createQueryReader).toHaveBeenCalledOnce();
+      {
+        const cachedQueryArg = imodelAccess.createQueryReader.mock.calls[0][0];
+        expect(cachedQueryArg.ecsql).toContain("FROM (ROOT)");
+        expect(cachedQueryArg.ecsql).toContain("IdSet(:targetInstanceKeys)");
+        expect(cachedQueryArg.bindings).to.deep.eq({
+          param1: { type: "string", value: "test" },
+          targetInstanceKeys: { type: "idset", value: ["0x1"] },
+        });
+      }
+      expect(rootInstanceNodes2).toEqual(rootInstanceNodes);
     });
 
     it("clears cache on data source change", async () => {

--- a/packages/shared/api/presentation-shared.api.md
+++ b/packages/shared/api/presentation-shared.api.md
@@ -350,7 +350,7 @@ export type ECSqlBinding = {
 
 // @public
 export interface ECSqlQueryDef {
-    bindings?: ECSqlBinding[];
+    bindings?: ECSqlBinding[] | Record<string, ECSqlBinding>;
     ctes?: string[];
     ecsql: string;
 }

--- a/packages/shared/src/shared/ECSqlCore.ts
+++ b/packages/shared/src/shared/ECSqlCore.ts
@@ -36,6 +36,11 @@ export interface ECSqlQueryDef {
 
   /**
    * Values to bind to the query.
+   *
+   * Provide bindings either as an array or as a record:
+   * - `ECSqlBinding[]` binds values by parameter position.
+   * - `Record<string, ECSqlBinding>` binds values by parameter name, where each key is the ECSQL parameter name.
+   *
    * @see https://www.itwinjs.org/learning/ecsql/#ecsql-parameters
    */
   bindings?: ECSqlBinding[] | Record<string, ECSqlBinding>;

--- a/packages/shared/src/shared/ECSqlCore.ts
+++ b/packages/shared/src/shared/ECSqlCore.ts
@@ -38,7 +38,7 @@ export interface ECSqlQueryDef {
    * Values to bind to the query.
    * @see https://www.itwinjs.org/learning/ecsql/#ecsql-parameters
    */
-  bindings?: ECSqlBinding[];
+  bindings?: ECSqlBinding[] | Record<string, ECSqlBinding>;
 }
 
 /**


### PR DESCRIPTION
Expose ECSQL feature that'll make life easier when creating hierarchy definitions and, eventually, loading content.