### PR TITLE
`EC.Class`: Added `getOwnProperties` method

### DIFF
--- a/.changeset/direct-class-properties.md
+++ b/.changeset/direct-class-properties.md
@@ -1,0 +1,6 @@
+---
+"@itwin/presentation-shared": major
+"@itwin/presentation-core-interop": minor
+---
+
+`EC.Class`: Added `getOwnProperties` method that returns only the properties defined directly on the class, excluding those inherited from base classes.

--- a/packages/core-interop/src/core-interop/MetadataInternal.ts
+++ b/packages/core-interop/src/core-interop/MetadataInternal.ts
@@ -120,6 +120,14 @@ abstract class ECClassImpl<TCoreClass extends CoreClass> extends ECSchemaItemImp
     }
     return result;
   }
+  public async getOwnProperties(): Promise<Array<EC.Property>> {
+    const coreProperties = await this._coreSchemaItem.getProperties(true);
+    const result = new Array<EC.Property>();
+    for (const coreProperty of coreProperties) {
+      result.push(createECProperty(coreProperty, this));
+    }
+    return result;
+  }
   public async getDerivedClasses(): Promise<EC.Class[]> {
     const coreDerivedClasses = await this._coreSchemaItem.getDerivedClasses();
     return coreDerivedClasses ? coreDerivedClasses.map((coreClass) => createECClass(coreClass, this.schema)) : [];

--- a/packages/core-interop/src/test/Metadata.test.ts
+++ b/packages/core-interop/src/test/Metadata.test.ts
@@ -414,6 +414,36 @@ describe("createECClass", () => {
     });
   });
 
+  describe("getOwnProperties", () => {
+    it("returns only direct properties from core class", async () => {
+      const coreClass = {
+        schemaItemType: SchemaItemType.EntityClass,
+        fullName: "s.c",
+        name: "c",
+        label: "C",
+        getProperties: vi
+          .fn()
+          .mockResolvedValue([
+            {
+              isArray: () => false,
+              isStruct: () => false,
+              isEnumeration: () => false,
+              isNavigation: () => false,
+              isPrimitive: () => true,
+            },
+          ]),
+      } as unknown as CoreClass;
+      const ecClass = createECClass(coreClass, schema);
+      const properties = await ecClass.getOwnProperties();
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(coreClass.getProperties).toHaveBeenCalledOnce();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(coreClass.getProperties).toHaveBeenCalledWith(true);
+      expect(properties.length).toBeGreaterThan(0);
+    });
+  });
+
   describe("getProperty", () => {
     it("returns property from core class", async () => {
       const coreClass = {

--- a/packages/shared/api/presentation-shared.api.md
+++ b/packages/shared/api/presentation-shared.api.md
@@ -161,6 +161,7 @@ export namespace EC {
         getCustomAttributes(): Promise<CustomAttributeSet>;
         // (undocumented)
         getDerivedClasses(): Promise<Class[]>;
+        getOwnProperties(): Promise<Array<Property>>;
         // (undocumented)
         getProperties(): Promise<Array<Property>>;
         // (undocumented)

--- a/packages/shared/src/shared/Metadata.ts
+++ b/packages/shared/src/shared/Metadata.ts
@@ -127,6 +127,8 @@ export namespace EC {
     is(other: Class): Promise<boolean>;
     getProperty(name: string): Promise<Property | undefined>;
     getProperties(): Promise<Array<Property>>;
+    /** Gets only the properties defined directly on this class, excluding those inherited from base classes. */
+    getOwnProperties(): Promise<Array<Property>>;
     isEntityClass(): this is EntityClass;
     isRelationshipClass(): this is RelationshipClass;
     isStructClass(): this is StructClass;


### PR DESCRIPTION
Prerequisite for https://github.com/iTwin/presentation/issues/1406.