### PR TITLE
Bump pnpm to 11.20.0

### DIFF
--- a/.github/skills/repo-context/SKILL.md
+++ b/.github/skills/repo-context/SKILL.md
@@ -20,7 +20,7 @@ This is a **pnpm monorepo** orchestrated with **Lage** and versioned with **Chan
 | Platform | iTwin.js (iModels, ECSQL, Presentation APIs) |
 | Reactive | RxJS |
 | API docs | `@itwin/build-tools` (extract-api, docs) |
-| Node | ^24, pnpm 10 |
+| Node | ^24, pnpm 11 |
 
 ## Packages
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": {
     "url": "https://github.com/iTwin/presentation.git"
   },
-  "packageManager": "pnpm@11.1.0",
+  "packageManager": "pnpm@11.20.0",
   "engines": {
     "node": "^24.0.0"
   },


### PR DESCRIPTION
Updates the repository's pnpm version from 11.1.0 to 11.20.0 and synchronizes the repository context documentation.

**Changes:**
- Update `packageManager` in `package.json` to `pnpm@11.20.0`
- Update repository skill documentation to reflect pnpm 11 requirement

**Validation:**
- Full build completed successfully with `pnpm build:all`
- All linting checks passed with `pnpm lint:all`