### PR TITLE
[Hierarchies react]: make pixel difference ratio 0 on `next`

### DIFF
--- a/packages/hierarchies-react/vitest.config.ts
+++ b/packages/hierarchies-react/vitest.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
             expect: {
               toMatchScreenshot: {
                 comparatorName: "pixelmatch",
-                comparatorOptions: { threshold: 0.2, allowedMismatchedPixelRatio: 0.01 },
+                comparatorOptions: { threshold: 0.2, allowedMismatchedPixelRatio: 0 },
               },
             },
           },

--- a/packages/hierarchies-react/vitest.config.ts
+++ b/packages/hierarchies-react/vitest.config.ts
@@ -35,12 +35,7 @@ export default defineConfig({
             provider: playwright(),
             headless: true,
             instances: [{ browser: "chromium", viewport: { width: 800, height: 600 } }],
-            expect: {
-              toMatchScreenshot: {
-                comparatorName: "pixelmatch",
-                comparatorOptions: { threshold: 0.2, allowedMismatchedPixelRatio: 0 },
-              },
-            },
+            expect: { toMatchScreenshot: { comparatorName: "pixelmatch" } },
           },
         },
       },

--- a/packages/hierarchies-react/vitest.config.ts
+++ b/packages/hierarchies-react/vitest.config.ts
@@ -35,7 +35,6 @@ export default defineConfig({
             provider: playwright(),
             headless: true,
             instances: [{ browser: "chromium", viewport: { width: 800, height: 600 } }],
-            expect: { toMatchScreenshot: { comparatorName: "pixelmatch" } },
           },
         },
       },


### PR DESCRIPTION
When making https://github.com/iTwin/presentation/pull/1477 had to delete snapshots for them to be updated. 