### PR TITLE
`content`: Added support for scoping content property fields to specific value-supplier classes

### DIFF
--- a/.changeset/source-scoped-property-fields.md
+++ b/.changeset/source-scoped-property-fields.md
@@ -1,0 +1,11 @@
+---
+"@itwin/presentation-content": patch
+---
+
+Added support for scoping content property fields to specific value-supplier classes.
+
+- `PropertyField` now carries a required `valueClassNames` list describing the concrete classes of the instances that supply the field's value (the primary classes for a direct property, or the terminal related-instance classes for a related property). The list is always non-empty, normalized, de-duplicated, and sorted.
+
+- `PropertyField.computeId` accepts an optional `forkKey` that is appended to the field ID, so a field carved for a subset of its value-supplier classes gets a distinct, stable ID. Omitting it keeps the previous ID unchanged.
+
+- `TransformableDescriptor.forkField(id, valueClassNames)` lets descriptor transformers carve a property field for a subset of its value-supplier classes: the given classes are removed from the original field and a clone scoped to exactly that subset is returned (idempotent, and a no-op fork when the subset covers all of the field's classes).

--- a/packages/content/api/presentation-content.api.md
+++ b/packages/content/api/presentation-content.api.md
@@ -266,6 +266,7 @@ export interface PropertyField extends BaseField {
     pathFromTarget: RelationshipPath;
     propertyName: string;
     sourceClassName: EC.FullClassName;
+    valueClassNames: EC.FullClassName[];
 }
 
 // @public (undocumented)
@@ -274,6 +275,7 @@ export namespace PropertyField {
         propertyClassName: EC.FullClassName;
         propertyName: string;
         pathFromTarget?: RelationshipPath;
+        forkKey?: string;
     }): Field["id"];
 }
 
@@ -354,6 +356,7 @@ interface TransformableDescriptor {
     readonly categories: Record<CategoryDefinition["id"], CategoryDefinition>;
     // (undocumented)
     readonly fields: Readonly<Record<Field["id"], TransformableField>>;
+    forkField(id: Field["id"], valueClassNames: EC.FullClassName[]): TransformableField<PropertyField>;
     // (undocumented)
     removeField(id: string): void;
     // (undocumented)
@@ -361,7 +364,7 @@ interface TransformableDescriptor {
 }
 
 // @public
-type TransformableField = Omit<Field, "id"> & {
+type TransformableField<TField = Field> = Omit<TField, "id"> & {
     readonly id: string;
 };
 

--- a/packages/content/src/content/extensions/DescriptorTransformer.ts
+++ b/packages/content/src/content/extensions/DescriptorTransformer.ts
@@ -3,8 +3,13 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { PropertyField } from "../model/Field.js";
+import { computeFieldForkKey, toSortedUniqueClassNames } from "../model/Utils.js";
+
+import type { EC } from "@itwin/presentation-shared";
 import type { ContentSource } from "../ContentTarget.js";
 import type { CategoryDefinition } from "../model/Category.js";
+import type { ContentDescriptor } from "../model/ContentDescriptor.js";
 import type { Field } from "../model/Field.js";
 
 /**
@@ -30,7 +35,8 @@ export const DEFAULT_DESCRIPTOR_TRANSFORMER_PRIORITY = 1000;
  * Rules:
  * - Transformers may hide, remove, or modify field metadata.
  * - Transformers must NOT change field ID (the stable key).
- * - Transformers must NOT add new fields (that's the provider's responsibility).
+ * - Transformers must NOT add new fields (that's the provider's responsibility), except by
+ *   carving an existing field via `forkField`.
  * - Transformers must NOT reorder fields (display order is a UI concern).
  *
  * Multiple transformers run sequentially in ascending priority order. Each receives
@@ -68,7 +74,7 @@ export function defineDescriptorTransformer(transformer: DescriptorTransformer):
  *
  * @public
  */
-type TransformableField = Omit<Field, "id"> & { readonly id: string };
+type TransformableField<TField = Field> = Omit<TField, "id"> & { readonly id: string };
 
 /**
  * A constrained view of {@link (ContentDescriptor:interface)} exposed to descriptor transformers.
@@ -78,6 +84,7 @@ type TransformableField = Omit<Field, "id"> & { readonly id: string };
  * - Field `id` is readonly — must not be changed.
  * - Field metadata (`label`, `categoryId`, `hidden`, `readOnly`) remains mutable.
  * - Fields can be removed via `descriptor.removeField(id)`.
+ * - A field can be carved for a subset of its value-supplier classes via `descriptor.forkField(id, subset)`.
  *
  * @public
  */
@@ -86,4 +93,69 @@ interface TransformableDescriptor {
   readonly fields: Readonly<Record<Field["id"], TransformableField>>;
   readonly categories: Record<CategoryDefinition["id"], CategoryDefinition>;
   removeField(id: string): void;
+  /**
+   * Carve a property field so a change can be scoped to a subset of the value-supplier
+   * classes it represents. Removes those classes from the original field's
+   * `valueClassNames` and returns a clone scoped to exactly that subset (inserted into
+   * `fields` under a forked ID). If the subset covers *all* of the field's classes, no
+   * clone is made and the original field is returned for in-place mutation. Forking the
+   * same subset twice returns the same field.
+   *
+   * @throws if `id` is missing or not a property field, if `valueClassNames` is empty, or
+   * if it contains a class not represented by the field.
+   */
+  forkField(id: Field["id"], valueClassNames: EC.FullClassName[]): TransformableField<PropertyField>;
+}
+
+/**
+ * Creates a {@link TransformableDescriptor} view over a {@link (ContentDescriptor:interface)},
+ * backing `removeField` and `forkField` against the descriptor's live `fields` record.
+ *
+ * @internal
+ */
+export function createTransformableDescriptor(descriptor: ContentDescriptor): TransformableDescriptor {
+  return {
+    sources: descriptor.sources,
+    categories: descriptor.categories,
+    fields: descriptor.fields,
+    removeField(id) {
+      delete descriptor.fields[id];
+    },
+    forkField(id, valueClassNames) {
+      if (!(id in descriptor.fields)) {
+        throw new Error(`Cannot fork field "${id}": no such field.`);
+      }
+      const field = descriptor.fields[id];
+      if (field.kind !== "property") {
+        throw new Error(`Cannot fork field "${id}": only property fields can be forked.`);
+      }
+      const subset = toSortedUniqueClassNames(valueClassNames);
+      if (subset.length === 0) {
+        throw new Error(`Cannot fork field "${id}": the value class subset must not be empty.`);
+      }
+      const forkedId = PropertyField.computeId({
+        propertyClassName: field.sourceClassName,
+        propertyName: field.propertyName,
+        pathFromTarget: field.pathFromTarget,
+        forkKey: computeFieldForkKey(subset),
+      });
+      if (forkedId in descriptor.fields) {
+        return descriptor.fields[forkedId] as PropertyField;
+      }
+      const represented = new Set(field.valueClassNames);
+      for (const className of subset) {
+        if (!represented.has(className)) {
+          throw new Error(`Cannot fork field "${id}": class "${className}" is not represented by the field.`);
+        }
+      }
+      if (subset.length === field.valueClassNames.length) {
+        // The subset covers every value-supplier class: mutate in place, no fork.
+        return field;
+      }
+      field.valueClassNames = field.valueClassNames.filter((className) => !subset.includes(className));
+      const fork: PropertyField = { ...field, id: forkedId, valueClassNames: subset };
+      descriptor.fields[forkedId] = fork;
+      return fork;
+    },
+  };
 }

--- a/packages/content/src/content/extensions/DescriptorTransformer.ts
+++ b/packages/content/src/content/extensions/DescriptorTransformer.ts
@@ -101,8 +101,9 @@ interface TransformableDescriptor {
    * clone is made and the original field is returned for in-place mutation. Forking the
    * same subset twice returns the same field.
    *
-   * @throws if `id` is missing or not a property field, if `valueClassNames` is empty, or
-   * if it contains a class not represented by the field.
+   * @throws if `id` is missing or not a property field, if the field itself represents no
+   * value-supplier classes, if `valueClassNames` is empty, or if it contains a class not
+   * represented by the field.
    */
   forkField(id: Field["id"], valueClassNames: EC.FullClassName[]): TransformableField<PropertyField>;
 }
@@ -128,6 +129,9 @@ export function createTransformableDescriptor(descriptor: ContentDescriptor): Tr
       const field = descriptor.fields[id];
       if (field.kind !== "property") {
         throw new Error(`Cannot fork field "${id}": only property fields can be forked.`);
+      }
+      if (field.valueClassNames.length === 0) {
+        throw new Error(`Cannot fork field "${id}": the field represents no value-supplier classes.`);
       }
       const subset = toSortedUniqueClassNames(valueClassNames);
       if (subset.length === 0) {

--- a/packages/content/src/content/model/Field.ts
+++ b/packages/content/src/content/model/Field.ts
@@ -42,7 +42,11 @@ interface BaseField {
  */
 export interface PropertyField extends BaseField {
   kind: "property";
-  /** Full class name of the class that owns this property (e.g., "BisCore.Element"). */
+  /**
+   * Full class name of the class that *declares* this property (e.g., "BisCore.Element").
+   * Drives the SQL column / property metadata. Distinct from {@link (PropertyField:interface).valueClassNames},
+   * which are the concrete *value-supplier* classes this field represents.
+   */
   sourceClassName: EC.FullClassName;
   /** The EC property name within the source class. */
   propertyName: string;
@@ -51,6 +55,25 @@ export interface PropertyField extends BaseField {
    * Empty array means the field belongs to the target class directly.
    */
   pathFromTarget: RelationshipPath;
+  /**
+   * Concrete classes of the instances that supply this field's value (the field's "value origin").
+   *
+   * For a direct property (empty {@link (PropertyField:interface).pathFromTarget}) these are the
+   * primary (selected) classes; for a related property they are the concrete classes at the
+   * relationship path's terminal end. For example, `["Stuff.Door", "Stuff.Window"]` for a
+   * `Height` declared on `Stuff.Thing`, or `["BisCore.ExternalSourceAspectX",
+   * "BisCore.ExternalSourceAspectY"]` for an `Identifier` declared on
+   * `BisCore.ExternalSourceAspect` and loaded over a relationship.
+   *
+   * Do not confuse this with:
+   * - {@link (PropertyField:interface).sourceClassName} — the class that *declares* the property.
+   * - The content *target* classes (the classes content was requested for). For a direct property the
+   *   value classes coincide with the target classes, but for a related property they are the
+   *   related-endpoint classes rather than the target.
+   *
+   * Always non-empty, normalized, de-duplicated, and sorted by normalized full name.
+   */
+  valueClassNames: EC.FullClassName[];
 }
 /** @public */
 export namespace PropertyField {
@@ -58,15 +81,24 @@ export namespace PropertyField {
    * Computes the ID of a property field from its source class, property name,
    * and relationship path from the target. Use this to look up property fields
    * directly in `descriptor.fields`.
+   *
+   * When a non-empty `forkKey` is provided, it is appended as a `#${forkKey}` suffix so a field
+   * that has been carved for a subset of its value-supplier classes gets a distinct, stable ID.
+   * An `undefined` or empty `forkKey` leaves the identity unchanged — so a survivor field keeps
+   * its original ID.
    */
   export function computeId(props: {
     propertyClassName: EC.FullClassName;
     propertyName: string;
     pathFromTarget?: RelationshipPath;
+    forkKey?: string;
   }): Field["id"] {
     let identity = `${normalizeFullClassName(props.propertyClassName)}.${props.propertyName}`;
     if (props.pathFromTarget && props.pathFromTarget.length > 0) {
       identity += `(${serializeRelationshipPath(props.pathFromTarget)})`;
+    }
+    if (props.forkKey) {
+      identity += `#${props.forkKey}`;
     }
     return identity;
   }

--- a/packages/content/src/content/model/PropertyFieldMerge.ts
+++ b/packages/content/src/content/model/PropertyFieldMerge.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PropertyField } from "./Field.js";
+import { toSortedUniqueClassNames } from "./Utils.js";
+
+import type { Field } from "./Field.js";
+
+/**
+ * Merges per-source candidate property fields into the descriptor's `fields` record,
+ * keyed by field ID, applying the **merge-by-default** contract:
+ *
+ * - Candidates are grouped by their base ID (`PropertyField.computeId` without a `forkKey`),
+ *   i.e. by declared `(sourceClassName, propertyName, pathFromTarget)`. Concrete-endpoint
+ *   variants of the same declared property therefore collapse into one field.
+ * - Each group produces a single field whose `valueClassNames` is the sorted, de-duplicated
+ *   union of the group's value-supplier classes.
+ * - Field metadata (`label`, `categoryId`, `hidden`, `readOnly`, `type`, `kind`) comes from the
+ *   first candidate in a group. Grouped candidates are expected to be identical apart from their
+ *   `valueClassNames`; a mismatch indicates a provider bug and throws.
+ *
+ * This is the inverse of `forkField`: it merges many candidates into one field on the way in,
+ * while `forkField` splits one field into a carved subset on demand. It is a contract-only
+ * foundation and is not wired into the content pipeline yet — Stage 2 `createContentProvider`
+ * (still a stub) will call it to assemble `descriptor.fields` from raw provider candidates.
+ *
+ * @internal
+ */
+export function mergePropertyFieldsByIdentity(candidates: PropertyField[]): Record<Field["id"], PropertyField> {
+  const result: Record<Field["id"], PropertyField> = {};
+  for (const candidate of candidates) {
+    const baseId = PropertyField.computeId({
+      propertyClassName: candidate.sourceClassName,
+      propertyName: candidate.propertyName,
+      pathFromTarget: candidate.pathFromTarget,
+    });
+    if (!(baseId in result)) {
+      result[baseId] = {
+        ...candidate,
+        id: baseId,
+        valueClassNames: toSortedUniqueClassNames(candidate.valueClassNames),
+      };
+      continue;
+    }
+    const existing = result[baseId];
+    assertMetadataAgrees(existing, candidate);
+    existing.valueClassNames = toSortedUniqueClassNames([...existing.valueClassNames, ...candidate.valueClassNames]);
+  }
+  return result;
+}
+
+function assertMetadataAgrees(existing: PropertyField, candidate: PropertyField): void {
+  if (
+    existing.label !== candidate.label ||
+    existing.categoryId !== candidate.categoryId ||
+    existing.hidden !== candidate.hidden ||
+    existing.readOnly !== candidate.readOnly
+  ) {
+    throw new Error(
+      `Cannot merge property field "${existing.id}": candidates for the same declared property have divergent metadata.`,
+    );
+  }
+}

--- a/packages/content/src/content/model/PropertyFieldMerge.ts
+++ b/packages/content/src/content/model/PropertyFieldMerge.ts
@@ -6,6 +6,7 @@
 import { PropertyField } from "./Field.js";
 import { toSortedUniqueClassNames } from "./Utils.js";
 
+import type { ValueDescriptor } from "@itwin/presentation-shared";
 import type { Field } from "./Field.js";
 
 /**
@@ -17,7 +18,7 @@ import type { Field } from "./Field.js";
  *   variants of the same declared property therefore collapse into one field.
  * - Each group produces a single field whose `valueClassNames` is the sorted, de-duplicated
  *   union of the group's value-supplier classes.
- * - Field metadata (`label`, `categoryId`, `hidden`, `readOnly`, `type`, `kind`) comes from the
+ * - Field metadata (`label`, `categoryId`, `hidden`, `readOnly`, `type`) comes from the
  *   first candidate in a group. Grouped candidates are expected to be identical apart from their
  *   `valueClassNames`; a mismatch indicates a provider bug and throws.
  *
@@ -56,10 +57,33 @@ function assertMetadataAgrees(existing: PropertyField, candidate: PropertyField)
     existing.label !== candidate.label ||
     existing.categoryId !== candidate.categoryId ||
     existing.hidden !== candidate.hidden ||
-    existing.readOnly !== candidate.readOnly
+    existing.readOnly !== candidate.readOnly ||
+    !valueDescriptorsAgree(existing.type, candidate.type)
   ) {
     throw new Error(
       `Cannot merge property field "${existing.id}": candidates for the same declared property have divergent metadata.`,
     );
+  }
+}
+
+// Structural equality for value shapes. `ValueDescriptor` is a recursive union, so it cannot be
+// compared by reference (distinct candidates carry distinct instances) — a mismatch signals a
+// provider bug where the same declared property was given different value shapes. Both descriptors
+// are reduced to a canonical nested-tuple form and compared as JSON to avoid separator ambiguity.
+function valueDescriptorsAgree(a: ValueDescriptor, b: ValueDescriptor): boolean {
+  return JSON.stringify(toComparableValueDescriptor(a)) === JSON.stringify(toComparableValueDescriptor(b));
+}
+
+function toComparableValueDescriptor(descriptor: ValueDescriptor): unknown {
+  switch (descriptor.kind) {
+    case "primitive":
+      return ["primitive", descriptor.type, descriptor.kindOfQuantity ?? null];
+    case "array":
+      return ["array", toComparableValueDescriptor(descriptor.elementType)];
+    case "struct":
+      return [
+        "struct",
+        descriptor.members.map((member) => [member.name, member.label, toComparableValueDescriptor(member.type)]),
+      ];
   }
 }

--- a/packages/content/src/content/model/PropertyFieldMerge.ts
+++ b/packages/content/src/content/model/PropertyFieldMerge.ts
@@ -66,10 +66,12 @@ function assertMetadataAgrees(existing: PropertyField, candidate: PropertyField)
   }
 }
 
-// Structural equality for value shapes. `ValueDescriptor` is a recursive union, so it cannot be
-// compared by reference (distinct candidates carry distinct instances) — a mismatch signals a
-// provider bug where the same declared property was given different value shapes. Both descriptors
-// are reduced to a canonical nested-tuple form and compared as JSON to avoid separator ambiguity.
+/**
+ * Structural equality for value shapes. `ValueDescriptor` is a recursive union, so it cannot be
+ * compared by reference (distinct candidates carry distinct instances) — a mismatch signals a
+ * provider bug where the same declared property was given different value shapes. Both descriptors
+ * are reduced to a canonical nested-tuple form and compared as JSON to avoid separator ambiguity.
+ */
 function valueDescriptorsAgree(a: ValueDescriptor, b: ValueDescriptor): boolean {
   return JSON.stringify(toComparableValueDescriptor(a)) === JSON.stringify(toComparableValueDescriptor(b));
 }

--- a/packages/content/src/content/model/Utils.ts
+++ b/packages/content/src/content/model/Utils.ts
@@ -5,7 +5,7 @@
 
 import { normalizeFullClassName } from "@itwin/presentation-shared";
 
-import type { RelationshipPath } from "@itwin/presentation-shared";
+import type { EC, RelationshipPath } from "@itwin/presentation-shared";
 
 export function serializeRelationshipPath(path: RelationshipPath): string {
   let result = "";
@@ -19,4 +19,46 @@ export function serializeRelationshipPath(path: RelationshipPath): string {
     result += `-${rel}->${normalizeFullClassName(step.targetClassName)}`;
   }
   return result;
+}
+
+/**
+ * Normalizes, de-duplicates, and sorts the given class names. Produces the canonical
+ * representation used for a property field's `valueClassNames` invariant.
+ */
+export function toSortedUniqueClassNames(classNames: EC.FullClassName[]): EC.FullClassName[] {
+  return Array.from(new Set(classNames.map((name) => normalizeFullClassName(name)))).sort();
+}
+
+/**
+ * Deterministic, bounded discriminator for a subset of value-supplier classes, used as the
+ * `forkKey` when carving a property field. The same subset always yields the same key
+ * (normalized + sorted), so forking the same subset twice produces the same field ID.
+ */
+export function computeFieldForkKey(valueClassNames: EC.FullClassName[]): string {
+  const joined = toSortedUniqueClassNames(valueClassNames).join(";");
+  // Keep the key human-readable when short; fall back to a stable hash when long.
+  return joined.length <= MAX_READABLE_FORK_KEY_LENGTH ? joined : hashString(joined);
+}
+
+const MAX_READABLE_FORK_KEY_LENGTH = 100;
+
+/**
+ * Deterministic 32-bit FNV-1a hash rendered in base-36. Stable across runs so it can be
+ * embedded in cache-stable field IDs.
+ */
+function hashString(value: string): string {
+  // FNV-1a 32-bit: start from the FNV offset basis, then for each char XOR it in and
+  // multiply by the FNV prime (`Math.imul` keeps the multiply in 32-bit space).
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const FNV_OffsetBasis = 0x811c9dc5;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const FNV_Prime = 0x01000193;
+
+  let hash = FNV_OffsetBasis;
+  for (let i = 0; i < value.length; ++i) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, FNV_Prime);
+  }
+  // Coerce back to an unsigned 32-bit integer before rendering compactly in base-36.
+  return (hash >>> 0).toString(36);
 }

--- a/packages/content/src/test/extensions/DescriptorTransformer.test.ts
+++ b/packages/content/src/test/extensions/DescriptorTransformer.test.ts
@@ -1,0 +1,202 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+import { createTransformableDescriptor } from "../../content/extensions/DescriptorTransformer.js";
+import { PropertyField } from "../../content/model/Field.js";
+import { computeFieldForkKey, toSortedUniqueClassNames } from "../../content/model/Utils.js";
+
+import type { EC } from "@itwin/presentation-shared";
+import type { ContentDescriptor } from "../../content/model/ContentDescriptor.js";
+import type { CalculatedField, Field } from "../../content/model/Field.js";
+
+function propertyField(props: {
+  sourceClassName: EC.FullClassName;
+  propertyName: string;
+  valueClassNames: EC.FullClassName[];
+  pathFromTarget?: PropertyField["pathFromTarget"];
+}): PropertyField {
+  return {
+    kind: "property",
+    id: PropertyField.computeId({
+      propertyClassName: props.sourceClassName,
+      propertyName: props.propertyName,
+      pathFromTarget: props.pathFromTarget,
+    }),
+    label: "Label",
+    type: { kind: "primitive", type: "String" },
+    sourceClassName: props.sourceClassName,
+    propertyName: props.propertyName,
+    pathFromTarget: props.pathFromTarget ?? [],
+    valueClassNames: toSortedUniqueClassNames(props.valueClassNames),
+  };
+}
+
+function createDescriptor(fields: Field[]): ContentDescriptor {
+  return { sources: [], categories: {}, fields: Object.fromEntries(fields.map((f) => [f.id, f])) };
+}
+
+describe("createTransformableDescriptor", () => {
+  it("exposes sources, categories, and fields of the backing descriptor", () => {
+    const field = propertyField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Door"],
+    });
+    const descriptor = createDescriptor([field]);
+    const transformable = createTransformableDescriptor(descriptor);
+    expect(transformable.sources).to.equal(descriptor.sources);
+    expect(transformable.categories).to.equal(descriptor.categories);
+    expect(transformable.fields[field.id]).to.equal(field);
+  });
+
+  describe("removeField", () => {
+    it("removes a field from the backing descriptor", () => {
+      const field = propertyField({
+        sourceClassName: "Stuff:Thing",
+        propertyName: "Height",
+        valueClassNames: ["Stuff:Door"],
+      });
+      const descriptor = createDescriptor([field]);
+      const transformable = createTransformableDescriptor(descriptor);
+      transformable.removeField(field.id);
+      expect(descriptor.fields[field.id]).to.be.undefined;
+    });
+  });
+
+  describe("forkField", () => {
+    it("carves a strict subset into a new field and shrinks the original", () => {
+      const field = propertyField({
+        sourceClassName: "Stuff:Thing",
+        propertyName: "Height",
+        valueClassNames: ["Stuff:Door", "Stuff:Window", "Stuff:Roof"],
+      });
+      const descriptor = createDescriptor([field]);
+      const transformable = createTransformableDescriptor(descriptor);
+
+      const fork = transformable.forkField(field.id, ["Stuff:Door"]);
+      const forkedId = PropertyField.computeId({
+        propertyClassName: "Stuff:Thing",
+        propertyName: "Height",
+        forkKey: computeFieldForkKey(["Stuff.Door"]),
+      });
+
+      expect(fork.id).to.equal(forkedId);
+      expect(fork.valueClassNames).to.deep.equal(["Stuff.Door"]);
+      expect(descriptor.fields[forkedId]).to.equal(fork);
+      // original is shrunk to the remainder
+      expect(field.valueClassNames).to.deep.equal(["Stuff.Roof", "Stuff.Window"]);
+      expect(field.id).to.equal(PropertyField.computeId({ propertyClassName: "Stuff:Thing", propertyName: "Height" }));
+    });
+
+    it("carves a related-endpoint subclass over a relationship path", () => {
+      const path: PropertyField["pathFromTarget"] = [
+        {
+          sourceClassName: "BisCore:Element",
+          targetClassName: "BisCore:ExternalSourceAspect",
+          relationshipName: "BisCore:ElementOwnsMultiAspects",
+        },
+      ];
+      const field = propertyField({
+        sourceClassName: "BisCore:ExternalSourceAspect",
+        propertyName: "Identifier",
+        pathFromTarget: path,
+        valueClassNames: ["BisCore:ExternalSourceAspectX", "BisCore:ExternalSourceAspectY"],
+      });
+      const descriptor = createDescriptor([field]);
+      const transformable = createTransformableDescriptor(descriptor);
+
+      const fork = transformable.forkField(field.id, ["BisCore:ExternalSourceAspectX"]);
+      expect(fork.valueClassNames).to.deep.equal(["BisCore.ExternalSourceAspectX"]);
+      expect(field.valueClassNames).to.deep.equal(["BisCore.ExternalSourceAspectY"]);
+    });
+
+    it("returns the original field in place when the subset covers all classes", () => {
+      const field = propertyField({
+        sourceClassName: "Stuff:Thing",
+        propertyName: "Height",
+        valueClassNames: ["Stuff:Door", "Stuff:Window"],
+      });
+      const descriptor = createDescriptor([field]);
+      const transformable = createTransformableDescriptor(descriptor);
+
+      const fork = transformable.forkField(field.id, ["Stuff:Window", "Stuff:Door"]);
+      expect(fork).to.equal(field);
+      expect(Object.keys(descriptor.fields)).to.deep.equal([field.id]);
+      expect(field.valueClassNames).to.deep.equal(["Stuff.Door", "Stuff.Window"]);
+    });
+
+    it("is idempotent — forking the same subset twice returns the same field", () => {
+      const field = propertyField({
+        sourceClassName: "Stuff:Thing",
+        propertyName: "Height",
+        valueClassNames: ["Stuff:Door", "Stuff:Window"],
+      });
+      const descriptor = createDescriptor([field]);
+      const transformable = createTransformableDescriptor(descriptor);
+
+      const first = transformable.forkField(field.id, ["Stuff:Door"]);
+      const second = transformable.forkField(field.id, ["Stuff:Door"]);
+      expect(second).to.equal(first);
+      // original stays shrunk to the remainder, not shrunk twice
+      expect(field.valueClassNames).to.deep.equal(["Stuff.Window"]);
+      expect(Object.keys(descriptor.fields)).to.have.length(2);
+    });
+
+    it("keeps the forked field's target classes independent of the original", () => {
+      const field = propertyField({
+        sourceClassName: "Stuff:Thing",
+        propertyName: "Height",
+        valueClassNames: ["Stuff:Door", "Stuff:Window"],
+      });
+      const descriptor = createDescriptor([field]);
+      const transformable = createTransformableDescriptor(descriptor);
+
+      const fork = transformable.forkField(field.id, ["Stuff:Door"]);
+      expect(fork.valueClassNames).to.not.equal(field.valueClassNames);
+    });
+
+    it("throws when the field does not exist", () => {
+      const descriptor = createDescriptor([]);
+      const transformable = createTransformableDescriptor(descriptor);
+      expect(() => transformable.forkField("missing", ["Stuff:Door"])).to.throw(/no such field/);
+    });
+
+    it("throws when the field is not a property field", () => {
+      const calculated: CalculatedField = {
+        kind: "calculated",
+        id: "calc",
+        label: "Calc",
+        type: { kind: "primitive", type: "String" },
+        expression: "1",
+      };
+      const descriptor = createDescriptor([calculated]);
+      const transformable = createTransformableDescriptor(descriptor);
+      expect(() => transformable.forkField("calc", ["Stuff:Door"])).to.throw(/only property fields/);
+    });
+
+    it("throws when the target class subset is empty", () => {
+      const field = propertyField({
+        sourceClassName: "Stuff:Thing",
+        propertyName: "Height",
+        valueClassNames: ["Stuff:Door"],
+      });
+      const descriptor = createDescriptor([field]);
+      const transformable = createTransformableDescriptor(descriptor);
+      expect(() => transformable.forkField(field.id, [])).to.throw(/must not be empty/);
+    });
+
+    it("throws when a subset class is not represented by the field", () => {
+      const field = propertyField({
+        sourceClassName: "Stuff:Thing",
+        propertyName: "Height",
+        valueClassNames: ["Stuff:Door"],
+      });
+      const descriptor = createDescriptor([field]);
+      const transformable = createTransformableDescriptor(descriptor);
+      expect(() => transformable.forkField(field.id, ["Stuff:Window"])).to.throw(/not represented/);
+    });
+  });
+});

--- a/packages/content/src/test/extensions/DescriptorTransformer.test.ts
+++ b/packages/content/src/test/extensions/DescriptorTransformer.test.ts
@@ -177,6 +177,13 @@ describe("createTransformableDescriptor", () => {
       expect(() => transformable.forkField("calc", ["Stuff:Door"])).to.throw(/only property fields/);
     });
 
+    it("throws when the field represents no value-supplier classes", () => {
+      const field = propertyField({ sourceClassName: "Stuff:Thing", propertyName: "Height", valueClassNames: [] });
+      const descriptor = createDescriptor([field]);
+      const transformable = createTransformableDescriptor(descriptor);
+      expect(() => transformable.forkField(field.id, ["Stuff:Door"])).to.throw(/represents no value-supplier classes/);
+    });
+
     it("throws when the target class subset is empty", () => {
       const field = propertyField({
         sourceClassName: "Stuff:Thing",

--- a/packages/content/src/test/model/Field.test.ts
+++ b/packages/content/src/test/model/Field.test.ts
@@ -94,5 +94,46 @@ describe("PropertyField", () => {
         "BisCore.Element.UserLabel(BisCore.Element-[!BisCore.ModelContainsElements]->BisCore.Model-[BisCore.ModelModelsElement]->BisCore.Element)",
       );
     });
+
+    it("appends fork key as a suffix", () => {
+      const result = PropertyField.computeId({
+        propertyClassName: "BisCore:Element",
+        propertyName: "CodeValue",
+        forkKey: "Stuff.Door",
+      });
+      expect(result).to.equal("BisCore.Element.CodeValue#Stuff.Door");
+    });
+
+    it("appends fork key after the path", () => {
+      const result = PropertyField.computeId({
+        propertyClassName: "BisCore:ElementAspect",
+        propertyName: "Value",
+        pathFromTarget: [
+          {
+            sourceClassName: "BisCore:Element",
+            targetClassName: "BisCore:ElementAspect",
+            relationshipName: "BisCore:ElementOwnsUniqueAspect",
+          },
+        ],
+        forkKey: "BisCore.ElementAspectX",
+      });
+      expect(result).to.equal(
+        "BisCore.ElementAspect.Value(BisCore.Element-[BisCore.ElementOwnsUniqueAspect]->BisCore.ElementAspect)#BisCore.ElementAspectX",
+      );
+    });
+
+    it("does not append fork key when provided as an empty string", () => {
+      const result = PropertyField.computeId({
+        propertyClassName: "BisCore.Element",
+        propertyName: "CodeValue",
+        forkKey: "",
+      });
+      expect(result).to.equal("BisCore.Element.CodeValue");
+    });
+
+    it("produces the same id for the same fork key", () => {
+      const props = { propertyClassName: "BisCore.Element" as const, propertyName: "CodeValue", forkKey: "Stuff.Door" };
+      expect(PropertyField.computeId(props)).to.equal(PropertyField.computeId(props));
+    });
   });
 });

--- a/packages/content/src/test/model/PropertyFieldMerge.test.ts
+++ b/packages/content/src/test/model/PropertyFieldMerge.test.ts
@@ -17,13 +17,14 @@ function createField(props: {
   categoryId?: string;
   hidden?: boolean;
   readOnly?: boolean;
+  type?: PropertyField["type"];
   pathFromTarget?: PropertyField["pathFromTarget"];
 }): PropertyField {
   return {
     kind: "property",
     id: "unused",
     label: props.label ?? "Label",
-    type: { kind: "primitive", type: "String" },
+    type: props.type ?? { kind: "primitive", type: "String" },
     categoryId: props.categoryId,
     hidden: props.hidden,
     readOnly: props.readOnly,
@@ -190,5 +191,49 @@ describe("mergePropertyFieldsByIdentity", () => {
       readOnly: false,
     });
     expect(() => mergePropertyFieldsByIdentity([a, b])).to.throw(/divergent metadata/);
+  });
+
+  it("throws when grouped candidates have divergent value type", () => {
+    const a = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Door"],
+      type: { kind: "primitive", type: "String" },
+    });
+    const b = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Window"],
+      type: { kind: "primitive", type: "Double" },
+    });
+    expect(() => mergePropertyFieldsByIdentity([a, b])).to.throw(/divergent metadata/);
+  });
+
+  it("merges candidates whose value types are structurally equal but distinct instances", () => {
+    const type = (): PropertyField["type"] => ({
+      kind: "struct",
+      members: [
+        {
+          name: "coords",
+          label: "Coords",
+          type: { kind: "array", elementType: { kind: "primitive", type: "Double", kindOfQuantity: "Units.LENGTH" } },
+        },
+      ],
+    });
+    const a = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Point",
+      valueClassNames: ["Stuff:Door"],
+      type: type(),
+    });
+    const b = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Point",
+      valueClassNames: ["Stuff:Window"],
+      type: type(),
+    });
+    const result = mergePropertyFieldsByIdentity([a, b]);
+    const id = PropertyField.computeId({ propertyClassName: "Stuff:Thing", propertyName: "Point" });
+    expect(result[id].valueClassNames).to.deep.equal(["Stuff.Door", "Stuff.Window"]);
   });
 });

--- a/packages/content/src/test/model/PropertyFieldMerge.test.ts
+++ b/packages/content/src/test/model/PropertyFieldMerge.test.ts
@@ -1,0 +1,194 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+import { PropertyField } from "../../content/model/Field.js";
+import { mergePropertyFieldsByIdentity } from "../../content/model/PropertyFieldMerge.js";
+
+import type { EC } from "@itwin/presentation-shared";
+
+function createField(props: {
+  sourceClassName: EC.FullClassName;
+  propertyName: string;
+  valueClassNames: EC.FullClassName[];
+  label?: string;
+  categoryId?: string;
+  hidden?: boolean;
+  readOnly?: boolean;
+  pathFromTarget?: PropertyField["pathFromTarget"];
+}): PropertyField {
+  return {
+    kind: "property",
+    id: "unused",
+    label: props.label ?? "Label",
+    type: { kind: "primitive", type: "String" },
+    categoryId: props.categoryId,
+    hidden: props.hidden,
+    readOnly: props.readOnly,
+    sourceClassName: props.sourceClassName,
+    propertyName: props.propertyName,
+    pathFromTarget: props.pathFromTarget ?? [],
+    valueClassNames: props.valueClassNames,
+  };
+}
+
+describe("mergePropertyFieldsByIdentity", () => {
+  it("returns an empty record for no candidates", () => {
+    expect(mergePropertyFieldsByIdentity([])).to.deep.equal({});
+  });
+
+  it("passes a single candidate through, keyed by base id, with normalized target classes", () => {
+    const field = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Window", "Stuff:Door"],
+    });
+    const result = mergePropertyFieldsByIdentity([field]);
+    const id = PropertyField.computeId({ propertyClassName: "Stuff:Thing", propertyName: "Height" });
+    expect(result).to.deep.equal({ [id]: { ...field, id, valueClassNames: ["Stuff.Door", "Stuff.Window"] } });
+  });
+
+  it("does not mutate the input candidate", () => {
+    const field = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Window"],
+    });
+    mergePropertyFieldsByIdentity([field]);
+    expect(field.id).to.equal("unused");
+    expect(field.valueClassNames).to.deep.equal(["Stuff:Window"]);
+  });
+
+  it("unions target classes of direct-property candidates that share identity", () => {
+    const a = createField({ sourceClassName: "Stuff:Thing", propertyName: "Height", valueClassNames: ["Stuff:Door"] });
+    const b = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Window"],
+    });
+    const result = mergePropertyFieldsByIdentity([a, b]);
+    const id = PropertyField.computeId({ propertyClassName: "Stuff:Thing", propertyName: "Height" });
+    expect(result[id].valueClassNames).to.deep.equal(["Stuff.Door", "Stuff.Window"]);
+  });
+
+  it("de-duplicates overlapping target classes across candidates", () => {
+    const a = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Door", "Stuff:Window"],
+    });
+    const b = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Window", "Stuff:Roof"],
+    });
+    const result = mergePropertyFieldsByIdentity([a, b]);
+    const id = PropertyField.computeId({ propertyClassName: "Stuff:Thing", propertyName: "Height" });
+    expect(result[id].valueClassNames).to.deep.equal(["Stuff.Door", "Stuff.Roof", "Stuff.Window"]);
+  });
+
+  it("unions related-endpoint candidates that share identity", () => {
+    const path: PropertyField["pathFromTarget"] = [
+      {
+        sourceClassName: "BisCore:Element",
+        targetClassName: "BisCore:ExternalSourceAspect",
+        relationshipName: "BisCore:ElementOwnsMultiAspects",
+      },
+    ];
+    const a = createField({
+      sourceClassName: "BisCore:ExternalSourceAspect",
+      propertyName: "Identifier",
+      pathFromTarget: path,
+      valueClassNames: ["BisCore:ExternalSourceAspectX"],
+    });
+    const b = createField({
+      sourceClassName: "BisCore:ExternalSourceAspect",
+      propertyName: "Identifier",
+      pathFromTarget: path,
+      valueClassNames: ["BisCore:ExternalSourceAspectY"],
+    });
+    const result = mergePropertyFieldsByIdentity([a, b]);
+    const id = PropertyField.computeId({
+      propertyClassName: "BisCore:ExternalSourceAspect",
+      propertyName: "Identifier",
+      pathFromTarget: path,
+    });
+    expect(result[id].valueClassNames).to.deep.equal([
+      "BisCore.ExternalSourceAspectX",
+      "BisCore.ExternalSourceAspectY",
+    ]);
+  });
+
+  it("keeps candidates with distinct identities separate", () => {
+    const a = createField({ sourceClassName: "Stuff:Thing", propertyName: "Height", valueClassNames: ["Stuff:Door"] });
+    const b = createField({ sourceClassName: "Stuff:Thing", propertyName: "Width", valueClassNames: ["Stuff:Door"] });
+    const result = mergePropertyFieldsByIdentity([a, b]);
+    expect(Object.keys(result)).to.have.length(2);
+  });
+
+  it("throws when grouped candidates have divergent metadata", () => {
+    const a = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Door"],
+      label: "One",
+    });
+    const b = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Window"],
+      label: "Two",
+    });
+    expect(() => mergePropertyFieldsByIdentity([a, b])).to.throw(/divergent metadata/);
+  });
+
+  it("throws when grouped candidates have divergent category", () => {
+    const a = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Door"],
+      categoryId: "a",
+    });
+    const b = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Window"],
+      categoryId: "b",
+    });
+    expect(() => mergePropertyFieldsByIdentity([a, b])).to.throw(/divergent metadata/);
+  });
+
+  it("throws when grouped candidates have divergent hidden flag", () => {
+    const a = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Door"],
+      hidden: true,
+    });
+    const b = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Window"],
+      hidden: false,
+    });
+    expect(() => mergePropertyFieldsByIdentity([a, b])).to.throw(/divergent metadata/);
+  });
+
+  it("throws when grouped candidates have divergent readOnly flag", () => {
+    const a = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Door"],
+      readOnly: true,
+    });
+    const b = createField({
+      sourceClassName: "Stuff:Thing",
+      propertyName: "Height",
+      valueClassNames: ["Stuff:Window"],
+      readOnly: false,
+    });
+    expect(() => mergePropertyFieldsByIdentity([a, b])).to.throw(/divergent metadata/);
+  });
+});

--- a/packages/content/src/test/model/Utils.test.ts
+++ b/packages/content/src/test/model/Utils.test.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+import { computeFieldForkKey, toSortedUniqueClassNames } from "../../content/model/Utils.js";
+
+import type { EC } from "@itwin/presentation-shared";
+
+describe("toSortedUniqueClassNames", () => {
+  it("normalizes, de-duplicates, and sorts class names", () => {
+    const result = toSortedUniqueClassNames(["Stuff:Window", "Stuff.Door", "Stuff:Window", "Stuff:Door"]);
+    expect(result).to.deep.equal(["Stuff.Door", "Stuff.Window"]);
+  });
+});
+
+describe("computeFieldForkKey", () => {
+  it("uses a readable joined key for short subsets", () => {
+    expect(computeFieldForkKey(["Stuff:Window", "Stuff:Door"])).to.equal("Stuff.Door;Stuff.Window");
+  });
+
+  it("is deterministic and order-independent", () => {
+    expect(computeFieldForkKey(["Stuff:Window", "Stuff:Door"])).to.equal(
+      computeFieldForkKey(["Stuff:Door", "Stuff:Window"]),
+    );
+  });
+
+  it("falls back to a bounded hash for long subsets", () => {
+    const longSubset = Array.from({ length: 20 }, (_, i) => `Schema.VeryLongClassNameNumber${i}`) as EC.FullClassName[];
+    const key = computeFieldForkKey(longSubset);
+    expect(key).to.not.contain(";");
+    expect(key.length).to.be.lessThan(20);
+    // stable across calls
+    expect(key).to.equal(computeFieldForkKey(longSubset));
+  });
+});


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/1424