### PR TITLE
`shared`: Add support for `instanceFilter` when creating joins clause from a relationship path

### DIFF
--- a/.changeset/good-hawks-dig.md
+++ b/.changeset/good-hawks-dig.md
@@ -1,0 +1,15 @@
+---
+"@itwin/presentation-shared": major
+---
+
+**Breaking:** `createRelationshipPathJoinClause` now returns `{ joins: string; bindings?: Record<string, ECSqlBinding> }` instead of a plain `string`. Callers must be updated to read the SQL clause from the `joins` property:
+
+```ts
+// Before
+const joinClause = await createRelationshipPathJoinClause({ schemaProvider, path });
+
+// After
+const { joins: joinClause, bindings } = await createRelationshipPathJoinClause({ schemaProvider, path });
+```
+
+`RelationshipPathStep` now accepts an optional `instanceFilter` attribute. When provided, the resolved expression is appended as an `AND` condition to the relevant JOIN's `ON` clause. ECSQL parameter bindings declared in `instanceFilter.bindings` are collected across all steps and returned in the `bindings` field of the result.

--- a/packages/hierarchies/src/hierarchies/imodel/NodeSelectQueryFactory.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/NodeSelectQueryFactory.ts
@@ -411,12 +411,14 @@ async function createInstanceFilterClauses(props: {
   let joins: string[] | undefined;
   try {
     joins = await Promise.all(
-      filter.relatedInstances.map(async (rel, i) =>
-        ECSql.createRelationshipPathJoinClause({
+      filter.relatedInstances.map(async (rel, i) => {
+        const res = await ECSql.createRelationshipPathJoinClause({
           schemaProvider: imodelAccess,
           path: assignRelationshipPathAliases(rel.path, i, contentClass.alias, rel.alias),
-        }),
-      ),
+        });
+        assert(!res.bindings, "Expecting no bindings as the relationship path has no instance filter.");
+        return res.joins;
+      }),
     );
   } catch (e) {
     /* v8 ignore else -- @preserve */

--- a/packages/shared/api/presentation-shared.api.md
+++ b/packages/shared/api/presentation-shared.api.md
@@ -119,7 +119,10 @@ function createRawPrimitiveValueSelector(value: PrimitiveValue | undefined): str
 function createRawPropertyValueSelector(classAlias: string, propertyName: string, componentName?: string): string;
 
 // @public
-function createRelationshipPathJoinClause(props: CreateRelationshipPathJoinClauseProps): Promise<string>;
+function createRelationshipPathJoinClause(props: CreateRelationshipPathJoinClauseProps): Promise<{
+    joins: string;
+    bindings?: Record<string, ECSqlBinding>;
+}>;
 
 // @public
 interface CreateRelationshipPathJoinClauseProps {
@@ -534,6 +537,12 @@ type RelationshipPath<TStep extends RelationshipPathStep = RelationshipPathStep>
 
 // @public
 interface RelationshipPathStep {
+    instanceFilter?: {
+        expression: string;
+        targetAlias?: string;
+        relationshipAlias?: string;
+        bindings?: Record<string, ECSqlBinding>;
+    };
     relationshipName: EC.FullClassName;
     relationshipReverse?: boolean;
     sourceClassName: EC.FullClassName;

--- a/packages/shared/src/shared/Metadata.ts
+++ b/packages/shared/src/shared/Metadata.ts
@@ -360,7 +360,10 @@ export interface RelationshipPathStep {
   /**
    * Optional filter applied to instances at this step.
    * Only instances matching the filter will be included when traversing this relationship.
-   * The filter expression can reference both target class and relationship class properties.
+   * The filter expression can reference target class properties and, for non-navigation-property
+   * relationships (link table relationships), also relationship class properties.
+   * Referencing relationship class properties via `relationshipAlias` is not supported for
+   * navigation-property steps because the relationship table is not part of the query in that case.
    */
   instanceFilter?: {
     /**
@@ -391,6 +394,10 @@ export interface RelationshipPathStep {
      * The placeholder used in `expression` to reference the relationship class (`relationshipName`).
      * Every occurrence of `{relationshipAlias}.` in the expression will be replaced with the
      * actual relationship alias at query generation time.
+     *
+     * Only meaningful for non-navigation-property (link table) relationships. When the step uses a
+     * navigation property, the relationship table is not part of the query, so any reference via
+     * this alias will produce invalid ECSQL.
      *
      * @default "rel"
      */

--- a/packages/shared/src/shared/Metadata.ts
+++ b/packages/shared/src/shared/Metadata.ts
@@ -6,6 +6,8 @@
 import { LRUMap } from "@itwin/core-bentley";
 import { parseFullClassName } from "./Utils.js";
 
+import type { ECSqlBinding } from "./ECSqlCore.js";
+
 /**
  * An interface for an object that knows how to get an ECSchema from an iModel.
  *
@@ -355,6 +357,50 @@ export interface RelationshipPathStep {
    * describes a step from `B` to `A`.
    */
   relationshipReverse?: boolean;
+  /**
+   * Optional filter applied to instances at this step.
+   * Only instances matching the filter will be included when traversing this relationship.
+   * The filter expression can reference both target class and relationship class properties.
+   */
+  instanceFilter?: {
+    /**
+     * ECSQL WHERE clause expression (without the WHERE keyword).
+     *
+     * Use `targetAlias` (defaults to `"this"`) followed by a dot to reference properties
+     * of the filtered class, and `relationshipAlias` (defaults to `"rel"`) to reference
+     * properties on the relationship class. At query generation time, the pipeline performs
+     * a literal replacement of all `{alias}.` occurrences with the actual query aliases.
+     *
+     * @example
+     * ```
+     * expression: "this.Area > :minArea AND rel.Priority > 0"
+     * ```
+     */
+    expression: string;
+
+    /**
+     * The placeholder used in `expression` to reference the target class (`targetClassName`).
+     * Every occurrence of `{targetAlias}.` in the expression will be replaced with the
+     * actual query alias at query generation time.
+     *
+     * @default "this"
+     */
+    targetAlias?: string;
+
+    /**
+     * The placeholder used in `expression` to reference the relationship class (`relationshipName`).
+     * Every occurrence of `{relationshipAlias}.` in the expression will be replaced with the
+     * actual relationship alias at query generation time.
+     *
+     * @default "rel"
+     */
+    relationshipAlias?: string;
+
+    /**
+     * Bind values for the expression, keyed by parameter name.
+     */
+    bindings?: Record<string, ECSqlBinding>;
+  };
 }
 
 /**

--- a/packages/shared/src/shared/ecsql-snippets/ECSqlJoinSnippets.ts
+++ b/packages/shared/src/shared/ecsql-snippets/ECSqlJoinSnippets.ts
@@ -88,7 +88,14 @@ export async function createRelationshipPathJoinClause(
     const navigationProperty = await getNavigationProperty(step);
     const filterCondition = resolveInstanceFilterCondition(step);
     if (step.instanceFilter?.bindings) {
-      Object.assign(bindings, step.instanceFilter.bindings);
+      for (const [key, value] of Object.entries(step.instanceFilter.bindings)) {
+        if (key in bindings) {
+          throw new Error(
+            `Binding key "${key}" is used in multiple steps of the relationship path. Each binding key must be unique across all steps.`,
+          );
+        }
+        bindings[key] = value;
+      }
     }
     if (navigationProperty) {
       const isNavigationPropertyForward = navigationProperty.direction === "Forward";

--- a/packages/shared/src/shared/ecsql-snippets/ECSqlJoinSnippets.ts
+++ b/packages/shared/src/shared/ecsql-snippets/ECSqlJoinSnippets.ts
@@ -6,6 +6,7 @@
 import { getClass } from "../Metadata.js";
 import { createRawPropertyValueSelector } from "./ECSqlValueSelectorSnippets.js";
 
+import type { ECSqlBinding } from "../ECSqlCore.js";
 import type { EC, ECSchemaProvider, RelationshipPath, RelationshipPathStep } from "../Metadata.js";
 
 /**
@@ -37,6 +38,12 @@ interface CreateRelationshipPathJoinClauseProps {
 /**
  * Creates an ECSQL JOIN snippet for given relationships' path.
  *
+ * When a step specifies `instanceFilter`, its resolved expression is appended as an `AND`
+ * condition to the target class JOIN's `ON` clause. In the outer-join case the condition also
+ * appears on the `INNER JOIN` inside the subquery so the pre-joined subquery is already
+ * filtered. Bindings declared in `instanceFilter.bindings` across all steps are collected
+ * and returned alongside the SQL string.
+ *
  * Possible results:
  * - When the relationship is represented by a navigation property on either source or target:
  *   ```SQL
@@ -44,33 +51,45 @@ interface CreateRelationshipPathJoinClauseProps {
  *   ```
  * - When outer joining through a non-navigation-property relationship:
  *   ```SQL
- *   LEFT JOIN (
+ *   OUTER JOIN (
  *     SELECT [relationship_alias].*
  *     FROM [relationship_schema_name].[relationship_class_name] [relationship_alias]
  *     INNER JOIN [target_schema_name].[target_class_name] [target_alias] ON [target_alias].[ECInstanceId] = [relationship_alias].[TargetECInstanceId]
- *   ) [relationship_alias]
- *   LEFT JOIN [target_schema_name].[target_class_name] [target_alias] ON [target_alias].[ECInstanceId] = [relationship_alias].[TargetECInstanceId]
+ *   ) [relationship_alias] ON [relationship_alias].[SourceECInstanceId] = [source_alias].[ECInstanceId]
+ *   OUTER JOIN [target_schema_name].[target_class_name] [target_alias] ON [target_alias].[ECInstanceId] = [relationship_alias].[TargetECInstanceId]
  *   ```
  * - When inner joining through a non-navigation-property relationship:
  *   ```SQL
  *   INNER JOIN [relationship_schema_name].[relationship_class_name] [relationship_alias] ON [relationship_alias].[SourceECInstanceId] = [source_alias].[ECInstanceId]
  *   INNER JOIN [target_schema_name].[target_class_name] [target_alias] ON [target_alias].[ECInstanceId] = [relationship_alias].[TargetECInstanceId]
  *   ```
+ *
+ * @returns An object containing:
+ *   - `joins`: the ECSQL JOIN clause string to embed in a query.
+ *   - `bindings`: ECSQL parameter bindings collected from `instanceFilter.bindings` across all steps,
+ *     or `undefined` if no step specified any bindings.
  * @public
  */
-export async function createRelationshipPathJoinClause(props: CreateRelationshipPathJoinClauseProps) {
+export async function createRelationshipPathJoinClause(
+  props: CreateRelationshipPathJoinClauseProps,
+): Promise<{ joins: string; bindings?: Record<string, ECSqlBinding> }> {
   if (props.path.length === 0) {
-    return "";
+    return { joins: "" };
   }
   let prev = {
     alias: props.path[0].sourceAlias,
     joinPropertyName: "ECInstanceId",
     className: props.path[0].sourceClassName,
   };
-  let clause = "";
+  let joins = "";
+  const bindings: Record<string, ECSqlBinding> = {};
   for (const stepDef of props.path) {
     const step = await getRelationshipPathStepClasses(props.schemaProvider, stepDef);
     const navigationProperty = await getNavigationProperty(step);
+    const filterCondition = resolveInstanceFilterCondition(step);
+    if (step.instanceFilter?.bindings) {
+      Object.assign(bindings, step.instanceFilter.bindings);
+    }
     if (navigationProperty) {
       const isNavigationPropertyForward = navigationProperty.direction === "Forward";
       const relationshipJoinPropertyNames =
@@ -83,9 +102,9 @@ export async function createRelationshipPathJoinClause(props: CreateRelationship
               this: createRawPropertyValueSelector(step.targetAlias, navigationProperty.name, "Id"),
               next: createRawPropertyValueSelector(prev.alias, prev.joinPropertyName),
             };
-      clause += `
+      joins += `
         ${getJoinClause(step.joinType)} ${getClassSelectClause(step.target, step.targetAlias)}
-          ON ${relationshipJoinPropertyNames.this} = ${relationshipJoinPropertyNames.next}
+          ON ${relationshipJoinPropertyNames.this} = ${relationshipJoinPropertyNames.next}${filterCondition}
       `;
       prev = { alias: step.targetAlias, className: step.target.fullName, joinPropertyName: "ECInstanceId" };
     } else {
@@ -93,33 +112,43 @@ export async function createRelationshipPathJoinClause(props: CreateRelationship
         ? { this: "SourceECInstanceId", next: "TargetECInstanceId" }
         : { this: "TargetECInstanceId", next: "SourceECInstanceId" };
       if (step.joinType === "outer") {
-        clause += `
+        joins += `
           ${getJoinClause("outer")} (
             SELECT [${step.relationshipAlias}].*
             FROM ${getClassSelectClause(step.relationship, step.relationshipAlias)}
             ${getJoinClause("inner")} ${getClassSelectClause(step.target, step.targetAlias)}
               ON ${createRawPropertyValueSelector(step.targetAlias, "ECInstanceId")}
-                = ${createRawPropertyValueSelector(step.relationshipAlias, relationshipJoinPropertyNames.next)}
+                = ${createRawPropertyValueSelector(step.relationshipAlias, relationshipJoinPropertyNames.next)}${filterCondition}
           ) [${step.relationshipAlias}]
           ON ${createRawPropertyValueSelector(step.relationshipAlias, relationshipJoinPropertyNames.this)}
             = ${createRawPropertyValueSelector(prev.alias, prev.joinPropertyName)}
         `;
       } else {
-        clause += `
+        joins += `
           ${getJoinClause("inner")} ${getClassSelectClause(step.relationship, step.relationshipAlias)}
             ON ${createRawPropertyValueSelector(step.relationshipAlias, relationshipJoinPropertyNames.this)}
               = ${createRawPropertyValueSelector(prev.alias, prev.joinPropertyName)}
         `;
       }
-      clause += `
+      joins += `
         ${getJoinClause(step.joinType)} ${getClassSelectClause(step.target, step.targetAlias)}
           ON ${createRawPropertyValueSelector(step.targetAlias, "ECInstanceId")}
-            = ${createRawPropertyValueSelector(step.relationshipAlias, relationshipJoinPropertyNames.next)}
+            = ${createRawPropertyValueSelector(step.relationshipAlias, relationshipJoinPropertyNames.next)}${filterCondition}
       `;
       prev = { alias: step.targetAlias, className: step.target.fullName, joinPropertyName: "ECInstanceId" };
     }
   }
-  return clause;
+  return { joins, bindings: Object.keys(bindings).length > 0 ? bindings : undefined };
+}
+
+function resolveInstanceFilterCondition(step: ResolvedRelationshipPathStep): string {
+  if (!step.instanceFilter) {
+    return "";
+  }
+  const { expression, targetAlias = "this", relationshipAlias = "rel" } = step.instanceFilter;
+  return ` AND ${expression
+    .replaceAll(`${targetAlias}.`, `[${step.targetAlias}].`)
+    .replaceAll(`${relationshipAlias}.`, `[${step.relationshipAlias}].`)}`;
 }
 
 type ResolvedRelationshipPathStep = Omit<

--- a/packages/shared/src/shared/ecsql-snippets/ECSqlJoinSnippets.ts
+++ b/packages/shared/src/shared/ecsql-snippets/ECSqlJoinSnippets.ts
@@ -146,9 +146,10 @@ function resolveInstanceFilterCondition(step: ResolvedRelationshipPathStep): str
     return "";
   }
   const { expression, targetAlias = "this", relationshipAlias = "rel" } = step.instanceFilter;
-  return ` AND ${expression
+  const resolvedExpression = expression
     .replaceAll(`${targetAlias}.`, `[${step.targetAlias}].`)
-    .replaceAll(`${relationshipAlias}.`, `[${step.relationshipAlias}].`)}`;
+    .replaceAll(`${relationshipAlias}.`, `[${step.relationshipAlias}].`);
+  return ` AND (${resolvedExpression})`;
 }
 
 type ResolvedRelationshipPathStep = Omit<

--- a/packages/shared/src/shared/instance-label-factory-impls/IModelInstanceLabelSelectClauseFactory.ts
+++ b/packages/shared/src/shared/instance-label-factory-impls/IModelInstanceLabelSelectClauseFactory.ts
@@ -440,15 +440,17 @@ async function buildRelationshipPathSubquery(props: {
     finalTargetAlias: props.finalTargetAlias,
     depth: props.depth,
   });
-
-  const joinClauses = await createRelationshipPathJoinClause({ schemaProvider: props.schemaProvider, path: joinPath });
+  const joinResult = await createRelationshipPathJoinClause({ schemaProvider: props.schemaProvider, path: joinPath });
+  assert(
+    !joinResult.bindings,
+    "Output of `toJoinRelationshipPath` should not contain an instance filter, thus no bindings",
+  );
 
   const { schemaName, className } = parseFullClassName(props.ruleClassName);
-
   return `(
     SELECT ${props.selectExpression}
     FROM [${schemaName}].[${className}] [${sourceAlias}]
-    ${joinClauses}
+    ${joinResult.joins}
     WHERE [${sourceAlias}].[ECInstanceId] = [${props.classAlias}].[ECInstanceId]
     LIMIT 1
   )`;

--- a/packages/shared/src/test/ecsql-snippets/ECSqlJoinSnippets.test.ts
+++ b/packages/shared/src/test/ecsql-snippets/ECSqlJoinSnippets.test.ts
@@ -505,7 +505,7 @@ describe("createRelationshipPathJoinClause", () => {
       });
       expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(
-          `INNER JOIN [${schemaName}].[PhysicalMaterial] [t] ON [t].[ECInstanceId] = [s].[PhysicalMaterial].[Id] AND [t].Area > 0`,
+          `INNER JOIN [${schemaName}].[PhysicalMaterial] [t] ON [t].[ECInstanceId] = [s].[PhysicalMaterial].[Id] AND ([t].Area > 0)`,
         ),
       );
       expect(result.bindings).toBeUndefined();
@@ -530,7 +530,7 @@ describe("createRelationshipPathJoinClause", () => {
       expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(`
           INNER JOIN [${schemaName}].[${relationship.name}] [r] ON [r].[SourceECInstanceId] = [s].[ECInstanceId]
-          INNER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId] AND [t].Name = :name AND [r].Priority > 0
+          INNER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId] AND ([t].Name = :name AND [r].Priority > 0)
         `),
       );
       expect(result.bindings).toBeUndefined();
@@ -558,9 +558,9 @@ describe("createRelationshipPathJoinClause", () => {
           OUTER JOIN (
             SELECT [r].*
             FROM [${schemaName}].[${relationship.name}] [r]
-            INNER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId] AND [t].Area > 0
+            INNER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId] AND ([t].Area > 0)
           ) [r] ON [r].[SourceECInstanceId] = [s].[ECInstanceId]
-          OUTER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId] AND [t].Area > 0
+          OUTER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId] AND ([t].Area > 0)
         `),
       );
       expect(result.bindings).toBeUndefined();
@@ -589,7 +589,7 @@ describe("createRelationshipPathJoinClause", () => {
       expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(`
           INNER JOIN [${schemaName}].[${relationship.name}] [r] ON [r].[SourceECInstanceId] = [s].[ECInstanceId]
-          INNER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId] AND [t].Area > :minArea
+          INNER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId] AND ([t].Area > :minArea)
         `),
       );
       expect(result.bindings).toEqual({ minArea: { type: "double", value: 10.5 } });
@@ -630,9 +630,9 @@ describe("createRelationshipPathJoinClause", () => {
       expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(`
           INNER JOIN [${schemaName}].[${step1.relationship.name}] [r1] ON [r1].[SourceECInstanceId] = [a].[ECInstanceId]
-          INNER JOIN [${schemaName}].[${step1.targetClass.name}] [b] ON [b].[ECInstanceId] = [r1].[TargetECInstanceId] AND [b].Active = :isActive
+          INNER JOIN [${schemaName}].[${step1.targetClass.name}] [b] ON [b].[ECInstanceId] = [r1].[TargetECInstanceId] AND ([b].Active = :isActive)
           INNER JOIN [${schemaName}].[${step2.relationship.name}] [r2] ON [r2].[SourceECInstanceId] = [b].[ECInstanceId]
-          INNER JOIN [${schemaName}].[${step2.targetClass.name}] [c] ON [c].[ECInstanceId] = [r2].[TargetECInstanceId] AND [r2].Weight > :minWeight
+          INNER JOIN [${schemaName}].[${step2.targetClass.name}] [c] ON [c].[ECInstanceId] = [r2].[TargetECInstanceId] AND ([r2].Weight > :minWeight)
         `),
       );
       expect(result.bindings).toEqual({

--- a/packages/shared/src/test/ecsql-snippets/ECSqlJoinSnippets.test.ts
+++ b/packages/shared/src/test/ecsql-snippets/ECSqlJoinSnippets.test.ts
@@ -20,7 +20,9 @@ describe("createRelationshipPathJoinClause", () => {
   });
 
   it("returns empty string if given empty relationship path", async () => {
-    expect(await createRelationshipPathJoinClause({ schemaProvider, path: [] })).toBe("");
+    const result = await createRelationshipPathJoinClause({ schemaProvider, path: [] });
+    expect(result.joins).toBe("");
+    expect(result.bindings).toBeUndefined();
   });
 
   describe("using navigation properties", () => {
@@ -32,23 +34,20 @@ describe("createRelationshipPathJoinClause", () => {
         target: "PhysicalMaterial",
         relationship: { name: "PhysicalElementIsOfPhysicalMaterial", direction: "Forward" },
       });
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: sourceClass.fullName,
-                sourceAlias: "s",
-                relationshipName: relationship.fullName,
-                relationshipAlias: "r",
-                targetClassName: targetClass.fullName,
-                targetAlias: "t",
-              },
-            ],
-          }),
-        ),
-      ).toBe(
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: sourceClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            targetClassName: targetClass.fullName,
+            targetAlias: "t",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(
           `INNER JOIN [${schemaName}].[PhysicalMaterial] [t] ON [t].[ECInstanceId] = [s].[PhysicalMaterial].[Id]`,
         ),
@@ -63,23 +62,20 @@ describe("createRelationshipPathJoinClause", () => {
         target: "Element",
         relationship: { name: "ModelModelsElement", direction: "Backward" },
       });
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: sourceClass.fullName,
-                sourceAlias: "s",
-                relationshipName: relationship.fullName,
-                relationshipAlias: "r",
-                targetClassName: targetClass.fullName,
-                targetAlias: "t",
-              },
-            ],
-          }),
-        ),
-      ).toBe(
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: sourceClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            targetClassName: targetClass.fullName,
+            targetAlias: "t",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(`INNER JOIN [${schemaName}].[Element] [t] ON [t].[ECInstanceId] = [s].[ModeledElement].[Id]`),
       );
     });
@@ -92,23 +88,22 @@ describe("createRelationshipPathJoinClause", () => {
         target: "Element",
         relationship: { name: "ModelContainsElements", direction: "Forward" },
       });
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: sourceClass.fullName,
-                sourceAlias: "s",
-                relationshipName: relationship.fullName,
-                relationshipAlias: "r",
-                targetClassName: targetClass.fullName,
-                targetAlias: "t",
-              },
-            ],
-          }),
-        ),
-      ).toBe(trimWhitespace(`INNER JOIN [${schemaName}].[Element] [t] ON [t].[Model].[Id] = [s].[ECInstanceId]`));
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: sourceClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            targetClassName: targetClass.fullName,
+            targetAlias: "t",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
+        trimWhitespace(`INNER JOIN [${schemaName}].[Element] [t] ON [t].[Model].[Id] = [s].[ECInstanceId]`),
+      );
     });
 
     it("creates a forward join on backward navigation property with backward relationship", async () => {
@@ -119,23 +114,20 @@ describe("createRelationshipPathJoinClause", () => {
         target: "ExternalSourceAspect",
         relationship: { name: "ElementScopesExternalSourceIdentifier", direction: "Backward" },
       });
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: sourceClass.fullName,
-                sourceAlias: "s",
-                relationshipName: relationship.fullName,
-                relationshipAlias: "r",
-                targetClassName: targetClass.fullName,
-                targetAlias: "t",
-              },
-            ],
-          }),
-        ),
-      ).toBe(
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: sourceClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            targetClassName: targetClass.fullName,
+            targetAlias: "t",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(
           `INNER JOIN [${schemaName}].[ExternalSourceAspect] [t] ON [t].[Scope].[Id] = [s].[ECInstanceId]`,
         ),
@@ -150,24 +142,21 @@ describe("createRelationshipPathJoinClause", () => {
         target: "PhysicalMaterial",
         relationship: { name: "PhysicalElementIsOfPhysicalMaterial", direction: "Forward" },
       });
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: targetClass.fullName,
-                sourceAlias: "s",
-                relationshipName: relationship.fullName,
-                relationshipAlias: "r",
-                relationshipReverse: true,
-                targetClassName: sourceClass.fullName,
-                targetAlias: "t",
-              },
-            ],
-          }),
-        ),
-      ).toBe(
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: targetClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            relationshipReverse: true,
+            targetClassName: sourceClass.fullName,
+            targetAlias: "t",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(
           `INNER JOIN [${schemaName}].[PhysicalElement] [t] ON [t].[PhysicalMaterial].[Id] = [s].[ECInstanceId]`,
         ),
@@ -182,24 +171,21 @@ describe("createRelationshipPathJoinClause", () => {
         target: "Element",
         relationship: { name: "ModelModelsElement", direction: "Backward" },
       });
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: targetClass.fullName,
-                sourceAlias: "s",
-                relationshipName: relationship.fullName,
-                relationshipAlias: "r",
-                relationshipReverse: true,
-                targetClassName: sourceClass.fullName,
-                targetAlias: "t",
-              },
-            ],
-          }),
-        ),
-      ).toBe(
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: targetClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            relationshipReverse: true,
+            targetClassName: sourceClass.fullName,
+            targetAlias: "t",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(`INNER JOIN [${schemaName}].[Model] [t] ON [t].[ModeledElement].[Id] = [s].[ECInstanceId]`),
       );
     });
@@ -212,24 +198,23 @@ describe("createRelationshipPathJoinClause", () => {
         target: "Element",
         relationship: { name: "ModelContainsElements", direction: "Forward" },
       });
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: targetClass.fullName,
-                sourceAlias: "s",
-                relationshipName: relationship.fullName,
-                relationshipAlias: "r",
-                relationshipReverse: true,
-                targetClassName: sourceClass.fullName,
-                targetAlias: "t",
-              },
-            ],
-          }),
-        ),
-      ).toBe(trimWhitespace(`INNER JOIN [${schemaName}].[Model] [t] ON [t].[ECInstanceId] = [s].[Model].[Id]`));
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: targetClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            relationshipReverse: true,
+            targetClassName: sourceClass.fullName,
+            targetAlias: "t",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
+        trimWhitespace(`INNER JOIN [${schemaName}].[Model] [t] ON [t].[ECInstanceId] = [s].[Model].[Id]`),
+      );
     });
 
     it("creates a reversed join on backward navigation property with backward relationship", async () => {
@@ -240,47 +225,43 @@ describe("createRelationshipPathJoinClause", () => {
         target: "ExternalSourceAspect",
         relationship: { name: "ElementScopesExternalSourceIdentifier", direction: "Backward" },
       });
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: targetClass.fullName,
-                sourceAlias: "s",
-                relationshipName: relationship.fullName,
-                relationshipAlias: "r",
-                relationshipReverse: true,
-                targetClassName: sourceClass.fullName,
-                targetAlias: "t",
-              },
-            ],
-          }),
-        ),
-      ).toBe(trimWhitespace(`INNER JOIN [${schemaName}].[Element] [t] ON [t].[ECInstanceId] = [s].[Scope].[Id]`));
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: targetClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            relationshipReverse: true,
+            targetClassName: sourceClass.fullName,
+            targetAlias: "t",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
+        trimWhitespace(`INNER JOIN [${schemaName}].[Element] [t] ON [t].[ECInstanceId] = [s].[Scope].[Id]`),
+      );
     });
   });
 
   describe("using link table relationships", () => {
     it("creates a forward inner join", async () => {
       const { sourceClass, targetClass, relationship } = setupLinkTableRelationshipClasses();
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: sourceClass.fullName,
-                sourceAlias: "s",
-                relationshipName: relationship.fullName,
-                relationshipAlias: "r",
-                targetClassName: targetClass.fullName,
-                targetAlias: "t",
-              },
-            ],
-          }),
-        ),
-      ).toBe(
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: sourceClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            targetClassName: targetClass.fullName,
+            targetAlias: "t",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(`
           INNER JOIN [${schemaName}].[${relationship.name}] [r] ON [r].[SourceECInstanceId] = [s].[ECInstanceId]
           INNER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId]
@@ -290,24 +271,21 @@ describe("createRelationshipPathJoinClause", () => {
 
     it("creates a forward outer join", async () => {
       const { sourceClass, targetClass, relationship } = setupLinkTableRelationshipClasses();
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: sourceClass.fullName,
-                sourceAlias: "s",
-                relationshipName: relationship.fullName,
-                relationshipAlias: "r",
-                targetClassName: targetClass.fullName,
-                targetAlias: "t",
-                joinType: "outer",
-              },
-            ],
-          }),
-        ),
-      ).toBe(
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: sourceClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            targetClassName: targetClass.fullName,
+            targetAlias: "t",
+            joinType: "outer",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(`
           OUTER JOIN (
             SELECT [r].*
@@ -321,24 +299,21 @@ describe("createRelationshipPathJoinClause", () => {
 
     it("creates a reversed inner join", async () => {
       const { sourceClass, targetClass, relationship } = setupLinkTableRelationshipClasses();
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: targetClass.fullName,
-                sourceAlias: "s",
-                relationshipName: relationship.fullName,
-                relationshipAlias: "r",
-                relationshipReverse: true,
-                targetClassName: sourceClass.fullName,
-                targetAlias: "t",
-              },
-            ],
-          }),
-        ),
-      ).toBe(
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: targetClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            relationshipReverse: true,
+            targetClassName: sourceClass.fullName,
+            targetAlias: "t",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(`
           INNER JOIN [${schemaName}].[${relationship.name}] [r] ON [r].[TargetECInstanceId] = [s].[ECInstanceId]
           INNER JOIN [${schemaName}].[${sourceClass.name}] [t] ON [t].[ECInstanceId] = [r].[SourceECInstanceId]
@@ -363,31 +338,28 @@ describe("createRelationshipPathJoinClause", () => {
         relationship: "r2",
         target: "c",
       });
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: step1.sourceClass.fullName,
-                sourceAlias: "a",
-                relationshipName: step1.relationship.fullName,
-                relationshipAlias: "r1",
-                targetClassName: step1.targetClass.fullName,
-                targetAlias: "b",
-              },
-              {
-                sourceClassName: step2.sourceClass.fullName,
-                sourceAlias: "b",
-                relationshipName: step2.relationship.fullName,
-                relationshipAlias: "r2",
-                targetClassName: step2.targetClass.fullName,
-                targetAlias: "c",
-              },
-            ],
-          }),
-        ),
-      ).toBe(
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: step1.sourceClass.fullName,
+            sourceAlias: "a",
+            relationshipName: step1.relationship.fullName,
+            relationshipAlias: "r1",
+            targetClassName: step1.targetClass.fullName,
+            targetAlias: "b",
+          },
+          {
+            sourceClassName: step2.sourceClass.fullName,
+            sourceAlias: "b",
+            relationshipName: step2.relationship.fullName,
+            relationshipAlias: "r2",
+            targetClassName: step2.targetClass.fullName,
+            targetAlias: "c",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(`
           INNER JOIN [${schemaName}].[${step1.targetClass.name}] [b] ON [b].[ECInstanceId] = [a].[${step1.navigationProperty.name}].[Id]
           INNER JOIN [${schemaName}].[${step2.targetClass.name}] [c] ON [c].[${step2.navigationProperty.name}].[Id] = [b].[ECInstanceId]
@@ -398,31 +370,28 @@ describe("createRelationshipPathJoinClause", () => {
     it("creates 2 link table relationship joins", async () => {
       const step1 = setupLinkTableRelationshipClasses({ source: "a", relationship: "r1", target: "b" });
       const step2 = setupLinkTableRelationshipClasses({ source: step1.targetClass, relationship: "r2", target: "c" });
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: step1.sourceClass.fullName,
-                sourceAlias: "a",
-                relationshipName: step1.relationship.fullName,
-                relationshipAlias: "r1",
-                targetClassName: step1.targetClass.fullName,
-                targetAlias: "b",
-              },
-              {
-                sourceClassName: step2.sourceClass.fullName,
-                sourceAlias: "b",
-                relationshipName: step2.relationship.fullName,
-                relationshipAlias: "r2",
-                targetClassName: step2.targetClass.fullName,
-                targetAlias: "c",
-              },
-            ],
-          }),
-        ),
-      ).toBe(
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: step1.sourceClass.fullName,
+            sourceAlias: "a",
+            relationshipName: step1.relationship.fullName,
+            relationshipAlias: "r1",
+            targetClassName: step1.targetClass.fullName,
+            targetAlias: "b",
+          },
+          {
+            sourceClassName: step2.sourceClass.fullName,
+            sourceAlias: "b",
+            relationshipName: step2.relationship.fullName,
+            relationshipAlias: "r2",
+            targetClassName: step2.targetClass.fullName,
+            targetAlias: "c",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(`
           INNER JOIN [${schemaName}].[${step1.relationship.name}] [r1] ON [r1].[SourceECInstanceId] = [a].[ECInstanceId]
           INNER JOIN [${schemaName}].[${step1.targetClass.name}] [b] ON [b].[ECInstanceId] = [r1].[TargetECInstanceId]
@@ -441,31 +410,28 @@ describe("createRelationshipPathJoinClause", () => {
         target: "b",
       });
       const step2 = setupLinkTableRelationshipClasses({ source: step1.targetClass, relationship: "r2", target: "c" });
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: step1.sourceClass.fullName,
-                sourceAlias: "a",
-                relationshipName: step1.relationship.fullName,
-                relationshipAlias: "r1",
-                targetClassName: step1.targetClass.fullName,
-                targetAlias: "b",
-              },
-              {
-                sourceClassName: step2.sourceClass.fullName,
-                sourceAlias: "b",
-                relationshipName: step2.relationship.fullName,
-                relationshipAlias: "r2",
-                targetClassName: step2.targetClass.fullName,
-                targetAlias: "c",
-              },
-            ],
-          }),
-        ),
-      ).toBe(
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: step1.sourceClass.fullName,
+            sourceAlias: "a",
+            relationshipName: step1.relationship.fullName,
+            relationshipAlias: "r1",
+            targetClassName: step1.targetClass.fullName,
+            targetAlias: "b",
+          },
+          {
+            sourceClassName: step2.sourceClass.fullName,
+            sourceAlias: "b",
+            relationshipName: step2.relationship.fullName,
+            relationshipAlias: "r2",
+            targetClassName: step2.targetClass.fullName,
+            targetAlias: "c",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(`
           INNER JOIN [${schemaName}].[${step1.targetClass.name}] [b] ON [b].[ECInstanceId] = [a].[${step1.navigationProperty.name}].[Id]
           INNER JOIN [${schemaName}].[${step2.relationship.name}] [r2] ON [r2].[SourceECInstanceId] = [b].[ECInstanceId]
@@ -483,37 +449,196 @@ describe("createRelationshipPathJoinClause", () => {
         relationship: "r2",
         target: "c",
       });
-      expect(
-        trimWhitespace(
-          await createRelationshipPathJoinClause({
-            schemaProvider,
-            path: [
-              {
-                sourceClassName: step1.sourceClass.fullName,
-                sourceAlias: "a",
-                relationshipName: step1.relationship.fullName,
-                relationshipAlias: "r1",
-                targetClassName: step1.targetClass.fullName,
-                targetAlias: "b",
-              },
-              {
-                sourceClassName: step2.sourceClass.fullName,
-                sourceAlias: "b",
-                relationshipName: step2.relationship.fullName,
-                relationshipAlias: "r2",
-                targetClassName: step2.targetClass.fullName,
-                targetAlias: "c",
-              },
-            ],
-          }),
-        ),
-      ).toBe(
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: step1.sourceClass.fullName,
+            sourceAlias: "a",
+            relationshipName: step1.relationship.fullName,
+            relationshipAlias: "r1",
+            targetClassName: step1.targetClass.fullName,
+            targetAlias: "b",
+          },
+          {
+            sourceClassName: step2.sourceClass.fullName,
+            sourceAlias: "b",
+            relationshipName: step2.relationship.fullName,
+            relationshipAlias: "r2",
+            targetClassName: step2.targetClass.fullName,
+            targetAlias: "c",
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
         trimWhitespace(`
           INNER JOIN [${schemaName}].[${step1.relationship.name}] [r1] ON [r1].[SourceECInstanceId] = [a].[ECInstanceId]
           INNER JOIN [${schemaName}].[${step1.targetClass.name}] [b] ON [b].[ECInstanceId] = [r1].[TargetECInstanceId]
           INNER JOIN [${schemaName}].[${step2.targetClass.name}] [c] ON [c].[${step2.navigationProperty.name}].[Id] = [b].[ECInstanceId]
         `),
       );
+    });
+  });
+
+  describe("with instanceFilter", () => {
+    it("appends instance filter expression to navigation property join ON clause", async () => {
+      const { sourceClass, targetClass, relationship } = await setupNavigationPropertyRelationshipClasses({
+        navigationPropertyDirection: "Forward",
+        navigationPropertyName: "PhysicalMaterial",
+        source: "PhysicalElement",
+        target: "PhysicalMaterial",
+        relationship: { name: "PhysicalElementIsOfPhysicalMaterial", direction: "Forward" },
+      });
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: sourceClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            targetClassName: targetClass.fullName,
+            targetAlias: "t",
+            instanceFilter: { expression: "this.Area > 0" },
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
+        trimWhitespace(
+          `INNER JOIN [${schemaName}].[PhysicalMaterial] [t] ON [t].[ECInstanceId] = [s].[PhysicalMaterial].[Id] AND [t].Area > 0`,
+        ),
+      );
+      expect(result.bindings).toBeUndefined();
+    });
+
+    it("appends instance filter expression to link table target INNER JOIN ON clause", async () => {
+      const { sourceClass, targetClass, relationship } = setupLinkTableRelationshipClasses();
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: sourceClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            targetClassName: targetClass.fullName,
+            targetAlias: "t",
+            instanceFilter: { expression: "this.Name = :name AND rel.Priority > 0" },
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
+        trimWhitespace(`
+          INNER JOIN [${schemaName}].[${relationship.name}] [r] ON [r].[SourceECInstanceId] = [s].[ECInstanceId]
+          INNER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId] AND [t].Name = :name AND [r].Priority > 0
+        `),
+      );
+      expect(result.bindings).toBeUndefined();
+    });
+
+    it("appends instance filter expression to link table target OUTER JOIN ON clause", async () => {
+      const { sourceClass, targetClass, relationship } = setupLinkTableRelationshipClasses();
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: sourceClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            targetClassName: targetClass.fullName,
+            targetAlias: "t",
+            joinType: "outer",
+            instanceFilter: { expression: "this.Area > 0" },
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
+        trimWhitespace(`
+          OUTER JOIN (
+            SELECT [r].*
+            FROM [${schemaName}].[${relationship.name}] [r]
+            INNER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId] AND [t].Area > 0
+          ) [r] ON [r].[SourceECInstanceId] = [s].[ECInstanceId]
+          OUTER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId] AND [t].Area > 0
+        `),
+      );
+      expect(result.bindings).toBeUndefined();
+    });
+
+    it("collects bindings from instanceFilter and substitutes custom alias placeholders", async () => {
+      const { sourceClass, targetClass, relationship } = setupLinkTableRelationshipClasses();
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: sourceClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            targetClassName: targetClass.fullName,
+            targetAlias: "t",
+            instanceFilter: {
+              expression: "target.Area > :minArea",
+              targetAlias: "target",
+              bindings: { minArea: { type: "double", value: 10.5 } },
+            },
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
+        trimWhitespace(`
+          INNER JOIN [${schemaName}].[${relationship.name}] [r] ON [r].[SourceECInstanceId] = [s].[ECInstanceId]
+          INNER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId] AND [t].Area > :minArea
+        `),
+      );
+      expect(result.bindings).toEqual({ minArea: { type: "double", value: 10.5 } });
+    });
+
+    it("applies instanceFilter on each step of a multi-step path and merges bindings", async () => {
+      const step1 = setupLinkTableRelationshipClasses({ source: "a", relationship: "r1", target: "b" });
+      const step2 = setupLinkTableRelationshipClasses({ source: step1.targetClass, relationship: "r2", target: "c" });
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: step1.sourceClass.fullName,
+            sourceAlias: "a",
+            relationshipName: step1.relationship.fullName,
+            relationshipAlias: "r1",
+            targetClassName: step1.targetClass.fullName,
+            targetAlias: "b",
+            instanceFilter: {
+              expression: "this.Active = :isActive",
+              bindings: { isActive: { type: "boolean", value: true } },
+            },
+          },
+          {
+            sourceClassName: step2.sourceClass.fullName,
+            sourceAlias: "b",
+            relationshipName: step2.relationship.fullName,
+            relationshipAlias: "r2",
+            targetClassName: step2.targetClass.fullName,
+            targetAlias: "c",
+            instanceFilter: {
+              expression: "rel.Weight > :minWeight",
+              bindings: { minWeight: { type: "double", value: 5.0 } },
+            },
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
+        trimWhitespace(`
+          INNER JOIN [${schemaName}].[${step1.relationship.name}] [r1] ON [r1].[SourceECInstanceId] = [a].[ECInstanceId]
+          INNER JOIN [${schemaName}].[${step1.targetClass.name}] [b] ON [b].[ECInstanceId] = [r1].[TargetECInstanceId] AND [b].Active = :isActive
+          INNER JOIN [${schemaName}].[${step2.relationship.name}] [r2] ON [r2].[SourceECInstanceId] = [b].[ECInstanceId]
+          INNER JOIN [${schemaName}].[${step2.targetClass.name}] [c] ON [c].[ECInstanceId] = [r2].[TargetECInstanceId] AND [r2].Weight > :minWeight
+        `),
+      );
+      expect(result.bindings).toEqual({
+        isActive: { type: "boolean", value: true },
+        minWeight: { type: "double", value: 5.0 },
+      });
     });
   });
 

--- a/packages/shared/src/test/ecsql-snippets/ECSqlJoinSnippets.test.ts
+++ b/packages/shared/src/test/ecsql-snippets/ECSqlJoinSnippets.test.ts
@@ -640,6 +640,42 @@ describe("createRelationshipPathJoinClause", () => {
         minWeight: { type: "double", value: 5.0 },
       });
     });
+
+    it("throws when two steps use the same binding key", async () => {
+      const step1 = setupLinkTableRelationshipClasses({ source: "a", relationship: "r1", target: "b" });
+      const step2 = setupLinkTableRelationshipClasses({ source: step1.targetClass, relationship: "r2", target: "c" });
+      await expect(
+        createRelationshipPathJoinClause({
+          schemaProvider,
+          path: [
+            {
+              sourceClassName: step1.sourceClass.fullName,
+              sourceAlias: "a",
+              relationshipName: step1.relationship.fullName,
+              relationshipAlias: "r1",
+              targetClassName: step1.targetClass.fullName,
+              targetAlias: "b",
+              instanceFilter: {
+                expression: "this.Value > :threshold",
+                bindings: { threshold: { type: "double", value: 1.0 } },
+              },
+            },
+            {
+              sourceClassName: step2.sourceClass.fullName,
+              sourceAlias: "b",
+              relationshipName: step2.relationship.fullName,
+              relationshipAlias: "r2",
+              targetClassName: step2.targetClass.fullName,
+              targetAlias: "c",
+              instanceFilter: {
+                expression: "this.Value < :threshold",
+                bindings: { threshold: { type: "double", value: 9.0 } },
+              },
+            },
+          ],
+        }),
+      ).rejects.toThrow(`Binding key "threshold" is used in multiple steps`);
+    });
   });
 
   async function setupNavigationPropertyRelationshipClasses(props: {


### PR DESCRIPTION
Based on https://github.com/iTwin/presentation/pull/1357#issue-4492402436:
> I'm planning to extract the `InstanceFilter` / `RelationshipPathStep.instanceFilter` change in `@itwin/presentation-shared` into a separate PR.