### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/extract-api.yaml
+++ b/.github/workflows/extract-api.yaml
@@ -16,6 +16,7 @@ jobs:
     name: Detect what files changed
     outputs:
       packages: ${{ steps.changes.outputs.packages }}
+      workspace_config: ${{ steps.changes.outputs.workspace_config }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -27,10 +28,12 @@ jobs:
           filters: |
             packages:
               - 'packages/**'
+            workspace_config:
+              - 'pnpm-workspace.yaml'
 
   extract-api:
     needs: [files-changed]
-    if: ${{ needs.files-changed.outputs.packages == 'true' }}
+    if: ${{ needs.files-changed.outputs.packages == 'true' || needs.files-changed.outputs.workspace_config == 'true' }}
     runs-on: ubuntu-latest
     name: Extract API
     steps:

--- a/.github/workflows/extract-api.yaml
+++ b/.github/workflows/extract-api.yaml
@@ -30,6 +30,10 @@ jobs:
               - 'packages/**'
             workspace_config:
               - 'pnpm-workspace.yaml'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+              - '.npmrc'
+              - '.pnpmfile.cjs'
 
   extract-api:
     needs: [files-changed]

--- a/packages/components/api/presentation-components.api.md
+++ b/packages/components/api/presentation-components.api.md
@@ -34,7 +34,7 @@ import { IPropertyDataProvider } from '@itwin/components-react';
 import { IPropertyValueRenderer } from '@itwin/components-react';
 import { ITreeDataProvider } from '@itwin/components-react';
 import { ITreeNodeLoader } from '@itwin/components-react';
-import { JSX } from 'react/jsx-runtime';
+import { JSX } from 'react';
 import { Keys } from '@itwin/presentation-common';
 import { KeySet } from '@itwin/presentation-common';
 import { Memoized } from 'micro-memoize';

--- a/packages/core-interop/api/presentation-core-interop.api.md
+++ b/packages/core-interop/api/presentation-core-interop.api.md
@@ -7,7 +7,7 @@
 import { ECSchemaProvider } from '@itwin/presentation-shared';
 import { ECSqlQueryExecutor } from '@itwin/presentation-shared';
 import { ECSqlReader } from '@itwin/core-common';
-import { Event as Event_2 } from '@itwin/presentation-shared';
+import { Event } from '@itwin/presentation-shared';
 import { ILogger } from '@itwin/presentation-shared';
 import { IPrimitiveValueFormatter } from '@itwin/presentation-shared';
 import { LogLevel } from '@itwin/core-bentley';
@@ -76,9 +76,9 @@ interface ICoreLogger {
 
 // @public
 interface ICoreTxnManager {
-    onChangesApplied: Event_2;
-    onCommit: Event_2;
-    onCommitted: Event_2;
+    onChangesApplied: Event;
+    onCommit: Event;
+    onCommitted: Event;
 }
 
 // @public

--- a/packages/core-interop/api/presentation-core-interop.api.md
+++ b/packages/core-interop/api/presentation-core-interop.api.md
@@ -7,7 +7,7 @@
 import { ECSchemaProvider } from '@itwin/presentation-shared';
 import { ECSqlQueryExecutor } from '@itwin/presentation-shared';
 import { ECSqlReader } from '@itwin/core-common';
-import { Event } from '@itwin/presentation-shared';
+import { Event as Event_2 } from '@itwin/presentation-shared';
 import { ILogger } from '@itwin/presentation-shared';
 import { IPrimitiveValueFormatter } from '@itwin/presentation-shared';
 import { LogLevel } from '@itwin/core-bentley';
@@ -76,9 +76,9 @@ interface ICoreLogger {
 
 // @public
 interface ICoreTxnManager {
-    onChangesApplied: Event;
-    onCommit: Event;
-    onCommitted: Event;
+    onChangesApplied: Event_2;
+    onCommit: Event_2;
+    onCommitted: Event_2;
 }
 
 // @public

--- a/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react.api.md
@@ -14,7 +14,7 @@ import { HierarchyNode } from '@itwin/presentation-hierarchies';
 import { HierarchyProvider } from '@itwin/presentation-hierarchies';
 import { InstanceKey } from '@itwin/presentation-shared';
 import { IPrimitiveValueFormatter } from '@itwin/presentation-shared';
-import { JSX } from 'react/jsx-runtime';
+import { JSX } from 'react';
 import { NodeData } from '@itwin/itwinui-react';
 import { NonGroupingHierarchyNode } from '@itwin/presentation-hierarchies';
 import { Props } from '@itwin/presentation-shared';

--- a/packages/unified-selection-react/api/unified-selection-react.api.md
+++ b/packages/unified-selection-react/api/unified-selection-react.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { JSX } from 'react/jsx-runtime';
+import { JSX } from 'react';
 import { PropsWithChildren } from 'react';
 import { SelectionStorage } from '@itwin/unified-selection';
 


### PR DESCRIPTION
https://github.com/iTwin/presentation/pull/1390 updated the workspace config, but didn't re-run the `extract-api` script to regerenate API summaries. 

- Update API summaries.
- Make `extract-api` required when workspace config changes.