### PR TITLE
[Components]: Fix race condition in tree reload handling

### DIFF
--- a/.changeset/tame-stamps-dig.md
+++ b/.changeset/tame-stamps-dig.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-components": patch
+---
+
+`usePresentationTreeState`: Fix a race condition where iModel and ruleset change notifications could be missed while the tree was reloading.

--- a/apps/full-stack-tests/src/components/tree/Update.test.tsx
+++ b/apps/full-stack-tests/src/components/tree/Update.test.tsx
@@ -485,9 +485,8 @@ describe("Tree update", () => {
         expect(result.current).toBeDefined();
       });
 
-      let lastNodeLoader: AbstractTreeNodeLoaderWithProvider<IPresentationTreeDataProvider> | undefined;
-      await expectTree(result.current!.nodeLoader, expectedTree);
-      lastNodeLoader = result.current!.nodeLoader;
+      let lastNodeLoader = result.current!.nodeLoader;
+      await expectTree(lastNodeLoader, expectedTree);
 
       return new (class implements VerifiedHierarchy {
         public getModelSource(): TreeModelSource {

--- a/apps/full-stack-tests/src/components/tree/Update.test.tsx
+++ b/apps/full-stack-tests/src/components/tree/Update.test.tsx
@@ -498,6 +498,7 @@ describe("Tree update", () => {
             },
             { timeout: 9999999 },
           );
+          await new Promise((resolve) => setTimeout(resolve, 0));
         }
       })();
     }

--- a/apps/full-stack-tests/src/components/tree/Update.test.tsx
+++ b/apps/full-stack-tests/src/components/tree/Update.test.tsx
@@ -484,7 +484,10 @@ describe("Tree update", () => {
       await waitFor(() => {
         expect(result.current).toBeDefined();
       });
+
+      let lastNodeLoader: AbstractTreeNodeLoaderWithProvider<IPresentationTreeDataProvider> | undefined;
       await expectTree(result.current!.nodeLoader, expectedTree);
+      lastNodeLoader = result.current!.nodeLoader;
 
       return new (class implements VerifiedHierarchy {
         public getModelSource(): TreeModelSource {
@@ -494,11 +497,13 @@ describe("Tree update", () => {
         public async verifyChange(expectedUpdatedTree: TreeHierarchy[]): Promise<void> {
           await waitFor(
             async () => {
+              // wait for tree to update
+              expect(lastNodeLoader).not.toBe(result.current!.nodeLoader);
               await expectTree(result.current!.nodeLoader, expectedUpdatedTree);
+              lastNodeLoader = result.current!.nodeLoader;
             },
             { timeout: 9999999 },
           );
-          await new Promise((resolve) => setTimeout(resolve, 0));
         }
       })();
     }

--- a/apps/full-stack-tests/src/components/tree/Update.test.tsx
+++ b/apps/full-stack-tests/src/components/tree/Update.test.tsx
@@ -484,9 +484,7 @@ describe("Tree update", () => {
       await waitFor(() => {
         expect(result.current).toBeDefined();
       });
-
-      let lastNodeLoader = result.current!.nodeLoader;
-      await expectTree(lastNodeLoader, expectedTree);
+      await expectTree(result.current!.nodeLoader, expectedTree);
 
       return new (class implements VerifiedHierarchy {
         public getModelSource(): TreeModelSource {
@@ -496,12 +494,9 @@ describe("Tree update", () => {
         public async verifyChange(expectedUpdatedTree: TreeHierarchy[]): Promise<void> {
           await waitFor(
             async () => {
-              // wait for tree to update
-              expect(lastNodeLoader).not.toBe(result.current!.nodeLoader);
               await expectTree(result.current!.nodeLoader, expectedUpdatedTree);
-              lastNodeLoader = result.current!.nodeLoader;
             },
-            { timeout: 9999999 },
+            { timeout: 30000 },
           );
         }
       })();

--- a/packages/components/src/presentation-components/tree/controlled/UsePresentationTreeState.ts
+++ b/packages/components/src/presentation-components/tree/controlled/UsePresentationTreeState.ts
@@ -173,11 +173,11 @@ export function usePresentationTreeState<TEventHandler extends TreeEventHandler 
     renderedItems.current = items;
   }, []);
 
+  const modelSourceRef = useLatest(state?.nodeLoader.modelSource);
   useTreeReload({
     pageSize: dataProviderProps.pagingSize,
-    modelSource: state?.nodeLoader.modelSource,
+    modelSource: modelSourceRef,
     dataProviderProps: treeStateProps,
-    ruleset: dataProviderProps.ruleset,
     onReload,
     renderedItems,
   });

--- a/packages/components/src/presentation-components/tree/controlled/UseTreeReload.ts
+++ b/packages/components/src/presentation-components/tree/controlled/UseTreeReload.ts
@@ -47,7 +47,8 @@ function useModelSourceUpdateOnBriefcaseUpdate(params: TreeReloadParams): void {
     let subscription: Subscription | undefined;
     const reload = () => {
       const currentModelSource = modelSource?.current;
-      if (!currentModelSource || !dataProviderProps.imodel.isBriefcaseConnection()) {
+      /* v8 ignore if -- @preserve */
+      if (!currentModelSource) {
         return;
       }
       /* v8 ignore next -- @preserve */
@@ -87,6 +88,7 @@ function useModelSourceUpdateOnIModelHierarchyUpdate(params: TreeReloadParams): 
         }
 
         const currentModelSource = modelSource?.current;
+        /* v8 ignore if -- @preserve */
         if (!currentModelSource) {
           return;
         }
@@ -121,6 +123,7 @@ function useModelSourceUpdateOnRulesetModification(params: TreeReloadParams): vo
       }
 
       const currentModelSource = modelSource?.current;
+      /* v8 ignore if -- @preserve */
       if (!currentModelSource) {
         return;
       }
@@ -153,6 +156,7 @@ function useModelSourceUpdateOnRulesetVariablesChange(params: TreeReloadParams):
       .vars(getRulesetId(dataProviderProps.ruleset))
       .onVariableChanged.addListener(() => {
         const currentModelSource = modelSource?.current;
+        /* v8 ignore if -- @preserve */
         if (!currentModelSource) {
           return;
         }
@@ -183,6 +187,7 @@ function useModelSourceUpdateOnUnitSystemChange(params: TreeReloadParams): void 
     let subscription: Subscription | undefined;
     const removeListener = IModelApp.quantityFormatter.onActiveFormattingUnitSystemChanged.addListener(() => {
       const currentModelSource = modelSource?.current;
+      /* v8 ignore if -- @preserve */
       if (!currentModelSource) {
         return;
       }

--- a/packages/components/src/presentation-components/tree/controlled/UseTreeReload.ts
+++ b/packages/components/src/presentation-components/tree/controlled/UseTreeReload.ts
@@ -7,7 +7,6 @@
 import { MutableRefObject, useEffect } from "react";
 import { RenderedItemsRange, Subscription, TreeModelSource } from "@itwin/components-react";
 import { IModelApp } from "@itwin/core-frontend";
-import { Ruleset } from "@itwin/presentation-common";
 import { IModelHierarchyChangeEventArgs, Presentation } from "@itwin/presentation-frontend";
 import { getRulesetId } from "../../common/Utils.js";
 import { PresentationTreeDataProvider, PresentationTreeDataProviderProps } from "../DataProvider.js";
@@ -23,8 +22,7 @@ export interface ReloadedTree {
 export interface TreeReloadParams {
   dataProviderProps: PresentationTreeDataProviderProps;
   pageSize: number;
-  ruleset: string | Ruleset;
-  modelSource?: TreeModelSource;
+  modelSource: MutableRefObject<TreeModelSource | undefined>;
   onReload: (params: ReloadedTree) => void;
   renderedItems: MutableRefObject<RenderedItemsRange | undefined>;
 }
@@ -39,19 +37,28 @@ export function useTreeReload(params: TreeReloadParams) {
 }
 
 function useModelSourceUpdateOnBriefcaseUpdate(params: TreeReloadParams): void {
-  const { dataProviderProps, ruleset, pageSize, modelSource, onReload, renderedItems } = params;
+  const { dataProviderProps, pageSize, modelSource, onReload, renderedItems } = params;
 
   useEffect(() => {
-    if (!modelSource || !dataProviderProps.imodel.isBriefcaseConnection()) {
+    if (!dataProviderProps.imodel.isBriefcaseConnection()) {
       return;
     }
 
     let subscription: Subscription | undefined;
-
     const reload = () => {
+      const currentModelSource = modelSource?.current;
+      if (!currentModelSource || !dataProviderProps.imodel.isBriefcaseConnection()) {
+        return;
+      }
       /* v8 ignore next -- @preserve */
       subscription?.unsubscribe();
-      subscription = startTreeReload({ dataProviderProps, ruleset, pageSize, modelSource, renderedItems, onReload });
+      subscription = startTreeReload({
+        dataProviderProps,
+        pageSize,
+        modelSource: currentModelSource,
+        renderedItems: renderedItems.current,
+        onReload,
+      });
     };
 
     const removePullListener = dataProviderProps.imodel.txns.onChangesPulled.addListener(reload);
@@ -62,27 +69,37 @@ function useModelSourceUpdateOnBriefcaseUpdate(params: TreeReloadParams): void {
       removePushListener();
       subscription?.unsubscribe();
     };
-  }, [modelSource, pageSize, dataProviderProps, ruleset, onReload, renderedItems]);
+  }, [modelSource, pageSize, dataProviderProps, onReload, renderedItems]);
 }
 
 function useModelSourceUpdateOnIModelHierarchyUpdate(params: TreeReloadParams): void {
-  const { dataProviderProps, ruleset, pageSize, modelSource, onReload, renderedItems } = params;
+  const { dataProviderProps, pageSize, modelSource, onReload, renderedItems } = params;
 
   useEffect(() => {
-    if (!modelSource) {
-      return;
-    }
-
     let subscription: Subscription | undefined;
     const removeListener = Presentation.presentation.onIModelHierarchyChanged.addListener(
       (args: IModelHierarchyChangeEventArgs) => {
-        if (args.rulesetId !== getRulesetId(ruleset) || args.imodelKey !== dataProviderProps.imodel.key) {
+        if (
+          args.rulesetId !== getRulesetId(dataProviderProps.ruleset) ||
+          args.imodelKey !== dataProviderProps.imodel.key
+        ) {
+          return;
+        }
+
+        const currentModelSource = modelSource?.current;
+        if (!currentModelSource) {
           return;
         }
 
         /* v8 ignore next -- @preserve */
         subscription?.unsubscribe();
-        subscription = startTreeReload({ dataProviderProps, ruleset, pageSize, modelSource, renderedItems, onReload });
+        subscription = startTreeReload({
+          dataProviderProps,
+          pageSize,
+          modelSource: currentModelSource,
+          renderedItems: renderedItems.current,
+          onReload,
+        });
       },
     );
 
@@ -90,20 +107,21 @@ function useModelSourceUpdateOnIModelHierarchyUpdate(params: TreeReloadParams): 
       removeListener();
       subscription?.unsubscribe();
     };
-  }, [modelSource, pageSize, dataProviderProps, ruleset, onReload, renderedItems]);
+  }, [modelSource, pageSize, dataProviderProps, onReload, renderedItems]);
 }
 
 function useModelSourceUpdateOnRulesetModification(params: TreeReloadParams): void {
-  const { dataProviderProps, ruleset, pageSize, modelSource, onReload, renderedItems } = params;
+  const { dataProviderProps, pageSize, modelSource, onReload, renderedItems } = params;
 
   useEffect(() => {
-    if (!modelSource) {
-      return;
-    }
-
     let subscription: Subscription | undefined;
     const removeListener = Presentation.presentation.rulesets().onRulesetModified.addListener((modifiedRuleset) => {
-      if (modifiedRuleset.id !== getRulesetId(ruleset)) {
+      if (modifiedRuleset.id !== getRulesetId(dataProviderProps.ruleset)) {
+        return;
+      }
+
+      const currentModelSource = modelSource?.current;
+      if (!currentModelSource) {
         return;
       }
 
@@ -111,11 +129,10 @@ function useModelSourceUpdateOnRulesetModification(params: TreeReloadParams): vo
       /* v8 ignore next -- @preserve */
       subscription?.unsubscribe();
       subscription = startTreeReload({
-        dataProviderProps,
-        ruleset: modifiedRuleset.id,
+        dataProviderProps: { ...dataProviderProps, ruleset: modifiedRuleset.id },
         pageSize,
-        modelSource,
-        renderedItems,
+        modelSource: currentModelSource,
+        renderedItems: renderedItems.current,
         onReload,
       });
     });
@@ -124,64 +141,82 @@ function useModelSourceUpdateOnRulesetModification(params: TreeReloadParams): vo
       removeListener();
       subscription?.unsubscribe();
     };
-  }, [dataProviderProps, ruleset, modelSource, pageSize, onReload, renderedItems]);
+  }, [dataProviderProps, modelSource, pageSize, onReload, renderedItems]);
 }
 
 function useModelSourceUpdateOnRulesetVariablesChange(params: TreeReloadParams): void {
-  const { dataProviderProps, pageSize, ruleset, modelSource, onReload, renderedItems } = params;
+  const { dataProviderProps, pageSize, modelSource, onReload, renderedItems } = params;
 
   useEffect(() => {
-    if (!modelSource) {
-      return;
-    }
-
     let subscription: Subscription | undefined;
-    const removeListener = Presentation.presentation.vars(getRulesetId(ruleset)).onVariableChanged.addListener(() => {
-      // note: we should probably debounce these events while accumulating changed variables in case multiple vars are changed
-      /* v8 ignore next -- @preserve */
-      subscription?.unsubscribe();
-      subscription = startTreeReload({ dataProviderProps, ruleset, pageSize, modelSource, renderedItems, onReload });
-    });
+    const removeListener = Presentation.presentation
+      .vars(getRulesetId(dataProviderProps.ruleset))
+      .onVariableChanged.addListener(() => {
+        const currentModelSource = modelSource?.current;
+        if (!currentModelSource) {
+          return;
+        }
+
+        // note: we should probably debounce these events while accumulating changed variables in case multiple vars are changed
+        /* v8 ignore next -- @preserve */
+        subscription?.unsubscribe();
+        subscription = startTreeReload({
+          dataProviderProps,
+          pageSize,
+          modelSource: currentModelSource,
+          renderedItems: renderedItems.current,
+          onReload,
+        });
+      });
 
     return () => {
       removeListener();
       subscription?.unsubscribe();
     };
-  }, [dataProviderProps, modelSource, pageSize, ruleset, onReload, renderedItems]);
+  }, [dataProviderProps, modelSource, pageSize, onReload, renderedItems]);
 }
 
 function useModelSourceUpdateOnUnitSystemChange(params: TreeReloadParams): void {
-  const { dataProviderProps, pageSize, ruleset, modelSource, onReload, renderedItems } = params;
+  const { dataProviderProps, pageSize, modelSource, onReload, renderedItems } = params;
 
   useEffect(() => {
-    if (!modelSource) {
-      return;
-    }
-
     let subscription: Subscription | undefined;
     const removeListener = IModelApp.quantityFormatter.onActiveFormattingUnitSystemChanged.addListener(() => {
+      const currentModelSource = modelSource?.current;
+      if (!currentModelSource) {
+        return;
+      }
+
       /* v8 ignore next -- @preserve */
       subscription?.unsubscribe();
-      subscription = startTreeReload({ dataProviderProps, ruleset, pageSize, modelSource, renderedItems, onReload });
+      subscription = startTreeReload({
+        dataProviderProps,
+        pageSize,
+        modelSource: currentModelSource,
+        renderedItems: renderedItems.current,
+        onReload,
+      });
     });
 
     return () => {
       removeListener();
       subscription?.unsubscribe();
     };
-  }, [dataProviderProps, modelSource, pageSize, ruleset, onReload, renderedItems]);
+  }, [dataProviderProps, modelSource, pageSize, onReload, renderedItems]);
 }
 
 function startTreeReload({
   dataProviderProps,
-  ruleset,
   modelSource,
   pageSize,
   renderedItems,
   onReload,
-}: Required<TreeReloadParams>): Subscription {
-  const dataProvider = new PresentationTreeDataProvider({ ...dataProviderProps, ruleset });
-  return reloadTree(modelSource.getModel(), dataProvider, pageSize, renderedItems.current).subscribe({
+}: Omit<Required<TreeReloadParams>, "modelSource" | "renderedItems"> & {
+  modelSource: TreeModelSource;
+  renderedItems: RenderedItemsRange | undefined;
+}): Subscription {
+  const dataProvider = new PresentationTreeDataProvider(dataProviderProps);
+  return reloadTree(modelSource.getModel(), dataProvider, pageSize, renderedItems).subscribe({
     next: (newModelSource) => onReload({ modelSource: newModelSource, dataProvider }),
   });
 }


### PR DESCRIPTION
~~A Flaky test (`detects a change in rule condition`) appeared when we switched to react 19, because of slight differences how react runs effects.~~

~~From my understanding the test fails because setting a variable trigger a reload, which produces a new modelSource React then re-runs the useEffect - removing the old listener and adding a new one. If the next variable change fires in the gap between removal and re-subscription, the event is lost and the test hangs.~~

Underlying issue was race condition in how tree reload is handled. It was possible for change event to be raised between listener is removed and added back. This meant that some events were missed and tree was not reloading.


