### PR TITLE
`content`: Decouple value selection from consumer-facing fields

### DIFF
--- a/packages/content/api/presentation-content.api.md
+++ b/packages/content/api/presentation-content.api.md
@@ -181,7 +181,7 @@ interface CreateIModelContentConfigurationProps {
     imodelAccess: ECSqlQueryExecutor & ECSchemaProvider;
 }
 
-// @alpha
+// @public
 type DeepReadonly<T> = T extends (...args: any[]) => any ? T : T extends (infer U)[] ? ReadonlyArray<DeepReadonly<U>> : T extends object ? {
     readonly [K in keyof T]: DeepReadonly<T[K]>;
 } : T;
@@ -289,6 +289,9 @@ interface InputPropertyDeclaration {
 
 // @public
 export function mapItems<TIn, TOut>(items: AsyncIterable<TIn>, transform: (item: TIn) => TOut | Promise<TOut>): AsyncIterable<TOut>;
+
+// @public
+type MutableFieldMetadata = "label" | "categoryId" | "hidden" | "readOnly";
 
 // @public
 export interface PropertyField extends BaseField {
@@ -409,13 +412,7 @@ interface TransformableDescriptor {
 }
 
 // @public
-type TransformableField<TField extends Field = Field> = TField extends Field ? Omit<TField, "id" | "selectorId"> & {
-    readonly id: string;
-} & (TField extends {
-    selectorId: string;
-} ? {
-    readonly selectorId: string;
-} : {}) : never;
+type TransformableField<TField extends Field = Field> = TField extends Field ? DeepReadonly<Omit<TField, MutableFieldMetadata>> & Pick<TField, MutableFieldMetadata> : never;
 
 // @public (undocumented)
 type ValueFilterOperator = "is-equal" | "is-not-equal" | "is-null" | "is-not-null" | "less-than" | "less-than-or-equal" | "greater-than" | "greater-than-or-equal" | "like" | "is-in";

--- a/packages/content/api/presentation-content.api.md
+++ b/packages/content/api/presentation-content.api.md
@@ -7,7 +7,7 @@
 import { EC } from '@itwin/presentation-shared';
 import type { ECClassHierarchyInspector } from '@itwin/presentation-shared';
 import type { ECSchemaProvider } from '@itwin/presentation-shared';
-import type { ECSqlBinding } from '@itwin/presentation-shared';
+import { ECSqlBinding } from '@itwin/presentation-shared';
 import type { ECSqlQueryExecutor } from '@itwin/presentation-shared';
 import type { Id64String } from '@itwin/core-bentley';
 import type { InstanceKey } from '@itwin/presentation-shared';
@@ -33,9 +33,11 @@ interface BaseFieldsProvider {
 
 // @public
 export interface CalculatedField extends BaseField {
+    bindings?: Record<string, ECSqlBinding>;
     expression: string;
     // (undocumented)
     kind: "calculated";
+    selectorId: string;
     targetAlias?: string;
 }
 
@@ -48,6 +50,13 @@ interface CalculatedFieldDeclaration {
     label: string;
     targetAlias?: string;
     type: ValueDescriptor;
+}
+
+// @public
+export interface CalculatedValueSelector extends Pick<CalculatedField, "expression" | "targetAlias" | "bindings"> {
+    id: string;
+    // (undocumented)
+    kind: "calculated";
 }
 
 // @public
@@ -90,6 +99,7 @@ export interface ContentConfiguration {
 export interface ContentDescriptor {
     categories: Record<CategoryDefinition["id"], CategoryDefinition>;
     fields: Record<Field["id"], Field>;
+    selectors: Record<ValueSelector["id"], ValueSelector>;
     sources: ContentSource[];
 }
 
@@ -286,6 +296,7 @@ export interface PropertyField extends BaseField {
     kind: "property";
     pathFromTarget: RelationshipPath;
     propertyName: string;
+    selectorId: string;
     sourceClassName: EC.FullClassName;
     valueClassNames: EC.FullClassName[];
 }
@@ -318,6 +329,13 @@ type PropertySelection = "all" | "none" | {
 } | {
     exclude: string[];
 };
+
+// @public
+export interface PropertyValueSelector extends Pick<PropertyField, "sourceClassName" | "propertyName" | "pathFromTarget"> {
+    id: string;
+    // (undocumented)
+    kind: "property";
+}
 
 // @public
 interface QueryFilterClauses {
@@ -391,12 +409,19 @@ interface TransformableDescriptor {
 }
 
 // @public
-type TransformableField<TField extends Field = Field> = TField extends Field ? Omit<TField, "id"> & {
+type TransformableField<TField extends Field = Field> = TField extends Field ? Omit<TField, "id" | "selectorId"> & {
     readonly id: string;
-} : never;
+} & (TField extends {
+    selectorId: string;
+} ? {
+    readonly selectorId: string;
+} : {}) : never;
 
 // @public (undocumented)
 type ValueFilterOperator = "is-equal" | "is-not-equal" | "is-null" | "is-not-null" | "less-than" | "less-than-or-equal" | "greater-than" | "greater-than-or-equal" | "like" | "is-in";
+
+// @public
+export type ValueSelector = PropertyValueSelector | CalculatedValueSelector;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/content/api/presentation-content.exports.csv
+++ b/packages/content/api/presentation-content.exports.csv
@@ -1,6 +1,7 @@
 sep=;
 Release Tag;API Item Type;API Item Name
 public;interface;CalculatedField
+public;interface;CalculatedValueSelector
 public;interface;CategoryDefinition
 public;namespace;CategoryDefinition
 public;interface;ContentConfiguration
@@ -23,5 +24,7 @@ public;function;getDistinctFieldValues
 public;function;mapItems
 public;interface;PropertyField
 public;namespace;PropertyField
+public;interface;PropertyValueSelector
 public;function;reduceItems
 public;function;resolveContentSources
+public;type;ValueSelector

--- a/packages/content/src/content/extensions/DescriptorTransformer.ts
+++ b/packages/content/src/content/extensions/DescriptorTransformer.ts
@@ -12,6 +12,7 @@ import type { ContentSource } from "../ContentTarget.js";
 import type { CategoryDefinition } from "../model/Category.js";
 import type { ContentDescriptor } from "../model/ContentDescriptor.js";
 import type { Field } from "../model/Field.js";
+import type { DeepReadonly } from "../model/Utils.js";
 
 /**
  * Default priority for descriptor transformers.
@@ -76,9 +77,24 @@ export function defineDescriptorTransformer(transformer: DescriptorTransformer):
 }
 
 /**
- * A field with its ID and selector ID made readonly — transformers may modify metadata
- * (label, categoryId, hidden, readOnly) but must not change the field's identity or the column
- * it reads.
+ * The set of {@link Field} properties a descriptor transformer is allowed to mutate. Everything
+ * else (identity, value shape, and the column-defining coordinates that back a field's selector) is
+ * made readonly in the transformer view.
+ *
+ * @public
+ */
+type MutableFieldMetadata = "label" | "categoryId" | "hidden" | "readOnly";
+
+/**
+ * A field exposed to descriptor transformers with everything except display metadata made readonly.
+ *
+ * Transformers may only modify metadata (`label`, `categoryId`, `hidden`, `readOnly`). Identity
+ * (`id`, `selectorId`), value shape (`type`), and the column-defining properties a field reads
+ * (`sourceClassName`/`propertyName`/`pathFromTarget` for property fields,
+ * `expression`/`targetAlias`/`bindings` for calculated fields) are deeply readonly, so a transformer
+ * can never silently change the column a field selects — not even by mutating a nested array or
+ * object (e.g. `pathFromTarget`, `valueClassNames`, or `type`). Value-supplier scoping is done
+ * through `forkField`, not by mutating `valueClassNames` directly.
  *
  * Distributes over the {@link Field} union so the `kind` discriminant is preserved: a
  * `field.kind === "property"` check narrows a `TransformableField` to the property member
@@ -87,9 +103,7 @@ export function defineDescriptorTransformer(transformer: DescriptorTransformer):
  * @public
  */
 type TransformableField<TField extends Field = Field> = TField extends Field
-  ? Omit<TField, "id" | "selectorId"> & { readonly id: string } & (TField extends { selectorId: string }
-        ? { readonly selectorId: string }
-        : {})
+  ? DeepReadonly<Omit<TField, MutableFieldMetadata>> & Pick<TField, MutableFieldMetadata>
   : never;
 
 /**
@@ -97,8 +111,8 @@ type TransformableField<TField extends Field = Field> = TField extends Field
  *
  * Enforces transformer rules at the type level:
  * - `sources` is readonly — the resolved source structure is immutable at this stage.
- * - Field `id` is readonly — must not be changed.
- * - Field metadata (`label`, `categoryId`, `hidden`, `readOnly`) remains mutable.
+ * - Only field display metadata (`label`, `categoryId`, `hidden`, `readOnly`) is mutable; a field's
+ *   identity, value shape, and column-defining properties are readonly.
  * - Fields can be removed via `descriptor.removeField(id)`.
  * - A field can be carved for a subset of its value-supplier classes via `descriptor.forkField(id, subset)`.
  *

--- a/packages/content/src/content/extensions/DescriptorTransformer.ts
+++ b/packages/content/src/content/extensions/DescriptorTransformer.ts
@@ -76,8 +76,9 @@ export function defineDescriptorTransformer(transformer: DescriptorTransformer):
 }
 
 /**
- * A field with its ID made readonly — transformers may modify metadata
- * (label, categoryId, hidden, readOnly) but must not change ID.
+ * A field with its ID and selector ID made readonly — transformers may modify metadata
+ * (label, categoryId, hidden, readOnly) but must not change the field's identity or the column
+ * it reads.
  *
  * Distributes over the {@link Field} union so the `kind` discriminant is preserved: a
  * `field.kind === "property"` check narrows a `TransformableField` to the property member
@@ -86,7 +87,9 @@ export function defineDescriptorTransformer(transformer: DescriptorTransformer):
  * @public
  */
 type TransformableField<TField extends Field = Field> = TField extends Field
-  ? Omit<TField, "id"> & { readonly id: string }
+  ? Omit<TField, "id" | "selectorId"> & { readonly id: string } & (TField extends { selectorId: string }
+        ? { readonly selectorId: string }
+        : {})
   : never;
 
 /**

--- a/packages/content/src/content/extensions/ExternalFieldsProvider.ts
+++ b/packages/content/src/content/extensions/ExternalFieldsProvider.ts
@@ -63,9 +63,9 @@ export interface ExternalFieldsProvider<
 /**
  * A request for an iModel property that the external fields provider needs as input.
  *
- * The system checks whether the property already exists in the descriptor:
- * - If yes, it pins the field (prevents removal by transformers).
- * - If no, it adds the property as a hidden field (queried but not displayed).
+ * The system ensures a value selector (column) exists for the requested property so it can be fed
+ * into `getValues`. The column is selected regardless of whether any output field references it, and
+ * cannot be removed by descriptor transformers.
  *
  * @public
  */

--- a/packages/content/src/content/extensions/presentation-rules/DescriptorTransformerFactory.ts
+++ b/packages/content/src/content/extensions/presentation-rules/DescriptorTransformerFactory.ts
@@ -6,7 +6,6 @@
 import { checkRequiredSchemas, classMatchesSpec, mapPropertyCategories, resolveCategoryId } from "./Utils.js";
 
 import type { EC, ECClassHierarchyInspector, ECSchemaProvider, Props } from "@itwin/presentation-shared";
-import type { PropertyField } from "../../model/Field.js";
 import type { DescriptorTransformer } from "../DescriptorTransformer.js";
 import type * as PresentationRules from "./PresentationRules.js";
 
@@ -57,7 +56,7 @@ export function createDescriptorTransformerFromContentModifierRule({
       // Snapshot the candidate property fields: direct fields always, related fields only when
       // `applyOnNestedContent` is set. Snapshotting up front means forks added during the pass are
       // not themselves re-processed.
-      const candidates: PropertyField[] = [];
+      const candidates: TransformablePropertyField[] = [];
       for (const field of Object.values(descriptor.fields)) {
         if (field.kind !== "property") {
           continue;
@@ -73,7 +72,7 @@ export function createDescriptorTransformerFromContentModifierRule({
 
       // Precompute the matched value-class subset per candidate (before any forking shrinks the
       // originals), so repeat specs and the cross-field "hide others" rule re-resolve the same forks.
-      const matchedByCandidate = new Map<PropertyField, EC.FullClassName[]>();
+      const matchedByCandidate = new Map<TransformablePropertyField, EC.FullClassName[]>();
       for (const candidate of candidates) {
         matchedByCandidate.set(candidate, await computeMatchedValueClasses(imodelAccess, candidate, rule.class));
       }
@@ -134,7 +133,7 @@ export function createDescriptorTransformerFromContentModifierRule({
  */
 async function computeMatchedValueClasses(
   imodelAccess: ECClassHierarchyInspector & ECSchemaProvider,
-  field: PropertyField,
+  field: TransformablePropertyField,
   classSpec: PresentationRules.SingleSchemaClassSpecification | undefined,
 ): Promise<EC.FullClassName[]> {
   if (!classSpec) {
@@ -151,11 +150,18 @@ async function computeMatchedValueClasses(
 
 /** The constrained descriptor view handed to a transformer. */
 type TransformableDescriptor = Props<DescriptorTransformer["transform"]>["descriptor"];
-/** A property field carved out for mutation by `forkField`. */
-type WorkingField = ReturnType<TransformableDescriptor["forkField"]>;
+/**
+ * A property field as seen through the transformer view: deeply readonly except for display
+ * metadata. This is the type of both the candidate fields read from the descriptor and the forks
+ * returned by `forkField` for mutation.
+ */
+type TransformablePropertyField = ReturnType<TransformableDescriptor["forkField"]>;
 
 /** Applies a single `PropertySpecification`'s supported overrides to a working field. */
-function applyPropertySpecification(field: WorkingField, spec: PresentationRules.PropertySpecification): void {
+function applyPropertySpecification(
+  field: TransformablePropertyField,
+  spec: PresentationRules.PropertySpecification,
+): void {
   if (spec.labelOverride !== undefined) {
     field.label = spec.labelOverride;
   }

--- a/packages/content/src/content/model/ContentDescriptor.ts
+++ b/packages/content/src/content/model/ContentDescriptor.ts
@@ -6,6 +6,7 @@
 import type { ContentSource } from "../ContentTarget.js";
 import type { CategoryDefinition } from "./Category.js";
 import type { Field } from "./Field.js";
+import type { ValueSelector } from "./ValueSelector.js";
 
 /**
  * The schema of the content result. Computed before loading any values.
@@ -34,4 +35,11 @@ export interface ContentDescriptor {
    * All category definitions referenced by fields in this descriptor, keyed by category ID.
    */
   categories: Record<CategoryDefinition["id"], CategoryDefinition>;
+
+  /**
+   * Columns to SELECT from the iModel, keyed by selector ID. The deduplicated union of the columns
+   * backing this descriptor's SQL-backed fields and the columns required by external fields
+   * providers' inputs. Multiple fields may reference the same selector via their `selectorId`.
+   */
+  selectors: Record<ValueSelector["id"], ValueSelector>;
 }

--- a/packages/content/src/content/model/Field.ts
+++ b/packages/content/src/content/model/Field.ts
@@ -5,6 +5,7 @@
 
 import {
   type EC,
+  type ECSqlBinding,
   normalizeFullClassName,
   type RelationshipPath,
   type ValueDescriptor,
@@ -74,6 +75,12 @@ export interface PropertyField extends BaseField {
    * Always non-empty, normalized, de-duplicated, and sorted by normalized full name.
    */
   valueClassNames: EC.FullClassName[];
+  /**
+   * ID of the {@link ValueSelector} (column) this field reads. Equals this field's *base* id (its
+   * {@link (PropertyField:namespace).computeId} result without a `forkKey`), so all fork/override
+   * variants of the same underlying property share one selector. Immutable in the transformer view.
+   */
+  selectorId: string;
 }
 /** @public */
 export namespace PropertyField {
@@ -138,6 +145,15 @@ export interface CalculatedField extends BaseField {
    * @default "this"
    */
   targetAlias?: string;
+  /**
+   * Bind values referenced by `expression`, keyed by parameter name.
+   */
+  bindings?: Record<string, ECSqlBinding>;
+  /**
+   * ID of the {@link ValueSelector} (column) this field reads. Equals this field's id
+   * (`${providerId}:${localId}`). Immutable in the transformer view.
+   */
+  selectorId: string;
 }
 
 /**

--- a/packages/content/src/content/model/PropertyFieldMerge.ts
+++ b/packages/content/src/content/model/PropertyFieldMerge.ts
@@ -41,6 +41,7 @@ export function mergePropertyFieldsByIdentity(candidates: PropertyField[]): Reco
       result[baseId] = {
         ...candidate,
         id: baseId,
+        selectorId: baseId,
         valueClassNames: toSortedUniqueClassNames(candidate.valueClassNames),
       };
       continue;

--- a/packages/content/src/content/model/Utils.ts
+++ b/packages/content/src/content/model/Utils.ts
@@ -9,7 +9,7 @@ import type { EC, RelationshipPath } from "@itwin/presentation-shared";
 
 /**
  * Recursively marks all properties as readonly with no depth limit.
- * @alpha
+ * @public
  */
 export type DeepReadonly<T> = T extends (...args: any[]) => any
   ? T

--- a/packages/content/src/content/model/ValueSelector.ts
+++ b/packages/content/src/content/model/ValueSelector.ts
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PropertyField } from "./Field.js";
+
+import type { EC, ECSqlBinding, RelationshipPath } from "@itwin/presentation-shared";
+import type { CalculatedField, Field } from "./Field.js";
+
+/**
+ * A deduplicated instruction for selecting one raw value (column) from the iModel.
+ *
+ * A selector represents *what column to SELECT*, distinct from a {@link Field}, which represents
+ * *what to display*. Multiple fields (e.g. an override and its base, or several `forkField` carves)
+ * can share a single selector, and an external fields provider input can require a selector with no
+ * output field at all.
+ *
+ * @public
+ */
+export type ValueSelector = PropertyValueSelector | CalculatedValueSelector;
+
+/**
+ * A {@link ValueSelector} that selects a real EC property column.
+ *
+ * Reuses the column-locating coordinates of the {@link (PropertyField:interface)}(s) that read it
+ * (`sourceClassName`, `propertyName`, `pathFromTarget`) via `Pick`, so the field stays the single
+ * source of truth. Unlike a field, a selector is deduplicated and may exist with no backing field
+ * (an external fields provider input column).
+ *
+ * @public
+ */
+export interface PropertyValueSelector extends Pick<
+  PropertyField,
+  "sourceClassName" | "propertyName" | "pathFromTarget"
+> {
+  kind: "property";
+  /**
+   * Stable column identity — equals a property field's *base* id (its
+   * {@link (PropertyField:namespace).computeId} result without a `forkKey`), so every fork/override
+   * variant of the same underlying property collapses to one selector id.
+   */
+  id: string;
+}
+
+/**
+ * A {@link ValueSelector} that selects the result of an ECSQL expression.
+ *
+ * Reuses the expression-defining fields of the {@link (CalculatedField:interface)}(s) that read it
+ * (`expression`, `targetAlias`, `bindings`) via `Pick`, so the field stays the single source of
+ * truth. Unlike a field, a selector is deduplicated.
+ *
+ * @public
+ */
+export interface CalculatedValueSelector extends Pick<CalculatedField, "expression" | "targetAlias" | "bindings"> {
+  kind: "calculated";
+  /** Stable column identity — equals the calculated field id (`${providerId}:${localId}`). */
+  id: string;
+}
+
+/**
+ * Computes the stable id of a {@link PropertyValueSelector} — the *base* id of the property field(s)
+ * that read this column. A thin wrapper over `PropertyField.computeId` with no `forkKey`.
+ *
+ * @internal
+ */
+export function computePropertySelectorId(props: {
+  propertyClassName: EC.FullClassName;
+  propertyName: string;
+  pathFromTarget?: RelationshipPath;
+}): ValueSelector["id"] {
+  return PropertyField.computeId({
+    propertyClassName: props.propertyClassName,
+    propertyName: props.propertyName,
+    pathFromTarget: props.pathFromTarget,
+  });
+}
+
+/**
+ * Creates a {@link PropertyValueSelector} with its id derived from the property's identity.
+ *
+ * @internal
+ */
+export function createPropertySelector(props: {
+  sourceClassName: EC.FullClassName;
+  propertyName: string;
+  pathFromTarget?: RelationshipPath;
+}): PropertyValueSelector {
+  return {
+    kind: "property",
+    id: computePropertySelectorId({
+      propertyClassName: props.sourceClassName,
+      propertyName: props.propertyName,
+      pathFromTarget: props.pathFromTarget,
+    }),
+    sourceClassName: props.sourceClassName,
+    propertyName: props.propertyName,
+    pathFromTarget: props.pathFromTarget ?? [],
+  };
+}
+
+/**
+ * Creates a {@link CalculatedValueSelector}. Its id equals the calculated field id and must be
+ * supplied by the caller (it is not derivable from the expression).
+ *
+ * @internal
+ */
+export function createCalculatedSelector(props: {
+  id: string;
+  expression: string;
+  targetAlias?: string;
+  bindings?: Record<string, ECSqlBinding>;
+}): CalculatedValueSelector {
+  const selector: CalculatedValueSelector = { kind: "calculated", id: props.id, expression: props.expression };
+  if (props.targetAlias !== undefined) {
+    selector.targetAlias = props.targetAlias;
+  }
+  if (props.bindings !== undefined) {
+    selector.bindings = props.bindings;
+  }
+  return selector;
+}
+
+/**
+ * Collects the deduplicated set of {@link ValueSelector}s to SELECT, keyed by selector id.
+ *
+ * The result is the union of:
+ * - one selector per SQL-backed field (`property`/`calculated`), and
+ * - one property selector per external fields provider input.
+ *
+ * External-input selectors are added unconditionally, so removing an output field can never remove
+ * an input column. When a field-backed selector and an input selector share an id, the field-backed
+ * one is kept (they are otherwise identical).
+ *
+ * @internal
+ */
+export function collectSelectors(
+  fields: Iterable<Field>,
+  externalInputs: Iterable<{ className: EC.FullClassName; propertyName: string; path?: RelationshipPath }>,
+): Record<ValueSelector["id"], ValueSelector> {
+  const result: Record<ValueSelector["id"], ValueSelector> = {};
+  for (const field of fields) {
+    switch (field.kind) {
+      case "property": {
+        const selector = createPropertySelector({
+          sourceClassName: field.sourceClassName,
+          propertyName: field.propertyName,
+          pathFromTarget: field.pathFromTarget,
+        });
+        result[selector.id] = selector;
+        break;
+      }
+      case "calculated": {
+        const selector = createCalculatedSelector({
+          id: field.selectorId,
+          expression: field.expression,
+          targetAlias: field.targetAlias,
+          bindings: field.bindings,
+        });
+        result[selector.id] = selector;
+        break;
+      }
+      // external fields have no selector — populated out-of-band, not via SQL.
+    }
+  }
+  for (const input of externalInputs) {
+    const selector = createPropertySelector({
+      sourceClassName: input.className,
+      propertyName: input.propertyName,
+      pathFromTarget: input.path,
+    });
+    result[selector.id] ??= selector;
+  }
+  return result;
+}

--- a/packages/content/src/content/model/ValueSelector.ts
+++ b/packages/content/src/content/model/ValueSelector.ts
@@ -78,21 +78,16 @@ export function computePropertySelectorId(props: {
 
 /**
  * Creates a {@link PropertyValueSelector} with its id derived from the property's identity.
- *
- * @internal
  */
-export function createPropertySelector(props: {
+function createPropertySelector(props: {
+  id: string;
   sourceClassName: EC.FullClassName;
   propertyName: string;
   pathFromTarget?: RelationshipPath;
 }): PropertyValueSelector {
   return {
     kind: "property",
-    id: computePropertySelectorId({
-      propertyClassName: props.sourceClassName,
-      propertyName: props.propertyName,
-      pathFromTarget: props.pathFromTarget,
-    }),
+    id: props.id,
     sourceClassName: props.sourceClassName,
     propertyName: props.propertyName,
     pathFromTarget: props.pathFromTarget ?? [],
@@ -102,10 +97,8 @@ export function createPropertySelector(props: {
 /**
  * Creates a {@link CalculatedValueSelector}. Its id equals the calculated field id and must be
  * supplied by the caller (it is not derivable from the expression).
- *
- * @internal
  */
-export function createCalculatedSelector(props: {
+function createCalculatedSelector(props: {
   id: string;
   expression: string;
   targetAlias?: string;
@@ -136,27 +129,21 @@ export function createCalculatedSelector(props: {
  */
 export function collectSelectors(
   fields: Iterable<Field>,
-  externalInputs: Iterable<{ className: EC.FullClassName; propertyName: string; path?: RelationshipPath }>,
+  externalInputs: Iterable<{
+    propertyClassName: EC.FullClassName;
+    propertyName: string;
+    pathFromTarget?: RelationshipPath;
+  }>,
 ): Record<ValueSelector["id"], ValueSelector> {
   const result: Record<ValueSelector["id"], ValueSelector> = {};
   for (const field of fields) {
     switch (field.kind) {
       case "property": {
-        const selector = createPropertySelector({
-          sourceClassName: field.sourceClassName,
-          propertyName: field.propertyName,
-          pathFromTarget: field.pathFromTarget,
-        });
-        result[selector.id] = selector;
+        result[field.selectorId] = createPropertySelector({ ...field, id: field.selectorId });
         break;
       }
       case "calculated": {
-        const selector = createCalculatedSelector({
-          id: field.selectorId,
-          expression: field.expression,
-          targetAlias: field.targetAlias,
-          bindings: field.bindings,
-        });
+        const selector = createCalculatedSelector({ ...field, id: field.selectorId });
         result[selector.id] = selector;
         break;
       }
@@ -165,9 +152,10 @@ export function collectSelectors(
   }
   for (const input of externalInputs) {
     const selector = createPropertySelector({
-      sourceClassName: input.className,
+      id: computePropertySelectorId(input),
+      sourceClassName: input.propertyClassName,
       propertyName: input.propertyName,
-      pathFromTarget: input.path,
+      pathFromTarget: input.pathFromTarget,
     });
     result[selector.id] ??= selector;
   }

--- a/packages/content/src/presentation-content.ts
+++ b/packages/content/src/presentation-content.ts
@@ -7,6 +7,7 @@
 export type { ContentTarget, ContentSource } from "./content/ContentTarget.js";
 export type { ContentDescriptor } from "./content/model/ContentDescriptor.js";
 export type { Field, PropertyField, CalculatedField, ExternalField } from "./content/model/Field.js";
+export type { ValueSelector, PropertyValueSelector, CalculatedValueSelector } from "./content/model/ValueSelector.js";
 export { CategoryDefinition } from "./content/model/Category.js";
 export type { ContentItem, ContentValues } from "./content/model/ContentItem.js";
 

--- a/packages/content/src/test/extensions/DescriptorTransformer.test.ts
+++ b/packages/content/src/test/extensions/DescriptorTransformer.test.ts
@@ -18,13 +18,15 @@ function propertyField(props: {
   valueClassNames: EC.FullClassName[];
   pathFromTarget?: PropertyField["pathFromTarget"];
 }): PropertyField {
+  const fieldId = PropertyField.computeId({
+    propertyClassName: props.sourceClassName,
+    propertyName: props.propertyName,
+    pathFromTarget: props.pathFromTarget,
+  });
   return {
     kind: "property",
-    id: PropertyField.computeId({
-      propertyClassName: props.sourceClassName,
-      propertyName: props.propertyName,
-      pathFromTarget: props.pathFromTarget,
-    }),
+    id: fieldId,
+    selectorId: fieldId,
     label: "Label",
     type: { kind: "primitive", type: "String" },
     sourceClassName: props.sourceClassName,
@@ -35,7 +37,7 @@ function propertyField(props: {
 }
 
 function createDescriptor(fields: Field[]): ContentDescriptor {
-  return { sources: [], categories: {}, fields: Object.fromEntries(fields.map((f) => [f.id, f])) };
+  return { sources: [], categories: {}, selectors: {}, fields: Object.fromEntries(fields.map((f) => [f.id, f])) };
 }
 
 describe("createTransformableDescriptor", () => {
@@ -158,6 +160,20 @@ describe("createTransformableDescriptor", () => {
       expect(fork.valueClassNames).to.not.equal(field.valueClassNames);
     });
 
+    it("copies the parent's selectorId onto the fork", () => {
+      const field = propertyField({
+        sourceClassName: "Stuff:Thing",
+        propertyName: "Height",
+        valueClassNames: ["Stuff:Door", "Stuff:Window"],
+      });
+      const descriptor = createDescriptor([field]);
+      const transformable = createTransformableDescriptor(descriptor);
+
+      const fork = transformable.forkField(field.id, ["Stuff:Door"]);
+      expect(fork.id).to.not.equal(field.selectorId);
+      expect(fork.selectorId).to.equal(field.selectorId);
+    });
+
     it("throws when the field does not exist", () => {
       const descriptor = createDescriptor([]);
       const transformable = createTransformableDescriptor(descriptor);
@@ -168,6 +184,7 @@ describe("createTransformableDescriptor", () => {
       const calculated: CalculatedField = {
         kind: "calculated",
         id: "calc",
+        selectorId: "calc",
         label: "Calc",
         type: { kind: "primitive", type: "String" },
         expression: "1",

--- a/packages/content/src/test/extensions/presentation-rules/DescriptorTransformerFactory.test.ts
+++ b/packages/content/src/test/extensions/presentation-rules/DescriptorTransformerFactory.test.ts
@@ -22,13 +22,15 @@ function propertyField(props: {
   label?: string;
   hidden?: boolean;
 }): PropertyField {
+  const id = PropertyField.computeId({
+    propertyClassName: props.sourceClassName,
+    propertyName: props.propertyName,
+    pathFromTarget: props.pathFromTarget,
+  });
   return {
     kind: "property",
-    id: PropertyField.computeId({
-      propertyClassName: props.sourceClassName,
-      propertyName: props.propertyName,
-      pathFromTarget: props.pathFromTarget,
-    }),
+    id,
+    selectorId: id,
     label: props.label ?? "Label",
     type: { kind: "primitive", type: "String" },
     sourceClassName: props.sourceClassName,
@@ -50,7 +52,7 @@ function calculatedField(id: string): CalculatedField {
 }
 
 function createDescriptor(fields: Field[]): ContentDescriptor {
-  return { sources: [], categories: {}, fields: Object.fromEntries(fields.map((f) => [f.id, f])) };
+  return { sources: [], categories: {}, selectors: {}, fields: Object.fromEntries(fields.map((f) => [f.id, f])) };
 }
 
 function forkedId(props: {

--- a/packages/content/src/test/model/ContentItem.test.ts
+++ b/packages/content/src/test/model/ContentItem.test.ts
@@ -15,13 +15,14 @@ function createTestDescriptor(fields: Field[]): ContentDescriptor {
   for (const f of fields) {
     fieldMap[f.id] = f;
   }
-  return { sources: [], fields: fieldMap, categories: {} };
+  return { sources: [], fields: fieldMap, categories: {}, selectors: {} };
 }
 
 function createTestPropertyField(id: string): PropertyField {
   return {
     kind: "property",
     id,
+    selectorId: id,
     label: id,
     type: { kind: "primitive", type: "String" },
     sourceClassName: "BisCore.Element",

--- a/packages/content/src/test/model/PropertyFieldMerge.test.ts
+++ b/packages/content/src/test/model/PropertyFieldMerge.test.ts
@@ -23,6 +23,7 @@ function createField(props: {
   return {
     kind: "property",
     id: "unused",
+    selectorId: "unused",
     label: props.label ?? "Label",
     type: props.type ?? { kind: "primitive", type: "String" },
     categoryId: props.categoryId,
@@ -48,7 +49,9 @@ describe("mergePropertyFieldsByIdentity", () => {
     });
     const result = mergePropertyFieldsByIdentity([field]);
     const id = PropertyField.computeId({ propertyClassName: "Stuff:Thing", propertyName: "Height" });
-    expect(result).to.deep.equal({ [id]: { ...field, id, valueClassNames: ["Stuff.Door", "Stuff.Window"] } });
+    expect(result).to.deep.equal({
+      [id]: { ...field, id, selectorId: id, valueClassNames: ["Stuff.Door", "Stuff.Window"] },
+    });
   });
 
   it("does not mutate the input candidate", () => {

--- a/packages/content/src/test/model/ValueSelector.test.ts
+++ b/packages/content/src/test/model/ValueSelector.test.ts
@@ -1,0 +1,171 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+import { createTransformableDescriptor } from "../../content/extensions/DescriptorTransformer.js";
+import { PropertyField } from "../../content/model/Field.js";
+import { toSortedUniqueClassNames } from "../../content/model/Utils.js";
+import {
+  collectSelectors,
+  computePropertySelectorId,
+  createCalculatedSelector,
+  createPropertySelector,
+} from "../../content/model/ValueSelector.js";
+
+import type { EC } from "@itwin/presentation-shared";
+import type { ContentDescriptor } from "../../content/model/ContentDescriptor.js";
+import type { CalculatedField, Field, PropertyField as PropertyFieldType } from "../../content/model/Field.js";
+
+function propertyField(props: {
+  sourceClassName: EC.FullClassName;
+  propertyName: string;
+  valueClassNames: string[];
+  label?: string;
+  pathFromTarget?: PropertyFieldType["pathFromTarget"];
+}): PropertyFieldType {
+  const selectorId = PropertyField.computeId({
+    propertyClassName: props.sourceClassName,
+    propertyName: props.propertyName,
+    pathFromTarget: props.pathFromTarget,
+  });
+  return {
+    kind: "property",
+    id: selectorId,
+    selectorId,
+    label: props.label ?? "Label",
+    type: { kind: "primitive", type: "String" },
+    sourceClassName: props.sourceClassName,
+    propertyName: props.propertyName,
+    pathFromTarget: props.pathFromTarget ?? [],
+    valueClassNames: toSortedUniqueClassNames(props.valueClassNames as EC.FullClassName[]),
+  };
+}
+
+function calculatedField(props: { id: string; expression: string; targetAlias?: string }): CalculatedField {
+  return {
+    kind: "calculated",
+    id: props.id,
+    selectorId: props.id,
+    label: "Calc",
+    type: { kind: "primitive", type: "String" },
+    expression: props.expression,
+    targetAlias: props.targetAlias,
+  };
+}
+
+function createDescriptor(fields: Field[]): ContentDescriptor {
+  return { sources: [], categories: {}, selectors: {}, fields: Object.fromEntries(fields.map((f) => [f.id, f])) };
+}
+
+describe("ValueSelector", () => {
+  describe("computePropertySelectorId", () => {
+    it("returns the base property field id (delegates to PropertyField.computeId without a forkKey)", () => {
+      const props = { propertyClassName: "Stuff:Thing" as EC.FullClassName, propertyName: "Height" };
+      expect(computePropertySelectorId(props)).to.equal(PropertyField.computeId(props));
+    });
+  });
+
+  describe("createCalculatedSelector", () => {
+    it("builds a calculated selector from the given id and expression", () => {
+      expect(createCalculatedSelector({ id: "provider:calc", expression: "1 + 1" })).to.deep.equal({
+        kind: "calculated",
+        id: "provider:calc",
+        expression: "1 + 1",
+      });
+    });
+
+    it("includes targetAlias and bindings only when provided", () => {
+      expect(
+        createCalculatedSelector({
+          id: "a",
+          expression: "x",
+          targetAlias: "e",
+          bindings: { p: { type: "string", value: "v" } },
+        }),
+      ).to.deep.equal({
+        kind: "calculated",
+        id: "a",
+        expression: "x",
+        targetAlias: "e",
+        bindings: { p: { type: "string", value: "v" } },
+      });
+
+      const minimal = createCalculatedSelector({ id: "a", expression: "x" });
+      expect(minimal).to.not.have.property("targetAlias");
+      expect(minimal).to.not.have.property("bindings");
+    });
+  });
+
+  describe("collectSelectors", () => {
+    it("produces one selector per SQL-backed field", () => {
+      const prop = propertyField({
+        sourceClassName: "Stuff:Thing",
+        propertyName: "Height",
+        valueClassNames: ["Stuff:Door"],
+      });
+      const calc = calculatedField({ id: "provider:calc", expression: "1" });
+      const selectors = collectSelectors([prop, calc], []);
+      expect(Object.keys(selectors)).to.have.members([prop.selectorId, calc.selectorId]);
+      expect(selectors[prop.selectorId].kind).to.equal("property");
+      expect(selectors[calc.selectorId].kind).to.equal("calculated");
+    });
+
+    it("deduplicates a property field and its fork into a single selector", () => {
+      const field = propertyField({
+        sourceClassName: "Stuff:Thing",
+        propertyName: "Height",
+        valueClassNames: ["Stuff:Door", "Stuff:Window"],
+      });
+      const descriptor = createDescriptor([field]);
+      const fork = createTransformableDescriptor(descriptor).forkField(field.id, ["Stuff:Door"]);
+      expect(fork.id).to.not.equal(field.id);
+
+      const selectors = collectSelectors(Object.values(descriptor.fields), []);
+      expect(Object.keys(selectors)).to.deep.equal([field.selectorId]);
+    });
+
+    it("adds a field-less selector for an external input with no matching field", () => {
+      const selectors = collectSelectors([], [{ className: "Stuff:Thing", propertyName: "Height" }]);
+      const id = computePropertySelectorId({ propertyClassName: "Stuff:Thing", propertyName: "Height" });
+      expect(Object.keys(selectors)).to.deep.equal([id]);
+      expect(selectors[id]).to.deep.equal(
+        createPropertySelector({ sourceClassName: "Stuff:Thing", propertyName: "Height" }),
+      );
+    });
+
+    it("reuses the field-backed selector for an external input matching a field (no duplicate)", () => {
+      const prop = propertyField({
+        sourceClassName: "Stuff:Thing",
+        propertyName: "Height",
+        valueClassNames: ["Stuff:Door"],
+      });
+      const selectors = collectSelectors([prop], [{ className: "Stuff:Thing", propertyName: "Height" }]);
+      expect(Object.keys(selectors)).to.deep.equal([prop.selectorId]);
+    });
+
+    it("drops a removed output field's selector on recompute, but keeps it when it is also an external input (pinning replacement)", () => {
+      const removable = propertyField({
+        sourceClassName: "Stuff:Thing",
+        propertyName: "Height",
+        valueClassNames: ["Stuff:Door"],
+      });
+      const inputBacked = propertyField({
+        sourceClassName: "Stuff:Thing",
+        propertyName: "Width",
+        valueClassNames: ["Stuff:Door"],
+      });
+      const descriptor = createDescriptor([removable, inputBacked]);
+      const externalInputs = [{ className: "Stuff:Thing" as EC.FullClassName, propertyName: "Width" }];
+
+      const transformable = createTransformableDescriptor(descriptor);
+      transformable.removeField(removable.id);
+      transformable.removeField(inputBacked.id);
+
+      const selectors = collectSelectors(Object.values(descriptor.fields), externalInputs);
+      expect(selectors).to.have.property(inputBacked.selectorId);
+      expect(selectors).to.not.have.property(removable.selectorId);
+    });
+  });
+});

--- a/packages/content/src/test/model/ValueSelector.test.ts
+++ b/packages/content/src/test/model/ValueSelector.test.ts
@@ -7,14 +7,9 @@ import { describe, expect, it } from "vitest";
 import { createTransformableDescriptor } from "../../content/extensions/DescriptorTransformer.js";
 import { PropertyField } from "../../content/model/Field.js";
 import { toSortedUniqueClassNames } from "../../content/model/Utils.js";
-import {
-  collectSelectors,
-  computePropertySelectorId,
-  createCalculatedSelector,
-  createPropertySelector,
-} from "../../content/model/ValueSelector.js";
+import { collectSelectors, computePropertySelectorId } from "../../content/model/ValueSelector.js";
 
-import type { EC } from "@itwin/presentation-shared";
+import type { EC, ECSqlBinding } from "@itwin/presentation-shared";
 import type { ContentDescriptor } from "../../content/model/ContentDescriptor.js";
 import type { CalculatedField, Field, PropertyField as PropertyFieldType } from "../../content/model/Field.js";
 
@@ -43,7 +38,12 @@ function propertyField(props: {
   };
 }
 
-function calculatedField(props: { id: string; expression: string; targetAlias?: string }): CalculatedField {
+function calculatedField(props: {
+  id: string;
+  expression: string;
+  targetAlias?: string;
+  bindings?: Record<string, ECSqlBinding>;
+}): CalculatedField {
   return {
     kind: "calculated",
     id: props.id,
@@ -52,6 +52,7 @@ function calculatedField(props: { id: string; expression: string; targetAlias?: 
     type: { kind: "primitive", type: "String" },
     expression: props.expression,
     targetAlias: props.targetAlias,
+    bindings: props.bindings,
   };
 }
 
@@ -60,44 +61,6 @@ function createDescriptor(fields: Field[]): ContentDescriptor {
 }
 
 describe("ValueSelector", () => {
-  describe("computePropertySelectorId", () => {
-    it("returns the base property field id (delegates to PropertyField.computeId without a forkKey)", () => {
-      const props = { propertyClassName: "Stuff:Thing" as EC.FullClassName, propertyName: "Height" };
-      expect(computePropertySelectorId(props)).to.equal(PropertyField.computeId(props));
-    });
-  });
-
-  describe("createCalculatedSelector", () => {
-    it("builds a calculated selector from the given id and expression", () => {
-      expect(createCalculatedSelector({ id: "provider:calc", expression: "1 + 1" })).to.deep.equal({
-        kind: "calculated",
-        id: "provider:calc",
-        expression: "1 + 1",
-      });
-    });
-
-    it("includes targetAlias and bindings only when provided", () => {
-      expect(
-        createCalculatedSelector({
-          id: "a",
-          expression: "x",
-          targetAlias: "e",
-          bindings: { p: { type: "string", value: "v" } },
-        }),
-      ).to.deep.equal({
-        kind: "calculated",
-        id: "a",
-        expression: "x",
-        targetAlias: "e",
-        bindings: { p: { type: "string", value: "v" } },
-      });
-
-      const minimal = createCalculatedSelector({ id: "a", expression: "x" });
-      expect(minimal).to.not.have.property("targetAlias");
-      expect(minimal).to.not.have.property("bindings");
-    });
-  });
-
   describe("collectSelectors", () => {
     it("produces one selector per SQL-backed field", () => {
       const prop = propertyField({
@@ -110,6 +73,23 @@ describe("ValueSelector", () => {
       expect(Object.keys(selectors)).to.have.members([prop.selectorId, calc.selectorId]);
       expect(selectors[prop.selectorId].kind).to.equal("property");
       expect(selectors[calc.selectorId].kind).to.equal("calculated");
+    });
+
+    it("carries a calculated field's expression, targetAlias, and bindings onto its selector", () => {
+      const calc = calculatedField({
+        id: "provider:calc",
+        expression: "this.A * :factor",
+        targetAlias: "this",
+        bindings: { factor: { type: "double", value: 2 } },
+      });
+      const selectors = collectSelectors([calc], []);
+      expect(selectors[calc.selectorId]).to.deep.equal({
+        kind: "calculated",
+        id: calc.selectorId,
+        expression: "this.A * :factor",
+        targetAlias: "this",
+        bindings: { factor: { type: "double", value: 2 } },
+      });
     });
 
     it("deduplicates a property field and its fork into a single selector", () => {
@@ -127,12 +107,16 @@ describe("ValueSelector", () => {
     });
 
     it("adds a field-less selector for an external input with no matching field", () => {
-      const selectors = collectSelectors([], [{ className: "Stuff:Thing", propertyName: "Height" }]);
+      const selectors = collectSelectors([], [{ propertyClassName: "Stuff:Thing", propertyName: "Height" }]);
       const id = computePropertySelectorId({ propertyClassName: "Stuff:Thing", propertyName: "Height" });
       expect(Object.keys(selectors)).to.deep.equal([id]);
-      expect(selectors[id]).to.deep.equal(
-        createPropertySelector({ sourceClassName: "Stuff:Thing", propertyName: "Height" }),
-      );
+      expect(selectors[id]).to.deep.equal({
+        kind: "property",
+        id,
+        sourceClassName: "Stuff:Thing",
+        propertyName: "Height",
+        pathFromTarget: [],
+      });
     });
 
     it("reuses the field-backed selector for an external input matching a field (no duplicate)", () => {
@@ -141,7 +125,7 @@ describe("ValueSelector", () => {
         propertyName: "Height",
         valueClassNames: ["Stuff:Door"],
       });
-      const selectors = collectSelectors([prop], [{ className: "Stuff:Thing", propertyName: "Height" }]);
+      const selectors = collectSelectors([prop], [{ propertyClassName: "Stuff:Thing", propertyName: "Height" }]);
       expect(Object.keys(selectors)).to.deep.equal([prop.selectorId]);
     });
 
@@ -157,7 +141,7 @@ describe("ValueSelector", () => {
         valueClassNames: ["Stuff:Door"],
       });
       const descriptor = createDescriptor([removable, inputBacked]);
-      const externalInputs = [{ className: "Stuff:Thing" as EC.FullClassName, propertyName: "Width" }];
+      const externalInputs = [{ propertyClassName: "Stuff:Thing" as EC.FullClassName, propertyName: "Width" }];
 
       const transformable = createTransformableDescriptor(descriptor);
       transformable.removeField(removable.id);

--- a/packages/content/ts-content-rewrite.md
+++ b/packages/content/ts-content-rewrite.md
@@ -77,6 +77,7 @@ Multiple content sources (from multiple targets) are fed together into descripto
 The schema of the content result. Computed _before_ loading any values. Describes _what fields exist_ — it is purely structural and does not carry request-level concerns like sorting, filtering, or paging. Contains:
 
 - The list of **content sources** that were used to compute it (one per target class).
+- The set of **value selectors** — the deduplicated set of raw columns to SELECT from the iModel, keyed by selector ID. A value selector describes _what column to pull_, distinct from a field, which describes _what to display_. Multiple fields can share one selector (e.g., an override and its base), and an external fields provider input can require a selector with no output field at all. See "Value selector" below.
 - The full list of fields, organized as a two-level structure:
   - **Direct fields** — property fields and calculated fields that belong to the target class directly (no relationship path).
   - **Related field groups** — containers that group fields loaded via a specific relationship path. Each group carries its relationship path. Groups can nest for multi-step paths. Fields inside a group that have no explicit category are implicitly categorized by the group's target class (its display label becomes the category label). Groups are purely organizational — they carry no value themselves; values in content items are keyed by leaf field ID as usual.
@@ -102,6 +103,27 @@ Field kinds:
 2. **SQL calculated field** — carries an ECSQL expression evaluated in the query. The query builder includes it in the SELECT clause; the value comes back from the database like any other column. Can participate in sorting, filtering, and distinct values.
 
 Note: The current system's "related content field" (a field that contains child fields) is replaced by **related field groups** in the descriptor structure (see Content descriptor above). Groups are organizational containers, not fields — they don't have a value type or appear as columns in content items.
+
+### Value selector
+
+Describes a single **raw column to SELECT** from the iModel, deduplicated across the fields that read it. Value selectors separate two concerns that a field used to conflate:
+
+1. **What to display** — the consumer-facing field (label, category, value classes, overrides).
+2. **What column to SELECT** — how to pull one raw value out of the iModel.
+
+These are not 1:1:
+
+- **N fields : 1 column.** A field with overrides and one without (or several forks carved for different value classes) all read the **same** underlying property column. They select one column, not N.
+- **0 fields : 1 column.** An external fields provider's input needs a property **selected** so it can feed `getValues`, but there may be **no output field** for it.
+
+Selector kinds mirror the SQL-backed field kinds:
+
+- **Property value selector** — selects a real EC property column. Its ID equals the property field's _base_ ID (source class + property name + path, with no fork suffix), so every fork/override variant of the same property collapses to one selector.
+- **Calculated value selector** — selects the result of an ECSQL expression. Its ID equals the calculated field ID.
+
+External fields have **no** selector — they are populated out-of-band, not via SQL.
+
+Each SQL-backed field carries a **`selectorId`** referencing the column it reads. At value loading, one loaded column (per selector) is written to every field that references it. The descriptor's selector set is the deduplicated union of the columns backing its SQL-backed fields plus the columns required by external fields providers' inputs — see "External fields provider".
 
 ### Content values and content item
 
@@ -179,7 +201,9 @@ Provider specs are applied first (the system uses them during field generation t
 **Input:** Content descriptor (possibly modified by the consumer or by descriptor transformers).
 **Output:** ECSQL query (or queries).
 
-This stage translates the descriptor into one or more ECSQL queries. It selects columns for all fields present in the descriptor, including hidden ones (hidden fields are still queried — their values exist in content items but are flagged for UI to skip). Only fields that have been **removed** from the descriptor entirely are not queried. SQL calculated fields carry their ECSQL expression as metadata — the query builder includes that expression in the SELECT clause like any other column. Query filterers can inject additional WHERE clauses or JOINs at this point.
+This stage translates the descriptor into one or more ECSQL queries. It emits **one column per value selector** in the descriptor — not one per field. Because multiple fields can share a selector (overrides, forks), and external-input columns exist as selectors with no field, the selector set is the precise column list to SELECT. Hidden fields are still queried (their selector remains); a transformer that removes an output field drops the field's selector automatically **unless** the same column is also required as an external-input selector. Calculated value selectors carry their ECSQL expression — the query builder includes that expression in the SELECT clause like any other column. Query filterers can inject additional WHERE clauses or JOINs at this point.
+
+A property value selector carries **no column alias** — it carries semantic coordinates (`sourceClassName`, `propertyName`, `pathFromTarget`). To emit its SELECT term the builder needs `(alias, propertyName)`: `propertyName` comes straight from the selector, and the **alias is derived from `pathFromTarget`**. The builder assigns a deterministic alias per path/step while constructing the FROM + JOINs from the content source's resolved paths, then looks that alias up when emitting the selector's column (`pathFromTarget: []` → the primary-class alias; a related property → the terminal step's alias). `sourceClassName` is used only for EC metadata resolution, not for aliasing. The alias cannot live on the selector because selectors are deduplicated and query-independent, whereas aliases are per-query and depend on the FROM/JOIN shape (which may be split across multiple queries for the 64-JOIN / 1:many cases). The path→alias map must use the same path serialization the selector ID uses so the two agree on path identity.
 
 ### Stage 4: Value loading
 
@@ -304,8 +328,9 @@ Final field list:
     - "iot.lastMaintenance"   (dateTime, external)
 
   Input resolution:
-    - "pumpName" input → matches existing field "Pump.Name" → pinned (stays visible)
-    - (If no matching field existed, pipeline would add it as hidden)
+    - "pumpName" input → property value selector for Pump.Name → added to descriptor.selectors
+    - The selector's column is queried regardless of whether any output field references it,
+      and a transformer removing "Pump.Name" cannot drop the column.
 
 Descriptor transformer runs (e.g., "hide all read-only fields"):
   - "Pump.FlowRate" is marked read-only in EC metadata → transformer hides it
@@ -527,7 +552,7 @@ An external fields provider declares:
 The plan originally proposed `inputs?: (descriptor: Descriptor) => string[]` — a callback that receives the finalized descriptor and returns field ID strings. This was rejected because:
 
 1. **External fields providers cannot know what fields exist** — The descriptor's field set depends on which iModel fields providers are registered and what schema the iModel has. An external provider has no way to predict field IDs at registration time, and making it search the descriptor by class + property + path is fragile (what if the field isn't there?).
-2. **Static declarations are self-describing** — The provider declares exactly what it needs (`className`, `propertyName`, `path?`). The pipeline takes responsibility for ensuring the property is queried — either by finding an existing field that matches, or by adding a hidden field. The provider never needs to "find" anything in the descriptor.
+2. **Static declarations are self-describing** — The provider declares exactly what it needs (`className`, `propertyName`, `path?`). The pipeline takes responsibility for ensuring the property is queried by adding a value selector (column) for it. The provider never needs to "find" anything in the descriptor.
 3. **Type safety** — Static declarations enable compile-time type inference. The record keys become the typed `inputValues` accessor names in `getValues`, so TypeScript catches typos and missing inputs at compile time. A dynamic callback returning `string[]` provides no such guarantee.
 4. **Decouples from field ID encoding** — Field IDs are an internal encoding concern (class + property + path hash, etc.). Static declarations use semantic coordinates (class name + property name + path) — stable, readable, and independent of ID encoding strategy.
 
@@ -553,7 +578,7 @@ interface InputPropertyDeclaration {
 }
 ```
 
-**Input field visibility rule:** For each declared input property, the pipeline checks whether a matching field already exists in the descriptor (same class + property + path). If yes, it pins the field (prevents removal by transformers). If no, it adds the property as a hidden field (queried but not displayed). The provider never observes the descriptor directly — it just declares what it needs and the pipeline handles the rest.
+**Input column rule:** For each declared input property, the pipeline adds a **property value selector** (its column) to the descriptor unconditionally — regardless of whether any output field references the same column. Because the selector set is independent of the field set, a transformer removing an output field can never remove an input column, and no field needs to be added or "pinned". The provider never observes the descriptor directly — it just declares what it needs and the pipeline guarantees the column is selected and its value pre-extracted into `inputValues`.
 
 External fields providers run during Stage 4, after query execution but before items are emitted to the consumer. They enable external data to be first-class in the descriptor — their declared fields appear in the field list, carry categories and metadata, and can be hidden/shown like any other field.
 
@@ -562,7 +587,7 @@ External fields providers run during Stage 4, after query execution but before i
 - External fields cannot participate in SQL-level sorting, filtering, or distinct values (their data doesn't exist in the query).
 - External fields providers must not modify fields they don't own.
 
-**Example:** An external fields provider declares `inputs: { externalId: { className: "BisCore:Element", propertyName: "CodeValue" } }`. It declares `fields: [{ id: "externalName", ... }, { id: "externalStatus", ... }]`. Since no iModel fields provider independently declared `CodeValue`, the pipeline adds it as a hidden field (queried but not displayed). During Stage 4, the provider's `getValues` function reads `item.inputValues.externalId` from each item, calls an external service once with all values, and returns `externalName` and `externalStatus` for each item in the batch.
+**Example:** An external fields provider declares `inputs: { externalId: { className: "BisCore:Element", propertyName: "CodeValue" } }`. It declares `fields: [{ id: "externalName", ... }, { id: "externalStatus", ... }]`. The pipeline adds a value selector for `CodeValue` so the column is queried (no field is created). During Stage 4, the provider's `getValues` function reads `item.inputValues.externalId` from each item, calls an external service once with all values, and returns `externalName` and `externalStatus` for each item in the batch.
 
 ### Registration and ordering
 
@@ -812,7 +837,7 @@ The pipeline exposes an **async iterator** — consumers `for await` over conten
 
 5. ~~**Undo/redo interaction:**~~ **Resolved.** Consumer's responsibility. The pipeline treats the descriptor as an opaque input — it does not track modification history or support undo.
 
-6. ~~**External value sources (non-iModel data):**~~ **Resolved.** Two-phase loading with **external fields providers**. After ECSQL materializes rows, registered external fields providers are called in bulk with the page of items. Each provider declares which fields it populates, reads input values from existing (potentially hidden) fields, calls external services in batch, and fills in its fields. This keeps external data first-class in the descriptor while keeping the pipeline in control of value population. See "External fields provider" in Extension Points.
+6. ~~**External value sources (non-iModel data):**~~ **Resolved.** Two-phase loading with **external fields providers**. After ECSQL materializes rows, registered external fields providers are called in bulk with the page of items. Each provider declares which fields it populates, reads input values from columns selected on its behalf (value selectors), calls external services in batch, and fills in its fields. This keeps external data first-class in the descriptor while keeping the pipeline in control of value population. See "External fields provider" in Extension Points.
 
 7. ~~**1:many related content loading strategy:**~~ Moved to Implementation Notes — this is an internal implementation concern, not an API design question.
 


### PR DESCRIPTION
Prerequisite for https://github.com/iTwin/presentation/issues/1406.

Splits a descriptor `Field`'s two conflated concerns — *what to display* vs. *what column to SELECT* — by introducing a **value selector**: the deduplicated "column to select".

This removes the need to model the same column N times (fields + their `forkField`/override variants) and to keep external-input columns alive via hidden fields + pinning.

## Changes

- **New `model/ValueSelector.ts`**: `ValueSelector = PropertyValueSelector | CalculatedValueSelector` (`@public`, each `Pick`s its column fields from the matching `Field`), plus `@internal` helpers `computePropertySelectorId`, `createPropertySelector`, `createCalculatedSelector`, `collectSelectors`.
- **`ContentDescriptor`**: added `selectors` (keyed by selector id).
- **`Field`**: added required `selectorId` to `PropertyField` + `CalculatedField`; `CalculatedField` gains optional `bindings`.
- **`PropertyFieldMerge`**: stamps `selectorId` (= base id) on merged fields.
- **`DescriptorTransformer`**: `selectorId` is readonly in the transformer view; `forkField` copies it onto the fork. No pinning added.
- **`ExternalFieldsProvider`**: input columns are guaranteed via selectors instead of hidden/pinned fields.

## Identity

- Property selector id = `PropertyField.computeId(...)` **without** a `forkKey`, so all fork/override variants share one selector.
- Calculated selector id = the calculated field id.
- External-input selectors are added unconditionally, so removing an output field never drops an input column — replacing pinning.
