### PR TITLE
Pin node version to avoid hangs in workflows

### DIFF
--- a/.github/workflows/benchmark-hierarchies.yml
+++ b/.github/workflows/benchmark-hierarchies.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/benchmark-pr-hierarchies.yml
+++ b/.github/workflows/benchmark-pr-hierarchies.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/benchmark-pr-unified-selection.yml
+++ b/.github/workflows/benchmark-pr-unified-selection.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/benchmark-unified-selection.yml
+++ b/.github/workflows/benchmark-unified-selection.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24
+          node-version: 24.15.0
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: "pnpm"
 
       - name: Install dependencies
@@ -49,7 +49,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/extract-api.yaml
+++ b/.github/workflows/extract-api.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Update dependencies for testing
@@ -88,7 +88,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Download artifacts

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/weekly-dependency-update.yml
+++ b/.github/workflows/weekly-dependency-update.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: "pnpm"
 
       - name: Update dependencies


### PR DESCRIPTION
Pinned node version to 24.15.0 due to issue in extract-zip. It is used by playwright to extract browser zip and with node 24.16.0 it hangs.

https://github.com/iTwin/itwinjs-core/issues/9325