### PR TITLE
`content`: ECExpression to ECSQL

### DIFF
--- a/.changeset/eager-lions-relate.md
+++ b/.changeset/eager-lions-relate.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-content": patch
+---
+
+Convert ECExpression instance filters and calculated property values into ECSQL instead of passing them through unchanged. The generated ECSQL uses bracket-quoted identifiers and parameterizes literals, so `CalculatedFieldDeclaration` now carries an optional `bindings` map with the values referenced by its `expression`.

--- a/.changeset/gentle-otters-cover.md
+++ b/.changeset/gentle-otters-cover.md
@@ -1,0 +1,7 @@
+---
+"@itwin/presentation-shared": patch
+---
+
+`createRelationshipPathJoinClause`: The step `instanceFilter` alias placeholders are now substituted in both their bare (`this.`, `rel.`) and bracket-quoted (`[this].`, `[rel].`) forms.
+
+Previously only the bare form was replaced, so a bracket-quoted placeholder was left referencing a non-existent alias in the generated JOIN `ON` clause.

--- a/cspell.json
+++ b/cspell.json
@@ -1,6 +1,7 @@
 {
   "words": [
     "ANDALSO",
+    "anymatches",
     "appender",
     "appenders",
     "appicon",
@@ -9,10 +10,12 @@
     "baytown",
     "betools",
     "concatenator",
+    "classid",
     "ecschema",
     "cospace",
     "ctes",
     "ecdb",
+    "ecexpressions",
     "ecsql",
     "ecsqloptions",
     "favorited",
@@ -47,6 +50,7 @@
     "nenurodyta",
     "overscan",
     "oxfmtrc",
+    "orelse",
     "parentless",
     "parentship",
     "popout",

--- a/packages/content/api/presentation-content.api.md
+++ b/packages/content/api/presentation-content.api.md
@@ -40,6 +40,7 @@ export interface CalculatedField extends BaseField {
 
 // @public
 interface CalculatedFieldDeclaration {
+    bindings?: Record<string, ECSqlBinding>;
     categoryId?: string;
     expression: string;
     id: string;

--- a/packages/content/src/content/extensions/ecexpressions/ECExpressionToECSql.ts
+++ b/packages/content/src/content/extensions/ecexpressions/ECExpressionToECSql.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter } from "./Emitter.js";
+import { parse } from "./Parser.js";
+
+import type { Id64String } from "@itwin/core-bentley";
+import type { EC, ECSqlBinding, IInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
+import type { SymbolValues } from "./Emitter.js";
+
+/**
+ * Properties for `convertECExpressionToECSql`.
+ * @internal
+ */
+export interface ConvertECExpressionToECSqlProps {
+  /**
+   * The presentation ECExpression to convert.
+   */
+  expression: string;
+
+  /**
+   * Alias used for the primary (`this`) instance in the produced ECSQL. Defaults to `"this"`.
+   */
+  primaryClassAlias?: string;
+
+  /**
+   * Full name of the primary (`this`) class. When provided, instance label select clauses generated for
+   * the primary instance can be more efficient.
+   */
+  primaryClassName?: EC.FullClassName;
+
+  /**
+   * Factory used to generate instance label select clauses for `GetDisplayLabel` and related-instance label functions.
+   * Required only when the expression uses those functions.
+   */
+  labelSelectClauseFactory?: IInstanceLabelSelectClauseFactory;
+
+  /**
+   * Hooks for resolving context-dependent symbols used by some ECExpression functions.
+   */
+  context?: {
+    /** Returns the currently selected instance ids, used by `SelectedInstanceKeys`. */
+    getSelectedInstanceIds?: () => Id64String[];
+    /**
+     * Resolves a symbol root (e.g. `ParentNode`) to a nested map of its member values. Leaf members are
+     * `string` or `number`; nested objects represent further member access (e.g. `{ ECInstanceId: "0x10" }`
+     * for `ParentNode.ECInstanceId`). Returning `undefined` leaves the root unresolved, so the access is
+     * emitted as a regular property reference.
+     */
+    resolveRoot?: (root: string) => SymbolValues | undefined;
+  };
+}
+
+/**
+ * Result of `convertECExpressionToECSql`.
+ * @internal
+ */
+export interface ConvertECExpressionToECSqlResult {
+  /** The generated ECSQL fragment. */
+  ecsql: string;
+  /** Bindings generated for literal and resolved values, keyed by binding name. Omitted when empty. */
+  bindings?: Record<string, ECSqlBinding>;
+}
+
+/**
+ * Converts a presentation ECExpression into an equivalent standard ECSQL fragment together with any generated bindings.
+ *
+ * Throws an `Error` for constructs that have no portable ECSQL equivalent (e.g. presentation-runtime-only
+ * functions, DateTime literals, array indexing, unsupported operators).
+ * @internal
+ */
+export async function convertECExpressionToECSql(
+  props: ConvertECExpressionToECSqlProps,
+): Promise<ConvertECExpressionToECSqlResult> {
+  const { expression, ...emitterProps } = props;
+  const ast = parse(expression);
+  return Emitter.convert(ast, emitterProps);
+}

--- a/packages/content/src/content/extensions/ecexpressions/Emitter.ts
+++ b/packages/content/src/content/extensions/ecexpressions/Emitter.ts
@@ -1,0 +1,510 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ECSql, normalizeFullClassName } from "@itwin/presentation-shared";
+import { ECSQL_PREFIX } from "../../InternalUtils.js";
+
+import type { Id64String } from "@itwin/core-bentley";
+import type { EC, ECSqlBinding, IInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
+import type {
+  AnyMatchesNode,
+  BinaryNode,
+  CallNode,
+  LambdaNode,
+  LiteralNode,
+  Node,
+  PropertyNode,
+  UnaryNode,
+} from "./Parser.js";
+
+/**
+ * A nested map of resolved symbol member values. Leaf members are `string` or `number`; nested objects
+ * represent further member access (e.g. `{ Parent: { ECInstanceId: "0x1" } }` for `ParentNode.Parent.ECInstanceId`).
+ * @internal
+ */
+export interface SymbolValues {
+  [member: string]: string | number | SymbolValues;
+}
+
+/**
+ * Options controlling how an ECExpression AST is emitted to ECSQL.
+ * @internal
+ */
+export interface EmitterOptions {
+  primaryClassAlias?: string;
+  primaryClassName?: EC.FullClassName;
+  labelSelectClauseFactory?: IInstanceLabelSelectClauseFactory;
+  context?: { getSelectedInstanceIds?: () => Id64String[]; resolveRoot?: (root: string) => SymbolValues | undefined };
+}
+
+const IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** The ECExpression root symbol referring to the primary/current instance. */
+const PRIMARY_INSTANCE_ROOT = "this";
+
+const BUILTIN_FUNCTIONS = toLowerCaseValues({
+  isOfClass: "IsOfClass",
+  getDisplayLabel: "GetDisplayLabel",
+  getECClassId: "GetECClassId",
+  iif: "IIf",
+  isNull: "IsNull",
+  ifNull: "IfNull",
+  hasRelatedInstance: "HasRelatedInstance",
+  getRelatedInstancesCount: "GetRelatedInstancesCount",
+  getRelatedValue: "GetRelatedValue",
+  getRelatedDisplayLabel: "GetRelatedDisplayLabel",
+  set: "Set",
+});
+
+const RELATED_FUNCTIONS = new Set([
+  BUILTIN_FUNCTIONS.hasRelatedInstance,
+  BUILTIN_FUNCTIONS.getRelatedInstancesCount,
+  BUILTIN_FUNCTIONS.getRelatedValue,
+  BUILTIN_FUNCTIONS.getRelatedDisplayLabel,
+]);
+
+const BUILTIN_UNSUPPORTED_FUNCTIONS = new Set(
+  [
+    "GetVariableStringValue",
+    "GetVariableBoolValue",
+    "GetVariableIntValue",
+    "GetVariableIntValues",
+    "HasVariable",
+    "GetLabelDisplayValue",
+    "GetFormattedValue",
+    "CompareDateTimes",
+    "GetSettingValue",
+    "GetSettingIntValue",
+    "GetSettingIntValues",
+    "GetSettingBoolValue",
+    "GetSettingStringValue",
+    "HasSetting",
+  ].map((name) => name.toLowerCase()),
+);
+
+/**
+ * Walks an ECExpression AST and produces an ECSQL fragment plus any generated bindings.
+ * @internal
+ */
+export class Emitter {
+  readonly #primaryClassAlias: string;
+  readonly #primaryClassName?: EC.FullClassName;
+  readonly #labelFactory?: IInstanceLabelSelectClauseFactory;
+  readonly #getSelectedInstanceIds?: () => Id64String[];
+  readonly #resolveRoot?: (root: string) => SymbolValues | undefined;
+
+  readonly #bindings: Record<string, ECSqlBinding> = {};
+  readonly #paramSubstitutions = new Map<string, string>();
+  #bindingIndex = 0;
+
+  private constructor(options: EmitterOptions) {
+    this.#primaryClassAlias = options.primaryClassAlias ?? PRIMARY_INSTANCE_ROOT;
+    this.#primaryClassName = options.primaryClassName;
+    this.#labelFactory = options.labelSelectClauseFactory;
+    this.#getSelectedInstanceIds = options.context?.getSelectedInstanceIds;
+    this.#resolveRoot = options.context?.resolveRoot;
+  }
+
+  /**
+   * Emits the ECSQL fragment for the given AST node together with any bindings generated while doing so.
+   * Bindings are omitted from the result when none were generated.
+   */
+  public static async convert(
+    node: Node,
+    options: EmitterOptions = {},
+  ): Promise<{ ecsql: string; bindings?: Record<string, ECSqlBinding> }> {
+    const emitter = new Emitter(options);
+    const ecsql = await emitter.#emit(node);
+    return Object.keys(emitter.#bindings).length > 0 ? { ecsql, bindings: emitter.#bindings } : { ecsql };
+  }
+
+  async #emit(node: Node): Promise<string> {
+    switch (node.kind) {
+      case "literal":
+        return this.#emitLiteral(node);
+      case "paren":
+        return `(${await this.#emit(node.expr)})`;
+      case "property":
+        return this.#emitProperty(node);
+      case "unary":
+        return this.#emitUnary(node);
+      case "binary":
+        return this.#emitBinary(node);
+      case "call":
+        return this.#emitCall(node);
+      case "anyMatches":
+        return this.#emitAnyMatches(node);
+      /* v8 ignore next 2 -- defensive: lambdas only appear inside call argument lists, never as standalone nodes */
+      case "lambda":
+        throw new Error("Unexpected lambda expression outside of a supported context.");
+    }
+  }
+
+  #addBinding(binding: ECSqlBinding): string {
+    const name = `${ECSQL_PREFIX}expr${this.#bindingIndex++}`;
+    this.#bindings[name] = binding;
+    return `:${name}`;
+  }
+
+  #emitLiteral(node: LiteralNode): string {
+    switch (node.type) {
+      case "bool":
+        return node.value ? "TRUE" : "FALSE";
+      case "null":
+        return "NULL";
+      case "int":
+      case "double":
+        return node.value;
+      case "string":
+        return this.#addBinding({ type: "string", value: node.value });
+    }
+  }
+
+  #emitProperty(node: PropertyNode): string {
+    const substitution = this.#paramSubstitutions.get(node.root);
+    if (substitution !== undefined) {
+      return substitution;
+    }
+    const symbols = this.#resolveRoot?.(node.root);
+    if (symbols) {
+      let current: string | number | SymbolValues = symbols;
+      for (const segment of node.path) {
+        if (typeof current !== "object" || !(segment in current)) {
+          throw new Error(`Unable to resolve symbol '${node.root}.${node.path.join(".")}'.`);
+        }
+        current = current[segment];
+      }
+      if (typeof current === "object") {
+        throw new Error(`Unable to resolve symbol '${node.root}.${node.path.join(".")}'.`);
+      }
+      return this.#bindResolvedValue(current);
+    }
+    return this.#mapProperty(node.root, node.path);
+  }
+
+  #mapProperty(root: string, path: string[]): string {
+    return [root === PRIMARY_INSTANCE_ROOT ? this.#primaryClassAlias : root, ...path]
+      .map((segment) => bracket(segment))
+      .join(".");
+  }
+
+  #bindResolvedValue(value: string | number): string {
+    if (typeof value === "number") {
+      return this.#addBinding({ type: Number.isInteger(value) ? "int" : "double", value });
+    }
+    return this.#addBinding({ type: "string", value });
+  }
+
+  async #emitUnary(node: UnaryNode): Promise<string> {
+    const operand = await this.#emit(node.operand);
+    return node.op === "-" ? `-${operand}` : `NOT ${operand}`;
+  }
+
+  async #emitBinary(node: BinaryNode): Promise<string> {
+    if (node.op === "=" || node.op === "<>") {
+      if (isNullLiteral(node.right)) {
+        const operand = await this.#emit(node.left);
+        return `${operand} ${node.op === "=" ? "IS NULL" : "IS NOT NULL"}`;
+      }
+      if (isNullLiteral(node.left)) {
+        const operand = await this.#emit(node.right);
+        return `${operand} ${node.op === "=" ? "IS NULL" : "IS NOT NULL"}`;
+      }
+    }
+
+    const left = await this.#emit(node.left);
+    const right = await this.#emit(node.right);
+    switch (node.op) {
+      case "and":
+        return `${left} AND ${right}`;
+      case "or":
+        return `${left} OR ${right}`;
+      case "mod":
+        return `${left} % ${right}`;
+      case "&":
+        return `${left} || ${right}`;
+      case "\\":
+        return `CAST(${left} / ${right} AS INTEGER)`;
+      case "~":
+        return `CAST(${left} AS TEXT) LIKE ${right} ESCAPE '\\'`;
+      default:
+        return `${left} ${node.op} ${right}`;
+    }
+  }
+
+  async #emitCall(node: CallNode): Promise<string> {
+    const lower = node.name.toLowerCase();
+
+    if (RELATED_FUNCTIONS.has(lower)) {
+      return this.#emitRelated(node);
+    }
+    if (lower === BUILTIN_FUNCTIONS.isOfClass) {
+      return this.#emitIsOfClass(node);
+    }
+    if (lower === BUILTIN_FUNCTIONS.getDisplayLabel) {
+      return this.#emitGetDisplayLabel(node);
+    }
+    if (lower === BUILTIN_FUNCTIONS.getECClassId) {
+      return `ec_classid(${await this.#emitArgs(node.args)})`;
+    }
+    if (lower === BUILTIN_FUNCTIONS.iif) {
+      return `IIF(${await this.#emitArgs(node.args)})`;
+    }
+    if (lower === BUILTIN_FUNCTIONS.isNull) {
+      if (node.args.length !== 1) {
+        throw new Error("`IsNull` expects a single argument.");
+      }
+      return `(${await this.#emit(node.args[0])}) IS NULL`;
+    }
+    if (lower === BUILTIN_FUNCTIONS.ifNull) {
+      return `IFNULL(${await this.#emitArgs(node.args)})`;
+    }
+
+    if (this.#isUnsupportedFunction(lower)) {
+      throw new Error(`Function '${node.name}' is not supported.`);
+    }
+
+    if (node.receiver) {
+      throw new Error(`Unsupported method '${node.name}'.`);
+    }
+    /* v8 ignore next 3 -- defensive: call names always originate from identifier tokens */
+    if (!IDENTIFIER_PATTERN.test(node.name)) {
+      throw new Error(`Invalid function name '${node.name}'.`);
+    }
+    return `${node.name}(${await this.#emitArgs(node.args)})`;
+  }
+
+  #isUnsupportedFunction(lowerName: string): boolean {
+    return BUILTIN_UNSUPPORTED_FUNCTIONS.has(lowerName);
+  }
+
+  async #emitArgs(args: Node[]): Promise<string> {
+    const parts: string[] = [];
+    for (const arg of args) {
+      if (arg.kind === "lambda") {
+        throw new Error("Unexpected lambda argument.");
+      }
+      parts.push(await this.#emit(arg));
+    }
+    return parts.join(", ");
+  }
+
+  async #emitRelated(node: CallNode): Promise<string> {
+    if (!node.receiver) {
+      throw new Error(`'${node.name}' must be called on an instance (e.g. \`this.${node.name}(...)\`).`);
+    }
+    const lower = node.name.toLowerCase();
+    const lambda = node.args.find((arg): arg is LambdaNode => arg.kind === "lambda");
+
+    if (lambda) {
+      const strings = node.args.filter((arg) => arg.kind !== "lambda");
+      const lambdaClass = normalizeFullClassName(asStringLiteral(strings[0]));
+      const alias = lambda.param;
+      const where = await this.#emit(lambda.body);
+      const lambdaFrom = `FROM ${ECSql.createClassSelector(lambdaClass)} ${bracket(alias)} WHERE ${where}`;
+      switch (lower) {
+        case BUILTIN_FUNCTIONS.hasRelatedInstance:
+          return `EXISTS (SELECT 1 ${lambdaFrom})`;
+        case BUILTIN_FUNCTIONS.getRelatedInstancesCount:
+          return `(SELECT COUNT(1) ${lambdaFrom})`;
+        case BUILTIN_FUNCTIONS.getRelatedValue:
+          return `(SELECT ${bracketPath(alias, asStringLiteral(strings[1]))} ${lambdaFrom} LIMIT 1)`;
+        case BUILTIN_FUNCTIONS.getRelatedDisplayLabel:
+          return `(SELECT ${await this.#labelClause(alias, lambdaClass)} ${lambdaFrom} LIMIT 1)`;
+      }
+    }
+
+    const relationship = normalizeFullClassName(asStringLiteral(node.args[0]));
+    const direction = asStringLiteral(node.args[1]);
+    const relatedClass = normalizeFullClassName(asStringLiteral(node.args[2]));
+    const forward = validateDirection(direction);
+    const receiver = this.#mapProperty(node.receiver.root, node.receiver.path);
+    const relatedEnd = forward ? "Target" : "Source";
+    const receiverEnd = forward ? "Source" : "Target";
+    const from = `
+      FROM ${ECSql.createClassSelector(relationship)} ${bracket("relationship")}
+      JOIN ${ECSql.createClassSelector(relatedClass)} ${bracket("related")}
+        ON [related].[ECClassId] = [relationship].[${relatedEnd}ECClassId] AND [related].[ECInstanceId] = [relationship].[${relatedEnd}ECInstanceId]
+      WHERE [relationship].[${receiverEnd}ECClassId] = ${receiver}.[ECClassId] AND [relationship].[${receiverEnd}ECInstanceId] = ${receiver}.[ECInstanceId]
+    `;
+
+    switch (lower) {
+      case BUILTIN_FUNCTIONS.hasRelatedInstance:
+        return `EXISTS (SELECT 1 ${from})`;
+      case BUILTIN_FUNCTIONS.getRelatedInstancesCount:
+        return `(SELECT COUNT(1) ${from})`;
+      case BUILTIN_FUNCTIONS.getRelatedValue:
+        return `(SELECT ${bracketPath("related", asStringLiteral(node.args[3]))} ${from} LIMIT 1)`;
+      case BUILTIN_FUNCTIONS.getRelatedDisplayLabel:
+        return `(SELECT ${await this.#labelClause("related", relatedClass)} ${from} LIMIT 1)`;
+      /* v8 ignore next 2 -- defensive: lower is always one of RELATED_FUNCTIONS */
+      default:
+        throw new Error(`Unsupported related-instance function '${node.name}'.`);
+    }
+  }
+
+  #emitIsOfClass(node: CallNode): string {
+    if (!node.receiver) {
+      throw new Error("`IsOfClass` must be called on an instance (e.g. `this.IsOfClass(...)`).");
+    }
+    if (node.args.length === 2 && isStringLiteral(node.args[0]) && isStringLiteral(node.args[1])) {
+      const className = validatedIdentifier(node.args[0].value);
+      const schemaName = validatedIdentifier(node.args[1].value);
+      const receiver = this.#mapProperty(node.receiver.root, node.receiver.path);
+      return `${receiver}.[ECClassId] IS (${schemaName}.${className})`;
+    }
+    throw new Error("`IsOfClass` id overload is not supported.");
+  }
+
+  async #emitGetDisplayLabel(node: CallNode): Promise<string> {
+    if (!node.receiver) {
+      throw new Error("`GetDisplayLabel` must be called on an instance (e.g. `this.GetDisplayLabel()`).");
+    }
+    const root = node.receiver.root;
+    const alias = root === PRIMARY_INSTANCE_ROOT ? this.#primaryClassAlias : root;
+    const className = root === PRIMARY_INSTANCE_ROOT ? this.#primaryClassName : undefined;
+    return this.#labelClause(alias, className);
+  }
+
+  async #labelClause(classAlias: string, className?: EC.FullClassName): Promise<string> {
+    if (!this.#labelFactory) {
+      throw new Error("Generating an instance label requires a `labelSelectClauseFactory` option.");
+    }
+    return this.#labelFactory.createSelectClause({
+      classAlias,
+      className,
+      selectorsConcatenator: ECSql.createConcatenatedValueStringSelector,
+    });
+  }
+
+  async #emitAnyMatches(node: AnyMatchesNode): Promise<string> {
+    const items = this.#resolveListItems(node.source);
+    if (items.length === 0) {
+      return "FALSE";
+    }
+
+    const equality = detectEquality(node.condition, node.param);
+    if (equality) {
+      const expr = await this.#emit(equality.otherSide);
+      const names = items.map((binding) => this.#addBinding(binding));
+      return `${expr} IN (${names.join(", ")})`;
+    }
+
+    const parts: string[] = [];
+    for (const binding of items) {
+      const name = this.#addBinding(binding);
+      this.#paramSubstitutions.set(node.param, name);
+      try {
+        parts.push(await this.#emit(node.condition));
+      } finally {
+        this.#paramSubstitutions.delete(node.param);
+      }
+    }
+    return `(${parts.join(" OR ")})`;
+  }
+
+  #resolveListItems(source: Node): ECSqlBinding[] {
+    if (source.kind === "call") {
+      const lower = source.name.toLowerCase();
+      if (lower === BUILTIN_FUNCTIONS.set) {
+        return source.args.map((arg) => {
+          if (arg.kind !== "literal") {
+            throw new Error("`Set(...)` items must be literal values.");
+          }
+          return literalToBinding(arg);
+        });
+      }
+      if (this.#isUnsupportedFunction(lower)) {
+        throw new Error(`Function '${source.name}' is not supported.`);
+      }
+    }
+    if (source.kind === "property" && source.root === "SelectedInstanceKeys" && source.path.length === 0) {
+      if (!this.#getSelectedInstanceIds) {
+        throw new Error("`SelectedInstanceKeys` requires a `getSelectedInstanceIds` context hook.");
+      }
+      return this.#getSelectedInstanceIds().map((value) => ({ type: "id", value }));
+    }
+    throw new Error("Unsupported `AnyMatches` list source.");
+  }
+}
+
+function bracket(identifier: string): string {
+  return `[${validatedIdentifier(identifier)}]`;
+}
+
+function bracketPath(alias: string, dottedProperty: string): string {
+  return [alias, ...dottedProperty.split(".")].map((segment) => bracket(segment)).join(".");
+}
+
+function validatedIdentifier(identifier: string): string {
+  if (!IDENTIFIER_PATTERN.test(identifier)) {
+    throw new Error(`Invalid identifier '${identifier}'.`);
+  }
+  return identifier;
+}
+
+function validateDirection(direction: string): boolean {
+  const lower = direction.toLowerCase();
+  if (lower === "forward") {
+    return true;
+  }
+  if (lower === "backward") {
+    return false;
+  }
+  throw new Error(`Invalid relationship direction '${direction}'; expected 'Forward' or 'Backward'.`);
+}
+
+function isStringLiteral(node: Node): node is Extract<LiteralNode, { type: "string" }> {
+  return node.kind === "literal" && node.type === "string";
+}
+
+function asStringLiteral(node: Node | undefined): string {
+  if (!node || !isStringLiteral(node)) {
+    throw new Error("Expected a string literal argument.");
+  }
+  return node.value;
+}
+
+function isNullLiteral(node: Node): boolean {
+  return node.kind === "literal" && node.type === "null";
+}
+
+function literalToBinding(node: LiteralNode): ECSqlBinding {
+  switch (node.type) {
+    case "string":
+      return { type: "string", value: node.value };
+    case "int":
+      return { type: "int", value: Number(node.value) };
+    case "double":
+      return { type: "double", value: Number(node.value) };
+    case "bool":
+      return { type: "boolean", value: node.value };
+    case "null":
+      return { type: "string", value: undefined };
+  }
+}
+
+function detectEquality(condition: Node, param: string): { otherSide: Node } | undefined {
+  if (condition.kind !== "binary" || condition.op !== "=") {
+    return undefined;
+  }
+  const leftIsParam = isParamReference(condition.left, param);
+  const rightIsParam = isParamReference(condition.right, param);
+  if (leftIsParam === rightIsParam) {
+    return undefined;
+  }
+  return { otherSide: leftIsParam ? condition.right : condition.left };
+}
+
+function isParamReference(node: Node, param: string): boolean {
+  return node.kind === "property" && node.root === param;
+}
+
+function toLowerCaseValues<T extends Record<string, string>>(names: T): Record<keyof T, string> {
+  return Object.fromEntries(Object.entries(names).map(([key, name]) => [key, name.toLowerCase()])) as Record<
+    keyof T,
+    string
+  >;
+}

--- a/packages/content/src/content/extensions/ecexpressions/Emitter.ts
+++ b/packages/content/src/content/extensions/ecexpressions/Emitter.ts
@@ -392,6 +392,14 @@ export class Emitter {
       return `${expr} IN (${names.join(", ")})`;
     }
 
+    // When the condition does not reference the lambda parameter, its truth value is the same for
+    // every item. Since an empty list is already handled above, the result for a non-empty list is
+    // simply the condition evaluated once (repeating it per item would be redundant and would emit
+    // bindings for the — unused — list values).
+    if (!referencesParam(node.condition, node.param)) {
+      return `(${await this.#emit(node.condition)})`;
+    }
+
     const parts: string[] = [];
     for (const binding of items) {
       const name = this.#addBinding(binding);
@@ -500,6 +508,24 @@ function detectEquality(condition: Node, param: string): { otherSide: Node } | u
 
 function isParamReference(node: Node, param: string): boolean {
   return node.kind === "property" && node.root === param;
+}
+
+/**
+ * Whether the given AST subtree references the lambda `param` (as the root of any property access).
+ * Traverses the node generically so every nested position (operands, arguments, sub-conditions) is covered.
+ */
+function referencesParam(node: unknown, param: string): boolean {
+  if (Array.isArray(node)) {
+    return node.some((child) => referencesParam(child, param));
+  }
+  if (node !== null && typeof node === "object") {
+    const record = node as Record<string, unknown>;
+    if (record.kind === "property" && record.root === param) {
+      return true;
+    }
+    return Object.values(record).some((value) => referencesParam(value, param));
+  }
+  return false;
 }
 
 function toLowerCaseValues<T extends Record<string, string>>(names: T): Record<keyof T, string> {

--- a/packages/content/src/content/extensions/ecexpressions/Parser.ts
+++ b/packages/content/src/content/extensions/ecexpressions/Parser.ts
@@ -1,0 +1,351 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { tokenize } from "./Tokenizer.js";
+
+import type { Token } from "./Tokenizer.js";
+
+/**
+ * A literal value node.
+ * @internal
+ */
+export type LiteralNode =
+  | { kind: "literal"; type: "int"; value: string }
+  | { kind: "literal"; type: "double"; value: string }
+  | { kind: "literal"; type: "string"; value: string }
+  | { kind: "literal"; type: "bool"; value: boolean }
+  | { kind: "literal"; type: "null" };
+
+/**
+ * A property/member access chain (e.g. `this.Code.Value`, `parent.ECInstanceId`, `Label`).
+ * @internal
+ */
+export interface PropertyNode {
+  kind: "property";
+  root: string;
+  path: string[];
+}
+
+/**
+ * An explicitly parenthesized sub-expression; preserved so emission keeps the author's grouping.
+ * @internal
+ */
+export interface ParenNode {
+  kind: "paren";
+  expr: Node;
+}
+
+/**
+ * A unary prefix operation (`-` negation or `Not`).
+ * @internal
+ */
+export interface UnaryNode {
+  kind: "unary";
+  op: "-" | "not";
+  operand: Node;
+}
+
+/**
+ * A binary operation. `op` is the normalized ECExpression operator (`and`, `or`, `mod`, or the raw symbol).
+ * @internal
+ */
+export interface BinaryNode {
+  kind: "binary";
+  op: string;
+  left: Node;
+  right: Node;
+}
+
+/**
+ * A function or method call. `receiver` is set for method-style calls (e.g. `this.IsOfClass(...)`).
+ * The emitter classifies the call by `name`.
+ * @internal
+ */
+export interface CallNode {
+  kind: "call";
+  receiver?: PropertyNode;
+  name: string;
+  args: Node[];
+}
+
+/**
+ * A lambda argument (`param => body`), only valid inside `AnyMatches` and related-instance overloads.
+ * @internal
+ */
+export interface LambdaNode {
+  kind: "lambda";
+  param: string;
+  body: Node;
+}
+
+/**
+ * A `<listSource>.AnyMatches(param => condition)` postfix application.
+ * @internal
+ */
+export interface AnyMatchesNode {
+  kind: "anyMatches";
+  source: Node;
+  param: string;
+  condition: Node;
+}
+
+/**
+ * Union of all ECExpression AST node shapes.
+ * @internal
+ */
+export type Node =
+  | LiteralNode
+  | PropertyNode
+  | ParenNode
+  | UnaryNode
+  | BinaryNode
+  | CallNode
+  | LambdaNode
+  | AnyMatchesNode;
+
+interface BinaryOp {
+  canonical: string;
+  precedence: number;
+}
+
+const NOT_OPERAND_PRECEDENCE = 4;
+
+class Parser {
+  readonly #tokens: Token[];
+  #pos = 0;
+
+  constructor(tokens: Token[]) {
+    this.#tokens = tokens;
+  }
+
+  public parse(): Node {
+    if (this.#peek().type === "eof") {
+      throw new Error("Expression is empty.");
+    }
+    const node = this.#parseBinary(0);
+    if (this.#peek().type !== "eof") {
+      const token = this.#peek();
+      throw new Error(`Unexpected token '${token.value}' at position ${token.position}.`);
+    }
+    return node;
+  }
+
+  #peek(offset = 0): Token {
+    return this.#tokens[Math.min(this.#pos + offset, this.#tokens.length - 1)];
+  }
+
+  #next(): Token {
+    return this.#tokens[this.#pos++];
+  }
+
+  #isOperator(value: string, offset = 0): boolean {
+    const token = this.#peek(offset);
+    return token.type === "operator" && token.value === value;
+  }
+
+  #isKeyword(value: string, offset = 0): boolean {
+    const token = this.#peek(offset);
+    return token.type === "identifier" && token.value.toLowerCase() === value.toLowerCase();
+  }
+
+  #expectOperator(value: string): void {
+    if (!this.#isOperator(value)) {
+      const token = this.#peek();
+      throw new Error(`Expected '${value}' but found '${token.value}' at position ${token.position}.`);
+    }
+    this.#next();
+  }
+
+  #expectIdentifier(): string {
+    const token = this.#peek();
+    if (token.type !== "identifier") {
+      throw new Error(`Expected an identifier but found '${token.value}' at position ${token.position}.`);
+    }
+    this.#next();
+    return token.value;
+  }
+
+  #peekBinaryOp(): BinaryOp | undefined {
+    const token = this.#peek();
+    if (token.type === "operator") {
+      switch (token.value) {
+        case "^":
+        case ">>>":
+          throw new Error(`Operator '${token.value}' is not supported.`);
+        case "=":
+        case "<>":
+        case "<":
+        case "<=":
+        case ">":
+        case ">=":
+        case "~":
+          return { canonical: token.value, precedence: 4 };
+        case "&":
+        case "<<":
+        case ">>":
+          return { canonical: token.value, precedence: 5 };
+        case "+":
+        case "-":
+          return { canonical: token.value, precedence: 6 };
+        case "*":
+        case "/":
+        case "\\":
+          return { canonical: token.value, precedence: 7 };
+        default:
+          return undefined;
+      }
+    }
+    if (token.type === "identifier") {
+      switch (token.value.toLowerCase()) {
+        case "and":
+        case "andalso":
+          return { canonical: "and", precedence: 2 };
+        case "or":
+        case "orelse":
+          return { canonical: "or", precedence: 1 };
+        case "mod":
+          return { canonical: "mod", precedence: 7 };
+        case "xor":
+          throw new Error("Operator 'Xor' is not supported.");
+        default:
+          return undefined;
+      }
+    }
+    return undefined;
+  }
+
+  #parseBinary(minPrecedence: number): Node {
+    let left = this.#parseUnary();
+    for (;;) {
+      const op = this.#peekBinaryOp();
+      if (!op || op.precedence < minPrecedence) {
+        break;
+      }
+      this.#next();
+      const right = this.#parseBinary(op.precedence + 1);
+      left = { kind: "binary", op: op.canonical, left, right };
+    }
+    return left;
+  }
+
+  #parseUnary(): Node {
+    if (this.#isOperator("-")) {
+      this.#next();
+      return { kind: "unary", op: "-", operand: this.#parseUnary() };
+    }
+    if (this.#isKeyword("not")) {
+      this.#next();
+      return { kind: "unary", op: "not", operand: this.#parseBinary(NOT_OPERAND_PRECEDENCE) };
+    }
+    return this.#parsePrimary();
+  }
+
+  #parsePrimary(): Node {
+    const token = this.#peek();
+
+    if (token.type === "number") {
+      this.#next();
+      return { kind: "literal", type: token.numberKind === "double" ? "double" : "int", value: token.value };
+    }
+    if (token.type === "string") {
+      this.#next();
+      return { kind: "literal", type: "string", value: token.value };
+    }
+    if (this.#isOperator("(")) {
+      this.#next();
+      const expr = this.#parseBinary(0);
+      this.#expectOperator(")");
+      return { kind: "paren", expr };
+    }
+    if (token.type === "identifier") {
+      const lower = token.value.toLowerCase();
+      if (lower === "true" || lower === "false") {
+        this.#next();
+        return { kind: "literal", type: "bool", value: lower === "true" };
+      }
+      if (lower === "null") {
+        this.#next();
+        return { kind: "literal", type: "null" };
+      }
+      return this.#parseIdentifierExpression();
+    }
+
+    throw new Error(`Unexpected token '${token.value}' at position ${token.position}.`);
+  }
+
+  #parseIdentifierExpression(): Node {
+    const name = this.#expectIdentifier();
+    let node: Node;
+    if (this.#isOperator("(")) {
+      node = { kind: "call", name, args: this.#parseArgumentList() };
+    } else {
+      node = { kind: "property", root: name, path: [] };
+    }
+    return this.#parsePostfix(node);
+  }
+
+  #parsePostfix(node: Node): Node {
+    while (this.#isOperator(".")) {
+      this.#next();
+      const segment = this.#expectIdentifier();
+      if (this.#isOperator("(")) {
+        const args = this.#parseArgumentList();
+        if (segment.toLowerCase() === "anymatches") {
+          if (args.length !== 1 || args[0].kind !== "lambda") {
+            throw new Error("`AnyMatches` expects a single lambda argument.");
+          }
+          node = { kind: "anyMatches", source: node, param: args[0].param, condition: args[0].body };
+        } else {
+          if (node.kind !== "property") {
+            throw new Error(`Cannot call method '${segment}' on this expression.`);
+          }
+          node = { kind: "call", receiver: node, name: segment, args };
+        }
+      } else {
+        if (node.kind !== "property") {
+          throw new Error(`Cannot access member '${segment}' on this expression.`);
+        }
+        node = { kind: "property", root: node.root, path: [...node.path, segment] };
+      }
+    }
+    return node;
+  }
+
+  #parseArgumentList(): Node[] {
+    this.#expectOperator("(");
+    const args: Node[] = [];
+    if (this.#isOperator(")")) {
+      this.#next();
+      return args;
+    }
+    for (;;) {
+      args.push(this.#parseArgument());
+      if (this.#isOperator(",")) {
+        this.#next();
+        continue;
+      }
+      break;
+    }
+    this.#expectOperator(")");
+    return args;
+  }
+
+  #parseArgument(): Node {
+    if (this.#peek().type === "identifier" && this.#isOperator("=>", 1)) {
+      const param = this.#expectIdentifier();
+      this.#expectOperator("=>");
+      return { kind: "lambda", param, body: this.#parseBinary(0) };
+    }
+    return this.#parseBinary(0);
+  }
+}
+
+/**
+ * Parses an ECExpression string into an AST.
+ * @internal
+ */
+export function parse(expression: string): Node {
+  return new Parser(tokenize(expression)).parse();
+}

--- a/packages/content/src/content/extensions/ecexpressions/Tokenizer.ts
+++ b/packages/content/src/content/extensions/ecexpressions/Tokenizer.ts
@@ -1,0 +1,170 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Kind of a lexical token produced by `tokenize`.
+ * @internal
+ */
+export type TokenType = "number" | "string" | "identifier" | "operator" | "eof";
+
+/**
+ * A lexical token of an ECExpression.
+ * @internal
+ */
+export interface Token {
+  type: TokenType;
+  /**
+   * For `string` tokens this is the decoded value (with `""` un-escaped to `"`); for `number` tokens it is the
+   * emission-ready numeric literal; otherwise it is the raw source text.
+   */
+  value: string;
+  /** For `number` tokens, whether the literal is an integer or a floating-point number. */
+  numberKind?: "int" | "double";
+  /** Zero-based offset of the token in the source string. */
+  position: number;
+}
+
+const IDENT_START = /[A-Za-z_]/;
+const IDENT_PART = /[A-Za-z0-9_]/;
+
+function isDigit(char: string): boolean {
+  return char >= "0" && char <= "9";
+}
+
+/**
+ * Splits an ECExpression string into a flat list of lexical tokens, terminated by an `eof` token.
+ * Throws a descriptive `Error` for unterminated strings, unsupported literals, and stray characters.
+ * @internal
+ */
+export function tokenize(expression: string): Token[] {
+  const tokens: Token[] = [];
+  const length = expression.length;
+  let i = 0;
+
+  while (i < length) {
+    const char = expression[i];
+
+    // whitespace
+    if (char === " " || char === "\t" || char === "\n" || char === "\r") {
+      ++i;
+      continue;
+    }
+
+    const start = i;
+
+    // string literal (double-quoted, `""` escapes a quote)
+    if (char === '"') {
+      ++i;
+      let value = "";
+      let closed = false;
+      while (i < length) {
+        if (expression[i] === '"') {
+          if (expression[i + 1] === '"') {
+            value += '"';
+            i += 2;
+            continue;
+          }
+          ++i;
+          closed = true;
+          break;
+        }
+        value += expression[i++];
+      }
+      if (!closed) {
+        throw new Error(`Unterminated string literal at position ${start}.`);
+      }
+      tokens.push({ type: "string", value, position: start });
+      continue;
+    }
+
+    // DateTime literal `@<ticks>` is intentionally unsupported
+    if (char === "@") {
+      throw new Error("DateTime literals (`@<ticks>`) are not supported.");
+    }
+
+    // array indexing is intentionally unsupported
+    if (char === "[") {
+      throw new Error("Array indexing (`[...]`) is not supported.");
+    }
+
+    // number literal (int, hex, double)
+    if (isDigit(char) || (char === "." && isDigit(expression[i + 1]))) {
+      if (char === "0" && (expression[i + 1] === "x" || expression[i + 1] === "X")) {
+        let k = i + 2;
+        while (k < length && /[0-9A-Fa-f]/.test(expression[k])) {
+          ++k;
+        }
+        tokens.push({ type: "number", value: expression.slice(i, k), numberKind: "int", position: start });
+        i = k;
+        continue;
+      }
+      let j = i;
+      let isDouble = false;
+      while (j < length && isDigit(expression[j])) {
+        ++j;
+      }
+      if (expression[j] === ".") {
+        isDouble = true;
+        ++j;
+        while (j < length && isDigit(expression[j])) {
+          ++j;
+        }
+      }
+      if (expression[j] === "e" || expression[j] === "E") {
+        isDouble = true;
+        ++j;
+        if (expression[j] === "+" || expression[j] === "-") {
+          ++j;
+        }
+        while (j < length && isDigit(expression[j])) {
+          ++j;
+        }
+      }
+      tokens.push({
+        type: "number",
+        value: expression.slice(i, j),
+        numberKind: isDouble ? "double" : "int",
+        position: start,
+      });
+      i = j;
+      continue;
+    }
+
+    // identifier / keyword
+    if (IDENT_START.test(char)) {
+      let j = i + 1;
+      while (j < length && IDENT_PART.test(expression[j])) {
+        ++j;
+      }
+      tokens.push({ type: "identifier", value: expression.slice(i, j), position: start });
+      i = j;
+      continue;
+    }
+
+    // operators (longest match first)
+    const three = expression.slice(i, i + 3);
+    if (three === ">>>") {
+      tokens.push({ type: "operator", value: three, position: start });
+      i += 3;
+      continue;
+    }
+    const two = expression.slice(i, i + 2);
+    if (two === "<=" || two === ">=" || two === "<>" || two === "=>" || two === "<<" || two === ">>") {
+      tokens.push({ type: "operator", value: two, position: start });
+      i += 2;
+      continue;
+    }
+    if ("=<>+-*/\\&~(),.:^".includes(char)) {
+      tokens.push({ type: "operator", value: char, position: start });
+      ++i;
+      continue;
+    }
+
+    throw new Error(`Unexpected character '${char}' at position ${start}.`);
+  }
+
+  tokens.push({ type: "eof", value: "", position: length });
+  return tokens;
+}

--- a/packages/content/src/content/extensions/fields-providers/ContentModifierRuleFieldsProviderFactory.ts
+++ b/packages/content/src/content/extensions/fields-providers/ContentModifierRuleFieldsProviderFactory.ts
@@ -5,6 +5,7 @@
 
 import { getClass } from "@itwin/presentation-shared";
 import { CategoryDefinition } from "../../model/Category.js";
+import { convertECExpressionToECSql } from "../ecexpressions/ECExpressionToECSql.js";
 
 import type {
   EC,
@@ -80,7 +81,7 @@ export function createFieldsProviderFromContentModifierRule(
 
       let calculatedFields: CalculatedFieldDeclaration[] | undefined;
       if (rule.calculatedProperties && rule.calculatedProperties.length > 0) {
-        calculatedFields = mapCalculatedProperties(rule.calculatedProperties);
+        calculatedFields = await mapCalculatedProperties(rule.calculatedProperties);
       }
 
       if (rule.propertyCategories && rule.propertyCategories.length > 0) {
@@ -167,15 +168,6 @@ async function matchesClass(
 }
 
 // ── Relationship path mapping ────────────────────────────────────────
-
-/**
- * Stub: returns the expression unchanged.
- */
-function convertECExpressionToECSql(expression: string): string {
-  // TODO: Implement proper ECExpression → ECSQL conversion
-  // https://github.com/iTwin/presentation/issues/1420
-  return expression;
-}
 
 /** Returns the display label of a class. */
 async function getClassLabel(imodelAccess: ECSchemaProvider, className: EC.FullClassName): Promise<string> {
@@ -370,13 +362,18 @@ async function mapRelatedPropertiesSpec(props: {
       targetClassName = constraintClass.fullName;
     }
 
+    let instanceFilter: RelationshipPath[number]["instanceFilter"];
+    if (isLastStep && spec.instanceFilter) {
+      const { ecsql, bindings } = await convertECExpressionToECSql({ expression: spec.instanceFilter });
+      instanceFilter = { expression: ecsql, ...(bindings ? { bindings } : undefined) };
+    }
+
     path.push({
       sourceClassName: currentSourceClassName,
       targetClassName,
       relationshipName: `${step.relationship.schemaName}.${step.relationship.className}`,
       relationshipReverse: step.direction === "Backward",
-      instanceFilter:
-        isLastStep && spec.instanceFilter ? { expression: convertECExpressionToECSql(spec.instanceFilter) } : undefined,
+      instanceFilter,
     });
 
     currentSourceClassName = targetClassName;
@@ -597,16 +594,22 @@ const CALC_TYPE_MAP: Record<
  * Maps an array of `CalculatedPropertiesSpecification` into `CalculatedFieldDeclaration[]`.
  * Generates a stable `id` for each field based on its index.
  */
-function mapCalculatedProperties(
+async function mapCalculatedProperties(
   specs: PresentationRules.CalculatedPropertiesSpecification[],
-): CalculatedFieldDeclaration[] {
-  return specs.map((spec, i) => ({
-    id: `calc_${i}`,
-    label: spec.label,
-    expression: convertECExpressionToECSql(spec.value),
-    type: { kind: "primitive", type: CALC_TYPE_MAP[spec.type ?? "string"] } satisfies ValueDescriptor,
-    categoryId: resolveCategoryId(spec.categoryId),
-  }));
+): Promise<CalculatedFieldDeclaration[]> {
+  return Promise.all(
+    specs.map(async (spec, i) => {
+      const { ecsql, bindings } = await convertECExpressionToECSql({ expression: spec.value });
+      return {
+        id: `calc_${i}`,
+        label: spec.label,
+        expression: ecsql,
+        ...(bindings ? { bindings } : undefined),
+        type: { kind: "primitive", type: CALC_TYPE_MAP[spec.type ?? "string"] } satisfies ValueDescriptor,
+        categoryId: resolveCategoryId(spec.categoryId),
+      };
+    }),
+  );
 }
 
 // ── Category mapping ─────────────────────────────────────────────────

--- a/packages/content/src/content/extensions/fields-providers/IModelFieldsProvider.ts
+++ b/packages/content/src/content/extensions/fields-providers/IModelFieldsProvider.ts
@@ -110,8 +110,9 @@ interface CalculatedFieldDeclaration {
    * ECSQL expression that computes this field's value.
    *
    * Use `targetAlias` (defaults to `"this"`) followed by a dot to reference properties
-   * of the content target class. At query generation time, the pipeline performs a literal
-   * replacement of all `{targetAlias}.` occurrences with the actual query alias.
+   * of the content target class. At query generation time, the pipeline replaces all
+   * `{targetAlias}.` occurrences (in both their bare `{targetAlias}.` and bracket-quoted
+   * `[{targetAlias}].` forms) with the actual query alias.
    *
    * @example
    * ```
@@ -121,8 +122,9 @@ interface CalculatedFieldDeclaration {
   expression: string;
   /**
    * The placeholder used in `expression` to reference the content target class.
-   * Every occurrence of `{targetAlias}.` in the expression will be replaced with the
-   * actual query alias at query generation time.
+   * Every occurrence of `{targetAlias}.` in the expression, whether bare (`{targetAlias}.`)
+   * or bracket-quoted (`[{targetAlias}].`), will be replaced with the actual query alias at
+   * query generation time.
    *
    * @default "this"
    */

--- a/packages/content/src/content/extensions/fields-providers/IModelFieldsProvider.ts
+++ b/packages/content/src/content/extensions/fields-providers/IModelFieldsProvider.ts
@@ -5,6 +5,7 @@
 
 import type {
   ECSchemaProvider,
+  ECSqlBinding,
   ECSqlQueryExecutor,
   RelationshipPath,
   ValueDescriptor,
@@ -126,6 +127,8 @@ interface CalculatedFieldDeclaration {
    * @default "this"
    */
   targetAlias?: string;
+  /** Bind values for `expression`, keyed by parameter name. */
+  bindings?: Record<string, ECSqlBinding>;
   /** The value type of the computed result. */
   type: ValueDescriptor;
   /** Category to assign this field to (references a `CategoryDefinition.id`). */

--- a/packages/content/src/test/extensions/ecexpressions/ECExpressionToECSql.test.ts
+++ b/packages/content/src/test/extensions/ecexpressions/ECExpressionToECSql.test.ts
@@ -1,0 +1,754 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+/* eslint-disable @typescript-eslint/naming-convention */
+import { describe, expect, it } from "vitest";
+import { trimWhitespace } from "@itwin/presentation-shared";
+import { convertECExpressionToECSql } from "../../../content/extensions/ecexpressions/ECExpressionToECSql.js";
+
+import type { IInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
+
+const labelSelectClauseFactory: IInstanceLabelSelectClauseFactory = {
+  async createSelectClause(props) {
+    return `LABEL(${props.classAlias}${props.className ? `, ${props.className}` : ""})`;
+  },
+};
+
+describe("convertECExpressionToECSql", () => {
+  describe("literals", () => {
+    it("emits integer literals inline", async () => {
+      expect(await convertECExpressionToECSql({ expression: "42" })).to.deep.equal({ ecsql: "42" });
+    });
+
+    it("emits double literals inline", async () => {
+      expect(await convertECExpressionToECSql({ expression: "1.5" })).to.deep.equal({ ecsql: "1.5" });
+    });
+
+    it("emits a number starting with a decimal point", async () => {
+      expect(await convertECExpressionToECSql({ expression: ".5" })).to.deep.equal({ ecsql: ".5" });
+    });
+
+    it("emits numbers in exponent notation", async () => {
+      expect(await convertECExpressionToECSql({ expression: "1e2" })).to.deep.equal({ ecsql: "1e2" });
+      expect(await convertECExpressionToECSql({ expression: "2.5E-3" })).to.deep.equal({ ecsql: "2.5E-3" });
+    });
+
+    it("emits hexadecimal literals unchanged", async () => {
+      expect(await convertECExpressionToECSql({ expression: "0xFF" })).to.deep.equal({ ecsql: "0xFF" });
+    });
+
+    it("emits boolean literals case-insensitively", async () => {
+      expect(await convertECExpressionToECSql({ expression: "True" })).to.deep.equal({ ecsql: "TRUE" });
+      expect(await convertECExpressionToECSql({ expression: "TRUE" })).to.deep.equal({ ecsql: "TRUE" });
+      expect(await convertECExpressionToECSql({ expression: "false" })).to.deep.equal({ ecsql: "FALSE" });
+    });
+
+    it("emits the NULL literal case-insensitively", async () => {
+      expect(await convertECExpressionToECSql({ expression: "Null" })).to.deep.equal({ ecsql: "NULL" });
+      expect(await convertECExpressionToECSql({ expression: "NULL" })).to.deep.equal({ ecsql: "NULL" });
+      expect(await convertECExpressionToECSql({ expression: "null" })).to.deep.equal({ ecsql: "NULL" });
+    });
+
+    it("binds string literals", async () => {
+      expect(await convertECExpressionToECSql({ expression: `"abc"` })).to.deep.equal({
+        ecsql: ":pres_expr0",
+        bindings: { pres_expr0: { type: "string", value: "abc" } },
+      });
+    });
+
+    it("decodes escaped quotes in string literals", async () => {
+      expect(await convertECExpressionToECSql({ expression: `"a""b"` })).to.deep.equal({
+        ecsql: ":pres_expr0",
+        bindings: { pres_expr0: { type: "string", value: `a"b` } },
+      });
+    });
+  });
+
+  describe("bindings", () => {
+    it("produces string bindings", async () => {
+      expect(
+        await convertECExpressionToECSql({ expression: `Set("a", "b").AnyMatches(x => x = this.V)` }),
+      ).to.deep.equal({
+        ecsql: "[this].[V] IN (:pres_expr0, :pres_expr1)",
+        bindings: { pres_expr0: { type: "string", value: "a" }, pres_expr1: { type: "string", value: "b" } },
+      });
+    });
+
+    it("produces integer bindings", async () => {
+      expect(await convertECExpressionToECSql({ expression: "Set(1, 2).AnyMatches(x => x = this.V)" })).to.deep.equal({
+        ecsql: "[this].[V] IN (:pres_expr0, :pres_expr1)",
+        bindings: { pres_expr0: { type: "int", value: 1 }, pres_expr1: { type: "int", value: 2 } },
+      });
+    });
+
+    it("produces double bindings", async () => {
+      expect(await convertECExpressionToECSql({ expression: "Set(1.5).AnyMatches(x => x = this.V)" })).to.deep.equal({
+        ecsql: "[this].[V] IN (:pres_expr0)",
+        bindings: { pres_expr0: { type: "double", value: 1.5 } },
+      });
+    });
+
+    it("produces boolean bindings", async () => {
+      expect(
+        await convertECExpressionToECSql({ expression: "Set(True, False).AnyMatches(x => x = this.V)" }),
+      ).to.deep.equal({
+        ecsql: "[this].[V] IN (:pres_expr0, :pres_expr1)",
+        bindings: { pres_expr0: { type: "boolean", value: true }, pres_expr1: { type: "boolean", value: false } },
+      });
+    });
+
+    it("produces null bindings", async () => {
+      expect(await convertECExpressionToECSql({ expression: "Set(Null).AnyMatches(x => x = this.V)" })).to.deep.equal({
+        ecsql: "[this].[V] IN (:pres_expr0)",
+        bindings: { pres_expr0: { type: "string", value: undefined } },
+      });
+    });
+
+    it("produces id bindings", async () => {
+      expect(
+        await convertECExpressionToECSql({
+          expression: "SelectedInstanceKeys.AnyMatches(x => x = this.ECInstanceId)",
+          context: { getSelectedInstanceIds: () => ["0x1", "0x2"] },
+        }),
+      ).to.deep.equal({
+        ecsql: "[this].[ECInstanceId] IN (:pres_expr0, :pres_expr1)",
+        bindings: { pres_expr0: { type: "id", value: "0x1" }, pres_expr1: { type: "id", value: "0x2" } },
+      });
+    });
+  });
+
+  describe("properties", () => {
+    it("brackets property access with default alias", async () => {
+      expect(await convertECExpressionToECSql({ expression: "this.PropertyName" })).to.deep.equal({
+        ecsql: "[this].[PropertyName]",
+      });
+    });
+
+    it("substitutes the primary class alias", async () => {
+      expect(await convertECExpressionToECSql({ expression: "this.Prop", primaryClassAlias: "x" })).to.deep.equal({
+        ecsql: "[x].[Prop]",
+      });
+    });
+
+    it("brackets nested property access", async () => {
+      expect(await convertECExpressionToECSql({ expression: "this.Code.Value" })).to.deep.equal({
+        ecsql: "[this].[Code].[Value]",
+      });
+    });
+  });
+
+  describe("operators", () => {
+    it("emits arithmetic with precedence", async () => {
+      expect(await convertECExpressionToECSql({ expression: "1 + 2 * 3" })).to.deep.equal({ ecsql: "1 + 2 * 3" });
+    });
+
+    it("emits a lower-precedence operator trailing a higher-precedence one", async () => {
+      expect(await convertECExpressionToECSql({ expression: "this.A * this.B + this.C" })).to.deep.equal({
+        ecsql: "[this].[A] * [this].[B] + [this].[C]",
+      });
+    });
+
+    it("emits division", async () => {
+      expect(await convertECExpressionToECSql({ expression: "10 / 2" })).to.deep.equal({ ecsql: "10 / 2" });
+    });
+
+    it("preserves explicit parentheses", async () => {
+      expect(await convertECExpressionToECSql({ expression: "(1 + 2) * 3" })).to.deep.equal({ ecsql: "(1 + 2) * 3" });
+    });
+
+    it("emits comparison operators", async () => {
+      expect(await convertECExpressionToECSql({ expression: "this.A < 5" })).to.deep.equal({ ecsql: "[this].[A] < 5" });
+      expect(await convertECExpressionToECSql({ expression: "this.A <= 5" })).to.deep.equal({
+        ecsql: "[this].[A] <= 5",
+      });
+      expect(await convertECExpressionToECSql({ expression: "this.A > 5" })).to.deep.equal({ ecsql: "[this].[A] > 5" });
+      expect(await convertECExpressionToECSql({ expression: "this.A >= 5" })).to.deep.equal({
+        ecsql: "[this].[A] >= 5",
+      });
+      expect(await convertECExpressionToECSql({ expression: "this.A <> 5" })).to.deep.equal({
+        ecsql: "[this].[A] <> 5",
+      });
+    });
+
+    it("emits logical operators", async () => {
+      expect(await convertECExpressionToECSql({ expression: "this.A And this.B Or this.C" })).to.deep.equal({
+        ecsql: "[this].[A] AND [this].[B] OR [this].[C]",
+      });
+    });
+
+    it("maps AndAlso and OrElse to AND and OR", async () => {
+      expect(await convertECExpressionToECSql({ expression: "this.A AndAlso this.B" })).to.deep.equal({
+        ecsql: "[this].[A] AND [this].[B]",
+      });
+      expect(await convertECExpressionToECSql({ expression: "this.A OrElse this.B" })).to.deep.equal({
+        ecsql: "[this].[A] OR [this].[B]",
+      });
+    });
+
+    it("maps Mod to %", async () => {
+      expect(await convertECExpressionToECSql({ expression: "5 Mod 2" })).to.deep.equal({ ecsql: "5 % 2" });
+    });
+
+    it("maps integer division to CAST", async () => {
+      expect(await convertECExpressionToECSql({ expression: "7 \\ 2" })).to.deep.equal({
+        ecsql: "CAST(7 / 2 AS INTEGER)",
+      });
+    });
+
+    it("maps concatenation to ||", async () => {
+      expect(await convertECExpressionToECSql({ expression: `"a" & "b"` })).to.deep.equal({
+        ecsql: ":pres_expr0 || :pres_expr1",
+        bindings: { pres_expr0: { type: "string", value: "a" }, pres_expr1: { type: "string", value: "b" } },
+      });
+    });
+
+    it("maps ~ to a LIKE comparison", async () => {
+      expect(await convertECExpressionToECSql({ expression: `this.Name ~ "A%"` })).to.deep.equal({
+        ecsql: `CAST([this].[Name] AS TEXT) LIKE :pres_expr0 ESCAPE '\\'`,
+        bindings: { pres_expr0: { type: "string", value: "A%" } },
+      });
+    });
+
+    it("emits bit-shift operators", async () => {
+      expect(await convertECExpressionToECSql({ expression: "this.A << 2" })).to.deep.equal({
+        ecsql: "[this].[A] << 2",
+      });
+      expect(await convertECExpressionToECSql({ expression: "this.A >> 2" })).to.deep.equal({
+        ecsql: "[this].[A] >> 2",
+      });
+    });
+
+    it("emits null comparisons using IS", async () => {
+      expect(await convertECExpressionToECSql({ expression: "this.Prop = Null" })).to.deep.equal({
+        ecsql: "[this].[Prop] IS NULL",
+      });
+      expect(await convertECExpressionToECSql({ expression: "this.Prop <> Null" })).to.deep.equal({
+        ecsql: "[this].[Prop] IS NOT NULL",
+      });
+      expect(await convertECExpressionToECSql({ expression: "Null = this.Prop" })).to.deep.equal({
+        ecsql: "[this].[Prop] IS NULL",
+      });
+      expect(await convertECExpressionToECSql({ expression: "Null <> this.Prop" })).to.deep.equal({
+        ecsql: "[this].[Prop] IS NOT NULL",
+      });
+    });
+
+    it("emits unary negation and NOT", async () => {
+      expect(await convertECExpressionToECSql({ expression: "-5" })).to.deep.equal({ ecsql: "-5" });
+      expect(await convertECExpressionToECSql({ expression: "Not this.Flag" })).to.deep.equal({
+        ecsql: "NOT [this].[Flag]",
+      });
+    });
+  });
+
+  describe("mapped functions", () => {
+    it("maps IIf", async () => {
+      expect(await convertECExpressionToECSql({ expression: "IIf(this.A, 1, 2)" })).to.deep.equal({
+        ecsql: "IIF([this].[A], 1, 2)",
+      });
+    });
+
+    it("maps IsNull", async () => {
+      expect(await convertECExpressionToECSql({ expression: "IsNull(this.A)" })).to.deep.equal({
+        ecsql: "([this].[A]) IS NULL",
+      });
+    });
+
+    it("maps IfNull", async () => {
+      expect(await convertECExpressionToECSql({ expression: "IfNull(this.A, 0)" })).to.deep.equal({
+        ecsql: "IFNULL([this].[A], 0)",
+      });
+    });
+
+    it("maps GetECClassId to ec_classid", async () => {
+      expect(await convertECExpressionToECSql({ expression: `GetECClassId("MyClass", "MySchema")` })).to.deep.equal({
+        ecsql: "ec_classid(:pres_expr0, :pres_expr1)",
+        bindings: {
+          pres_expr0: { type: "string", value: "MyClass" },
+          pres_expr1: { type: "string", value: "MySchema" },
+        },
+      });
+    });
+
+    it("maps IsOfClass to an IS check", async () => {
+      expect(await convertECExpressionToECSql({ expression: `this.IsOfClass("MyClass", "MySchema")` })).to.deep.equal({
+        ecsql: "[this].[ECClassId] IS (MySchema.MyClass)",
+      });
+    });
+
+    it("passes unknown functions through", async () => {
+      expect(await convertECExpressionToECSql({ expression: "Upper(this.Name)" })).to.deep.equal({
+        ecsql: "Upper([this].[Name])",
+      });
+    });
+
+    it("passes a function without arguments through", async () => {
+      expect(await convertECExpressionToECSql({ expression: "Now()" })).to.deep.equal({ ecsql: "Now()" });
+    });
+  });
+
+  describe("labels", () => {
+    it("emits a label select clause for the method form", async () => {
+      expect(
+        await convertECExpressionToECSql({ expression: "this.GetDisplayLabel()", labelSelectClauseFactory }),
+      ).to.deep.equal({ ecsql: "LABEL(this)" });
+    });
+
+    it("uses the primary class name when available", async () => {
+      expect(
+        await convertECExpressionToECSql({
+          expression: "this.GetDisplayLabel()",
+          primaryClassAlias: "x",
+          primaryClassName: "Schema.Class",
+          labelSelectClauseFactory,
+        }),
+      ).to.deep.equal({ ecsql: "LABEL(x, Schema.Class)" });
+    });
+
+    it("emits a label select clause for a non-primary receiver", async () => {
+      expect(
+        await convertECExpressionToECSql({ expression: "rel.GetDisplayLabel()", labelSelectClauseFactory }),
+      ).to.deep.equal({ ecsql: "LABEL(rel)" });
+    });
+
+    it("throws when no label factory is provided", async () => {
+      await expect(convertECExpressionToECSql({ expression: "this.GetDisplayLabel()" })).rejects.toThrow(
+        /labelSelectClauseFactory/,
+      );
+    });
+
+    it("throws when GetDisplayLabel is called as a free function", async () => {
+      await expect(
+        convertECExpressionToECSql({ expression: "GetDisplayLabel(this)", labelSelectClauseFactory }),
+      ).rejects.toThrow(/must be called on an instance/);
+    });
+  });
+
+  describe("related instances", () => {
+    it("emits EXISTS for the HasRelatedInstance string form (backward)", async () => {
+      const result = await convertECExpressionToECSql({
+        expression: `this.HasRelatedInstance("BisCore:ModelContainsElements", "Backward", "BisCore:Model")`,
+      });
+      expect(result.bindings).to.be.undefined;
+      expect(trimWhitespace(result.ecsql)).to.equal(
+        trimWhitespace(`
+          EXISTS (
+            SELECT 1
+            FROM [BisCore].[ModelContainsElements] [relationship]
+            JOIN [BisCore].[Model] [related]
+              ON [related].[ECClassId] = [relationship].[SourceECClassId] AND [related].[ECInstanceId] = [relationship].[SourceECInstanceId]
+            WHERE [relationship].[TargetECClassId] = [this].[ECClassId] AND [relationship].[TargetECInstanceId] = [this].[ECInstanceId]
+          )
+        `),
+      );
+    });
+
+    it("emits COUNT for the GetRelatedInstancesCount string form (forward)", async () => {
+      const result = await convertECExpressionToECSql({
+        expression: `this.GetRelatedInstancesCount("BisCore:ModelContainsElements", "Forward", "BisCore:Element")`,
+      });
+      expect(trimWhitespace(result.ecsql)).to.equal(
+        trimWhitespace(`
+          (
+            SELECT COUNT(1)
+            FROM [BisCore].[ModelContainsElements] [relationship]
+            JOIN [BisCore].[Element] [related]
+              ON [related].[ECClassId] = [relationship].[TargetECClassId] AND [related].[ECInstanceId] = [relationship].[TargetECInstanceId]
+            WHERE [relationship].[SourceECClassId] = [this].[ECClassId] AND [relationship].[SourceECInstanceId] = [this].[ECInstanceId]
+          )
+        `),
+      );
+    });
+
+    it("emits a scalar subquery for the GetRelatedValue string form", async () => {
+      const result = await convertECExpressionToECSql({
+        expression: `this.GetRelatedValue("BisCore:ModelContainsElements", "Forward", "BisCore:Element", "UserLabel")`,
+      });
+      expect(trimWhitespace(result.ecsql)).to.equal(
+        trimWhitespace(`
+          (
+            SELECT [related].[UserLabel]
+            FROM [BisCore].[ModelContainsElements] [relationship]
+            JOIN [BisCore].[Element] [related]
+              ON [related].[ECClassId] = [relationship].[TargetECClassId] AND [related].[ECInstanceId] = [relationship].[TargetECInstanceId]
+            WHERE [relationship].[SourceECClassId] = [this].[ECClassId] AND [relationship].[SourceECInstanceId] = [this].[ECInstanceId]
+            LIMIT 1
+          )
+        `),
+      );
+    });
+
+    it("emits a label subquery for the GetRelatedDisplayLabel string form", async () => {
+      const result = await convertECExpressionToECSql({
+        expression: `this.GetRelatedDisplayLabel("BisCore:ModelContainsElements", "Forward", "BisCore:Element")`,
+        labelSelectClauseFactory,
+      });
+      expect(trimWhitespace(result.ecsql)).to.equal(
+        trimWhitespace(`
+          (
+            SELECT LABEL(related, BisCore.Element)
+            FROM [BisCore].[ModelContainsElements] [relationship]
+            JOIN [BisCore].[Element] [related]
+              ON [related].[ECClassId] = [relationship].[TargetECClassId] AND [related].[ECInstanceId] = [relationship].[TargetECInstanceId]
+            WHERE [relationship].[SourceECClassId] = [this].[ECClassId] AND [relationship].[SourceECInstanceId] = [this].[ECInstanceId]
+            LIMIT 1
+          )
+        `),
+      );
+    });
+
+    it("emits EXISTS for the HasRelatedInstance lambda form", async () => {
+      const result = await convertECExpressionToECSql({
+        expression: `this.HasRelatedInstance("BisCore:Element", e => e.UserLabel = "test")`,
+      });
+      expect(trimWhitespace(result.ecsql)).to.equal(
+        trimWhitespace(`
+          EXISTS (
+            SELECT 1
+            FROM [BisCore].[Element] [e]
+            WHERE [e].[UserLabel] = :pres_expr0
+          )
+        `),
+      );
+      expect(result.bindings).to.deep.equal({ pres_expr0: { type: "string", value: "test" } });
+    });
+
+    it("emits COUNT for the GetRelatedInstancesCount lambda form", async () => {
+      const result = await convertECExpressionToECSql({
+        expression: `this.GetRelatedInstancesCount("BisCore:Element", e => e.Name = "x")`,
+      });
+      expect(trimWhitespace(result.ecsql)).to.equal(
+        trimWhitespace(`
+          (
+            SELECT COUNT(1)
+            FROM [BisCore].[Element] [e]
+            WHERE [e].[Name] = :pres_expr0
+          )
+        `),
+      );
+      expect(result.bindings).to.deep.equal({ pres_expr0: { type: "string", value: "x" } });
+    });
+
+    it("emits a scalar subquery for the GetRelatedValue lambda form", async () => {
+      const result = await convertECExpressionToECSql({
+        expression: `this.GetRelatedValue("BisCore:Element", "UserLabel", e => e.Name = "x")`,
+      });
+      expect(trimWhitespace(result.ecsql)).to.equal(
+        trimWhitespace(`
+          (
+            SELECT [e].[UserLabel]
+            FROM [BisCore].[Element] [e]
+            WHERE [e].[Name] = :pres_expr0
+            LIMIT 1
+          )
+        `),
+      );
+      expect(result.bindings).to.deep.equal({ pres_expr0: { type: "string", value: "x" } });
+    });
+
+    it("emits a label subquery for the GetRelatedDisplayLabel lambda form", async () => {
+      const result = await convertECExpressionToECSql({
+        expression: `this.GetRelatedDisplayLabel("BisCore:Element", e => e.Name = "x")`,
+        labelSelectClauseFactory,
+      });
+      expect(trimWhitespace(result.ecsql)).to.equal(
+        trimWhitespace(`
+          (
+            SELECT LABEL(e, BisCore.Element)
+            FROM [BisCore].[Element] [e]
+            WHERE [e].[Name] = :pres_expr0
+            LIMIT 1
+          )
+        `),
+      );
+      expect(result.bindings).to.deep.equal({ pres_expr0: { type: "string", value: "x" } });
+    });
+  });
+
+  describe("AnyMatches", () => {
+    it("emits IN for equality against a Set", async () => {
+      expect(
+        await convertECExpressionToECSql({ expression: "Set(1, 2, 3).AnyMatches(x => x = this.Value)" }),
+      ).to.deep.equal({
+        ecsql: "[this].[Value] IN (:pres_expr0, :pres_expr1, :pres_expr2)",
+        bindings: {
+          pres_expr0: { type: "int", value: 1 },
+          pres_expr1: { type: "int", value: 2 },
+          pres_expr2: { type: "int", value: 3 },
+        },
+      });
+    });
+
+    it("handles the lambda parameter on the right of an equality", async () => {
+      expect(await convertECExpressionToECSql({ expression: `Set("a").AnyMatches(x => this.V = x)` })).to.deep.equal({
+        ecsql: "[this].[V] IN (:pres_expr0)",
+        bindings: { pres_expr0: { type: "string", value: "a" } },
+      });
+    });
+
+    it("emits IN for SelectedInstanceKeys", async () => {
+      const result = await convertECExpressionToECSql({
+        expression: "SelectedInstanceKeys.AnyMatches(x => x = this.ECInstanceId)",
+        context: { getSelectedInstanceIds: () => ["0x1", "0x2"] },
+      });
+      expect(result).to.deep.equal({
+        ecsql: "[this].[ECInstanceId] IN (:pres_expr0, :pres_expr1)",
+        bindings: { pres_expr0: { type: "id", value: "0x1" }, pres_expr1: { type: "id", value: "0x2" } },
+      });
+    });
+
+    it("emits FALSE for an empty selection", async () => {
+      expect(
+        await convertECExpressionToECSql({
+          expression: "SelectedInstanceKeys.AnyMatches(x => x = this.ECInstanceId)",
+          context: { getSelectedInstanceIds: () => [] },
+        }),
+      ).to.deep.equal({ ecsql: "FALSE" });
+    });
+
+    it("emits an OR chain for non-equality conditions", async () => {
+      expect(
+        await convertECExpressionToECSql({ expression: "Set(1, 2).AnyMatches(x => x > this.Value)" }),
+      ).to.deep.equal({
+        ecsql: "(:pres_expr0 > [this].[Value] OR :pres_expr1 > [this].[Value])",
+        bindings: { pres_expr0: { type: "int", value: 1 }, pres_expr1: { type: "int", value: 2 } },
+      });
+    });
+
+    it("emits an OR chain when neither side references the lambda parameter", async () => {
+      expect(await convertECExpressionToECSql({ expression: "Set(1).AnyMatches(x => this.A = this.B)" })).to.deep.equal(
+        { ecsql: "([this].[A] = [this].[B])", bindings: { pres_expr0: { type: "int", value: 1 } } },
+      );
+    });
+
+    it("throws when SelectedInstanceKeys has no hook", async () => {
+      await expect(
+        convertECExpressionToECSql({ expression: "SelectedInstanceKeys.AnyMatches(x => x = this.ECInstanceId)" }),
+      ).rejects.toThrow(/getSelectedInstanceIds/);
+    });
+
+    it("throws when a Set item is not a literal", async () => {
+      await expect(
+        convertECExpressionToECSql({ expression: "Set(this.X).AnyMatches(x => x = this.V)" }),
+      ).rejects.toThrow(/literal/);
+    });
+
+    it("throws for an unsupported function list source", async () => {
+      await expect(
+        convertECExpressionToECSql({ expression: `GetVariableIntValues("x").AnyMatches(x => x = this.V)` }),
+      ).rejects.toThrow(/not supported/);
+    });
+
+    it("throws for an unsupported list source", async () => {
+      await expect(convertECExpressionToECSql({ expression: "this.Rel.AnyMatches(x => x = this.V)" })).rejects.toThrow(
+        /list source/,
+      );
+      await expect(convertECExpressionToECSql({ expression: `Foo("x").AnyMatches(x => x = this.V)` })).rejects.toThrow(
+        /list source/,
+      );
+    });
+
+    it("throws when AnyMatches receives a non-lambda argument", async () => {
+      await expect(convertECExpressionToECSql({ expression: "x.AnyMatches(5)" })).rejects.toThrow(/AnyMatches/);
+    });
+  });
+
+  describe("context symbols", () => {
+    it("resolves context symbols from the nested member map", async () => {
+      const result = await convertECExpressionToECSql({
+        expression: "this.Id = ParentNode.ECInstanceId",
+        context: { resolveRoot: (root) => (root === "ParentNode" ? { ECInstanceId: "0x10" } : undefined) },
+      });
+      expect(result).to.deep.equal({
+        ecsql: "[this].[Id] = :pres_expr0",
+        bindings: { pres_expr0: { type: "string", value: "0x10" } },
+      });
+    });
+
+    it("walks nested member objects", async () => {
+      expect(
+        await convertECExpressionToECSql({
+          expression: "ParentNode.Parent.ECInstanceId",
+          context: { resolveRoot: () => ({ Parent: { ECInstanceId: "0x20" } }) },
+        }),
+      ).to.deep.equal({ ecsql: ":pres_expr0", bindings: { pres_expr0: { type: "string", value: "0x20" } } });
+    });
+
+    it("binds numeric resolved values by kind", async () => {
+      expect(
+        await convertECExpressionToECSql({
+          expression: "ParentNode.Level",
+          context: { resolveRoot: () => ({ Level: 42 }) },
+        }),
+      ).to.deep.equal({ ecsql: ":pres_expr0", bindings: { pres_expr0: { type: "int", value: 42 } } });
+      expect(
+        await convertECExpressionToECSql({
+          expression: "ParentNode.Ratio",
+          context: { resolveRoot: () => ({ Ratio: 1.5 }) },
+        }),
+      ).to.deep.equal({ ecsql: ":pres_expr0", bindings: { pres_expr0: { type: "double", value: 1.5 } } });
+    });
+
+    it("emits a property reference when the root is not resolved", async () => {
+      expect(await convertECExpressionToECSql({ expression: "ParentNode.ECInstanceId" })).to.deep.equal({
+        ecsql: "[ParentNode].[ECInstanceId]",
+      });
+      expect(
+        await convertECExpressionToECSql({
+          expression: "ParentNode.ECInstanceId",
+          context: { resolveRoot: () => undefined },
+        }),
+      ).to.deep.equal({ ecsql: "[ParentNode].[ECInstanceId]" });
+    });
+
+    it("throws when a resolved root is missing the accessed member", async () => {
+      await expect(
+        convertECExpressionToECSql({ expression: "ParentNode.Missing", context: { resolveRoot: () => ({}) } }),
+      ).rejects.toThrow(/Unable to resolve/);
+    });
+
+    it("throws when the path descends past a leaf value", async () => {
+      await expect(
+        convertECExpressionToECSql({
+          expression: "ParentNode.Level.Deeper",
+          context: { resolveRoot: () => ({ Level: 1 }) },
+        }),
+      ).rejects.toThrow(/Unable to resolve/);
+    });
+
+    it("throws when the path stops on an intermediate object", async () => {
+      await expect(
+        convertECExpressionToECSql({
+          expression: "ParentNode.Parent",
+          context: { resolveRoot: () => ({ Parent: { ECInstanceId: "0x20" } }) },
+        }),
+      ).rejects.toThrow(/Unable to resolve/);
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws for an empty expression", async () => {
+      await expect(convertECExpressionToECSql({ expression: "" })).rejects.toThrow(/empty/);
+    });
+
+    it("throws for DateTime literals", async () => {
+      await expect(convertECExpressionToECSql({ expression: "@123" })).rejects.toThrow(/DateTime/);
+    });
+
+    it("throws for array indexing", async () => {
+      await expect(convertECExpressionToECSql({ expression: "this.Arr[0]" })).rejects.toThrow(/Array indexing/);
+    });
+
+    it("throws for an unterminated string", async () => {
+      await expect(convertECExpressionToECSql({ expression: `"abc` })).rejects.toThrow(/Unterminated/);
+    });
+
+    it("throws for a stray character", async () => {
+      await expect(convertECExpressionToECSql({ expression: "this.A # 1" })).rejects.toThrow(/Unexpected character/);
+    });
+
+    it("throws for unsupported operators", async () => {
+      await expect(convertECExpressionToECSql({ expression: "2 ^ 3" })).rejects.toThrow(/not supported/);
+      await expect(convertECExpressionToECSql({ expression: "1 >>> 2" })).rejects.toThrow(/not supported/);
+      await expect(convertECExpressionToECSql({ expression: "this.A Xor this.B" })).rejects.toThrow(/Xor/);
+    });
+
+    it("throws for a trailing token", async () => {
+      await expect(convertECExpressionToECSql({ expression: "1 2" })).rejects.toThrow(/Unexpected token/);
+      await expect(convertECExpressionToECSql({ expression: "this.A this.B" })).rejects.toThrow(/Unexpected token/);
+    });
+
+    it("throws for a token that cannot start an expression", async () => {
+      await expect(convertECExpressionToECSql({ expression: "," })).rejects.toThrow(/Unexpected token/);
+    });
+
+    it("throws for a missing closing parenthesis", async () => {
+      await expect(convertECExpressionToECSql({ expression: "(1 + 2" })).rejects.toThrow(/Expected '\)'/);
+    });
+
+    it("throws for a dangling member access", async () => {
+      await expect(convertECExpressionToECSql({ expression: "this." })).rejects.toThrow(/Expected an identifier/);
+    });
+
+    it("throws when accessing a member on a call result", async () => {
+      await expect(convertECExpressionToECSql({ expression: "Foo().Bar" })).rejects.toThrow(/Cannot access member/);
+    });
+
+    it("throws when calling a method on a call result", async () => {
+      await expect(convertECExpressionToECSql({ expression: "Foo().Baz()" })).rejects.toThrow(/Cannot call method/);
+    });
+
+    it("throws for blacklisted functions", async () => {
+      await expect(convertECExpressionToECSql({ expression: `GetFormattedValue(this.Prop, "en")` })).rejects.toThrow(
+        /not supported/,
+      );
+      await expect(convertECExpressionToECSql({ expression: `GetVariableStringValue("x")` })).rejects.toThrow(
+        /not supported/,
+      );
+      await expect(convertECExpressionToECSql({ expression: `GetSettingValue("x")` })).rejects.toThrow(/not supported/);
+      await expect(convertECExpressionToECSql({ expression: `CompareDateTimes(this.A, this.B)` })).rejects.toThrow(
+        /not supported/,
+      );
+    });
+
+    it("throws for an unsupported method call", async () => {
+      await expect(convertECExpressionToECSql({ expression: "this.Foo()" })).rejects.toThrow(/Unsupported method/);
+    });
+
+    it("throws when a passthrough function receives a lambda argument", async () => {
+      await expect(convertECExpressionToECSql({ expression: "Upper(x => x)" })).rejects.toThrow(/lambda/);
+    });
+
+    it("throws when IsNull has the wrong number of arguments", async () => {
+      await expect(convertECExpressionToECSql({ expression: "IsNull(this.A, this.B)" })).rejects.toThrow(
+        /single argument/,
+      );
+    });
+
+    it("throws when IsOfClass is called without a receiver", async () => {
+      await expect(convertECExpressionToECSql({ expression: `IsOfClass("MyClass", "MySchema")` })).rejects.toThrow(
+        /must be called on an instance/,
+      );
+    });
+
+    it("throws for the IsOfClass id overload", async () => {
+      await expect(convertECExpressionToECSql({ expression: "this.IsOfClass(this.ClassId)" })).rejects.toThrow(
+        /id overload/,
+      );
+    });
+
+    it("throws when a related-instance function is called without a receiver", async () => {
+      await expect(
+        convertECExpressionToECSql({ expression: `HasRelatedInstance("A:B", "Forward", "C:D")` }),
+      ).rejects.toThrow(/must be called on an instance/);
+    });
+
+    it("throws for a non-string related-instance argument", async () => {
+      await expect(convertECExpressionToECSql({ expression: "this.HasRelatedInstance(123)" })).rejects.toThrow(
+        /string literal/,
+      );
+    });
+
+    it("throws for an invalid full class name", async () => {
+      await expect(
+        convertECExpressionToECSql({ expression: `this.HasRelatedInstance("NoColon", "Forward", "Bis:Model")` }),
+      ).rejects.toThrow(/Invalid full class name/);
+    });
+
+    it("throws for an invalid related property identifier", async () => {
+      await expect(
+        convertECExpressionToECSql({ expression: `this.GetRelatedValue("S:C", "Forward", "S2:C2", "Bad Name")` }),
+      ).rejects.toThrow(/Invalid identifier/);
+    });
+
+    it("throws for an invalid relationship direction", async () => {
+      await expect(
+        convertECExpressionToECSql({
+          expression: `this.HasRelatedInstance("BisCore:Rel", "Sideways", "BisCore:Model")`,
+        }),
+      ).rejects.toThrow(/direction/);
+    });
+  });
+});

--- a/packages/content/src/test/extensions/ecexpressions/ECExpressionToECSql.test.ts
+++ b/packages/content/src/test/extensions/ecexpressions/ECExpressionToECSql.test.ts
@@ -517,10 +517,10 @@ describe("convertECExpressionToECSql", () => {
       });
     });
 
-    it("emits an OR chain when neither side references the lambda parameter", async () => {
-      expect(await convertECExpressionToECSql({ expression: "Set(1).AnyMatches(x => this.A = this.B)" })).to.deep.equal(
-        { ecsql: "([this].[A] = [this].[B])", bindings: { pres_expr0: { type: "int", value: 1 } } },
-      );
+    it("emits the condition once when it does not reference the lambda parameter", async () => {
+      expect(
+        await convertECExpressionToECSql({ expression: "Set(1, 2).AnyMatches(x => this.A = this.B)" }),
+      ).to.deep.equal({ ecsql: "([this].[A] = [this].[B])" });
     });
 
     it("throws when SelectedInstanceKeys has no hook", async () => {

--- a/packages/content/src/test/extensions/fields-providers/ContentModifierRuleFieldsProviderFactory.test.ts
+++ b/packages/content/src/test/extensions/fields-providers/ContentModifierRuleFieldsProviderFactory.test.ts
@@ -372,14 +372,16 @@ describe("createFieldsProviderFromContentModifierRule", () => {
     it("maps calculated properties with default type (string)", async () => {
       const provider = createFieldsProviderFromContentModifierRule({
         imodelAccess: createIModelAccess(),
-        rule: { calculatedProperties: [{ label: "Full Name", value: "this.FirstName || ' ' || this.LastName" }] },
+        rule: { calculatedProperties: [{ label: "Full Name", value: 'this.FirstName & " " & this.LastName' }] },
       });
       const result = await provider.getContribution({ imodelAccess: {} as ECSchemaProvider, target: createTarget() });
       expect(result?.calculatedFields).toEqual([
         {
           id: "calc_0",
           label: "Full Name",
-          expression: "this.FirstName || ' ' || this.LastName",
+          expression: "[this].[FirstName] || :pres_expr0 || [this].[LastName]",
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          bindings: { pres_expr0: { type: "string", value: " " } },
           type: { kind: "primitive", type: "String" },
           categoryId: undefined,
         },
@@ -741,7 +743,38 @@ describe("createFieldsProviderFromContentModifierRule", () => {
       expect(path).toHaveLength(2);
       // The filter is applied only to the last step, not the intermediate one.
       expect(path[0].instanceFilter).toBeUndefined();
-      expect(path[1].instanceFilter).toEqual({ expression: "this.IsActive = true" });
+      expect(path[1].instanceFilter).toEqual({ expression: "[this].[IsActive] = TRUE" });
+    });
+
+    it("threads instance filter bindings through", async () => {
+      const imodelAccess = createIModelAccessWithRelationship({
+        relSchemaName: "TestSchema",
+        relClassName: "ElementOwnsChild",
+        targetSchemaName: "TestSchema",
+        targetClassName: "ChildElement",
+      });
+
+      const provider = createFieldsProviderFromContentModifierRule({
+        imodelAccess,
+        rule: {
+          relatedProperties: [
+            {
+              propertiesSource: {
+                relationship: { schemaName: "TestSchema", className: "ElementOwnsChild" },
+                direction: "Forward",
+              },
+              instanceFilter: 'this.Name = "abc"',
+              properties: "*",
+            },
+          ],
+        },
+      });
+      const result = await provider.getContribution({ imodelAccess: {} as ECSchemaProvider, target: createTarget() });
+      expect(result!.relatedProperties![0].path[0].instanceFilter).toEqual({
+        expression: "[this].[Name] = :pres_expr0",
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        bindings: { pres_expr0: { type: "string", value: "abc" } },
+      });
     });
 
     it("defaults properties when neither properties nor propertyNames is specified", async () => {

--- a/packages/shared/src/shared/Metadata.ts
+++ b/packages/shared/src/shared/Metadata.ts
@@ -460,8 +460,9 @@ export interface RelationshipPathStep {
      *
      * Use `targetAlias` (defaults to `"this"`) followed by a dot to reference properties
      * of the filtered class, and `relationshipAlias` (defaults to `"rel"`) to reference
-     * properties on the relationship class. At query generation time, the pipeline performs
-     * a literal replacement of all `{alias}.` occurrences with the actual query aliases.
+     * properties on the relationship class. At query generation time, the pipeline replaces
+     * all `{alias}.` occurrences (in both their bare `{alias}.` and bracket-quoted `[{alias}].`
+     * forms) with the actual query aliases.
      *
      * @example
      * ```
@@ -472,8 +473,9 @@ export interface RelationshipPathStep {
 
     /**
      * The placeholder used in `expression` to reference the target class (`targetClassName`).
-     * Every occurrence of `{targetAlias}.` in the expression will be replaced with the
-     * actual query alias at query generation time.
+     * Every occurrence of `{targetAlias}.` in the expression, whether bare (`{targetAlias}.`)
+     * or bracket-quoted (`[{targetAlias}].`), will be replaced with the actual query alias at
+     * query generation time.
      *
      * @default "this"
      */
@@ -481,8 +483,9 @@ export interface RelationshipPathStep {
 
     /**
      * The placeholder used in `expression` to reference the relationship class (`relationshipName`).
-     * Every occurrence of `{relationshipAlias}.` in the expression will be replaced with the
-     * actual relationship alias at query generation time.
+     * Every occurrence of `{relationshipAlias}.` in the expression, whether bare (`{relationshipAlias}.`)
+     * or bracket-quoted (`[{relationshipAlias}].`), will be replaced with the actual relationship alias
+     * at query generation time.
      *
      * Only meaningful for non-navigation-property (link table) relationships. When the step uses a
      * navigation property, the relationship table is not part of the query, so any reference via

--- a/packages/shared/src/shared/ecsql-snippets/ECSqlJoinSnippets.ts
+++ b/packages/shared/src/shared/ecsql-snippets/ECSqlJoinSnippets.ts
@@ -154,7 +154,9 @@ function resolveInstanceFilterCondition(step: ResolvedRelationshipPathStep): str
   }
   const { expression, targetAlias = "this", relationshipAlias = "rel" } = step.instanceFilter;
   const resolvedExpression = expression
+    .replaceAll(`[${targetAlias}].`, `[${step.targetAlias}].`)
     .replaceAll(`${targetAlias}.`, `[${step.targetAlias}].`)
+    .replaceAll(`[${relationshipAlias}].`, `[${step.relationshipAlias}].`)
     .replaceAll(`${relationshipAlias}.`, `[${step.relationshipAlias}].`);
   return ` AND (${resolvedExpression})`;
 }

--- a/packages/shared/src/test/ecsql-snippets/ECSqlJoinSnippets.test.ts
+++ b/packages/shared/src/test/ecsql-snippets/ECSqlJoinSnippets.test.ts
@@ -595,6 +595,31 @@ describe("createRelationshipPathJoinClause", () => {
       expect(result.bindings).toEqual({ minArea: { type: "double", value: 10.5 } });
     });
 
+    it("substitutes bracket-quoted alias placeholders", async () => {
+      const { sourceClass, targetClass, relationship } = setupLinkTableRelationshipClasses();
+      const result = await createRelationshipPathJoinClause({
+        schemaProvider,
+        path: [
+          {
+            sourceClassName: sourceClass.fullName,
+            sourceAlias: "s",
+            relationshipName: relationship.fullName,
+            relationshipAlias: "r",
+            targetClassName: targetClass.fullName,
+            targetAlias: "t",
+            instanceFilter: { expression: "[this].Name = :name AND [rel].Priority > 0" },
+          },
+        ],
+      });
+      expect(trimWhitespace(result.joins)).toBe(
+        trimWhitespace(`
+          INNER JOIN [${schemaName}].[${relationship.name}] [r] ON [r].[SourceECInstanceId] = [s].[ECInstanceId]
+          INNER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId] AND ([t].Name = :name AND [r].Priority > 0)
+        `),
+      );
+      expect(result.bindings).toBeUndefined();
+    });
+
     it("applies instanceFilter on each step of a multi-step path and merges bindings", async () => {
       const step1 = setupLinkTableRelationshipClasses({ source: "a", relationship: "r1", target: "b" });
       const step2 = setupLinkTableRelationshipClasses({ source: step1.targetClass, relationship: "r2", target: "c" });


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/1420.

Doesn't cover everything that native implementation supports, but should cover everything that's actually used.