### PR TITLE
Introduce TypeScript 7

### DIFF
--- a/apps/full-stack-tests/package.json
+++ b/apps/full-stack-tests/package.json
@@ -64,6 +64,7 @@
     "rxjs": "catalog:rxjs",
     "sanitize-filename": "^1.6.4",
     "sass": "^1.101.0",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools",
     "vitest": "catalog:test-tools"
   }

--- a/apps/load-tests/backend/package.json
+++ b/apps/load-tests/backend/package.json
@@ -23,6 +23,7 @@
     "@types/node": "catalog:build-tools",
     "eslint": "catalog:build-tools",
     "rimraf": "catalog:build-tools",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools"
   }
 }

--- a/apps/load-tests/tests/package.json
+++ b/apps/load-tests/tests/package.json
@@ -37,6 +37,7 @@
     "eslint": "catalog:build-tools",
     "rimraf": "catalog:build-tools",
     "rxjs": "catalog:rxjs",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools"
   }
 }

--- a/apps/performance-tests/package.json
+++ b/apps/performance-tests/package.json
@@ -35,6 +35,7 @@
     "presentation-test-utilities": "workspace:^",
     "rimraf": "catalog:build-tools",
     "rxjs": "catalog:rxjs",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools",
     "vitest": "catalog:test-tools"
   }

--- a/apps/test-app/backend/package.json
+++ b/apps/test-app/backend/package.json
@@ -32,6 +32,7 @@
     "electron": "^39.8.10",
     "eslint": "catalog:build-tools",
     "rimraf": "catalog:build-tools",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools"
   }
 }

--- a/apps/test-app/common/package.json
+++ b/apps/test-app/common/package.json
@@ -27,6 +27,7 @@
     "@itwin/presentation-common": "catalog:itwinjs-core-dev",
     "eslint": "catalog:build-tools",
     "rimraf": "catalog:build-tools",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools"
   }
 }

--- a/apps/test-app/frontend/package.json
+++ b/apps/test-app/frontend/package.json
@@ -58,6 +58,7 @@
     "rss-parser": "^3.13.0",
     "rxjs": "catalog:rxjs",
     "sass": "^1.101.0",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools",
     "vite": "catalog:build-tools",
     "vite-plugin-static-copy": "^4.1.1"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -120,6 +120,7 @@
     "react": "catalog:react",
     "react-dom": "catalog:react",
     "rimraf": "catalog:build-tools",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools"
   }
 }

--- a/packages/core-interop/package.json
+++ b/packages/core-interop/package.json
@@ -67,6 +67,7 @@
     "eslint": "catalog:build-tools",
     "rimraf": "catalog:build-tools",
     "rxjs-for-await": "catalog:rxjs",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools",
     "vitest": "catalog:test-tools"
   }

--- a/packages/hierarchies-react/package.json
+++ b/packages/hierarchies-react/package.json
@@ -105,6 +105,7 @@
     "react": "catalog:react",
     "react-dom": "catalog:react",
     "rimraf": "catalog:build-tools",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools",
     "vitest": "catalog:test-tools"
   }

--- a/packages/hierarchies/package.json
+++ b/packages/hierarchies/package.json
@@ -66,6 +66,7 @@
     "eslint": "catalog:build-tools",
     "presentation-test-utilities": "workspace:^",
     "rimraf": "catalog:build-tools",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools",
     "vitest": "catalog:test-tools"
   }

--- a/packages/models-tree/package.json
+++ b/packages/models-tree/package.json
@@ -53,6 +53,7 @@
     "cpx2": "catalog:build-tools",
     "eslint": "catalog:build-tools",
     "rimraf": "catalog:build-tools",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools"
   }
 }

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -63,6 +63,7 @@
     "cross-env": "catalog:build-tools",
     "eslint": "catalog:build-tools",
     "rimraf": "catalog:build-tools",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools",
     "vitest": "catalog:test-tools"
   }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -56,6 +56,7 @@
     "eslint": "catalog:build-tools",
     "presentation-test-utilities": "workspace:^",
     "rimraf": "catalog:build-tools",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools",
     "vitest": "catalog:test-tools"
   }

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -30,6 +30,7 @@
     "eslint": "catalog:build-tools",
     "rimraf": "catalog:build-tools",
     "rxjs": "catalog:rxjs",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools"
   }
 }

--- a/packages/unified-selection-react/package.json
+++ b/packages/unified-selection-react/package.json
@@ -67,6 +67,7 @@
     "happy-dom": "catalog:test-tools",
     "react": "catalog:react",
     "rimraf": "catalog:build-tools",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools",
     "vitest": "catalog:test-tools"
   }

--- a/packages/unified-selection/package.json
+++ b/packages/unified-selection/package.json
@@ -66,6 +66,7 @@
     "eslint": "catalog:build-tools",
     "presentation-test-utilities": "workspace:^",
     "rimraf": "catalog:build-tools",
+    "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools",
     "vitest": "catalog:test-tools"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ catalogs:
     '@types/node':
       specifier: ^24.13.3
       version: 24.13.3
+    '@typescript/native':
+      specifier: npm:typescript@^7.0.2
+      version: 7.0.2
     '@vitejs/plugin-react':
       specifier: ^6.0.3
       version: 6.0.3
@@ -47,8 +50,8 @@ catalogs:
       specifier: ^6.1.3
       version: 6.1.3
     typescript:
-      specifier: ~6.0.3
-      version: 6.0.3
+      specifier: npm:@typescript/typescript6@^6.0.2
+      version: 6.0.2
     vite:
       specifier: ^8.1.5
       version: 8.1.5
@@ -280,7 +283,7 @@ importers:
         version: 5.11.3(@itwin/core-backend@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-geometry@5.11.3)(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3)))(@opentelemetry/api@1.9.1))(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-geometry@5.11.3)(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3)))(@itwin/ecschema-rpcinterface-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-geometry@5.11.3)(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3))))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@itwin/imodel-components-react':
         specifier: catalog:appui
         version: 5.33.0(6072bf571279992e58d51ea5de25cbe6)
@@ -341,6 +344,9 @@ importers:
       '@types/react-dom':
         specifier: catalog:react
         version: 19.2.3(@types/react@19.2.17)
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       cpx2:
         specifier: catalog:build-tools
         version: 7.0.2
@@ -385,7 +391,7 @@ importers:
         version: 1.101.0
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: catalog:test-tools
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@8.1.5(@types/node@24.13.3)(sass@1.101.0)(yaml@2.9.0))
@@ -412,7 +418,7 @@ importers:
         version: 5.11.3(@itwin/core-backend@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-geometry@5.11.3)(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3)))(@opentelemetry/api@1.9.1))(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-geometry@5.11.3)(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3)))(@itwin/ecschema-rpcinterface-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-geometry@5.11.3)(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3))))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@itwin/express-server':
         specifier: catalog:itwinjs-core-dev
         version: 5.11.3(@itwin/core-backend@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-geometry@5.11.3)(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3)))(@opentelemetry/api@1.9.1))(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))
@@ -425,6 +431,9 @@ importers:
       '@types/node':
         specifier: catalog:build-tools
         version: 24.13.3
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       eslint:
         specifier: catalog:build-tools
         version: 9.39.5
@@ -433,7 +442,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
 
   apps/load-tests/tests:
     devDependencies:
@@ -451,7 +460,7 @@ importers:
         version: 5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@itwin/presentation-common':
         specifier: catalog:itwinjs-core-dev
         version: 5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3))(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3)))
@@ -473,6 +482,9 @@ importers:
       '@types/node':
         specifier: catalog:build-tools
         version: 24.13.3
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       artillery:
         specifier: 2.0.33
         version: 2.0.33(@types/node@24.13.3)
@@ -490,7 +502,7 @@ importers:
         version: 7.8.2
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
 
   apps/performance-tests:
     devDependencies:
@@ -514,7 +526,7 @@ importers:
         version: 5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@itwin/presentation-core-interop':
         specifier: workspace:*
         version: link:../../packages/core-interop
@@ -533,6 +545,9 @@ importers:
       '@types/node':
         specifier: catalog:build-tools
         version: 24.13.3
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       as-table:
         specifier: ^1.0.55
         version: 1.0.55
@@ -553,7 +568,7 @@ importers:
         version: 7.8.2
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: catalog:test-tools
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@8.1.5(@types/node@24.13.3)(sass@1.101.0)(yaml@2.9.0))
@@ -580,7 +595,7 @@ importers:
         version: 5.11.3(@itwin/core-backend@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-geometry@5.11.3)(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3)))(@opentelemetry/api@1.9.1))(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-geometry@5.11.3)(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3)))(@itwin/ecschema-rpcinterface-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-geometry@5.11.3)(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3))))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@itwin/express-server':
         specifier: catalog:itwinjs-core-dev
         version: 5.11.3(@itwin/core-backend@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-geometry@5.11.3)(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3)))(@opentelemetry/api@1.9.1))(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))
@@ -608,6 +623,9 @@ importers:
       '@test-app/common':
         specifier: workspace:*
         version: link:../common
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       cross-env:
         specifier: catalog:build-tools
         version: 7.0.3
@@ -622,7 +640,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
 
   apps/test-app/common:
     devDependencies:
@@ -640,10 +658,13 @@ importers:
         version: 5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-geometry@5.11.3)(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3)))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@itwin/presentation-common':
         specifier: catalog:itwinjs-core-dev
         version: 5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3))(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3)))
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       eslint:
         specifier: catalog:build-tools
         version: 9.39.5
@@ -652,7 +673,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
 
   apps/test-app/frontend:
     devDependencies:
@@ -703,7 +724,7 @@ importers:
         version: 5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-geometry@5.11.3)(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3)))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@itwin/imodel-components-react':
         specifier: catalog:appui
         version: 5.33.0(6072bf571279992e58d51ea5de25cbe6)
@@ -758,6 +779,9 @@ importers:
       '@types/react-dom':
         specifier: catalog:react
         version: 19.2.3(@types/react@19.2.17)
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       '@vitejs/plugin-react':
         specifier: catalog:build-tools
         version: 6.0.3(vite@8.1.5(@types/node@24.13.3)(sass@1.101.0)(yaml@2.9.0))
@@ -799,7 +823,7 @@ importers:
         version: 1.101.0
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vite:
         specifier: catalog:build-tools
         version: 8.1.5(@types/node@24.13.3)(sass@1.101.0)(yaml@2.9.0)
@@ -875,7 +899,7 @@ importers:
         version: 5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@itwin/imodel-components-react':
         specifier: catalog:appui
         version: 5.33.0(6072bf571279992e58d51ea5de25cbe6)
@@ -909,6 +933,9 @@ importers:
       '@types/react-dom':
         specifier: catalog:react
         version: 19.2.3(@types/react@19.2.17)
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       '@vitest/coverage-v8':
         specifier: catalog:test-tools
         version: 4.1.10(vitest@4.1.10)
@@ -941,7 +968,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: catalog:test-tools
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@8.1.5(@types/node@24.13.3)(sass@1.101.0)(yaml@2.9.0))
@@ -975,7 +1002,10 @@ importers:
         version: 5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3))
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       '@vitest/coverage-v8':
         specifier: catalog:test-tools
         version: 4.1.10(vitest@4.1.10)
@@ -993,7 +1023,7 @@ importers:
         version: 1.0.0(rxjs@7.8.2)
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: catalog:test-tools
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@8.1.5(@types/node@24.13.3)(sass@1.101.0)(yaml@2.9.0))
@@ -1024,13 +1054,16 @@ importers:
         version: 5.11.3(@types/node@24.13.3)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@types/natural-compare-lite':
         specifier: ^1.4.2
         version: 1.4.2
       '@types/node':
         specifier: catalog:build-tools
         version: 24.13.3
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       '@vitest/coverage-v8':
         specifier: catalog:test-tools
         version: 4.1.10(vitest@4.1.10)
@@ -1048,7 +1081,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: catalog:test-tools
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@8.1.5(@types/node@24.13.3)(sass@1.101.0)(yaml@2.9.0))
@@ -1091,7 +1124,7 @@ importers:
         version: 5.11.3(@types/node@24.13.3)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@itwin/itwinui-react':
         specifier: catalog:itwinui
         version: 3.21.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1113,6 +1146,9 @@ importers:
       '@types/react-dom':
         specifier: catalog:react
         version: 19.2.3(@types/react@19.2.17)
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       '@vitest/coverage-v8':
         specifier: catalog:test-tools
         version: 4.1.10(vitest@4.1.10)
@@ -1142,7 +1178,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: catalog:test-tools
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@8.1.5(@types/node@24.13.3)(sass@1.101.0)(yaml@2.9.0))
@@ -1164,10 +1200,13 @@ importers:
         version: 5.11.3(@types/node@24.13.3)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@itwin/presentation-hierarchies':
         specifier: workspace:^
         version: link:../hierarchies
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       cpx2:
         specifier: catalog:build-tools
         version: 7.0.2
@@ -1179,7 +1218,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
 
   packages/opentelemetry:
     devDependencies:
@@ -1188,7 +1227,7 @@ importers:
         version: 5.11.3(@types/node@24.13.3)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@itwin/presentation-common':
         specifier: catalog:itwinjs-core-dev
         version: 5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3))(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3)))
@@ -1198,6 +1237,9 @@ importers:
       '@types/node':
         specifier: catalog:build-tools
         version: 24.13.3
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       '@vitest/coverage-v8':
         specifier: catalog:test-tools
         version: 4.1.10(vitest@4.1.10)
@@ -1215,7 +1257,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: catalog:test-tools
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@8.1.5(@types/node@24.13.3)(sass@1.101.0)(yaml@2.9.0))
@@ -1231,10 +1273,13 @@ importers:
         version: 5.11.3(@types/node@24.13.3)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@types/node':
         specifier: catalog:build-tools
         version: 24.13.3
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       '@vitest/coverage-v8':
         specifier: catalog:test-tools
         version: 4.1.10(vitest@4.1.10)
@@ -1249,7 +1294,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: catalog:test-tools
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@8.1.5(@types/node@24.13.3)(sass@1.101.0)(yaml@2.9.0))
@@ -1267,10 +1312,13 @@ importers:
         version: 5.11.3
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@types/node':
         specifier: catalog:build-tools
         version: 24.13.3
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       eslint:
         specifier: catalog:build-tools
         version: 9.39.5
@@ -1282,7 +1330,7 @@ importers:
         version: 7.8.2
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
 
   packages/unified-selection:
     dependencies:
@@ -1304,10 +1352,13 @@ importers:
         version: 5.11.3(@types/node@24.13.3)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@types/node':
         specifier: catalog:build-tools
         version: 24.13.3
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       '@vitest/coverage-v8':
         specifier: catalog:test-tools
         version: 4.1.10(vitest@4.1.10)
@@ -1325,7 +1376,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: catalog:test-tools
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@8.1.5(@types/node@24.13.3)(sass@1.101.0)(yaml@2.9.0))
@@ -1337,7 +1388,7 @@ importers:
         version: 5.11.3(@types/node@24.13.3)
       '@itwin/eslint-plugin':
         specifier: catalog:build-tools
-        version: 6.1.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@itwin/unified-selection':
         specifier: workspace:^
         version: link:../unified-selection
@@ -1347,6 +1398,9 @@ importers:
       '@types/react':
         specifier: catalog:react
         version: 19.2.17
+      '@typescript/native':
+        specifier: catalog:build-tools
+        version: typescript@7.0.2
       '@vitest/coverage-v8':
         specifier: catalog:test-tools
         version: 4.1.10(vitest@4.1.10)
@@ -1373,7 +1427,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: catalog:build-tools
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: catalog:test-tools
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@8.1.5(@types/node@24.13.3)(sass@1.101.0)(yaml@2.9.0))
@@ -3517,6 +3571,130 @@ packages:
   '@typescript-eslint/visitor-keys@8.64.0':
     resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
 
   '@typespec/ts-http-runtime@0.3.7':
     resolution: {integrity: sha512-JVUD8X2tfDMWjcjLs4yVxxVrS8yR5vnh386GAXT9Qj79nBxxXSaHFQZg5FweLmT8HlPQ3kii6noUB+Z9RN7DvQ==}
@@ -7059,6 +7237,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   uc.micro@1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
 
@@ -8721,7 +8904,7 @@ snapshots:
       rimraf: 6.1.3
       tree-kill: 1.2.2
       typedoc: 0.28.20(typescript@5.6.3)
-      typedoc-plugin-merge-modules: 7.0.0(typedoc@0.28.20(typescript@5.6.3))
+      typedoc-plugin-merge-modules: 7.0.0(typedoc@0.28.20(@typescript/typescript6@6.0.2))
       typescript: 5.6.3
       wtfnode: 0.9.4
       yargs: 17.7.3
@@ -8871,13 +9054,13 @@ snapshots:
       '@itwin/ecschema-metadata': 5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3))
       '@itwin/ecschema-rpcinterface-common': 5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-common@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-geometry@5.11.3))(@itwin/core-geometry@5.11.3)(@itwin/ecschema-metadata@5.11.3(@itwin/core-bentley@5.11.3)(@itwin/core-quantity@5.11.3(@itwin/core-bentley@5.11.3)))
 
-  '@itwin/eslint-plugin@6.1.0(eslint@9.39.5)(typescript@6.0.3)':
+  '@itwin/eslint-plugin@6.1.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5))(@typescript/typescript6@6.0.2)(eslint@9.39.5)
+      '@typescript-eslint/parser': 8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       eslint: 9.39.5
       eslint-formatter-visualstudio: 8.40.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5))(eslint@9.39.5)
       eslint-plugin-jam3: 0.2.3
       eslint-plugin-jsdoc: 51.4.1(eslint@9.39.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5)
@@ -8885,7 +9068,7 @@ snapshots:
       eslint-plugin-react: 7.37.5(eslint@9.39.5)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.5)
       luxon: 3.7.2
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
       workspace-tools: 0.36.4
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
@@ -10055,40 +10238,40 @@ snapshots:
       '@types/node': 22.20.1
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5))(@typescript/typescript6@6.0.2)(eslint@9.39.5)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/type-utils': 8.64.0(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
+      '@typescript-eslint/utils': 8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       '@typescript-eslint/visitor-keys': 8.64.0
       eslint: 9.39.5
       ignore: 7.0.6
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/visitor-keys': 8.64.0
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.5
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.64.0(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.64.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.64.0
       debug: 4.4.3(supports-color@8.1.1)
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -10097,47 +10280,47 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
 
-  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.64.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@typescript-eslint/type-utils@8.64.0(eslint@9.39.5)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)':
     dependencies:
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.5
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.64.0': {}
 
-  '@typescript-eslint/typescript-estree@8.64.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.64.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.64.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.64.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.64.0(eslint@9.39.5)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5)
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(@typescript/typescript6@6.0.2)
       eslint: 9.39.5
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -10145,6 +10328,70 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.64.0
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   '@typespec/ts-http-runtime@0.3.7':
     dependencies:
@@ -11462,17 +11709,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
       eslint: 9.39.5
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5))(eslint@9.39.5):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11483,7 +11730,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -11495,7 +11742,7 @@ snapshots:
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -14096,9 +14343,9 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.5
 
-  ts-api-utils@2.5.0(typescript@6.0.3):
+  ts-api-utils@2.5.0(@typescript/typescript6@6.0.2):
     dependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
   ts-key-enum@2.0.13: {}
 
@@ -14164,7 +14411,7 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typedoc-plugin-merge-modules@7.0.0(typedoc@0.28.20(typescript@5.6.3)):
+  typedoc-plugin-merge-modules@7.0.0(typedoc@0.28.20(@typescript/typescript6@6.0.2)):
     dependencies:
       typedoc: 0.28.20(typescript@5.6.3)
 
@@ -14182,6 +14429,29 @@ snapshots:
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   uc.micro@1.0.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ catalogs:
       specifier: ^24.13.3
       version: 24.13.3
     '@typescript/native':
-      specifier: npm:typescript@^7.0.2
+      specifier: npm:typescript@~7.0.2
       version: 7.0.2
     '@vitejs/plugin-react':
       specifier: ^6.0.3
@@ -50,7 +50,7 @@ catalogs:
       specifier: ^6.1.3
       version: 6.1.3
     typescript:
-      specifier: npm:@typescript/typescript6@^6.0.2
+      specifier: npm:@typescript/typescript6@~6.0.2
       version: 6.0.2
     vite:
       specifier: ^8.1.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,7 +38,8 @@ catalogs:
     eslint: ^9.39.5
     eslint-plugin-react: ^7.37.5
     rimraf: ^6.1.3
-    typescript: ~6.0.3
+    '@typescript/native': npm:typescript@^7.0.2
+    typescript: npm:@typescript/typescript6@^6.0.2
     vite: ^8.1.5
   itwinjs-core:
     '@itwin/core-bentley': ^5.11.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,8 +38,8 @@ catalogs:
     eslint: ^9.39.5
     eslint-plugin-react: ^7.37.5
     rimraf: ^6.1.3
-    '@typescript/native': npm:typescript@^7.0.2
-    typescript: npm:@typescript/typescript6@^6.0.2
+    '@typescript/native': npm:typescript@~7.0.2
+    typescript: npm:@typescript/typescript6@~6.0.2
     vite: ^8.1.5
   itwinjs-core:
     '@itwin/core-bentley': ^5.11.3


### PR DESCRIPTION
Switched build to use TypeScript 7. This improved build time significantly: `pnpm lage build --no-cache` run time changed from `~35s` to `~11s` on my machine.

TypeScript 7 was release without API so tools that utilize TypeScript AST and other API do not work with v7. For this reason `@typescript/typescript6` package was introduced. Current setup installs it under `typescript` alias so all tools importing `typescript` would resolve to `@typescript/typescript6`. `@typescript/native` alias installs v7 and it bring `tsc` CLI for npm scripts.