### PR TITLE
[components] Deprecate favorites provider fields

### DIFF
--- a/.changeset/tough-cloths-doubt.md
+++ b/.changeset/tough-cloths-doubt.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": minor
+---
+
+Deprecated `FavoritePropertiesDataProvider.includeFieldsWithNoValues` and `FavoritePropertiesDataProvider.includeFieldsWithCompositeValues`.

--- a/packages/components/api/presentation-components.api.md
+++ b/packages/components/api/presentation-components.api.md
@@ -206,7 +206,9 @@ export interface FavoritePropertiesDataFiltererProps {
 export class FavoritePropertiesDataProvider implements IFavoritePropertiesDataProvider {
     constructor(props?: FavoritePropertiesDataProviderProps);
     getData(imodel: IModelConnection, elementIds: Id64Arg | KeySet): Promise<PropertyData>;
+    // @deprecated
     includeFieldsWithCompositeValues: boolean;
+    // @deprecated
     includeFieldsWithNoValues: boolean;
 }
 

--- a/packages/components/src/presentation-components/favorite-properties/DataProvider.ts
+++ b/packages/components/src/presentation-components/favorite-properties/DataProvider.ts
@@ -57,6 +57,8 @@ export class FavoritePropertiesDataProvider implements IFavoritePropertiesDataPr
    * - For *primitive* fields: `null`, `undefined`, `""` (empty string)
    * - For *array* fields: `[]` (empty array)
    * - For *struct* fields: `{}` (object with no members)
+   *
+   * @deprecated in 5.15. Use [FilteringPropertyDataProvider]($components-react) and [IPropertyDataFilterer]($components-react) APIs for filtering-out properties.
    */
   public includeFieldsWithNoValues: boolean;
 
@@ -65,12 +67,16 @@ export class FavoritePropertiesDataProvider implements IFavoritePropertiesDataPr
    * Fields with composite values:
    * - *array* fields.
    * - *struct* fields.
+   *
+   * @deprecated in 5.15. Use [FilteringPropertyDataProvider]($components-react) and [IPropertyDataFilterer]($components-react) APIs for filtering-out properties.
    */
   public includeFieldsWithCompositeValues: boolean;
 
   /** Constructor. */
   constructor(props?: FavoritePropertiesDataProviderProps) {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     this.includeFieldsWithNoValues = true;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     this.includeFieldsWithCompositeValues = true;
     this._customRuleset = /* v8 ignore next -- @preserve */ props?.ruleset;
     /* v8 ignore start -- @preserve */

--- a/packages/components/src/test/favorite-properties/DataProvider.test.ts
+++ b/packages/components/src/test/favorite-properties/DataProvider.test.ts
@@ -45,11 +45,13 @@ describe("FavoritePropertiesDataProvider", () => {
   });
 
   describe("constructor", () => {
-    it("sets `includeFieldsWithNoValues` to true", () => {
+    it("[deprecated] sets `includeFieldsWithNoValues` to true", () => {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       expect(provider.includeFieldsWithNoValues).toBe(true);
     });
 
-    it("sets `includeFieldsWithCompositeValues` to true", () => {
+    it("[deprecated] sets `includeFieldsWithCompositeValues` to true", () => {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       expect(provider.includeFieldsWithCompositeValues).toBe(true);
     });
   });


### PR DESCRIPTION
Added deprecations on `includeFieldsWithNoValues` and `includeFieldsWithCompositeValues` fields of `FavoritePropertiesDataProvider`. Internally used `PresentationPropertyDataProvider` have these fields deprecated in `3.x` version,