### PR TITLE
[Hierarchies-react]: Tree action base allow optional onClick

### DIFF
--- a/.changeset/yellow-kings-cut.md
+++ b/.changeset/yellow-kings-cut.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-hierarchies-react": patch
+---
+
+`TreeActionBase`: Made the `onClick` prop optional.

--- a/packages/hierarchies-react/api/presentation-hierarchies-react-extract.api.md
+++ b/packages/hierarchies-react/api/presentation-hierarchies-react-extract.api.md
@@ -224,7 +224,7 @@ export interface TreeActionBaseAttributes {
 
 // @alpha (undocumented)
 type TreeActionBaseProps = Omit<ComponentPropsWithoutRef<typeof Tree.ItemAction>, "onClick"> & TreeActionBaseAttributes & {
-    onClick: () => void;
+    onClick?: () => void;
 };
 
 // @alpha

--- a/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeAction.tsx
+++ b/packages/hierarchies-react/src/presentation-hierarchies-react/stratakit/TreeAction.tsx
@@ -35,7 +35,7 @@ export interface TreeActionBaseAttributes {
 export type TreeActionBaseProps = Omit<ComponentPropsWithoutRef<typeof Tree.ItemAction>, "onClick"> &
   TreeActionBaseAttributes & {
     /** Callback invoked when the action is clicked. */
-    onClick: () => void;
+    onClick?: () => void;
   };
 
 /**


### PR DESCRIPTION
In case `hide` is set to true we should not force consumers to pass in an onClick