### PR TITLE
Property grid selection storage

### DIFF
--- a/.changeset/olive-melons-travel.md
+++ b/.changeset/olive-melons-travel.md
@@ -1,0 +1,23 @@
+---
+"@itwin/presentation-components": major
+---
+
+**Breaking:** `usePropertyDataProviderWithUnifiedSelection` now requires `selectionStorage` prop.
+
+The `selectionStorage` prop in `PropertyDataProviderWithUnifiedSelectionProps` has been made required. Previously, when not provided, the hook fell back to the deprecated `SelectionManager` from `@itwin/presentation-frontend` package. Consumers must now explicitly supply a `SelectionStorage` instance from `@itwin/unified-selection`.
+
+Before:
+
+```tsx
+const { isOverLimit, numSelectedElements } = usePropertyDataProviderWithUnifiedSelection({ dataProvider });
+```
+
+After:
+
+```tsx
+import { createStorage } from "@itwin/unified-selection";
+
+const selectionStorage = createStorage(); // create once, share across all components
+
+const { isOverLimit, numSelectedElements } = usePropertyDataProviderWithUnifiedSelection({ dataProvider, selectionStorage });
+```

--- a/.changeset/petite-results-act.md
+++ b/.changeset/petite-results-act.md
@@ -1,0 +1,23 @@
+---
+"@itwin/presentation-components": major
+---
+
+**Breaking:** `usePresentationTableWithUnifiedSelection` now requires `selectionStorage` prop.
+
+The `selectionStorage` prop in `UsePresentationTableWithUnifiedSelectionProps` has been made required. Previously, when not provided, the hook fell back to the deprecated `SelectionManager` from `@itwin/presentation-frontend` package. Consumers must now explicitly supply a `SelectionStorage` instance from `@itwin/unified-selection`.
+
+Before:
+
+```tsx
+const { rows, columns } = usePresentationTableWithUnifiedSelection({ imodel, ruleset, columnMapper, rowMapper });
+```
+
+After:
+
+```tsx
+import { createStorage } from "@itwin/unified-selection";
+
+const selectionStorage = createStorage(); // create once, share across all components
+
+const { rows, columns } = usePresentationTableWithUnifiedSelection({ imodel, ruleset, columnMapper, rowMapper, selectionStorage });
+```

--- a/.changeset/six-icons-follow.md
+++ b/.changeset/six-icons-follow.md
@@ -1,0 +1,21 @@
+---
+"@itwin/presentation-components": major
+---
+
+**Breaking:** `FavoritePropertiesDataProvider` constructor now requires `FavoritePropertiesDataProviderProps` with `activeScopeProvider`.
+
+The constructor argument has been changed from optional to required, and `activeScopeProvider` within `FavoritePropertiesDataProviderProps` has been made required. Previously, when `activeScopeProvider` was not provided, the provider fell back to the deprecated `SelectionScopesManager` from `@itwin/presentation-frontend` package to determine the active scope. Consumers must now supply the `activeScopeProvider` callback explicitly.
+
+Before:
+
+```ts
+const provider = new FavoritePropertiesDataProvider();
+```
+
+After:
+
+```ts
+const provider = new FavoritePropertiesDataProvider({
+  activeScopeProvider: () => ({ id: "element" }),
+});
+```

--- a/packages/components/api/presentation-components.api.md
+++ b/packages/components/api/presentation-components.api.md
@@ -201,7 +201,7 @@ export interface FavoritePropertiesDataFiltererProps {
 
 // @public
 export class FavoritePropertiesDataProvider implements IFavoritePropertiesDataProvider {
-    constructor(props?: FavoritePropertiesDataProviderProps);
+    constructor(props: FavoritePropertiesDataProviderProps);
     getData(imodel: IModelConnection, elementIds: Id64Arg | KeySet): Promise<PropertyData>;
     // @deprecated
     includeFieldsWithCompositeValues: boolean;
@@ -211,7 +211,7 @@ export class FavoritePropertiesDataProvider implements IFavoritePropertiesDataPr
 
 // @public
 export interface FavoritePropertiesDataProviderProps {
-    activeScopeProvider?: () => Parameters<typeof computeSelection>[0]["scope"];
+    activeScopeProvider: () => Parameters<typeof computeSelection>[0]["scope"];
     ruleset?: Ruleset | string;
 }
 

--- a/packages/components/api/presentation-components.api.md
+++ b/packages/components/api/presentation-components.api.md
@@ -623,7 +623,7 @@ export interface PresentationTreeRendererProps extends Omit<TreeRendererProps, "
 export interface PropertyDataProviderWithUnifiedSelectionProps {
     dataProvider: IPresentationPropertyDataProvider;
     requestedContentInstancesLimit?: number;
-    selectionStorage?: SelectionStorage;
+    selectionStorage: SelectionStorage;
 }
 
 // @public

--- a/packages/components/api/presentation-components.api.md
+++ b/packages/components/api/presentation-components.api.md
@@ -840,7 +840,7 @@ export function usePresentationTableWithUnifiedSelection<TColumn, TRow>(props: U
 
 // @public
 export interface UsePresentationTableWithUnifiedSelectionProps<TColumn, TRow> extends Omit<UsePresentationTableProps<TColumn, TRow>, "keys"> {
-    selectionStorage?: SelectionStorage;
+    selectionStorage: SelectionStorage;
 }
 
 // @public

--- a/packages/components/src/presentation-components/common/Utils.ts
+++ b/packages/components/src/presentation-components/common/Utils.ts
@@ -29,8 +29,8 @@ import {
   Ruleset,
   Value,
 } from "@itwin/presentation-common";
-import { createSelectionScopeProps, Presentation, SelectionScopesManager } from "@itwin/presentation-frontend";
-import { computeSelection, Selectables } from "@itwin/unified-selection";
+import { Presentation } from "@itwin/presentation-frontend";
+import { Selectables } from "@itwin/unified-selection";
 
 /** @internal */
 export const localizationNamespaceName = "PresentationComponents";
@@ -277,37 +277,6 @@ export async function createKeySetFromSelectables(selectables: Selectables): Pro
   }
   return keys;
 }
-
-/* v8 ignore start -- @preserve */
-
-export function mapPresentationFrontendSelectionScopeToUnifiedSelectionScope(
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  scope: SelectionScopesManager["activeScope"],
-): Parameters<typeof computeSelection>[0]["scope"] {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  const scopeProps = createSelectionScopeProps(scope);
-  switch (scopeProps.id) {
-    case "functional-element":
-      return { id: "functional" };
-    case "functional-assembly":
-      return { id: "functional", ancestorLevel: 1 };
-    case "functional-top-assembly":
-      return { id: "functional", ancestorLevel: -1 };
-    case "element":
-      return { id: "element" };
-    case "assembly":
-      return { id: "element", ancestorLevel: 1 };
-    case "top-assembly":
-      return { id: "element", ancestorLevel: -1 };
-    case "category":
-      return { id: "category" };
-    case "model":
-      return { id: "model" };
-  }
-  throw new Error(`Unknown selection scope: "${scopeProps.id}"`);
-}
-
-/* v8 ignore stop -- @preserve */
 
 /**
  * A helper that disposes the given object, if it's disposable.

--- a/packages/components/src/presentation-components/favorite-properties/DataProvider.ts
+++ b/packages/components/src/presentation-components/favorite-properties/DataProvider.ts
@@ -11,9 +11,7 @@ import { Id64Arg } from "@itwin/core-bentley";
 import { IModelConnection } from "@itwin/core-frontend";
 import { KeySet, Ruleset } from "@itwin/presentation-common";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
-import { Presentation } from "@itwin/presentation-frontend";
 import { computeSelection } from "@itwin/unified-selection";
-import { mapPresentationFrontendSelectionScopeToUnifiedSelectionScope } from "../common/Utils.js";
 import { PresentationPropertyDataProvider } from "../propertygrid/DataProvider.js";
 import { getFavoritesCategory } from "./Utils.js";
 
@@ -39,9 +37,8 @@ export interface FavoritePropertiesDataProviderProps {
 
   /**
    * Active selection scope provider.
-   * Takes active scope from `Presentation.selection.scopes.activeScope` if not provided.
    */
-  activeScopeProvider?: () => Parameters<typeof computeSelection>[0]["scope"];
+  activeScopeProvider: () => Parameters<typeof computeSelection>[0]["scope"];
 }
 
 /**
@@ -73,17 +70,14 @@ export class FavoritePropertiesDataProvider implements IFavoritePropertiesDataPr
   public includeFieldsWithCompositeValues: boolean;
 
   /** Constructor. */
-  constructor(props?: FavoritePropertiesDataProviderProps) {
+  constructor(props: FavoritePropertiesDataProviderProps) {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     this.includeFieldsWithNoValues = true;
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     this.includeFieldsWithCompositeValues = true;
     this._customRuleset = /* v8 ignore next -- @preserve */ props?.ruleset;
     /* v8 ignore start -- @preserve */
-    this._getActiveScope =
-      props?.activeScopeProvider ??
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      (() => mapPresentationFrontendSelectionScopeToUnifiedSelectionScope(Presentation.selection.scopes.activeScope));
+    this._getActiveScope = props.activeScopeProvider;
     /* v8 ignore stop -- @preserve */
   }
 

--- a/packages/components/src/presentation-components/propertygrid/UseUnifiedSelection.tsx
+++ b/packages/components/src/presentation-components/propertygrid/UseUnifiedSelection.tsx
@@ -6,14 +6,13 @@
  * @module PropertyGrid
  */
 
-import { createContext, PropsWithChildren, useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { from, map, Subject, switchMap, takeLast } from "rxjs";
 import { IModelConnection } from "@itwin/core-frontend";
 import { KeySet } from "@itwin/presentation-common";
 import { createIModelKey } from "@itwin/presentation-core-interop";
-import { Presentation, SelectionChangeEventArgs, SelectionHandler } from "@itwin/presentation-frontend";
 import { SelectionStorage } from "@itwin/unified-selection";
-import { createKeySetFromSelectables, safeDispose } from "../common/Utils.js";
+import { createKeySetFromSelectables } from "../common/Utils.js";
 import { IPresentationPropertyDataProvider } from "./DataProvider.js";
 
 const DEFAULT_REQUESTED_CONTENT_INSTANCES_LIMIT = 100;
@@ -38,11 +37,8 @@ export interface PropertyDataProviderWithUnifiedSelectionProps {
 
   /**
    * Unified selection storage to use for listening and getting active selection.
-   *
-   * When not specified, the deprecated `SelectionManager` from `@itwin/presentation-frontend` package
-   * is used.
    */
-  selectionStorage?: SelectionStorage;
+  selectionStorage: SelectionStorage;
 }
 
 /**
@@ -54,23 +50,6 @@ export interface UsePropertyDataProviderWithUnifiedSelectionResult {
   isOverLimit: boolean;
   /** Selected element count. */
   numSelectedElements: number;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-deprecated
-const SelectionHandlerContext = createContext<SelectionHandler | undefined>(undefined);
-
-/** @internal */
-export function SelectionHandlerContextProvider({
-  selectionHandler,
-  children,
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-}: PropsWithChildren<{ selectionHandler: SelectionHandler }>) {
-  return <SelectionHandlerContext.Provider value={selectionHandler}>{children}</SelectionHandlerContext.Provider>;
-}
-
-/** @internal */
-export function useSelectionHandlerContext() {
-  return useContext(SelectionHandlerContext);
 }
 
 /**
@@ -86,23 +65,13 @@ export function usePropertyDataProviderWithUnifiedSelection(
     props.requestedContentInstancesLimit ?? DEFAULT_REQUESTED_CONTENT_INSTANCES_LIMIT;
   const [numSelectedElements, setNumSelectedElements] = useState(0);
 
-  const suppliedSelectionHandler = useSelectionHandlerContext();
-
   useEffect(() => {
     function onSelectionChanged(newSelection: KeySet) {
       setNumSelectedElements(newSelection.size);
       dataProvider.keys = isOverLimit(newSelection.size, requestedContentInstancesLimit) ? new KeySet() : newSelection;
     }
-    if (selectionStorage) {
-      return initUnifiedSelectionFromStorage({ imodel, selectionStorage, onSelectionChanged });
-    }
-    return initUnifiedSelectionFromPresentationFrontend({
-      imodel,
-      rulesetId,
-      suppliedSelectionHandler,
-      onSelectionChanged,
-    });
-  }, [dataProvider, imodel, rulesetId, requestedContentInstancesLimit, suppliedSelectionHandler, selectionStorage]);
+    return initUnifiedSelectionFromStorage({ imodel, selectionStorage, onSelectionChanged });
+  }, [dataProvider, imodel, rulesetId, requestedContentInstancesLimit, selectionStorage]);
 
   return { isOverLimit: isOverLimit(numSelectedElements, requestedContentInstancesLimit), numSelectedElements };
 }
@@ -137,67 +106,6 @@ function initUnifiedSelectionFromStorage({
     removeSelectionChangesListener();
     subscription.unsubscribe();
   };
-}
-
-function initUnifiedSelectionFromPresentationFrontend({
-  suppliedSelectionHandler,
-  imodel,
-  rulesetId,
-  onSelectionChanged,
-}: {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  suppliedSelectionHandler?: SelectionHandler;
-  imodel: IModelConnection;
-  rulesetId: string;
-  onSelectionChanged: (newSelection: KeySet) => void;
-}) {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  const updateProviderSelection = (selectionHandler: SelectionHandler, selectionLevel?: number) => {
-    const selection = getSelectedKeys(selectionHandler, selectionLevel);
-    selection && onSelectionChanged(selection);
-  };
-
-  /* v8 ignore start -- @preserve */
-  const handler =
-    suppliedSelectionHandler ??
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    new SelectionHandler({
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      manager: Presentation.selection,
-      name: "PropertyGrid",
-      imodel,
-      rulesetId,
-    });
-  /* v8 ignore stop -- @preserve */
-
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  handler.onSelect = (evt: SelectionChangeEventArgs): void => {
-    updateProviderSelection(handler, evt.level);
-  };
-
-  updateProviderSelection(handler);
-  return () => {
-    safeDispose(handler);
-  };
-}
-
-// eslint-disable-next-line @typescript-eslint/no-deprecated
-function getSelectedKeys(selectionHandler: SelectionHandler, selectionLevel?: number): KeySet | undefined {
-  if (undefined === selectionLevel) {
-    const availableLevels = selectionHandler.getSelectionLevels();
-    if (0 === availableLevels.length) {
-      return undefined;
-    }
-    selectionLevel = availableLevels[availableLevels.length - 1];
-  }
-
-  for (let i = selectionLevel; i >= 0; i--) {
-    const selection = selectionHandler.getSelection(i);
-    if (!selection.isEmpty) {
-      return new KeySet(selection);
-    }
-  }
-  return new KeySet();
 }
 
 function isOverLimit(numSelectedElements: number, limit: number): boolean {

--- a/packages/components/src/presentation-components/table/UsePresentationTable.ts
+++ b/packages/components/src/presentation-components/table/UsePresentationTable.ts
@@ -10,9 +10,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { debounceTime, EMPTY, from, map, mergeMap, Observable, of, Subject, switchMap, tap } from "rxjs";
 import { BeEvent, Guid } from "@itwin/core-bentley";
 import { IModelConnection } from "@itwin/core-frontend";
-import { Key, KeySet, NodeKey, Ruleset } from "@itwin/presentation-common";
+import { KeySet, Ruleset } from "@itwin/presentation-common";
 import { createIModelKey } from "@itwin/presentation-core-interop";
-import { Presentation } from "@itwin/presentation-frontend";
 import { parseFullClassName } from "@itwin/presentation-shared";
 import { SelectableInstanceKey, Selectables, SelectionStorage } from "@itwin/unified-selection";
 import { TableColumnDefinition, TableRowDefinition } from "./Types.js";
@@ -91,11 +90,8 @@ export interface UsePresentationTableWithUnifiedSelectionProps<TColumn, TRow> ex
 > {
   /**
    * Unified selection storage to use for listening, getting and changing active selection.
-   *
-   * When not specified, the deprecated `SelectionManager` from `@itwin/presentation-frontend` package
-   * is used.
    */
-  selectionStorage?: SelectionStorage;
+  selectionStorage: SelectionStorage;
 }
 
 /**
@@ -216,21 +212,13 @@ function useSelectionHandler({
   tableName,
 }: {
   imodel: IModelConnection;
-  selectionStorage?: SelectionStorage;
+  selectionStorage: SelectionStorage;
   tableName: string;
 }) {
   const [selectionChange] = useState(() => new BeEvent<(level: number) => void>());
   useEffect(() => {
-    if (selectionStorage) {
-      return selectionStorage.selectionChangeEvent.addListener((args) => {
-        if (args.imodelKey === createIModelKey(imodel) && args.source !== tableName) {
-          selectionChange.raiseEvent(args.level);
-        }
-      });
-    }
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    return Presentation.selection.selectionChange.addListener((args) => {
-      if (imodel === args.imodel && args.source !== tableName) {
+    return selectionStorage.selectionChangeEvent.addListener((args) => {
+      if (args.imodelKey === createIModelKey(imodel) && args.source !== tableName) {
         selectionChange.raiseEvent(args.level);
       }
     });
@@ -238,41 +226,32 @@ function useSelectionHandler({
 
   const getSelection = useCallback(
     async (args: { level: number }): Promise<SelectableInstanceKey[]> => {
-      return selectionStorage
-        ? loadInstanceKeysFromSelectables(
-            selectionStorage.getSelection({ imodelKey: createIModelKey(imodel), level: args.level }),
-          )
-        : // eslint-disable-next-line @typescript-eslint/no-deprecated
-          loadInstanceKeysFromKeySet(Presentation.selection.getSelection(imodel, args.level));
+      return loadInstanceKeysFromSelectables(
+        selectionStorage.getSelection({ imodelKey: createIModelKey(imodel), level: args.level }),
+      );
     },
     [imodel, selectionStorage],
   );
 
   const getSelectionKeySet = useCallback(
     async (args: { level: number }): Promise<KeySet> => {
-      return selectionStorage
-        ? new KeySet(
-            await loadInstanceKeysFromSelectables(
-              selectionStorage.getSelection({ imodelKey: createIModelKey(imodel), level: args.level }),
-            ),
-          )
-        : // eslint-disable-next-line @typescript-eslint/no-deprecated
-          new KeySet(Presentation.selection.getSelection(imodel, args.level));
+      return new KeySet(
+        await loadInstanceKeysFromSelectables(
+          selectionStorage.getSelection({ imodelKey: createIModelKey(imodel), level: args.level }),
+        ),
+      );
     },
     [imodel, selectionStorage],
   );
 
   const replaceSelection = useCallback(
     (args: { source: string; level: number; selectables: SelectableInstanceKey[] }) => {
-      return selectionStorage
-        ? selectionStorage.replaceSelection({
-            imodelKey: createIModelKey(imodel),
-            source: args.source,
-            level: args.level,
-            selectables: args.selectables,
-          })
-        : // eslint-disable-next-line @typescript-eslint/no-deprecated
-          Presentation.selection.replaceSelection(args.source, imodel, args.selectables, args.level);
+      selectionStorage.replaceSelection({
+        imodelKey: createIModelKey(imodel),
+        source: args.source,
+        level: args.level,
+        selectables: args.selectables,
+      });
     },
     [imodel, selectionStorage],
   );
@@ -287,21 +266,6 @@ async function loadInstanceKeysFromSelectables(selectables: Selectables) {
   for await (const selectable of Selectables.load(selectables)) {
     keys.push(selectable);
   }
-  return keys;
-}
-
-async function loadInstanceKeysFromKeySet(keySet: Readonly<KeySet>) {
-  const keys: SelectableInstanceKey[] = [];
-  keySet.forEach((key) => {
-    if (Key.isInstanceKey(key)) {
-      keys.push(key);
-      /* v8 ignore start -- @preserve */
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-    } else if (NodeKey.isInstancesNodeKey(key)) {
-      keys.push(...key.instanceKeys);
-    }
-    /* v8 ignore stop -- @preserve */
-  });
   return keys;
 }
 

--- a/packages/components/src/test/propertygrid/UseUnifiedSelection.test.tsx
+++ b/packages/components/src/test/propertygrid/UseUnifiedSelection.test.tsx
@@ -3,26 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { PropsWithChildren } from "react";
-import { beforeEach, describe, expect, it, Mocked, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { IModelConnection } from "@itwin/core-frontend";
 import { KeySet } from "@itwin/presentation-common";
-import {
-  ISelectionProvider,
-  SelectionChangeEventArgs,
-  SelectionChangeType,
-  SelectionHandler,
-} from "@itwin/presentation-frontend";
 import { createStorage, Selectables, SelectionStorage } from "@itwin/unified-selection";
 import { IPresentationPropertyDataProvider } from "../../presentation-components/propertygrid/DataProvider.js";
-import {
-  SelectionHandlerContextProvider,
-  usePropertyDataProviderWithUnifiedSelection,
-} from "../../presentation-components/propertygrid/UseUnifiedSelection.js";
+import { usePropertyDataProviderWithUnifiedSelection } from "../../presentation-components/propertygrid/UseUnifiedSelection.js";
 import { createTestECInstanceKey } from "../_helpers/Common.js";
-import { act, createMocked, renderHook, waitFor } from "../TestUtils.js";
-
-/* eslint-disable @typescript-eslint/no-deprecated */
+import { act, renderHook, waitFor } from "../TestUtils.js";
 
 describe("usePropertyDataProviderWithUnifiedSelection", () => {
   const imodelKey = "test-imodel-key";
@@ -42,145 +30,6 @@ describe("usePropertyDataProviderWithUnifiedSelection", () => {
   function getProvider() {
     return dataProvider as unknown as IPresentationPropertyDataProvider;
   }
-
-  describe("with deprecated SelectionHandler", () => {
-    let selectionHandler: Mocked<SelectionHandler>;
-    function SelectionHandlerWrapper({ children }: PropsWithChildren<{}>) {
-      return (
-        <SelectionHandlerContextProvider selectionHandler={selectionHandler}>
-          {children}
-        </SelectionHandlerContextProvider>
-      );
-    }
-
-    beforeEach(() => {
-      selectionHandler = createMocked(SelectionHandler);
-    });
-
-    it("doesn't set provider keys when handler returns no selection", () => {
-      selectionHandler.getSelectionLevels.mockReturnValue([]);
-
-      const { result } = renderHook(usePropertyDataProviderWithUnifiedSelection, {
-        initialProps: { dataProvider: getProvider() },
-        wrapper: SelectionHandlerWrapper,
-      });
-      expect(result.current).toBeDefined();
-      expect(result.current.isOverLimit).toBe(false);
-      expect(result.current.numSelectedElements).toEqual(0);
-
-      expect(setKeysSpy).not.toHaveBeenCalled();
-    });
-
-    it("sets empty keyset when handler returns empty selection", () => {
-      selectionHandler.getSelectionLevels.mockReturnValue([0]);
-      selectionHandler.getSelection.mockReturnValue(new KeySet());
-
-      const { result } = renderHook(usePropertyDataProviderWithUnifiedSelection, {
-        initialProps: { dataProvider: getProvider() },
-        wrapper: SelectionHandlerWrapper,
-      });
-      expect(result.current).toBeDefined();
-      expect(result.current.isOverLimit).toBe(false);
-      expect(result.current.numSelectedElements).toEqual(0);
-
-      expect(setKeysSpy.mock.calls[setKeysSpy.mock.calls.length - 1][0].isEmpty).toBe(true);
-    });
-
-    it("sets keyset when handler returns a selection", () => {
-      const setKeys = new KeySet([createTestECInstanceKey({ id: "0x1" }), createTestECInstanceKey({ id: "0x2" })]);
-
-      selectionHandler.getSelectionLevels.mockReturnValue([0]);
-      selectionHandler.getSelection.mockReturnValue(setKeys);
-
-      const { result } = renderHook(usePropertyDataProviderWithUnifiedSelection, {
-        initialProps: { dataProvider: getProvider() },
-        wrapper: SelectionHandlerWrapper,
-      });
-      expect(result.current).toBeDefined();
-      expect(result.current.isOverLimit).toBe(false);
-      expect(result.current.numSelectedElements).toEqual(2);
-
-      expect(equalKeySets(setKeys, setKeysSpy.mock.calls[setKeysSpy.mock.calls.length - 1][0])).toBe(true);
-    });
-
-    it("sets empty keyset when handler returns selection containing more keys than set limit", () => {
-      const setKeys = new KeySet([createTestECInstanceKey({ id: "0x1" }), createTestECInstanceKey({ id: "0x2" })]);
-      const instancesLimit = 1;
-
-      selectionHandler.getSelectionLevels.mockReturnValue([0]);
-      selectionHandler.getSelection.mockReturnValue(setKeys);
-
-      const { result } = renderHook(usePropertyDataProviderWithUnifiedSelection, {
-        initialProps: { selectionHandler, requestedContentInstancesLimit: instancesLimit, dataProvider: getProvider() },
-        wrapper: SelectionHandlerWrapper,
-      });
-
-      expect(result.current).toBeDefined();
-      expect(result.current.isOverLimit).toBe(true);
-      expect(result.current.numSelectedElements).toEqual(2);
-
-      expect(setKeysSpy.mock.calls[setKeysSpy.mock.calls.length - 1][0].isEmpty).toBe(true);
-    });
-
-    it("changes KeySet according to selection", () => {
-      const keys0 = new KeySet([createTestECInstanceKey({ id: "0x1" }), createTestECInstanceKey({ id: "0x2" })]);
-      const keys2 = new KeySet([createTestECInstanceKey({ id: "0x3" }), createTestECInstanceKey({ id: "0x4" })]);
-      const imodel = {} as IModelConnection;
-      const selectionProvider = {} as ISelectionProvider;
-      const selectionEvent: SelectionChangeEventArgs = {
-        changeType: SelectionChangeType.Add,
-        imodel,
-        keys: new KeySet(),
-        level: 2,
-        source: "Test",
-        timestamp: new Date(),
-      };
-
-      selectionHandler.getSelectionLevels.mockReturnValue([0]);
-      selectionHandler.getSelection.mockImplementation((level) => {
-        if (level === 0) {
-          return keys0;
-        }
-        if (level === 2) {
-          return keys2;
-        }
-        return new KeySet();
-      });
-
-      const { result } = renderHook(usePropertyDataProviderWithUnifiedSelection, {
-        initialProps: { dataProvider: getProvider() },
-        wrapper: SelectionHandlerWrapper,
-      });
-
-      expect(equalKeySets(keys0, setKeysSpy.mock.calls[setKeysSpy.mock.calls.length - 1][0])).toBe(true);
-
-      expect(selectionHandler.onSelect).toBeDefined();
-      expect(result.current).toBeDefined();
-      expect(result.current.isOverLimit).toBe(false);
-      expect(result.current.numSelectedElements).toEqual(2);
-
-      act(() => {
-        selectionHandler.onSelect!(selectionEvent, selectionProvider);
-      });
-
-      expect(equalKeySets(keys2, setKeysSpy.mock.calls[setKeysSpy.mock.calls.length - 1][0])).toBe(true);
-    });
-
-    it("disposes selection handler when unmounts", () => {
-      const setKeys = new KeySet([createTestECInstanceKey({ id: "0x1" }), createTestECInstanceKey({ id: "0x2" })]);
-      selectionHandler.getSelectionLevels.mockReturnValue([0]);
-      selectionHandler.getSelection.mockReturnValue(setKeys);
-
-      const { unmount } = renderHook(usePropertyDataProviderWithUnifiedSelection, {
-        initialProps: { dataProvider: getProvider() },
-        wrapper: SelectionHandlerWrapper,
-      });
-
-      unmount();
-
-      expect(selectionHandler.dispose).toHaveBeenCalled();
-    });
-  });
 
   describe("with unified selection storage", () => {
     let selectionStorage: SelectionStorage;

--- a/packages/components/src/test/table/UsePresentationTable.test.tsx
+++ b/packages/components/src/test/table/UsePresentationTable.test.tsx
@@ -8,8 +8,8 @@ import { beforeEach, describe, expect, it, Mocked, vi } from "vitest";
 import { BeUiEvent } from "@itwin/core-bentley";
 import { FormattingUnitSystemChangedArgs, IModelApp, IModelConnection, QuantityFormatter } from "@itwin/core-frontend";
 import { InstanceKey, Item, KeySet } from "@itwin/presentation-common";
-import { Presentation, PresentationManager, SelectionManager } from "@itwin/presentation-frontend";
-import { createStorage, Selectables, SelectionStorage } from "@itwin/unified-selection";
+import { Presentation, PresentationManager } from "@itwin/presentation-frontend";
+import { createStorage, Selectables } from "@itwin/unified-selection";
 import { TableColumnDefinition, TableRowDefinition } from "../../presentation-components/table/Types.js";
 import {
   usePresentationTable,
@@ -23,10 +23,7 @@ import {
   createTestContentItem,
   createTestPropertiesContentField,
 } from "../_helpers/Content.js";
-import { createTestECClassGroupingNodeKey, createTestECInstancesNodeKey } from "../_helpers/Hierarchy.js";
 import { act, createMocked, renderHook, waitFor } from "../TestUtils.js";
-
-/* eslint-disable @typescript-eslint/no-deprecated */
 
 describe("usePresentationTable", () => {
   const imodel = { key: "imodel_key" } as IModelConnection;
@@ -83,18 +80,21 @@ describe("usePresentationTable", () => {
 
 describe("usePresentationTableWithUnifiedSelection", () => {
   const imodel = { key: "imodel_key" } as IModelConnection;
+  const selectionStorage = createStorage();
   const initialProps: UsePresentationTableWithUnifiedSelectionProps<TableColumnDefinition, TableRowDefinition> = {
     imodel,
     ruleset: "ruleset_id",
     columnMapper: (col) => col,
     rowMapper: (row) => row,
     pageSize: 10,
+    selectionStorage,
   };
   const selectionSource = "TestSource";
 
   let presentationManager: Mocked<PresentationManager>;
 
   beforeEach(() => {
+    selectionStorage.clearStorage({ imodelKey: imodel.key });
     presentationManager = createMocked(PresentationManager);
     vi.spyOn(Presentation, "presentation", "get").mockReturnValue(presentationManager);
     vi.spyOn(IModelApp, "quantityFormatter", "get").mockReturnValue({
@@ -123,7 +123,6 @@ describe("usePresentationTableWithUnifiedSelection", () => {
     }));
 
     const selectedKey = createTestECInstanceKey();
-    const selectionStorage = createStorage();
     selectionStorage.addToSelection({ imodelKey: imodel.key, source: selectionSource, selectables: [selectedKey] });
 
     const { result } = renderHook(() =>
@@ -156,803 +155,408 @@ describe("usePresentationTableWithUnifiedSelection", () => {
     expect(result.current.rows).toHaveLength(0);
   });
 
-  describe("with deprecated `SelectionManager` from `presentation-frontend` package", () => {
-    beforeEach(() => {
-      const selectionManager = new SelectionManager({ scopes: undefined as any });
-      vi.spyOn(Presentation, "selection", "get").mockReturnValue(selectionManager);
-    });
-
-    it("loads data when grouping node is selected", async () => {
-      const groupingKey = createTestECClassGroupingNodeKey();
-      const keys = new KeySet([groupingKey]);
-
-      vi.spyOn(Presentation.selection, "getSelection").mockReturnValue(keys);
-
+  describe("updating unified selection on table selection changes (`onSelect` calls)", () => {
+    it("adds passed keys to storage", async () => {
       setupPresentationManager();
 
-      const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
+      const selectionLevel0 = [createTestECInstanceKey()];
+      selectionStorage.addToSelection({
+        imodelKey: imodel.key,
+        source: "UnifiedSelectionTable",
+        selectables: selectionLevel0,
+        level: 0,
+      });
+      expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(true);
 
+      const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        const stringifiedKeys: string[] = [];
+        selectionLevel0.forEach((key) => {
+          stringifiedKeys.push(JSON.stringify(key));
+        });
+        result.current.onSelect(stringifiedKeys);
+      });
+      await waitFor(() => {
+        expect(
+          Selectables.hasAll(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }), selectionLevel0),
+        ).toBe(true);
+      });
+    });
+
+    it("gets invalid keys and does not pass any to storage", async () => {
+      const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(true);
+
+      act(() => {
+        result.current.onSelect(["this is not a valid key", ""]);
+      });
+      expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(true);
+    });
+
+    it("gets valid keys for rows that are not loaded and does not pass any to storage", async () => {
+      const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(true);
+
+      act(() => {
+        const stringifiedKeys = [createTestECInstanceKey()].map((key) => JSON.stringify(key));
+        result.current.onSelect(stringifiedKeys);
+      });
+      expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(true);
+    });
+  });
+
+  describe("reacting to unified selection changes", () => {
+    it("loads rows when unified selection changes", async () => {
+      const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.rows).toHaveLength(0);
+      });
+      setupPresentationManager([createTestECInstanceKey()]);
+
+      const selectablesInstanceKeys = [
+        createTestECInstanceKey({ id: "0x123" }),
+        createTestECInstanceKey({ id: "0x456" }),
+      ];
+
+      act(() => {
+        // select the row to get loaded onto the component
+        selectionStorage.addToSelection({
+          imodelKey: imodel.key,
+          source: selectionSource,
+          selectables: [
+            selectablesInstanceKeys[0],
+            {
+              identifier: "custom",
+              loadInstanceKeys: () => createAsyncIterator([selectablesInstanceKeys[1]]),
+              data: undefined,
+            },
+          ],
+          level: 0,
+        });
+      });
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
         expect(result.current.rows).toHaveLength(1);
       });
-
       expect(presentationManager.getContentDescriptor).toHaveBeenCalled();
-      expect(presentationManager.getContentDescriptor.mock.lastCall![0].keys.hasAll(keys)).toBe(true);
+      expect(presentationManager.getContentDescriptor.mock.lastCall![0].keys.hasAll(selectablesInstanceKeys)).toBe(
+        true,
+      );
       expect(presentationManager.getContentIterator).toHaveBeenCalled();
-      expect(presentationManager.getContentIterator.mock.lastCall![0].keys.hasAll(keys)).toBe(true);
+      expect(presentationManager.getContentIterator.mock.lastCall![0].keys.hasAll(selectablesInstanceKeys)).toBe(true);
     });
 
-    describe("updating unified selection on table selection changes (`onSelect` calls)", () => {
-      it("adds passed keys to `SelectionManager`", async () => {
-        const keys = new KeySet([createTestECInstanceKey()]);
-        const stringifiedKeys: string[] = [];
-
-        keys.forEach((key) => {
-          stringifiedKeys.push(JSON.stringify(key));
-        });
-
-        vi.spyOn(Presentation.selection, "getSelection").mockReturnValue(keys);
-
-        setupPresentationManager();
-
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-
-        const replaceSpy = vi.spyOn(Presentation.selection, "replaceSelection");
-        await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-        const expectedKeys = result.current.rows.map((row) => JSON.parse(row.key));
-        act(() => {
-          result.current.onSelect(stringifiedKeys);
-        });
-        expect(replaceSpy).toHaveBeenCalledExactlyOnceWith(
-          expect.stringContaining("UnifiedSelectionTable"),
-          imodel,
-          expectedKeys,
-          1,
-        );
+    it("ignores selection changes on different imodel", async () => {
+      const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.rows).toHaveLength(0);
       });
-
-      it("gets invalid keys and does not pass any to `SelectionManager`", async () => {
-        const keys = ["this is not a valid key", ""];
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-        const replaceSpy = vi.spyOn(Presentation.selection, "replaceSelection");
-        act(() => {
-          result.current.onSelect(keys);
-        });
-
-        expect(replaceSpy).toHaveBeenCalledExactlyOnceWith(
-          expect.stringContaining("UnifiedSelectionTable"),
-          imodel,
-          [],
-          1,
-        );
-      });
-
-      it("gets valid keys for rows that are not loaded and does not pass any to `SelectionManager`", async () => {
-        const stringifiedKeys = [createTestECInstanceKey()].map((key) => JSON.stringify(key));
-
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-        const replaceSpy = vi.spyOn(Presentation.selection, "replaceSelection");
-        act(() => {
-          result.current.onSelect(stringifiedKeys);
-        });
-
-        await waitFor(() => {
-          expect(replaceSpy).toHaveBeenCalledExactlyOnceWith(
-            expect.stringContaining("UnifiedSelectionTable"),
-            imodel,
-            [],
-            1,
-          );
-        });
-      });
-    });
-
-    describe("reacting to unified selection changes", () => {
-      it("loads rows when unified selection changes", async () => {
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          expect(result.current.rows).toHaveLength(0);
-        });
-        setupPresentationManager([createTestECInstanceKey()]);
-
-        const selectionChangeInstanceKeys = [
-          createTestECInstanceKey({ id: "0x123" }),
-          createTestECInstanceKey({ id: "0x456" }),
-          createTestECInstanceKey({ id: "0x789" }),
-        ];
-
-        const keySet = new KeySet([
-          selectionChangeInstanceKeys[0],
-          { classFullName: selectionChangeInstanceKeys[1].className, id: selectionChangeInstanceKeys[1].id },
-          createTestECInstancesNodeKey({ instanceKeys: [selectionChangeInstanceKeys[2]] }),
-        ]);
-
-        act(() => {
-          // select the row to get loaded onto the component
-          Presentation.selection.addToSelection(selectionSource, imodel, keySet, 0);
-        });
-
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          expect(result.current.rows).toHaveLength(1);
-        });
-        expect(presentationManager.getContentDescriptor).toHaveBeenCalled();
-        expect(presentationManager.getContentDescriptor.mock.lastCall![0].keys.hasAll(keySet)).toBe(true);
-        expect(presentationManager.getContentIterator).toHaveBeenCalled();
-        expect(presentationManager.getContentIterator.mock.lastCall![0].keys.hasAll(keySet)).toBe(true);
-      });
-
-      it("ignores selection changes on different imodel", async () => {
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          expect(result.current.rows).toHaveLength(0);
-        });
-        const instanceKey = createTestECInstanceKey();
-        setupPresentationManager([instanceKey]);
-
-        const otherIModel = { key: "other_imodel" } as IModelConnection;
-        IModelConnection.onOpen.raiseEvent(otherIModel);
-        act(() => {
-          // select the row to get loaded onto the component
-          Presentation.selection.addToSelection(selectionSource, otherIModel, new KeySet([instanceKey]), 0);
-        });
-
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          expect(result.current.rows).toHaveLength(0);
-          expect(presentationManager.getContentDescriptor).not.toHaveBeenCalled();
-        });
-      });
-
-      it("returns an array of selectedRows when keys are passed before the table is loaded", async () => {
-        const keys = new KeySet([createTestECInstanceKey()]);
-        setupPresentationManager();
-
-        // select the row to get loaded onto the component
-        Presentation.selection.addToSelection(selectionSource, imodel, keys, 0);
-        // add the instance to level 1 to make the row selected
-        Presentation.selection.addToSelection(selectionSource, imodel, keys, 1);
-
-        // wait for selection to be setup
-        await waitFor(() => {
-          expect(Presentation.selection.getSelection(imodel, 0).size).toBe(keys.size);
-          expect(Presentation.selection.getSelection(imodel, 1).size).toBe(keys.size);
-        });
-
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const resultAfterLoading = result.current.selectedRows;
-          expect(resultAfterLoading).toHaveLength(1);
-        });
-      });
-
-      it("returns an array of selectedRows when keys are added on selectionChange event", async () => {
-        const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
-        const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
-
-        setupPresentationManager([instanceKey1, instanceKey2]);
-
-        // select both instances at level 0 to get them displayed in the component
-        Presentation.selection.addToSelection(selectionSource, imodel, new KeySet([instanceKey1, instanceKey2]), 0);
-        // select instanceKey1 at level 1 to get its row selected
-        Presentation.selection.addToSelection(selectionSource, imodel, new KeySet([instanceKey1]), 1);
-
-        // wait for selection to be setup
-        await waitFor(() => {
-          expect(Presentation.selection.getSelection(imodel, 0).size).toBe(2);
-          expect(Presentation.selection.getSelection(imodel, 1).size).toBe(1);
-        });
-
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterLoading = result.current.selectedRows;
-          expect(selectedRowsAfterLoading).toHaveLength(1);
-        });
-
-        act(() => {
-          Presentation.selection.addToSelection(selectionSource, imodel, new KeySet([instanceKey2]), 1);
-        });
-
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterAdding = result.current.selectedRows;
-          expect(selectedRowsAfterAdding).toHaveLength(2);
-        });
-      });
-
-      it("returns new array of selectedRows when keys are replaced on selectionChange event", async () => {
-        const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
-        const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
-
-        setupPresentationManager([instanceKey1, instanceKey2]);
-
-        // select both instances at level 0 to get them displayed in the component
-        Presentation.selection.addToSelection(selectionSource, imodel, new KeySet([instanceKey1, instanceKey2]), 0);
-        // select instanceKey1 at level 1 to get its row selected
-        Presentation.selection.addToSelection(selectionSource, imodel, new KeySet([instanceKey1]), 1);
-
-        // wait for selection to be setup
-        await waitFor(() => {
-          expect(Presentation.selection.getSelection(imodel, 0).size).toBe(2);
-          expect(Presentation.selection.getSelection(imodel, 1).size).toBe(1);
-        });
-
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterLoading = result.current.selectedRows;
-          expect(selectedRowsAfterLoading).toHaveLength(1);
-          expect(selectedRowsAfterLoading[0].key).toEqual(JSON.stringify(instanceKey1));
-        });
-
-        act(() => {
-          Presentation.selection.replaceSelection(selectionSource, imodel, new KeySet([instanceKey2]), 1);
-        });
-
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterReplacing = result.current.selectedRows;
-          expect(selectedRowsAfterReplacing).toHaveLength(1);
-          expect(selectedRowsAfterReplacing[0].key).toEqual(JSON.stringify(instanceKey2));
-        });
-      });
-
-      it("returns smaller array of selectedRows when keys are removed on selectionChange event", async () => {
-        const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
-        const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
-
-        setupPresentationManager([instanceKey1, instanceKey2]);
-
-        // select both instances on both levels to make sure rows are loaded onto the component and selected on initial load.
-        Presentation.selection.addToSelection(selectionSource, imodel, new KeySet([instanceKey1, instanceKey2]), 0);
-        Presentation.selection.addToSelection(selectionSource, imodel, new KeySet([instanceKey1, instanceKey2]), 1);
-
-        // wait for selection to be setup
-        await waitFor(() => {
-          expect(Presentation.selection.getSelection(imodel, 0).size).toBe(2);
-          expect(Presentation.selection.getSelection(imodel, 1).size).toBe(2);
-        });
-
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterLoading = result.current.selectedRows;
-          expect(selectedRowsAfterLoading).toHaveLength(2);
-        });
-
-        act(() => {
-          Presentation.selection.removeFromSelection(selectionSource, imodel, new KeySet([instanceKey1]), 1);
-        });
-
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterRemoving = result.current.selectedRows;
-          expect(selectedRowsAfterRemoving).toHaveLength(1);
-          expect(selectedRowsAfterRemoving[0].key).toEqual(JSON.stringify(instanceKey2));
-        });
-      });
-
-      it("returns new array of selectedRows when keys are cleared on selectionChange event", async () => {
-        const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
-        const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
-
-        setupPresentationManager([instanceKey1, instanceKey2]);
-
-        // select both instances on both levels to make sure rows are loaded onto the component and selected on initial load.
-        Presentation.selection.addToSelection(selectionSource, imodel, new KeySet([instanceKey1, instanceKey2]), 0);
-        Presentation.selection.addToSelection(selectionSource, imodel, new KeySet([instanceKey1, instanceKey2]), 1);
-
-        // wait for selection to be setup
-        await waitFor(() => {
-          expect(Presentation.selection.getSelection(imodel, 0).size).toBe(2);
-          expect(Presentation.selection.getSelection(imodel, 1).size).toBe(2);
-        });
-
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterLoading = result.current.selectedRows;
-          expect(selectedRowsAfterLoading).toHaveLength(2);
-        });
-
-        act(() => {
-          Presentation.selection.clearSelection(selectionSource, imodel, 1);
-        });
-
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterClearing = result.current.selectedRows;
-          expect(selectedRowsAfterClearing).toHaveLength(0);
-        });
-      });
-
-      it("clears selected rows when selection in 0 level changes", async () => {
-        const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
-        const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
-
-        setupPresentationManager([instanceKey1]);
-
-        // select both instances on both levels to make sure rows are loaded onto the component and selected on initial load.
-        Presentation.selection.addToSelection(selectionSource, imodel, new KeySet([instanceKey1]), 0);
-        Presentation.selection.addToSelection(selectionSource, imodel, new KeySet([instanceKey1]), 1);
-
-        // wait for selection to be setup
-        await waitFor(() => {
-          expect(Presentation.selection.getSelection(imodel, 0).size).toBe(1);
-          expect(Presentation.selection.getSelection(imodel, 1).size).toBe(1);
-        });
-
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          expect(result.current.rows).toHaveLength(1);
-          expect(result.current.selectedRows).toHaveLength(1);
-        });
-
-        setupPresentationManager([instanceKey1, instanceKey2]);
-        act(() => {
-          Presentation.selection.addToSelection(selectionSource, imodel, new KeySet([instanceKey2]), 0);
-        });
-
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          expect(result.current.rows).toHaveLength(2);
-          expect(result.current.selectedRows).toHaveLength(0);
-        });
-      });
-
-      it("returns an empty array of selectedRows when keys are passed from the wrong level on selectionChange event", async () => {
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-
-        await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-        act(() => {
-          Presentation.selection.addToSelection(
-            selectionSource,
-            initialProps.imodel,
-            new KeySet([createTestECInstanceKey()]),
-            3,
-          );
-        });
-
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterAdding = result.current.selectedRows;
-          expect(selectedRowsAfterAdding).toHaveLength(0);
-        });
-      });
-    });
-  });
-
-  describe("with unified selection storage from `unified-selection` package", () => {
-    let selectionStorage: SelectionStorage;
-
-    beforeEach(() => {
-      selectionStorage = createStorage();
-      initialProps.selectionStorage = selectionStorage;
-    });
-
-    describe("updating unified selection on table selection changes (`onSelect` calls)", () => {
-      it("adds passed keys to storage", async () => {
-        setupPresentationManager();
-
-        const selectionLevel0 = [createTestECInstanceKey()];
-        selectionStorage.addToSelection({
-          imodelKey: imodel.key,
-          source: "UnifiedSelectionTable",
-          selectables: selectionLevel0,
-          level: 0,
-        });
-        expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(true);
-
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-        act(() => {
-          const stringifiedKeys: string[] = [];
-          selectionLevel0.forEach((key) => {
-            stringifiedKeys.push(JSON.stringify(key));
-          });
-          result.current.onSelect(stringifiedKeys);
-        });
-        await waitFor(() => {
-          expect(
-            Selectables.hasAll(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }), selectionLevel0),
-          ).toBe(true);
-        });
-      });
-
-      it("gets invalid keys and does not pass any to storage", async () => {
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => expect(result.current.isLoading).toBe(false));
-        expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(true);
-
-        act(() => {
-          result.current.onSelect(["this is not a valid key", ""]);
-        });
-        expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(true);
-      });
-
-      it("gets valid keys for rows that are not loaded and does not pass any to storage", async () => {
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => expect(result.current.isLoading).toBe(false));
-        expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(true);
-
-        act(() => {
-          const stringifiedKeys = [createTestECInstanceKey()].map((key) => JSON.stringify(key));
-          result.current.onSelect(stringifiedKeys);
-        });
-        expect(Selectables.isEmpty(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(true);
-      });
-    });
-
-    describe("reacting to unified selection changes", () => {
-      it("loads rows when unified selection changes", async () => {
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          expect(result.current.rows).toHaveLength(0);
-        });
-        setupPresentationManager([createTestECInstanceKey()]);
-
-        const selectablesInstanceKeys = [
-          createTestECInstanceKey({ id: "0x123" }),
-          createTestECInstanceKey({ id: "0x456" }),
-        ];
-
-        act(() => {
-          // select the row to get loaded onto the component
-          selectionStorage.addToSelection({
-            imodelKey: imodel.key,
-            source: selectionSource,
-            selectables: [
-              selectablesInstanceKeys[0],
-              {
-                identifier: "custom",
-                loadInstanceKeys: () => createAsyncIterator([selectablesInstanceKeys[1]]),
-                data: undefined,
-              },
-            ],
-            level: 0,
-          });
-        });
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          expect(result.current.rows).toHaveLength(1);
-        });
-        expect(presentationManager.getContentDescriptor).toHaveBeenCalled();
-        expect(presentationManager.getContentDescriptor.mock.lastCall![0].keys.hasAll(selectablesInstanceKeys)).toBe(
-          true,
-        );
-        expect(presentationManager.getContentIterator).toHaveBeenCalled();
-        expect(presentationManager.getContentIterator.mock.lastCall![0].keys.hasAll(selectablesInstanceKeys)).toBe(
-          true,
-        );
-      });
-
-      it("ignores selection changes on different imodel", async () => {
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          expect(result.current.rows).toHaveLength(0);
-        });
-        const instanceKey = createTestECInstanceKey();
-        setupPresentationManager([instanceKey]);
-
-        const otherIModel = { key: "other_imodel" } as IModelConnection;
-        IModelConnection.onOpen.raiseEvent(otherIModel);
-        act(() => {
-          // select the row to get loaded onto the component
-          selectionStorage.addToSelection({
-            imodelKey: otherIModel.key,
-            source: selectionSource,
-            selectables: [instanceKey],
-            level: 0,
-          });
-        });
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          expect(result.current.rows).toHaveLength(0);
-          expect(presentationManager.getContentDescriptor).not.toHaveBeenCalled();
-        });
-      });
-
-      it("returns an array of selectedRows when keys are passed before the table is loaded", async () => {
-        const instanceKey = createTestECInstanceKey();
-        setupPresentationManager();
-
+      const instanceKey = createTestECInstanceKey();
+      setupPresentationManager([instanceKey]);
+
+      const otherIModel = { key: "other_imodel" } as IModelConnection;
+      IModelConnection.onOpen.raiseEvent(otherIModel);
+      act(() => {
         // select the row to get loaded onto the component
         selectionStorage.addToSelection({
-          imodelKey: imodel.key,
+          imodelKey: otherIModel.key,
           source: selectionSource,
           selectables: [instanceKey],
           level: 0,
         });
-        // add the instance to level 1 to make the row selected
-        selectionStorage.addToSelection({
-          imodelKey: imodel.key,
-          source: selectionSource,
-          selectables: [instanceKey],
-          level: 1,
-        });
-        // wait for selection to be setup
-        await waitFor(() => {
-          expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 0 }))).toBe(1);
-          expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(1);
-        });
+      });
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.rows).toHaveLength(0);
+        expect(presentationManager.getContentDescriptor).not.toHaveBeenCalled();
+      });
+    });
 
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const resultAfterLoading = result.current.selectedRows;
-          expect(resultAfterLoading).toHaveLength(1);
-        });
+    it("returns an array of selectedRows when keys are passed before the table is loaded", async () => {
+      const instanceKey = createTestECInstanceKey();
+      setupPresentationManager();
+
+      // select the row to get loaded onto the component
+      selectionStorage.addToSelection({
+        imodelKey: imodel.key,
+        source: selectionSource,
+        selectables: [instanceKey],
+        level: 0,
+      });
+      // add the instance to level 1 to make the row selected
+      selectionStorage.addToSelection({
+        imodelKey: imodel.key,
+        source: selectionSource,
+        selectables: [instanceKey],
+        level: 1,
+      });
+      // wait for selection to be setup
+      await waitFor(() => {
+        expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 0 }))).toBe(1);
+        expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(1);
       });
 
-      it("returns an array of selectedRows when keys are added on selectionChange event", async () => {
-        const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
-        const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
-        setupPresentationManager([instanceKey1, instanceKey2]);
+      const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        const resultAfterLoading = result.current.selectedRows;
+        expect(resultAfterLoading).toHaveLength(1);
+      });
+    });
 
-        // select both instances at level 0 to get them displayed in the component
+    it("returns an array of selectedRows when keys are added on selectionChange event", async () => {
+      const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
+      const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
+      setupPresentationManager([instanceKey1, instanceKey2]);
+
+      // select both instances at level 0 to get them displayed in the component
+      selectionStorage.addToSelection({
+        imodelKey: imodel.key,
+        source: selectionSource,
+        selectables: [instanceKey1, instanceKey2],
+        level: 0,
+      });
+      // select instanceKey1 at level 1 to get its row selected
+      selectionStorage.addToSelection({
+        imodelKey: imodel.key,
+        source: selectionSource,
+        selectables: [instanceKey1],
+        level: 1,
+      });
+      // wait for selection to be setup
+      await waitFor(() => {
+        expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 0 }))).toBe(2);
+        expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(1);
+      });
+
+      const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        const selectedRowsAfterLoading = result.current.selectedRows;
+        expect(selectedRowsAfterLoading).toHaveLength(1);
+      });
+
+      act(() => {
         selectionStorage.addToSelection({
           imodelKey: imodel.key,
           source: selectionSource,
-          selectables: [instanceKey1, instanceKey2],
-          level: 0,
+          selectables: [instanceKey2],
+          level: 1,
         });
-        // select instanceKey1 at level 1 to get its row selected
-        selectionStorage.addToSelection({
+      });
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        const selectedRowsAfterAdding = result.current.selectedRows;
+        expect(selectedRowsAfterAdding).toHaveLength(2);
+      });
+    });
+
+    it("returns new array of selectedRows when keys are replaced on selectionChange event", async () => {
+      const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
+      const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
+      setupPresentationManager([instanceKey1, instanceKey2]);
+
+      // select both instances at level 0 to get them displayed in the component
+      selectionStorage.addToSelection({
+        imodelKey: imodel.key,
+        source: selectionSource,
+        selectables: [instanceKey1, instanceKey2],
+        level: 0,
+      });
+      // select instanceKey1 at level 1 to get its row selected
+      selectionStorage.addToSelection({
+        imodelKey: imodel.key,
+        source: selectionSource,
+        selectables: [instanceKey1],
+        level: 1,
+      });
+      // wait for selection to be setup
+      await waitFor(() => {
+        expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 0 }))).toBe(2);
+        expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(1);
+      });
+
+      const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        const selectedRowsAfterLoading = result.current.selectedRows;
+        expect(selectedRowsAfterLoading).toHaveLength(1);
+        expect(selectedRowsAfterLoading[0].key).toEqual(JSON.stringify(instanceKey1));
+      });
+
+      act(() => {
+        selectionStorage.replaceSelection({
+          imodelKey: imodel.key,
+          source: selectionSource,
+          selectables: [instanceKey2],
+          level: 1,
+        });
+      });
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        const selectedRowsAfterReplacing = result.current.selectedRows;
+        expect(selectedRowsAfterReplacing).toHaveLength(1);
+        expect(selectedRowsAfterReplacing[0].key).toEqual(JSON.stringify(instanceKey2));
+      });
+    });
+
+    it("returns smaller array of selectedRows when keys are removed on selectionChange event", async () => {
+      const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
+      const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
+      setupPresentationManager([instanceKey1, instanceKey2]);
+
+      // select both instances on both levels to make sure rows are loaded onto the component and selected on initial load.
+      selectionStorage.addToSelection({
+        imodelKey: imodel.key,
+        source: selectionSource,
+        selectables: [instanceKey1, instanceKey2],
+        level: 0,
+      });
+      selectionStorage.addToSelection({
+        imodelKey: imodel.key,
+        source: selectionSource,
+        selectables: [instanceKey1, instanceKey2],
+        level: 1,
+      });
+      // wait for selection to be setup
+      await waitFor(() => {
+        expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 0 }))).toBe(2);
+        expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(2);
+      });
+
+      const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        const selectedRowsAfterLoading = result.current.selectedRows;
+        expect(selectedRowsAfterLoading).toHaveLength(2);
+      });
+
+      act(() => {
+        selectionStorage.removeFromSelection({
           imodelKey: imodel.key,
           source: selectionSource,
           selectables: [instanceKey1],
           level: 1,
         });
-        // wait for selection to be setup
-        await waitFor(() => {
-          expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 0 }))).toBe(2);
-          expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(1);
-        });
+      });
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        const selectedRowsAfterRemoving = result.current.selectedRows;
+        expect(selectedRowsAfterRemoving).toHaveLength(1);
+        expect(selectedRowsAfterRemoving[0].key).toEqual(JSON.stringify(instanceKey2));
+      });
+    });
 
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterLoading = result.current.selectedRows;
-          expect(selectedRowsAfterLoading).toHaveLength(1);
-        });
+    it("returns new array of selectedRows when keys are cleared on selectionChange event", async () => {
+      const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
+      const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
+      setupPresentationManager([instanceKey1, instanceKey2]);
 
-        act(() => {
-          selectionStorage.addToSelection({
-            imodelKey: imodel.key,
-            source: selectionSource,
-            selectables: [instanceKey2],
-            level: 1,
-          });
-        });
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterAdding = result.current.selectedRows;
-          expect(selectedRowsAfterAdding).toHaveLength(2);
-        });
+      // select both instances on both levels to make sure rows are loaded onto the component and selected on initial load.
+      selectionStorage.addToSelection({
+        imodelKey: imodel.key,
+        source: selectionSource,
+        selectables: [instanceKey1, instanceKey2],
+        level: 0,
+      });
+      selectionStorage.addToSelection({
+        imodelKey: imodel.key,
+        source: selectionSource,
+        selectables: [instanceKey1, instanceKey2],
+        level: 1,
+      });
+      // wait for selection to be setup
+      await waitFor(() => {
+        expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 0 }))).toBe(2);
+        expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(2);
       });
 
-      it("returns new array of selectedRows when keys are replaced on selectionChange event", async () => {
-        const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
-        const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
-        setupPresentationManager([instanceKey1, instanceKey2]);
+      const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        const selectedRowsAfterLoading = result.current.selectedRows;
+        expect(selectedRowsAfterLoading).toHaveLength(2);
+      });
 
-        // select both instances at level 0 to get them displayed in the component
+      act(() => {
+        selectionStorage.clearSelection({ imodelKey: imodel.key, source: selectionSource, level: 1 });
+      });
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        const selectedRowsAfterClearing = result.current.selectedRows;
+        expect(selectedRowsAfterClearing).toHaveLength(0);
+      });
+    });
+
+    it("clears selected rows when selection in 0 level changes", async () => {
+      const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
+      const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
+      setupPresentationManager([instanceKey1]);
+
+      // select both instances on both levels to make sure rows are loaded onto the component and selected on initial load.
+      selectionStorage.addToSelection({
+        imodelKey: imodel.key,
+        source: selectionSource,
+        selectables: [instanceKey1],
+        level: 0,
+      });
+      selectionStorage.addToSelection({
+        imodelKey: imodel.key,
+        source: selectionSource,
+        selectables: [instanceKey1],
+        level: 1,
+      });
+      // wait for selection to be setup
+      await waitFor(() => {
+        expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 0 }))).toBe(1);
+        expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(1);
+      });
+
+      const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.rows).toHaveLength(1);
+        expect(result.current.selectedRows).toHaveLength(1);
+      });
+
+      setupPresentationManager([instanceKey1, instanceKey2]);
+      act(() => {
         selectionStorage.addToSelection({
           imodelKey: imodel.key,
           source: selectionSource,
-          selectables: [instanceKey1, instanceKey2],
+          selectables: [instanceKey2],
           level: 0,
         });
-        // select instanceKey1 at level 1 to get its row selected
+      });
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.rows).toHaveLength(2);
+        expect(result.current.selectedRows).toHaveLength(0);
+      });
+    });
+
+    it("returns an empty array of selectedRows when keys are passed from the wrong level on selectionChange event", async () => {
+      const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
         selectionStorage.addToSelection({
           imodelKey: imodel.key,
           source: selectionSource,
-          selectables: [instanceKey1],
-          level: 1,
-        });
-        // wait for selection to be setup
-        await waitFor(() => {
-          expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 0 }))).toBe(2);
-          expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(1);
-        });
-
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterLoading = result.current.selectedRows;
-          expect(selectedRowsAfterLoading).toHaveLength(1);
-          expect(selectedRowsAfterLoading[0].key).toEqual(JSON.stringify(instanceKey1));
-        });
-
-        act(() => {
-          selectionStorage.replaceSelection({
-            imodelKey: imodel.key,
-            source: selectionSource,
-            selectables: [instanceKey2],
-            level: 1,
-          });
-        });
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterReplacing = result.current.selectedRows;
-          expect(selectedRowsAfterReplacing).toHaveLength(1);
-          expect(selectedRowsAfterReplacing[0].key).toEqual(JSON.stringify(instanceKey2));
+          selectables: [createTestECInstanceKey()],
+          level: 3,
         });
       });
-
-      it("returns smaller array of selectedRows when keys are removed on selectionChange event", async () => {
-        const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
-        const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
-        setupPresentationManager([instanceKey1, instanceKey2]);
-
-        // select both instances on both levels to make sure rows are loaded onto the component and selected on initial load.
-        selectionStorage.addToSelection({
-          imodelKey: imodel.key,
-          source: selectionSource,
-          selectables: [instanceKey1, instanceKey2],
-          level: 0,
-        });
-        selectionStorage.addToSelection({
-          imodelKey: imodel.key,
-          source: selectionSource,
-          selectables: [instanceKey1, instanceKey2],
-          level: 1,
-        });
-        // wait for selection to be setup
-        await waitFor(() => {
-          expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 0 }))).toBe(2);
-          expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(2);
-        });
-
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterLoading = result.current.selectedRows;
-          expect(selectedRowsAfterLoading).toHaveLength(2);
-        });
-
-        act(() => {
-          selectionStorage.removeFromSelection({
-            imodelKey: imodel.key,
-            source: selectionSource,
-            selectables: [instanceKey1],
-            level: 1,
-          });
-        });
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterRemoving = result.current.selectedRows;
-          expect(selectedRowsAfterRemoving).toHaveLength(1);
-          expect(selectedRowsAfterRemoving[0].key).toEqual(JSON.stringify(instanceKey2));
-        });
-      });
-
-      it("returns new array of selectedRows when keys are cleared on selectionChange event", async () => {
-        const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
-        const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
-        setupPresentationManager([instanceKey1, instanceKey2]);
-
-        // select both instances on both levels to make sure rows are loaded onto the component and selected on initial load.
-        selectionStorage.addToSelection({
-          imodelKey: imodel.key,
-          source: selectionSource,
-          selectables: [instanceKey1, instanceKey2],
-          level: 0,
-        });
-        selectionStorage.addToSelection({
-          imodelKey: imodel.key,
-          source: selectionSource,
-          selectables: [instanceKey1, instanceKey2],
-          level: 1,
-        });
-        // wait for selection to be setup
-        await waitFor(() => {
-          expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 0 }))).toBe(2);
-          expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(2);
-        });
-
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterLoading = result.current.selectedRows;
-          expect(selectedRowsAfterLoading).toHaveLength(2);
-        });
-
-        act(() => {
-          selectionStorage.clearSelection({ imodelKey: imodel.key, source: selectionSource, level: 1 });
-        });
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterClearing = result.current.selectedRows;
-          expect(selectedRowsAfterClearing).toHaveLength(0);
-        });
-      });
-
-      it("clears selected rows when selection in 0 level changes", async () => {
-        const instanceKey1 = createTestECInstanceKey({ id: "0x1" });
-        const instanceKey2 = createTestECInstanceKey({ id: "0x2" });
-        setupPresentationManager([instanceKey1]);
-
-        // select both instances on both levels to make sure rows are loaded onto the component and selected on initial load.
-        selectionStorage.addToSelection({
-          imodelKey: imodel.key,
-          source: selectionSource,
-          selectables: [instanceKey1],
-          level: 0,
-        });
-        selectionStorage.addToSelection({
-          imodelKey: imodel.key,
-          source: selectionSource,
-          selectables: [instanceKey1],
-          level: 1,
-        });
-        // wait for selection to be setup
-        await waitFor(() => {
-          expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 0 }))).toBe(1);
-          expect(Selectables.size(selectionStorage.getSelection({ imodelKey: imodel.key, level: 1 }))).toBe(1);
-        });
-
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          expect(result.current.rows).toHaveLength(1);
-          expect(result.current.selectedRows).toHaveLength(1);
-        });
-
-        setupPresentationManager([instanceKey1, instanceKey2]);
-        act(() => {
-          selectionStorage.addToSelection({
-            imodelKey: imodel.key,
-            source: selectionSource,
-            selectables: [instanceKey2],
-            level: 0,
-          });
-        });
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          expect(result.current.rows).toHaveLength(2);
-          expect(result.current.selectedRows).toHaveLength(0);
-        });
-      });
-
-      it("returns an empty array of selectedRows when keys are passed from the wrong level on selectionChange event", async () => {
-        const { result } = renderHook(() => usePresentationTableWithUnifiedSelection(initialProps));
-        await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-        act(() => {
-          selectionStorage.addToSelection({
-            imodelKey: imodel.key,
-            source: selectionSource,
-            selectables: [createTestECInstanceKey()],
-            level: 3,
-          });
-        });
-        await waitFor(() => {
-          expect(result.current.isLoading).toBe(false);
-          const selectedRowsAfterAdding = result.current.selectedRows;
-          expect(selectedRowsAfterAdding).toHaveLength(0);
-        });
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        const selectedRowsAfterAdding = result.current.selectedRows;
+        expect(selectedRowsAfterAdding).toHaveLength(0);
       });
     });
   });


### PR DESCRIPTION
Part of https://github.com/iTwin/presentation/issues/1364

Updated `usePropertyDataProviderWithUnifiedSelection` to required `selectionStorage` prop.
Updated `usePresentationTableWithUnifiedSelection` to required `selectionStorage` prop.
Updated `FavoritesPropertiesDataProvider` to required `activeScopeProvider` prop.