### PR TITLE
Deprecate `ECClassHierarchyInspector` and `createCachingECClassHierarchyInspector`

### DIFF
--- a/.changeset/schema-provider-class-derives-from.md
+++ b/.changeset/schema-provider-class-derives-from.md
@@ -1,0 +1,46 @@
+---
+"@itwin/presentation-core-interop": minor
+"@itwin/presentation-hierarchies": major
+"@itwin/presentation-shared": major
+---
+
+`ECSchemaProvider`: Added a `classDerivesFrom` method for checking whether one ECClass is the same as, or derives from, another. `createECSchemaProvider` (in `@itwin/presentation-core-interop`) implements it using the class hierarchy information it already loads, so the answer is returned synchronously once the hierarchy has been loaded and no additional round-trips to the iModel are needed.
+
+Also, `ECClassHierarchyInspector` and `createCachingECClassHierarchyInspector` have been deprecated. Because `ECSchemaProvider` now exposes `classDerivesFrom` directly, a separate class hierarchy inspector is no longer needed when setting up iModel access:
+
+```ts
+// Before:
+import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
+import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+
+const schemaProvider = createECSchemaProvider(imodel);
+const imodelAccess = {
+...schemaProvider,
+...createCachingECClassHierarchyInspector({ schemaProvider }),
+...createECSqlQueryExecutor(imodel),
+};
+
+// After:
+import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+
+const imodelAccess = {
+...createECSchemaProvider(imodel), // now also provides `classDerivesFrom`
+...createECSqlQueryExecutor(imodel),
+};
+```
+
+**Breaking changes:**
+
+- `ECSchemaProvider` now requires a `classDerivesFrom` method. Objects created via `createECSchemaProvider` get it automatically, so most consumers don't need to change anything. Only custom, hand-written `ECSchemaProvider` implementations need to add the method.
+
+- Renamed the `classHierarchyInspector` prop to `imodelAccess` on `createClassBasedInstanceLabelSelectClauseFactory`, `createBisInstanceLabelSelectClauseFactory` (both in `@itwin/presentation-shared`) and `createPredicateBasedHierarchyDefinition` (in `@itwin/presentation-hierarchies`). The prop's type is unchanged, so the value passed to it doesn't need to change - only the prop name:
+
+    ```ts
+    // Before:
+    const classHierarchyInspector = createCachingECClassHierarchyInspector({ schemaProvider: createECSchemaProvider(imodel) });
+    createPredicateBasedHierarchyDefinition({ classHierarchyInspector, hierarchy });
+
+    // After:
+    const imodelAccess = createECSchemaProvider(imodel);
+    createPredicateBasedHierarchyDefinition({ imodelAccess, hierarchy });
+    ```

--- a/.changeset/schema-provider-class-derives-from.md
+++ b/.changeset/schema-provider-class-derives-from.md
@@ -15,17 +15,17 @@ import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/present
 
 const schemaProvider = createECSchemaProvider(imodel);
 const imodelAccess = {
-...schemaProvider,
-...createCachingECClassHierarchyInspector({ schemaProvider }),
-...createECSqlQueryExecutor(imodel),
+  ...schemaProvider,
+  ...createCachingECClassHierarchyInspector({ schemaProvider }),
+  ...createECSqlQueryExecutor(imodel),
 };
 
 // After:
 import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 
 const imodelAccess = {
-...createECSchemaProvider(imodel), // now also provides `classDerivesFrom`
-...createECSqlQueryExecutor(imodel),
+  ...createECSchemaProvider(imodel), // now also provides `classDerivesFrom`
+  ...createECSqlQueryExecutor(imodel),
 };
 ```
 

--- a/apps/full-stack-tests/src/content/Utils.ts
+++ b/apps/full-stack-tests/src/content/Utils.ts
@@ -9,7 +9,6 @@ import {
   createECSchemaProvider as createECSchemaProviderInterop,
   createECSqlQueryExecutor,
 } from "@itwin/presentation-core-interop";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 import { unifyIModelAPIs } from "../IModelUtils.js";
 
 import type { ECDb } from "@itwin/core-backend";
@@ -23,14 +22,13 @@ import type {
 import type { RelationshipPath } from "@itwin/presentation-shared";
 
 /**
- * Builds the `imodelAccess` object (schema provider + class-hierarchy inspector + ECSQL query executor)
+ * Builds the `imodelAccess` object (schema provider + ECSQL query executor)
  * required by the content pipeline APIs.
  */
 export function createContentIModelAccess(ecdb: ECDb) {
   const schemaProvider = createECSchemaProviderInterop(unifyIModelAPIs(ecdb));
-  const classHierarchyInspector = createCachingECClassHierarchyInspector({ schemaProvider });
   const queryExecutor = createECSqlQueryExecutor(ecdb);
-  return { ...schemaProvider, ...classHierarchyInspector, ...queryExecutor };
+  return { ...schemaProvider, ...queryExecutor };
 }
 
 export type ContentIModelAccess = ReturnType<typeof createContentIModelAccess>;

--- a/apps/full-stack-tests/src/hierarchies-react/learning-snippets/Localization.test.tsx
+++ b/apps/full-stack-tests/src/hierarchies-react/learning-snippets/Localization.test.tsx
@@ -2,12 +2,10 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable no-duplicate-imports */
 
 import { insertPhysicalModelWithPartition } from "presentation-test-utilities";
 import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.Localization.CommonImports
 import { Props } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
@@ -53,7 +51,6 @@ describe("Hierarchies React", () => {
         const access = {
           imodelKey: createIModelKey(imodelConnection),
           ...schemaProvider,
-          ...createCachingECClassHierarchyInspector({ schemaProvider, cacheSize: 100 }),
           ...createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodelConnection), 1000),
         };
         const getHierarchyDefinition: Props<typeof useIModelTree>["getHierarchyDefinition"] = () => ({

--- a/apps/full-stack-tests/src/hierarchies-react/learning-snippets/ReadmeExample.test.tsx
+++ b/apps/full-stack-tests/src/hierarchies-react/learning-snippets/ReadmeExample.test.tsx
@@ -7,7 +7,6 @@
 import { insertPhysicalModelWithPartition } from "presentation-test-utilities";
 // __PUBLISH_EXTRACT_START__ Presentation.HierarchiesReact.iModelAccess.Imports
 import { IModelConnection } from "@itwin/core-frontend";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
 // __PUBLISH_EXTRACT_END__
@@ -34,8 +33,6 @@ function createIModelAccess(imodel: IModelConnection) {
   return {
     imodelKey: createIModelKey(imodel),
     ...schemaProvider,
-    // while caching for hierarchy inspector is not mandatory, it's recommended to use it to improve performance
-    ...createCachingECClassHierarchyInspector({ schemaProvider, cacheSize: 100 }),
     // the second argument is the maximum number of rows the executor will return - this allows us to
     // avoid creating hierarchy levels of insane size (expensive to us and useless to users)
     ...createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 1000),

--- a/apps/full-stack-tests/src/hierarchies/HierarchySearch.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/HierarchySearch.test.ts
@@ -1874,7 +1874,7 @@ describe("Hierarchies", () => {
           return createProvider({
             imodelAccess,
             hierarchy: createPredicateBasedHierarchyDefinition({
-              classHierarchyInspector: imodelAccess,
+              imodelAccess,
               hierarchy: {
                 rootNodes: async ({ createSelectClause }) => [
                   {

--- a/apps/full-stack-tests/src/hierarchies/InstanceLabelSelectClauseFactory.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/InstanceLabelSelectClauseFactory.test.ts
@@ -34,7 +34,7 @@ describe("NodesQueryClauseFactory", () => {
     });
     const imodelAccess = createIModelAccess(imodelConnection);
 
-    const labelsQueryFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
+    const labelsQueryFactory = createBisInstanceLabelSelectClauseFactory({ imodelAccess });
 
     const ecsql = `
       SELECT ${await labelsQueryFactory.createSelectClause({

--- a/apps/full-stack-tests/src/hierarchies/Utils.ts
+++ b/apps/full-stack-tests/src/hierarchies/Utils.ts
@@ -11,7 +11,6 @@ import {
   createIModelKey,
 } from "@itwin/presentation-core-interop";
 import { createIModelHierarchyProvider, createLimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 import { createSchemaContext, unifyIModelAPIs } from "../IModelUtils.js";
 
 import type { ECDb } from "@itwin/core-backend";
@@ -24,12 +23,10 @@ type HierarchySearchPaths = NonNullable<NonNullable<HierarchyProviderProps["sear
 
 export function createIModelAccess(imodel: IModelConnection | IModelDb | ECDb) {
   const schemaProvider = createECSchemaProviderInterop(unifyIModelAPIs(imodel));
-  const classHierarchyInspector = createCachingECClassHierarchyInspector({ schemaProvider });
   const queryExecutor = createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 123);
   return {
     imodelKey: imodel instanceof IModelConnection || imodel instanceof IModelDb ? createIModelKey(imodel) : "ecdb",
     ...schemaProvider,
-    ...classHierarchyInspector,
     ...queryExecutor,
   };
 }

--- a/apps/full-stack-tests/src/hierarchies/imodel-hierarchy-merging/HierarchiesMerging.ts
+++ b/apps/full-stack-tests/src/hierarchies/imodel-hierarchy-merging/HierarchiesMerging.ts
@@ -118,7 +118,7 @@ export function createHierarchyDefinitionFactory({
 
   return ({ primaryIModelAccess }) =>
     createPredicateBasedHierarchyDefinition({
-      classHierarchyInspector: primaryIModelAccess,
+      imodelAccess: primaryIModelAccess,
       hierarchy: {
         rootNodes: async (props) => rootNodes(props),
         childNodes: [

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyDefinitions.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/HierarchyDefinitions.test.ts
@@ -257,7 +257,7 @@ describe("Hierarchies", () => {
         const imodelAccess = createIModelAccess(imodelConnection);
         // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.HierarchyDefinitions.PredicateBasedHierarchyDefinition
         const hierarchyDefinition = createPredicateBasedHierarchyDefinition({
-          classHierarchyInspector: imodelAccess,
+          imodelAccess,
           hierarchy: {
             // For root nodes, simply return one generic node
             rootNodes: async () => [{ node: { key: "physical-elements", label: "Physical elements" } }],

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/MergedIModelHierarchies.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/MergedIModelHierarchies.test.ts
@@ -131,9 +131,9 @@ describe("Hierarchies", () => {
         // Create a simple hierarchy definition that uses `BisCore.PhysicalModel` for root nodes and
         // `BisCore.PhysicalElement` for each model's child nodes.
         const hierarchyDefinition = createPredicateBasedHierarchyDefinition({
-          // Note: we use the latest version of the iModel as our class hierarchy inspector - that
+          // Note: we use the latest version of the iModel here - that
           // ensures we can find all classes even if they were not present in the base iModel
-          classHierarchyInspector: imodels[imodels.length - 1].imodelAccess,
+          imodelAccess: imodels[imodels.length - 1].imodelAccess,
           hierarchy: {
             rootNodes: async (props) => [
               await createInstanceNodesQueryDefinition({ ...props, fullClassName: "BisCore.PhysicalModel" }),

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/Migration.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/Migration.test.ts
@@ -65,7 +65,7 @@ describe("Hierarchies", () => {
           const imodel = emptyIModel;
           const imodelAccess = createIModelAccess(imodel);
           const hierarchyDefinition = createPredicateBasedHierarchyDefinition({
-            classHierarchyInspector: imodelAccess,
+            imodelAccess,
             hierarchy: { rootNodes: async () => [{ node: { key: "test", label: "Root node" } }], childNodes: [] },
           });
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.HierarchyProviderUsage
@@ -86,7 +86,7 @@ describe("Hierarchies", () => {
           const imodelAccess = createIModelAccess(emptyIModel);
           // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.Migration.PredicateBasedHierarchyDefinitionUsage
           const hierarchyDefinition = createPredicateBasedHierarchyDefinition({
-            classHierarchyInspector: imodelAccess,
+            imodelAccess,
             hierarchy: {
               rootNodes: async () => [
                 /* define root node specifications here */

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/ReadmeExample.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/ReadmeExample.test.ts
@@ -16,7 +16,7 @@ import { Logger } from "@itwin/core-bentley";
 import { IModelConnection } from "@itwin/core-frontend";
 import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor, HierarchyLevelDefinition } from "@itwin/presentation-hierarchies";
-import { createCachingECClassHierarchyInspector, Props } from "@itwin/presentation-shared";
+import { Props } from "@itwin/presentation-shared";
 // __PUBLISH_EXTRACT_END__
 // __PUBLISH_EXTRACT_START__ Presentation.Hierarchies.ReadmeExampleImports
 import {
@@ -38,10 +38,8 @@ function createIModelAccess(imodel: IModelConnection) {
   return {
     // The key of the iModel we're accessing
     imodelKey: createIModelKey(imodel),
-    // Schema provider provides access to EC information (metadata)
+    // Schema provider provides access to EC information (metadata) and class hierarchy inspection
     ...schemaProvider,
-    // While caching for hierarchy inspector is not mandatory, it's recommended to use it to improve performance
-    ...createCachingECClassHierarchyInspector({ schemaProvider, cacheSize: 100 }),
     // The second argument is the maximum number of rows the executor will return - this allows us to
     // avoid creating hierarchy levels of insane size (expensive to us and useless to users)
     ...createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 1000),
@@ -53,7 +51,7 @@ function createIModelAccess(imodel: IModelConnection) {
 function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider>["imodelAccess"]): HierarchyProvider {
   // Define the hierarchy
   const hierarchyDefinition = createPredicateBasedHierarchyDefinition({
-    classHierarchyInspector: imodelAccess,
+    imodelAccess,
     hierarchy: {
       // For root nodes, select all BisCore.GeometricModel3d instances
       rootNodes: async ({ createSelectClause }) => [

--- a/apps/full-stack-tests/src/unified-selection/SelectionSync.test.ts
+++ b/apps/full-stack-tests/src/unified-selection/SelectionSync.test.ts
@@ -23,7 +23,6 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import { withEditTxn } from "@itwin/core-backend";
 import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 import { createStorage, enableUnifiedSelectionSyncWithIModel, Selectables } from "@itwin/unified-selection";
 import { buildTestIModel, unifyIModelAPIs } from "../IModelUtils.js";
 import { initialize, terminate } from "../IntegrationTests.js";
@@ -64,13 +63,11 @@ describe("Unified selection sync with iModel", () => {
 
   function enableSync(props?: { selectionScope?: SelectionScope }): Disposable {
     const schemaProvider = createECSchemaProvider(unifyIModelAPIs(imodelConnection));
-    const classHierarchyInspector = createCachingECClassHierarchyInspector({ schemaProvider });
     const queryExecutor = createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodelConnection), 123);
     const dispose = enableUnifiedSelectionSyncWithIModel({
       imodelAccess: {
         key: createIModelKey(imodelConnection),
         ...schemaProvider,
-        ...classHierarchyInspector,
         ...queryExecutor,
         selectionSet: imodelConnection.selectionSet,
         hiliteSet: imodelConnection.hilited,

--- a/apps/full-stack-tests/src/unified-selection/learning-snippets/HiliteSets.test.ts
+++ b/apps/full-stack-tests/src/unified-selection/learning-snippets/HiliteSets.test.ts
@@ -13,7 +13,6 @@ import {
 } from "presentation-test-utilities";
 // __PUBLISH_EXTRACT_START__ Presentation.UnifiedSelection.HiliteSets.BasicProviderImports
 import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 import { createHiliteSetProvider } from "@itwin/unified-selection";
 // __PUBLISH_EXTRACT_END__
 // __PUBLISH_EXTRACT_START__ Presentation.UnifiedSelection.HiliteSets.IModelProviderImports
@@ -57,11 +56,7 @@ describe("Unified selection", () => {
         // __PUBLISH_EXTRACT_START__ Presentation.UnifiedSelection.HiliteSets.BasicProvider
         const schemaProvider = createECSchemaProvider(getIModelConnection());
         const hiliteProvider = createHiliteSetProvider({
-          imodelAccess: {
-            ...schemaProvider,
-            ...createCachingECClassHierarchyInspector({ schemaProvider }),
-            ...createECSqlQueryExecutor(getIModelConnection()),
-          },
+          imodelAccess: { ...schemaProvider, ...createECSqlQueryExecutor(getIModelConnection()) },
         });
         const hiliteSetIterator = hiliteProvider.getHiliteSet({ selectables });
         // __PUBLISH_EXTRACT_END__
@@ -96,7 +91,7 @@ describe("Unified selection", () => {
           if (imodelKey === createIModelKey(imodelConnection)) {
             return {
               ...createECSqlQueryExecutor(imodelConnection),
-              ...createCachingECClassHierarchyInspector({ schemaProvider: createECSchemaProvider(imodelConnection) }),
+              ...createECSchemaProvider(imodelConnection),
               key: imodelKey,
             };
           }

--- a/apps/full-stack-tests/src/unified-selection/learning-snippets/ReadmeExample.test.tsx
+++ b/apps/full-stack-tests/src/unified-selection/learning-snippets/ReadmeExample.test.tsx
@@ -20,7 +20,6 @@ import { createStorage, Selectables } from "@itwin/unified-selection";
 // __PUBLISH_EXTRACT_END__
 // __PUBLISH_EXTRACT_START__ Presentation.UnifiedSelection.IModelSelectionSync.Imports
 import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 import { enableUnifiedSelectionSyncWithIModel, SelectionStorage } from "@itwin/unified-selection";
 // __PUBLISH_EXTRACT_END__
 // __PUBLISH_EXTRACT_START__ Presentation.UnifiedSelection.LegacySelectionManagerSelectionSync.Imports
@@ -158,9 +157,7 @@ describe("Unified selection", () => {
                 // selection and hilite sets
                 imodelAccess: {
                   ...createECSqlQueryExecutor(iModelConnection),
-                  ...createCachingECClassHierarchyInspector({
-                    schemaProvider: createECSchemaProvider(iModelConnection),
-                  }),
+                  ...createECSchemaProvider(iModelConnection),
                   key: createIModelKey(iModelConnection),
                   hiliteSet: iModelConnection.hilited,
                   selectionSet: iModelConnection.selectionSet,

--- a/apps/load-tests/tests/src/processors/models-tree-stateless.ts
+++ b/apps/load-tests/tests/src/processors/models-tree-stateless.ts
@@ -16,7 +16,6 @@ import {
   RowsLimitExceededError,
 } from "@itwin/presentation-hierarchies";
 import { defaultHierarchyConfiguration, ModelsTreeDefinition } from "@itwin/presentation-models-tree";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 import { doRequest, getCurrentIModelName, loadNodes, loadVariables, openIModelConnectionIfNeeded } from "./common.js";
 
 import type { VUContext, VUEvents } from "artillery";
@@ -92,7 +91,6 @@ function createModelsTreeProvider(context: VUContext, events: VUEvents) {
   const imodelAccess = {
     imodelKey: imodelRpcProps.key,
     ...schemaProvider,
-    ...createCachingECClassHierarchyInspector({ schemaProvider, cacheSize: 1000 }),
     ...createLimitingECSqlQueryExecutor(queryExecutor, 1000),
   };
   const provider = createIModelHierarchyProvider({

--- a/apps/performance-tests/src/hierarchies/HideIfNoChildren.test.ts
+++ b/apps/performance-tests/src/hierarchies/HideIfNoChildren.test.ts
@@ -29,7 +29,7 @@ describe("hide if no children", () => {
         iModel,
         getHierarchyFactory: (imodelAccess) => {
           return createPredicateBasedHierarchyDefinition({
-            classHierarchyInspector: imodelAccess,
+            imodelAccess,
             hierarchy: {
               rootNodes: async ({ createSelectClause }) =>
                 createPhysicalElementsHierarchyLevelDefinition({ createSelectClause, limit: 5 }),
@@ -69,7 +69,7 @@ describe("hide if no children", () => {
         iModel,
         getHierarchyFactory: (imodelAccess) => {
           return createPredicateBasedHierarchyDefinition({
-            classHierarchyInspector: imodelAccess,
+            imodelAccess,
             hierarchy: {
               rootNodes: async ({ createSelectClause }) =>
                 createPhysicalElementsHierarchyLevelDefinition({ createSelectClause, limit: 5 }),

--- a/apps/performance-tests/src/hierarchies/ModelsTree.test.ts
+++ b/apps/performance-tests/src/hierarchies/ModelsTree.test.ts
@@ -16,17 +16,11 @@ import { run } from "../util/TestUtilities.js";
 import { StatelessHierarchyProvider } from "./StatelessHierarchyProvider.js";
 
 import type { IModelDb } from "@itwin/core-backend";
-import type {
-  ECClassHierarchyInspector,
-  ECSchemaProvider,
-  ECSqlQueryDef,
-  ECSqlQueryExecutor,
-  InstanceKey,
-} from "@itwin/presentation-shared";
+import type { ECSchemaProvider, ECSqlQueryDef, ECSqlQueryExecutor, InstanceKey } from "@itwin/presentation-shared";
 import type { IModelAccess } from "./StatelessHierarchyProvider.js";
 
 describe("models tree", () => {
-  const getHierarchyFactory = (imodelAccess: ECSchemaProvider & ECClassHierarchyInspector & ECSqlQueryExecutor) =>
+  const getHierarchyFactory = (imodelAccess: ECSchemaProvider & ECSqlQueryExecutor) =>
     new ModelsTreeDefinition({ imodelAccess });
   const setup = () => SnapshotDb.openFile(Datasets.getIModelPath("baytown"));
   const cleanup = (iModel: IModelDb) => iModel.close();

--- a/apps/performance-tests/src/hierarchies/StatelessHierarchyProvider.ts
+++ b/apps/performance-tests/src/hierarchies/StatelessHierarchyProvider.ts
@@ -6,7 +6,6 @@
 import { asyncScheduler, expand, filter, finalize, from, observeOn, of, tap } from "rxjs";
 import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 import { createIModelHierarchyProvider, createLimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 import { LOGGER } from "../util/Logging.js";
 
 import type { IModelDb } from "@itwin/core-backend";
@@ -17,11 +16,11 @@ import type {
   HierarchySearchTree,
   LimitingECSqlQueryExecutor,
 } from "@itwin/presentation-hierarchies";
-import type { ECClassHierarchyInspector, ECSchemaProvider } from "@itwin/presentation-shared";
+import type { ECSchemaProvider } from "@itwin/presentation-shared";
 
 interface ProviderOptionsBase {
   rowLimit?: number | "unbounded";
-  getHierarchyFactory(imodelAccess: ECSchemaProvider & ECClassHierarchyInspector): HierarchyDefinition;
+  getHierarchyFactory(imodelAccess: ECSchemaProvider): HierarchyDefinition;
   search?: { paths: HierarchySearchTree[] };
 }
 type ProviderOptionsWithIModel = { iModel: IModelDb } & ProviderOptionsBase;
@@ -40,9 +39,7 @@ function log(messageOrCallback: string | (() => string)) {
 
 const DEFAULT_ROW_LIMIT = 1000;
 
-export type IModelAccess = ECSchemaProvider &
-  ECClassHierarchyInspector &
-  LimitingECSqlQueryExecutor & { imodelKey: string };
+export type IModelAccess = ECSchemaProvider & LimitingECSqlQueryExecutor & { imodelKey: string };
 
 export class StatelessHierarchyProvider {
   private constructor(private readonly _provider: HierarchyProvider) {}
@@ -90,7 +87,6 @@ export class StatelessHierarchyProvider {
     const imodelAccess = {
       imodelKey: iModel.key,
       ...schemaProvider,
-      ...createCachingECClassHierarchyInspector({ schemaProvider, cacheSize: 1000 }),
       ...createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(iModel), rowLimitToUse),
     };
     return imodelAccess;

--- a/apps/performance-tests/src/unified-selection/HiliteSet.test.ts
+++ b/apps/performance-tests/src/unified-selection/HiliteSet.test.ts
@@ -6,7 +6,6 @@
 import { describe, expect } from "vitest";
 import { SnapshotDb } from "@itwin/core-backend";
 import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 import { createHiliteSetProvider, Selectables } from "@itwin/unified-selection";
 import { Datasets } from "../util/Datasets.js";
 import { run } from "../util/TestUtilities.js";
@@ -81,10 +80,7 @@ function runHiliteTest(
       const iModel = SnapshotDb.openFile(Datasets.getIModelPath(iModelName));
 
       const selectables: Selectable[] = [];
-      const imodelAccess = {
-        ...createECSqlQueryExecutor(iModel),
-        ...createCachingECClassHierarchyInspector({ schemaProvider: createECSchemaProvider(iModel), cacheSize: 100 }),
-      };
+      const imodelAccess = { ...createECSqlQueryExecutor(iModel), ...createECSchemaProvider(iModel) };
 
       for await (const row of imodelAccess.createQueryReader({ ecsql: testProps.inputQuery })) {
         selectables.push({ className: testProps.fullClassName, id: row.ECInstanceId });

--- a/apps/test-app/frontend/src/components/app/App.tsx
+++ b/apps/test-app/frontend/src/components/app/App.tsx
@@ -26,7 +26,6 @@ import { SchemaFormatsProvider, SchemaUnitProvider } from "@itwin/ecschema-metad
 import { ThemeProvider, ToggleSwitch } from "@itwin/itwinui-react";
 import { SchemaMetadataContextProvider } from "@itwin/presentation-components";
 import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 import { createHiliteSetProvider, enableUnifiedSelectionSyncWithIModel } from "@itwin/unified-selection";
 import { UnifiedSelectionContextProvider } from "@itwin/unified-selection-react";
 import { Root } from "@stratakit/mui";
@@ -128,10 +127,7 @@ export function App() {
       // determine what the viewport is hiliting
       const selectedView = IModelApp.viewManager.selectedView;
       const hiliteSetProvider = createHiliteSetProvider({
-        imodelAccess: {
-          ...createECSqlQueryExecutor(state.imodel),
-          ...createCachingECClassHierarchyInspector({ schemaProvider: createECSchemaProvider(state.imodel) }),
-        },
+        imodelAccess: { ...createECSqlQueryExecutor(state.imodel), ...createECSchemaProvider(state.imodel) },
       });
       from(
         hiliteSetProvider.getHiliteSet({
@@ -337,7 +333,7 @@ function IModelComponents(props: IModelComponentsProps) {
       enableUnifiedSelectionSyncWithIModel({
         imodelAccess: {
           ...createECSqlQueryExecutor(imodel),
-          ...createCachingECClassHierarchyInspector({ schemaProvider: createECSchemaProvider(imodel) }),
+          ...createECSchemaProvider(imodel),
           key: imodel.key,
           hiliteSet: imodel.hilited,
           selectionSet: imodel.selectionSet,

--- a/apps/test-app/frontend/src/components/tree-widget/MultiDataSourceTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/MultiDataSourceTree.tsx
@@ -23,11 +23,7 @@ import {
 } from "@itwin/presentation-hierarchies";
 import { useUnifiedSelectionTree } from "@itwin/presentation-hierarchies-react";
 import { StrataKitRootErrorRenderer, StrataKitTreeRenderer } from "@itwin/presentation-hierarchies-react/stratakit";
-import {
-  createBisInstanceLabelSelectClauseFactory,
-  createCachingECClassHierarchyInspector,
-  ECSql,
-} from "@itwin/presentation-shared";
+import { createBisInstanceLabelSelectClauseFactory, ECSql } from "@itwin/presentation-shared";
 import { useUnifiedSelectionContext } from "@itwin/unified-selection-react";
 import { SampleRpcInterface } from "@test-app/common";
 
@@ -73,7 +69,6 @@ function createIModelAccess(imodel: IModelConnection) {
   return {
     imodelKey: imodel.key,
     ...schemaProvider,
-    ...createCachingECClassHierarchyInspector({ schemaProvider }),
     ...createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 1000),
   };
 }
@@ -258,7 +253,7 @@ function debounced<TArgs>(callback: (args: TArgs) => void, delay: number) {
 
 function createModelsHierarchyDefinition({ imodelAccess }: { imodelAccess: IModelAccess }) {
   return createPredicateBasedHierarchyDefinition({
-    classHierarchyInspector: imodelAccess,
+    imodelAccess,
     hierarchy: {
       rootNodes: async ({ createSelectClause }) => [
         {
@@ -343,7 +338,7 @@ async function* getModelsHierarchySearchPaths({
   componentId: string;
   componentName: string;
 }): AsyncIterableIterator<HierarchySearchPath> {
-  const labelsFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: imodelAccess });
+  const labelsFactory = createBisInstanceLabelSelectClauseFactory({ imodelAccess });
   const [rootSubjectPathPromise, modelPaths] = [
     getRootSubjectSearchedPath({ imodelAccess, searchText, labelsFactory, componentId, componentName }),
     getModelsSearchPaths({ imodelAccess, searchText, labelsFactory, componentId, componentName }),

--- a/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
+++ b/apps/test-app/frontend/src/components/tree-widget/StatelessTree.tsx
@@ -25,7 +25,6 @@ import {
 import { LocalizationContextProvider, useIModelUnifiedSelectionTree } from "@itwin/presentation-hierarchies-react";
 import { StrataKitRootErrorRenderer } from "@itwin/presentation-hierarchies-react/stratakit";
 import { ModelsTreeDefinition } from "@itwin/presentation-models-tree";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 import { Selectable, Selectables } from "@itwin/unified-selection";
 import { useUnifiedSelectionContext } from "@itwin/unified-selection-react";
 import { Button, CircularProgress, Stack, Switch, TextField, Typography } from "@mui/material";
@@ -62,7 +61,6 @@ export function StatelessTreeV2({
     setIModelAccess({
       imodelKey: imodel.key,
       ...schemaProvider,
-      ...createCachingECClassHierarchyInspector({ schemaProvider }),
       ...createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 1000),
     });
   }, [imodel]);

--- a/packages/content/api/presentation-content.api.md
+++ b/packages/content/api/presentation-content.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { EC } from '@itwin/presentation-shared';
-import type { ECClassHierarchyInspector } from '@itwin/presentation-shared';
 import type { ECSchemaProvider } from '@itwin/presentation-shared';
 import { ECSqlBinding } from '@itwin/presentation-shared';
 import type { ECSqlQueryExecutor } from '@itwin/presentation-shared';
@@ -126,7 +125,7 @@ interface ContentProvider {
 // @public
 interface ContentProviderProps {
     config?: ContentConfiguration;
-    imodelAccess: ECSqlQueryExecutor & ECSchemaProvider & ECClassHierarchyInspector;
+    imodelAccess: ECSqlQueryExecutor & ECSchemaProvider;
     sources: ContentSource[];
 }
 
@@ -226,7 +225,7 @@ interface DescriptorTransformer {
     priority?: number;
     transform(props: {
         descriptor: TransformableDescriptor;
-        imodelAccess: ECSchemaProvider & ECClassHierarchyInspector;
+        imodelAccess: ECSchemaProvider;
     }): Promise<void>;
 }
 
@@ -292,7 +291,7 @@ interface GetDistinctFieldValuesProps {
 // @public
 interface IModelFieldsProvider extends BaseFieldsProvider {
     getContribution(props: {
-        imodelAccess: ECSchemaProvider & ECClassHierarchyInspector;
+        imodelAccess: ECSchemaProvider;
         target: ContentTarget;
     }): Promise<FieldsProviderContribution | undefined>;
 }
@@ -391,7 +390,7 @@ export function resolveContentSources(props: ResolveContentSourcesProps): Promis
 // @public
 interface ResolveContentSourcesProps {
     config?: Pick<ContentConfiguration, "imodelFieldsProviders">;
-    imodelAccess: ECSqlQueryExecutor & ECSchemaProvider & ECClassHierarchyInspector;
+    imodelAccess: ECSqlQueryExecutor & ECSchemaProvider;
     targets: ContentTarget[];
 }
 

--- a/packages/content/src/content/Content.ts
+++ b/packages/content/src/content/Content.ts
@@ -37,7 +37,6 @@ import { createContentProviderImpl } from "./CreateContentProvider.js";
 import { resolveContentSourcesImpl } from "./ResolveContentSources.js";
 
 import type {
-  ECClassHierarchyInspector,
   ECSchemaProvider,
   ECSqlQueryExecutor,
   InstanceKey,
@@ -186,7 +185,7 @@ export interface ContentConfiguration {
  */
 interface ResolveContentSourcesProps {
   /** Access to the iModel for schema introspection, class-hierarchy inspection, and path resolution. */
-  imodelAccess: ECSqlQueryExecutor & ECSchemaProvider & ECClassHierarchyInspector;
+  imodelAccess: ECSqlQueryExecutor & ECSchemaProvider;
   /** The content targets to resolve. */
   targets: ContentTarget[];
   /** Extension point configuration (only `imodelFieldsProviders` is used for resolution). */
@@ -223,7 +222,7 @@ export async function resolveContentSources(props: ResolveContentSourcesProps): 
  */
 interface ContentProviderProps {
   /** Access to the iModel for running ECSQL queries, schema introspection, and class-hierarchy checks. */
-  imodelAccess: ECSqlQueryExecutor & ECSchemaProvider & ECClassHierarchyInspector;
+  imodelAccess: ECSqlQueryExecutor & ECSchemaProvider;
 
   /** Pre-resolved content sources (output of `resolveContentSources`). */
   sources: ContentSource[];

--- a/packages/content/src/content/ResolveContentSources.ts
+++ b/packages/content/src/content/ResolveContentSources.ts
@@ -12,7 +12,6 @@ import { buildTargetFilter } from "./query/TargetFilter.js";
 import type { Observable } from "rxjs";
 import type {
   EC,
-  ECClassHierarchyInspector,
   ECSchemaProvider,
   ECSqlBinding,
   ECSqlQueryDef,
@@ -309,7 +308,7 @@ function resolveTarget({
   providers,
   target,
 }: {
-  imodelAccess: ECSqlQueryExecutor & ECSchemaProvider & ECClassHierarchyInspector;
+  imodelAccess: ECSqlQueryExecutor & ECSchemaProvider;
   providers: IModelFieldsProvider[];
   target: ContentTarget;
 }): Observable<ContentSource> {
@@ -346,7 +345,7 @@ function resolveTarget({
 // --- Public entry point ---
 
 export async function resolveContentSourcesImpl(props: {
-  imodelAccess: ECSqlQueryExecutor & ECSchemaProvider & ECClassHierarchyInspector;
+  imodelAccess: ECSqlQueryExecutor & ECSchemaProvider;
   targets: ContentTarget[];
   imodelFieldsProviders: IModelFieldsProvider[];
 }): Promise<ContentSource[]> {

--- a/packages/content/src/content/descriptor-building/BuildDescriptor.ts
+++ b/packages/content/src/content/descriptor-building/BuildDescriptor.ts
@@ -17,7 +17,7 @@ import { mergePropertyFieldsByIdentity } from "./PropertyFieldMerge.js";
 import { collectRelatedPropertyFields } from "./RelatedFields.js";
 import { collectSelectors } from "./Selectors.js";
 
-import type { ECClassHierarchyInspector, ECSchemaProvider } from "@itwin/presentation-shared";
+import type { ECSchemaProvider } from "@itwin/presentation-shared";
 import type { ContentConfiguration } from "../Content.js";
 import type { ContentSource } from "../ContentTarget.js";
 import type { ContentDescriptor } from "../model/ContentDescriptor.js";
@@ -29,7 +29,7 @@ import type { Field, PropertyField } from "../model/Field.js";
  */
 interface BuildContentDescriptorProps {
   /** Schema access used to enumerate fields from EC metadata (Stage 2 is schema-only — no queries). */
-  imodelAccess: ECSchemaProvider & ECClassHierarchyInspector;
+  imodelAccess: ECSchemaProvider;
   /** Pre-resolved content sources (output of Stage 1). */
   sources: ContentSource[];
   /** Extension point configuration (fields providers, external providers, transformers). */

--- a/packages/content/src/content/extensions/DescriptorTransformer.ts
+++ b/packages/content/src/content/extensions/DescriptorTransformer.ts
@@ -6,7 +6,7 @@
 import { PropertyField } from "../model/Field.js";
 import { computeFieldForkKey, toSortedUniqueClassNames } from "../model/Utils.js";
 
-import type { EC, ECClassHierarchyInspector, ECSchemaProvider } from "@itwin/presentation-shared";
+import type { EC, ECSchemaProvider } from "@itwin/presentation-shared";
 import type { ContentSource } from "../ContentTarget.js";
 import type { CategoryDefinition } from "../model/Category.js";
 import type { ContentDescriptor } from "../model/ContentDescriptor.js";
@@ -59,10 +59,7 @@ export interface DescriptorTransformer {
    * Runs asynchronously and receives `imodelAccess` for schema and class-hierarchy
    * lookups (e.g. polymorphic class matching via `classDerivesFrom`).
    */
-  transform(props: {
-    descriptor: TransformableDescriptor;
-    imodelAccess: ECSchemaProvider & ECClassHierarchyInspector;
-  }): Promise<void>;
+  transform(props: { descriptor: TransformableDescriptor; imodelAccess: ECSchemaProvider }): Promise<void>;
 }
 
 /**

--- a/packages/content/src/content/extensions/IModelFieldsProvider.ts
+++ b/packages/content/src/content/extensions/IModelFieldsProvider.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type {
-  ECClassHierarchyInspector,
   ECSchemaProvider,
   ECSqlBinding,
   ECSqlQueryExecutor,
@@ -37,7 +36,7 @@ export interface IModelFieldsProvider extends BaseFieldsProvider {
    * Called once per target during source resolution.
    */
   getContribution(props: {
-    imodelAccess: ECSchemaProvider & ECClassHierarchyInspector;
+    imodelAccess: ECSchemaProvider;
     target: ContentTarget;
   }): Promise<FieldsProviderContribution | undefined>;
 }

--- a/packages/content/src/content/extensions/presentation-rules/DescriptorTransformerFactory.ts
+++ b/packages/content/src/content/extensions/presentation-rules/DescriptorTransformerFactory.ts
@@ -5,7 +5,7 @@
 
 import { checkRequiredSchemas, classMatchesSpec, mapPropertyCategories, resolveCategoryId } from "./Utils.js";
 
-import type { EC, ECClassHierarchyInspector, ECSchemaProvider, Props } from "@itwin/presentation-shared";
+import type { EC, ECSchemaProvider, Props } from "@itwin/presentation-shared";
 import type { DescriptorTransformer } from "../DescriptorTransformer.js";
 import type * as PresentationRules from "./PresentationRules.js";
 
@@ -132,7 +132,7 @@ export function createDescriptorTransformerFromContentModifierRule({
  * When `classSpec` is undefined the whole set matches.
  */
 async function computeMatchedValueClasses(
-  imodelAccess: ECClassHierarchyInspector & ECSchemaProvider,
+  imodelAccess: ECSchemaProvider,
   field: TransformablePropertyField,
   classSpec: PresentationRules.SingleSchemaClassSpecification | undefined,
 ): Promise<EC.FullClassNameDotNotation[]> {

--- a/packages/content/src/content/extensions/presentation-rules/Utils.ts
+++ b/packages/content/src/content/extensions/presentation-rules/Utils.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import type { EC, ECClassHierarchyInspector, ECSchemaProvider } from "@itwin/presentation-shared";
+import type { EC, ECSchemaProvider } from "@itwin/presentation-shared";
 import type { CategoryDefinition } from "../../model/Category.js";
 import type * as PresentationRules from "./PresentationRules.js";
 
@@ -75,7 +75,7 @@ export async function checkRequiredSchemas(
  * @internal
  */
 export async function classMatchesSpec(
-  imodelAccess: ECClassHierarchyInspector,
+  imodelAccess: Pick<ECSchemaProvider, "classDerivesFrom">,
   className: EC.FullClassNameDotNotation,
   classSpec: PresentationRules.SingleSchemaClassSpecification | undefined,
 ): Promise<boolean> {

--- a/packages/content/src/test/Content.test.ts
+++ b/packages/content/src/test/Content.test.ts
@@ -9,7 +9,6 @@ import { TARGET_FILTER_JOIN_ALIAS } from "../content/query/TargetFilter.js";
 
 import type {
   EC,
-  ECClassHierarchyInspector,
   ECSchemaProvider,
   ECSqlQueryDef,
   ECSqlQueryExecutor,
@@ -78,7 +77,7 @@ function createMockIModelAccess(props?: {
   resolvePathsQueryResults?: ECSqlQueryRow[];
   primaryClassScanResults?: ECSqlQueryRow[];
   derivedClasses?: Record<string, string[]>;
-}): ECSqlQueryExecutor & ECSchemaProvider & ECClassHierarchyInspector {
+}): ECSqlQueryExecutor & ECSchemaProvider {
   const { resolvePathsQueryResults = [], primaryClassScanResults = [], derivedClasses = {} } = props ?? {};
   return {
     createQueryReader: vi.fn((query: ECSqlQueryDef) => {
@@ -1110,7 +1109,7 @@ describe("resolveContentSources", () => {
         relatedProperties: [{ path: pathA }, { path: pathB }],
       });
       let callCount = 0;
-      const imodelAccess: ECSqlQueryExecutor & ECSchemaProvider & ECClassHierarchyInspector = {
+      const imodelAccess: ECSqlQueryExecutor & ECSchemaProvider = {
         createQueryReader: vi.fn((_query: ECSqlQueryDef) => {
           callCount++;
           // First declaration gets no results, second gets results

--- a/packages/content/src/test/MetadataStubs.ts
+++ b/packages/content/src/test/MetadataStubs.ts
@@ -5,7 +5,7 @@
 
 import { normalizeFullClassName, parseFullClassName } from "@itwin/presentation-shared";
 
-import type { EC, ECClassHierarchyInspector, ECSchemaProvider } from "@itwin/presentation-shared";
+import type { EC, ECSchemaProvider } from "@itwin/presentation-shared";
 
 /** Creates a primitive `EC.Property` stub for tests. */
 export function createPrimitiveProperty(props: {
@@ -104,10 +104,10 @@ export function createMixinClass(props: {
 }
 
 /**
- * Creates an `ECSchemaProvider & ECClassHierarchyInspector` stub backed by the given classes,
+ * Creates an `ECSchemaProvider` stub backed by the given classes,
  * looked up by their (normalized) full name. `classDerivesFrom` walks the stubs' `baseClass` chain.
  */
-export function createSchemaAccess(classes: EC.Class[]): ECSchemaProvider & ECClassHierarchyInspector {
+export function createSchemaAccess(classes: EC.Class[]): ECSchemaProvider {
   const byFullName = new Map(classes.map((cls) => [cls.fullName, cls]));
   return {
     getSchema: async (schemaName: string) => ({

--- a/packages/content/src/test/descriptor-building/ContributionMemoizer.test.ts
+++ b/packages/content/src/test/descriptor-building/ContributionMemoizer.test.ts
@@ -6,13 +6,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { createContributionMemoizer } from "../../content/descriptor-building/ContributionMemoizer.js";
 
-import type { ECClassHierarchyInspector, ECSchemaProvider } from "@itwin/presentation-shared";
+import type { ECSchemaProvider } from "@itwin/presentation-shared";
 import type { ContentTarget } from "../../content/ContentTarget.js";
 import type { IModelFieldsProvider } from "../../content/extensions/IModelFieldsProvider.js";
 
 type Contribution = Awaited<ReturnType<IModelFieldsProvider["getContribution"]>>;
 
-const imodelAccess = {} as ECSchemaProvider & ECClassHierarchyInspector;
+const imodelAccess = {} as ECSchemaProvider;
 
 function createProvider(id: IModelFieldsProvider["id"], contribution: Contribution) {
   const getContribution = vi.fn<IModelFieldsProvider["getContribution"]>(async () => contribution);

--- a/packages/content/src/test/extensions/presentation-rules/DescriptorTransformerFactory.test.ts
+++ b/packages/content/src/test/extensions/presentation-rules/DescriptorTransformerFactory.test.ts
@@ -9,7 +9,7 @@ import { createDescriptorTransformerFromContentModifierRule } from "../../../con
 import { PropertyField } from "../../../content/model/Field.js";
 import { computeFieldForkKey, toSortedUniqueClassNames } from "../../../content/model/Utils.js";
 
-import type { EC, ECClassHierarchyInspector, ECSchemaProvider } from "@itwin/presentation-shared";
+import type { EC, ECSchemaProvider } from "@itwin/presentation-shared";
 import type * as PresentationRules from "../../../content/extensions/presentation-rules/PresentationRules.js";
 import type { ContentDescriptor } from "../../../content/model/ContentDescriptor.js";
 import type { CalculatedField, Field } from "../../../content/model/Field.js";
@@ -74,7 +74,7 @@ function createImodelAccess(props?: {
   schemas?: Map<string, EC.SchemaVersion>;
   /** Map of `derivedClass -> list of ancestor classes it derives from` (a class always derives from itself). */
   derivesFrom?: Record<string, string[]>;
-}): ECSchemaProvider & ECClassHierarchyInspector {
+}): ECSchemaProvider {
   const schemas = props?.schemas;
   const derivesFrom = props?.derivesFrom ?? {};
   return {

--- a/packages/content/src/test/extensions/presentation-rules/EmbeddedRulesets.test.ts
+++ b/packages/content/src/test/extensions/presentation-rules/EmbeddedRulesets.test.ts
@@ -33,6 +33,7 @@ function createIModelAccess(props: {
       const version = schemas?.get(name);
       return version ? ({ name, version } as unknown as EC.Schema) : undefined;
     },
+    classDerivesFrom: async () => false,
   };
 }
 

--- a/packages/content/src/test/extensions/presentation-rules/FieldsProviderFactory.test.ts
+++ b/packages/content/src/test/extensions/presentation-rules/FieldsProviderFactory.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createFieldsProviderFromContentModifierRule } from "../../../content/extensions/presentation-rules/FieldsProviderFactory.js";
 
-import type { EC, ECClassHierarchyInspector, ECSchemaProvider } from "@itwin/presentation-shared";
+import type { EC, ECSchemaProvider } from "@itwin/presentation-shared";
 import type { ContentTarget } from "../../../content/ContentTarget.js";
 import type * as PresentationRules from "../../../content/extensions/presentation-rules/PresentationRules.js";
 
@@ -72,8 +72,8 @@ function createStubRelationshipClass(props: {
 function createIModelAccess(props?: {
   schemas?: Map<string, EC.Schema>;
   classes?: Map<string, EC.Class>;
-  classDerivesFrom?: ECClassHierarchyInspector["classDerivesFrom"];
-}): ECSchemaProvider & ECClassHierarchyInspector {
+  classDerivesFrom?: ECSchemaProvider["classDerivesFrom"];
+}): ECSchemaProvider {
   const schemas = props?.schemas ?? new Map();
   return {
     getSchema: async (name: string) => schemas.get(name),
@@ -84,7 +84,7 @@ function createIModelAccess(props?: {
 function createIModelAccessFromClasses(
   classes: Map<string, EC.Class>,
   options?: { synthesizeMissing?: boolean },
-): ECSchemaProvider & ECClassHierarchyInspector {
+): ECSchemaProvider {
   const getSchema = async (name: string) =>
     ({
       name,
@@ -92,7 +92,6 @@ function createIModelAccessFromClasses(
       getClass: async (className: string) =>
         classes.get(`${name}.${className}`) ??
         (options?.synthesizeMissing ? createStubClass({ schemaName: name, className }) : undefined),
-      getCustomAttributes: async () => new Map(),
     }) as unknown as EC.Schema;
   return { getSchema, classDerivesFrom: async () => true };
 }
@@ -320,7 +319,7 @@ describe("createFieldsProviderFromContentModifierRule", () => {
     });
 
     it("returns undefined when classDerivesFrom returns false", async () => {
-      const classDerivesFrom = vi.fn<ECClassHierarchyInspector["classDerivesFrom"]>().mockResolvedValue(false);
+      const classDerivesFrom = vi.fn<ECSchemaProvider["classDerivesFrom"]>().mockResolvedValue(false);
       const provider = createFieldsProviderFromContentModifierRule({
         rule: { class: { schemaName: "TestSchema", className: "BaseElement" } },
       });
@@ -333,7 +332,7 @@ describe("createFieldsProviderFromContentModifierRule", () => {
     });
 
     it("returns contribution when classDerivesFrom returns true", async () => {
-      const classDerivesFrom = vi.fn<ECClassHierarchyInspector["classDerivesFrom"]>().mockResolvedValue(true);
+      const classDerivesFrom = vi.fn<ECSchemaProvider["classDerivesFrom"]>().mockResolvedValue(true);
       const provider = createFieldsProviderFromContentModifierRule({
         rule: {
           class: { schemaName: "TestSchema", className: "BaseElement" },

--- a/packages/content/src/test/query/QueryLimits.test.ts
+++ b/packages/content/src/test/query/QueryLimits.test.ts
@@ -167,6 +167,7 @@ describe("QueryLimits", () => {
               } as unknown as EC.RelationshipClass;
             },
           }) as unknown as EC.Schema,
+        classDerivesFrom: async () => false,
       };
     }
 

--- a/packages/core-interop/src/core-interop/Metadata.ts
+++ b/packages/core-interop/src/core-interop/Metadata.ts
@@ -86,10 +86,22 @@ export function createECSchemaProvider(
   // Ensures we only create a single `ECClassHierarchyResolver` for the iModel, which is used to resolve derived classes for all schemas.
   // Cache the promise (not the resolved value) so concurrent `getSchema` calls share one `createECClassHierarchyResolver` invocation.
   let cachedClassHierarchyResolverPromise: Promise<ECClassHierarchyResolver> | undefined;
+  // Set once the resolver promise settles. Allows `classDerivesFrom` to answer synchronously after the hierarchy is loaded.
+  let cachedClassHierarchyResolver: ECClassHierarchyResolver | undefined;
+  function getClassHierarchyResolver(): ECClassHierarchyResolver | Promise<ECClassHierarchyResolver> {
+    if (cachedClassHierarchyResolver) {
+      return cachedClassHierarchyResolver;
+    }
+    cachedClassHierarchyResolverPromise ??= createECClassHierarchyResolver(imodel).then((resolver) => {
+      cachedClassHierarchyResolver = resolver;
+      return resolver;
+    });
+    return cachedClassHierarchyResolverPromise;
+  }
+
   async function getSchemaProviderContext(schemaName: string) {
-    cachedClassHierarchyResolverPromise ??= createECClassHierarchyResolver(imodel);
     const [classHierarchyResolver, schemaView] = await Promise.all([
-      cachedClassHierarchyResolverPromise,
+      getClassHierarchyResolver(),
       getSchemaView(schemaName),
     ]);
     return { classHierarchyResolver, schemaView };
@@ -100,6 +112,19 @@ export function createECSchemaProvider(
       const { classHierarchyResolver, schemaView } = await getSchemaProviderContext(name);
       const svSchema = schemaView.getSchema(name);
       return svSchema ? createECSchemaFromSchemaView(svSchema, { schemaView, classHierarchyResolver }) : undefined;
+    },
+    classDerivesFrom(
+      derivedClassFullName: EC.FullClassNameDotNotation,
+      candidateBaseClassFullName: EC.FullClassNameDotNotation,
+    ): Promise<boolean> | boolean {
+      // A class always derives from itself. This matches the semantics of the deprecated `ECClassHierarchyInspector`.
+      if (derivedClassFullName === candidateBaseClassFullName) {
+        return true;
+      }
+      const resolver = getClassHierarchyResolver();
+      return resolver instanceof Promise
+        ? resolver.then((r) => r.classDerivesFrom(derivedClassFullName, candidateBaseClassFullName))
+        : resolver.classDerivesFrom(derivedClassFullName, candidateBaseClassFullName);
     },
   };
 }

--- a/packages/core-interop/src/test/Metadata.test.ts
+++ b/packages/core-interop/src/test/Metadata.test.ts
@@ -141,6 +141,44 @@ describe("createECSchemaProvider", () => {
     await provider.getSchema("SchemaA");
     expect(getSchemaView).toHaveBeenCalledTimes(2);
   });
+
+  describe("classDerivesFrom", () => {
+    function stubIModelWithQueryRows(rows: Array<[string, string]>) {
+      const createQueryReader = vi.fn(() =>
+        (async function* () {
+          for (const row of rows) {
+            yield row as unknown as QueryRowProxy;
+          }
+        })(),
+      );
+      return { getSchemaView: async () => createMockSchemaView(new Map()), createQueryReader };
+    }
+
+    it("returns `true` synchronously when the class names are equal, without loading the hierarchy", () => {
+      const imodel = stubIModelWithQueryRows([]);
+      const provider = createECSchemaProvider(imodel);
+      expect(provider.classDerivesFrom("Schema.A", "Schema.A")).toBe(true);
+      expect(imodel.createQueryReader).not.toHaveBeenCalled();
+    });
+
+    it("returns a promise on the first call and resolves to `true` for a derived class", async () => {
+      const provider = createECSchemaProvider(stubIModelWithQueryRows([["Schema.B", "Schema.A"]]));
+      const result = provider.classDerivesFrom("Schema.B", "Schema.A");
+      expect(result).toBeInstanceOf(Promise);
+      expect(await result).toBe(true);
+    });
+
+    it("resolves to `false` for unrelated classes", async () => {
+      const provider = createECSchemaProvider(stubIModelWithQueryRows([["Schema.B", "Schema.A"]]));
+      expect(await provider.classDerivesFrom("Schema.B", "Schema.C")).toBe(false);
+    });
+
+    it("answers synchronously once the class hierarchy has been loaded", async () => {
+      const provider = createECSchemaProvider(stubIModelWithQueryRows([["Schema.B", "Schema.A"]]));
+      await provider.classDerivesFrom("Schema.B", "Schema.A");
+      expect(provider.classDerivesFrom("Schema.B", "Schema.A")).toBe(true);
+    });
+  });
 });
 
 describe("createECSchemaFromSchemaView", () => {

--- a/packages/hierarchies-react/README.md
+++ b/packages/hierarchies-react/README.md
@@ -65,7 +65,6 @@ The hook takes 2 required properties:
 
   ```tsx
   import { IModelConnection } from "@itwin/core-frontend";
-  import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
   import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
   import { createLimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
 
@@ -74,8 +73,6 @@ The hook takes 2 required properties:
     return {
       imodelKey: createIModelKey(imodel),
       ...schemaProvider,
-      // while caching for hierarchy inspector is not mandatory, it's recommended to use it to improve performance
-      ...createCachingECClassHierarchyInspector({ schemaProvider, cacheSize: 100 }),
       // the second argument is the maximum number of rows the executor will return - this allows us to
       // avoid creating hierarchy levels of insane size (expensive to us and useless to users)
       ...createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 1000),
@@ -109,7 +106,6 @@ The component renders a virtualized tree using the `Tree` component from `@strat
 
 ```tsx
 import { IModelConnection } from "@itwin/core-frontend";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
 
@@ -125,8 +121,6 @@ function createIModelAccess(imodel: IModelConnection) {
   return {
     imodelKey: createIModelKey(imodel),
     ...schemaProvider,
-    // while caching for hierarchy inspector is not mandatory, it's recommended to use it to improve performance
-    ...createCachingECClassHierarchyInspector({ schemaProvider, cacheSize: 100 }),
     // the second argument is the maximum number of rows the executor will return - this allows us to
     // avoid creating hierarchy levels of insane size (expensive to us and useless to users)
     ...createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 1000),

--- a/packages/hierarchies/README.md
+++ b/packages/hierarchies/README.md
@@ -77,7 +77,7 @@ Here's a simple example of how to create a hierarchy provider and build a hierar
 import { IModelConnection } from "@itwin/core-frontend";
 import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor, HierarchyLevelDefinition } from "@itwin/presentation-hierarchies";
-import { createCachingECClassHierarchyInspector, Props } from "@itwin/presentation-shared";
+import { Props } from "@itwin/presentation-shared";
 
 import {
   createIModelHierarchyProvider,
@@ -93,10 +93,8 @@ function createIModelAccess(imodel: IModelConnection) {
   return {
     // The key of the iModel we're accessing
     imodelKey: createIModelKey(imodel),
-    // Schema provider provides access to EC information (metadata)
+    // Schema provider provides access to EC information (metadata) and class hierarchy inspection
     ...schemaProvider,
-    // While caching for hierarchy inspector is not mandatory, it's recommended to use it to improve performance
-    ...createCachingECClassHierarchyInspector({ schemaProvider, cacheSize: 100 }),
     // The second argument is the maximum number of rows the executor will return - this allows us to
     // avoid creating hierarchy levels of insane size (expensive to us and useless to users)
     ...createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 1000),
@@ -106,7 +104,7 @@ function createIModelAccess(imodel: IModelConnection) {
 function createProvider(imodelAccess: Props<typeof createIModelHierarchyProvider>["imodelAccess"]): HierarchyProvider {
   // Define the hierarchy
   const hierarchyDefinition = createPredicateBasedHierarchyDefinition({
-    classHierarchyInspector: imodelAccess,
+    imodelAccess,
     hierarchy: {
       // For root nodes, select all BisCore.GeometricModel3d instances
       rootNodes: async ({ createSelectClause }) => [

--- a/packages/hierarchies/api/presentation-hierarchies.api.md
+++ b/packages/hierarchies/api/presentation-hierarchies.api.md
@@ -6,7 +6,6 @@
 
 import type { ConcatenatedValue } from '@itwin/presentation-shared';
 import type { EC } from '@itwin/presentation-shared';
-import type { ECClassHierarchyInspector } from '@itwin/presentation-shared';
 import type { ECSchemaProvider } from '@itwin/presentation-shared';
 import type { ECSqlQueryDef } from '@itwin/presentation-shared';
 import type { ECSqlQueryExecutor } from '@itwin/presentation-shared';
@@ -87,7 +86,7 @@ export type DefineGenericNodeChildHierarchyLevelProps = Omit<DefineHierarchyLeve
 
 // @public
 export interface DefineHierarchyLevelProps extends Pick<NodesQueryClauseFactory, "createSelectClause" | "createFilterClauses"> {
-    imodelAccess: LimitingECSqlQueryExecutor & ECSchemaProvider & ECClassHierarchyInspector & {
+    imodelAccess: LimitingECSqlQueryExecutor & ECSchemaProvider & {
         imodelKey: string;
     };
     instanceFilter?: GenericInstanceFilter;
@@ -531,7 +530,7 @@ export namespace HierarchySearchTree {
 }
 
 // @public (undocumented)
-type IModelAccess = ECSchemaProvider & LimitingECSqlQueryExecutor & ECClassHierarchyInspector & {
+type IModelAccess = ECSchemaProvider & LimitingECSqlQueryExecutor & {
     imodelKey: string;
 };
 
@@ -700,11 +699,11 @@ type ParentHierarchyNode<TBase = HierarchyNode> = OmitOverUnion<TBase, "children
 
 // @public
 interface PredicateBasedHierarchyDefinitionProps extends Pick<HierarchyDefinition, "parseNode" | "preProcessNode" | "postProcessNode"> {
-    classHierarchyInspector: ECClassHierarchyInspector;
     hierarchy: {
         rootNodes: (props: DefineRootHierarchyLevelProps) => Promise<HierarchyLevelDefinition>;
         childNodes: PredicateBasedHierarchyLevelDefinition[];
     };
+    imodelAccess: Pick<ECSchemaProvider, "classDerivesFrom">;
 }
 
 // @public

--- a/packages/hierarchies/learning/PresentationRulesMigrationGuide.md
+++ b/packages/hierarchies/learning/PresentationRulesMigrationGuide.md
@@ -93,7 +93,7 @@ Matching hierarchy definition, created using `createPredicateBasedHierarchyDefin
 import { createPredicateBasedHierarchyDefinition } from "@itwin/presentation-hierarchies";
 
 const hierarchyDefinition = createPredicateBasedHierarchyDefinition({
-  classHierarchyInspector: imodelAccess,
+  imodelAccess,
   hierarchy: {
     rootNodes: async () => [
       /* define root node specifications here */

--- a/packages/hierarchies/learning/imodel/HierarchyDefinition.md
+++ b/packages/hierarchies/learning/imodel/HierarchyDefinition.md
@@ -246,7 +246,7 @@ import {
 } from "@itwin/presentation-hierarchies";
 
 const hierarchyDefinition = createPredicateBasedHierarchyDefinition({
-  classHierarchyInspector: imodelAccess,
+  imodelAccess,
   hierarchy: {
     // For root nodes, simply return one generic node
     rootNodes: async () => [{ node: { key: "physical-elements", label: "Physical elements" } }],

--- a/packages/hierarchies/learning/imodel/HierarchyProvider.md
+++ b/packages/hierarchies/learning/imodel/HierarchyProvider.md
@@ -20,17 +20,15 @@ The `createIModelHierarchyProvider` factory function takes an `imodelAccess` pro
 import { IModelConnection } from "@itwin/core-frontend";
 import { createECSchemaProvider, createECSqlQueryExecutor, createIModelKey } from "@itwin/presentation-core-interop";
 import { createLimitingECSqlQueryExecutor, HierarchyLevelDefinition } from "@itwin/presentation-hierarchies";
-import { createCachingECClassHierarchyInspector, Props } from "@itwin/presentation-shared";
+import { Props } from "@itwin/presentation-shared";
 
 function createIModelAccess(imodel: IModelConnection) {
   const schemaProvider = createECSchemaProvider(imodel);
   return {
     // The key of the iModel we're accessing
     imodelKey: createIModelKey(imodel),
-    // Schema provider provides access to EC information (metadata)
+    // Schema provider provides access to EC information (metadata) and class hierarchy inspection
     ...schemaProvider,
-    // While caching for hierarchy inspector is not mandatory, it's recommended to use it to improve performance
-    ...createCachingECClassHierarchyInspector({ schemaProvider, cacheSize: 100 }),
     // The second argument is the maximum number of rows the executor will return - this allows us to
     // avoid creating hierarchy levels of insane size (expensive to us and useless to users)
     ...createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 1000),

--- a/packages/hierarchies/learning/imodel/MergedIModelHierarchies.md
+++ b/packages/hierarchies/learning/imodel/MergedIModelHierarchies.md
@@ -62,9 +62,9 @@ async function createInstanceNodesQueryDefinition({
 // Create a simple hierarchy definition that uses `BisCore.PhysicalModel` for root nodes and
 // `BisCore.PhysicalElement` for each model's child nodes.
 const hierarchyDefinition = createPredicateBasedHierarchyDefinition({
-  // Note: we use the latest version of the iModel as our class hierarchy inspector - that
+  // Note: we use the latest version of the iModel here - that
   // ensures we can find all classes even if they were not present in the base iModel
-  classHierarchyInspector: imodels[imodels.length - 1].imodelAccess,
+  imodelAccess: imodels[imodels.length - 1].imodelAccess,
   hierarchy: {
     rootNodes: async (props) => [
       await createInstanceNodesQueryDefinition({ ...props, fullClassName: "BisCore.PhysicalModel" }),

--- a/packages/hierarchies/learning/imodel/PerformanceTuning.md
+++ b/packages/hierarchies/learning/imodel/PerformanceTuning.md
@@ -21,9 +21,3 @@ The library relies on the idea that it makes little sense to show users very lar
 The limiting functionality is achieved through the use of `LimitingECSqlQueryExecutor`, which is an input to `createIModelHierarchyProvider` as part of the `imodelAccess` prop. The executor's factory function `createLimitingECSqlQueryExecutor` takes a required `defaultLimit` argument, which sets the limit, and the recommended value would be around `1k` and up to `10k` - we don't recommend using a higher one.
 
 Then creating a query reader through a limiting query executor, it's possible to specify an override to the default limit. This feature is used by the hierarchy provider - its `getNodes` function takes a `hierarchyLevelSizeLimit` optional prop, which sets the override. This provides ability for components, using the hierarchy provider, to increase the limit per hierarchy level upon a user's request.
-
-## Class hierarchy inspector's cache size
-
-The hierarchy provider heavily relies on `ECClassHierarchyInspector` for checking if one ECClass derives from another. In some cases, the checks are done so often, that it could become a performance problem.
-
-For that reason, the `@itwin/presentation-shared` delivers the [`createCachingECClassHierarchyInspector`](https://github.com/iTwin/presentation/blob/master/packages/shared/README.md#ecclasshierarchyinspector--createcachingecclasshierarchyinspector) factory function, which creates an inspector with caching capability. As with all caches, there's a tradeoff of memory consumption VS performance, so the cache size should be limited. The cache size defaults to `0`, but we recommend using at around `100` for most cases.

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyDefinition.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { GenericInstanceFilter } from "@itwin/core-common";
-import type { EC, ECClassHierarchyInspector, ECSchemaProvider, ECSqlQueryDef } from "@itwin/presentation-shared";
+import type { EC, ECSchemaProvider, ECSqlQueryDef } from "@itwin/presentation-shared";
 import type { NonGroupingHierarchyNode, ParentHierarchyNode } from "../HierarchyNode.js";
 import type {
   ProcessedGenericHierarchyNode,
@@ -127,7 +127,7 @@ export interface DefineHierarchyLevelProps extends Pick<
   "createSelectClause" | "createFilterClauses"
 > {
   /** The iModel for which the hierarchy definition is being requested for. */
-  imodelAccess: LimitingECSqlQueryExecutor & ECSchemaProvider & ECClassHierarchyInspector & { imodelKey: string };
+  imodelAccess: LimitingECSqlQueryExecutor & ECSchemaProvider & { imodelKey: string };
 
   /** Parent node to get children for. Pass `undefined` to get root nodes. */
   parentNode: HierarchyDefinitionParentNode | undefined;

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
@@ -68,7 +68,6 @@ import type { Observable, ObservableInput, ObservedValueOf } from "rxjs";
 import type { GuidString } from "@itwin/core-bentley";
 import type {
   ConcatenatedValue,
-  ECClassHierarchyInspector,
   ECSchemaProvider,
   ECSqlQueryDef,
   Event,
@@ -121,7 +120,7 @@ interface IModelHierarchyProviderLocalizedStrings {
 }
 
 /** @public */
-type IModelAccess = ECSchemaProvider & LimitingECSqlQueryExecutor & ECClassHierarchyInspector & { imodelKey: string };
+type IModelAccess = ECSchemaProvider & LimitingECSqlQueryExecutor & { imodelKey: string };
 
 /**
  * Props for `createIModelHierarchyProvider`.
@@ -133,7 +132,6 @@ interface IModelHierarchyProviderProps {
    *
    * @see `ECSchemaProvider`
    * @see `LimitingECSqlQueryExecutor`
-   * @see `ECClassHierarchyInspector`
    */
   imodelAccess: IModelAccess;
 
@@ -224,7 +222,6 @@ interface MergedIModelHierarchyProviderProps extends Omit<
      *
      * @see `ECSchemaProvider`
      * @see `LimitingECSqlQueryExecutor`
-     * @see `ECClassHierarchyInspector`
      */
     imodelAccess: IModelAccess;
 

--- a/packages/hierarchies/src/hierarchies/imodel/NodeSelectQueryFactory.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/NodeSelectQueryFactory.ts
@@ -21,13 +21,7 @@ import type {
   GenericInstanceFilterRuleGroupOperator,
   GenericInstanceFilterRuleOperator,
 } from "@itwin/core-common";
-import type {
-  EC,
-  ECClassHierarchyInspector,
-  ECSchemaProvider,
-  IInstanceLabelSelectClauseFactory,
-  Props,
-} from "@itwin/presentation-shared";
+import type { EC, ECSchemaProvider, IInstanceLabelSelectClauseFactory, Props } from "@itwin/presentation-shared";
 import type { HierarchyNodeAutoExpandProp } from "./IModelHierarchyNode.js";
 
 /**
@@ -261,7 +255,7 @@ export interface NodesQueryClauseFactory {
  * Creates an instance of `NodeSelectQueryFactory`.
  */
 export function createNodesQueryClauseFactory(props: {
-  imodelAccess: ECSchemaProvider & ECClassHierarchyInspector;
+  imodelAccess: ECSchemaProvider;
   instanceLabelSelectClauseFactory: IInstanceLabelSelectClauseFactory;
 }): NodesQueryClauseFactory {
   return new NodeSelectQueryFactory(props);
@@ -269,11 +263,11 @@ export function createNodesQueryClauseFactory(props: {
 
 /** A factory for creating a nodes' select ECSQL query. */
 class NodeSelectQueryFactory {
-  private _imodelAccess: ECSchemaProvider & ECClassHierarchyInspector;
+  private _imodelAccess: ECSchemaProvider;
   private _instanceLabelSelectClauseFactory: IInstanceLabelSelectClauseFactory;
 
   public constructor(props: {
-    imodelAccess: ECSchemaProvider & ECClassHierarchyInspector;
+    imodelAccess: ECSchemaProvider;
     instanceLabelSelectClauseFactory: IInstanceLabelSelectClauseFactory;
   }) {
     this._imodelAccess = props.imodelAccess;
@@ -351,7 +345,7 @@ class NodeSelectQueryFactory {
  * is returned to make sure the resulting query is valid and doesn't return anything.
  */
 async function createInstanceFilterClauses(props: {
-  imodelAccess: ECSchemaProvider & ECClassHierarchyInspector;
+  imodelAccess: ECSchemaProvider;
   contentClass: { fullName: EC.FullClassNameDotNotation; alias: string };
   filter: GenericInstanceFilter;
 }): Promise<{ from: EC.FullClassNameDotNotation; where: string[]; joins: string[] }> {
@@ -495,7 +489,7 @@ function isSelector(x: any): x is ECSqlValueSelector {
 
 async function createGroupingSelector(
   grouping: ECSqlSelectClauseGroupingParams,
-  imodelAccess: ECSchemaProvider & ECClassHierarchyInspector,
+  imodelAccess: ECSchemaProvider,
   instanceLabelSelectClauseFactory: IInstanceLabelSelectClauseFactory,
 ): Promise<string> {
   const groupingSelectors = new Array<{ key: string; selector: string }>();
@@ -854,7 +848,7 @@ function assignRelationshipPathAliases(
 }
 
 interface SpecializeContentClassProps {
-  classHierarchyInspector: ECClassHierarchyInspector;
+  classHierarchyInspector: Pick<ECSchemaProvider, "classDerivesFrom">;
   contentClassName: EC.FullClassNameDotNotation;
   filterClassNames: EC.FullClassNameDotNotation[];
 }
@@ -875,7 +869,7 @@ async function specializeContentClass(
 }
 
 async function getSpecializedPropertyClass(
-  classHierarchyInspector: ECClassHierarchyInspector,
+  classHierarchyInspector: Pick<ECSchemaProvider, "classDerivesFrom">,
   classes: EC.FullClassNameDotNotation[],
 ): Promise<EC.FullClassNameDotNotation | undefined> {
   if (classes.length === 0) {

--- a/packages/hierarchies/src/hierarchies/imodel/PredicateBasedHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/PredicateBasedHierarchyDefinition.ts
@@ -7,7 +7,7 @@ import { concatMap, filter, firstValueFrom, from, mergeAll, mergeMap, toArray } 
 import { HierarchyNode } from "../HierarchyNode.js";
 
 import type { Id64String } from "@itwin/core-bentley";
-import type { EC, ECClassHierarchyInspector, InstanceKey } from "@itwin/presentation-shared";
+import type { EC, ECSchemaProvider, InstanceKey } from "@itwin/presentation-shared";
 import type { GenericNodeKey, InstancesNodeKey } from "../HierarchyNodeKey.js";
 import type {
   DefineHierarchyLevelProps,
@@ -145,7 +145,7 @@ interface PredicateBasedHierarchyDefinitionProps extends Pick<
   "parseNode" | "preProcessNode" | "postProcessNode"
 > {
   /** Access to ECClass hierarchy in the iModel */
-  classHierarchyInspector: ECClassHierarchyInspector;
+  imodelAccess: Pick<ECSchemaProvider, "classDerivesFrom">;
 
   /** Hierarchy level definitions */
   hierarchy: {
@@ -220,7 +220,7 @@ class PredicateBasedHierarchyDefinition implements HierarchyDefinition {
       return firstValueFrom(
         from(groupInstanceIdsByClass(parentNode.key.instanceKeys).entries()).pipe(
           mergeMap(async ([parentNodeClassName, parentNodeInstanceIds]) =>
-            createHierarchyLevelDefinitions(this._props.classHierarchyInspector, instancesParentNodeDefs, {
+            createHierarchyLevelDefinitions(this._props.imodelAccess, instancesParentNodeDefs, {
               ...props,
               parentNodeClassName,
               parentNodeInstanceIds,
@@ -238,7 +238,7 @@ class PredicateBasedHierarchyDefinition implements HierarchyDefinition {
 }
 
 async function createHierarchyLevelDefinitions(
-  classHierarchy: ECClassHierarchyInspector,
+  classHierarchy: Pick<ECSchemaProvider, "classDerivesFrom">,
   defs: InstancesNodeChildHierarchyLevelDefinition[],
   requestProps: DefineInstanceNodeChildHierarchyLevelProps,
 ) {

--- a/packages/hierarchies/src/hierarchies/imodel/SearchHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/SearchHierarchyDefinition.ts
@@ -16,7 +16,7 @@ import { ProcessedHierarchyNode } from "./IModelHierarchyNode.js";
 
 import type { Observable } from "rxjs";
 import type { Id64String } from "@itwin/core-bentley";
-import type { ECClassHierarchyInspector, InstanceKey } from "@itwin/presentation-shared";
+import type { ECSchemaProvider, InstanceKey } from "@itwin/presentation-shared";
 import type { IModelInstanceKey } from "../HierarchyNodeKey.js";
 import type { HierarchySearchTree } from "../HierarchySearch.js";
 import type {
@@ -34,7 +34,7 @@ import type {
 import type { ProcessedGroupingHierarchyNode } from "./IModelHierarchyNode.js";
 
 interface SearchHierarchyDefinitionProps {
-  imodelAccess: ECClassHierarchyInspector;
+  imodelAccess: Pick<ECSchemaProvider, "classDerivesFrom">;
   source: RxjsHierarchyDefinition;
   sourceName: string;
   targetPaths: HierarchySearchTree[];
@@ -43,7 +43,7 @@ interface SearchHierarchyDefinitionProps {
 
 /** @internal */
 export class SearchHierarchyDefinition implements RxjsHierarchyDefinition {
-  private _imodelAccess: ECClassHierarchyInspector;
+  private _imodelAccess: Pick<ECSchemaProvider, "classDerivesFrom">;
   private _source: RxjsHierarchyDefinition;
   private _targetPaths: HierarchySearchTree[];
   private _nodesParser: RxjsNodeParser;

--- a/packages/hierarchies/src/hierarchies/imodel/operators/Grouping.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/operators/Grouping.ts
@@ -40,7 +40,7 @@ import { createLabelGroups } from "./grouping/LabelGrouping.js";
 import { createPropertiesGroupingHandlers } from "./grouping/PropertiesGrouping.js";
 
 import type { Observable } from "rxjs";
-import type { ECClassHierarchyInspector, ECSchemaProvider, IPrimitiveValueFormatter } from "@itwin/presentation-shared";
+import type { ECSchemaProvider, IPrimitiveValueFormatter } from "@itwin/presentation-shared";
 import type { ParentHierarchyNode } from "../../HierarchyNode.js";
 import type {
   ProcessedGroupingHierarchyNode,
@@ -60,7 +60,7 @@ const LOGGING_NAMESPACE_PERFORMANCE_INTERNAL = createOperatorLoggingNamespace(
 
 /** @internal */
 export function createGroupingOperator(
-  imodelAccess: ECSchemaProvider & ECClassHierarchyInspector,
+  imodelAccess: ECSchemaProvider,
   parentNode: ParentHierarchyNode | undefined,
   valueFormatter: IPrimitiveValueFormatter,
   localizedStrings: PropertiesGroupingLocalizedStrings,
@@ -255,7 +255,7 @@ function mergeInPlace<T>(target: T[] | undefined, source: T[]) {
 }
 
 function createGroupingHandlers(
-  imodelAccess: ECSchemaProvider & ECClassHierarchyInspector,
+  imodelAccess: ECSchemaProvider,
   parentNode: ParentHierarchyNode | undefined,
   processedInstanceNodes: ProcessedInstanceHierarchyNode[],
   valueFormatter: IPrimitiveValueFormatter,

--- a/packages/hierarchies/src/hierarchies/imodel/operators/grouping/BaseClassGrouping.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/operators/grouping/BaseClassGrouping.ts
@@ -7,7 +7,7 @@ import { SortedArray } from "@itwin/core-bentley";
 import { createMainThreadReleaseOnTimePassedHandler, getClass } from "@itwin/presentation-shared";
 import { HierarchyNode } from "../../../HierarchyNode.js";
 
-import type { EC, ECClassHierarchyInspector, ECSchemaProvider } from "@itwin/presentation-shared";
+import type { EC, ECSchemaProvider } from "@itwin/presentation-shared";
 import type { ParentHierarchyNode } from "../../../HierarchyNode.js";
 import type { ClassGroupingNodeKey } from "../../../HierarchyNodeKey.js";
 import type { ProcessedInstanceHierarchyNode } from "../../IModelHierarchyNode.js";
@@ -53,7 +53,7 @@ export async function getBaseClassGroupingECClasses(
 export async function createBaseClassGroupsForSingleBaseClass(
   nodes: ProcessedInstanceHierarchyNode[],
   baseECClass: EC.Class,
-  classHierarchyInspector: ECClassHierarchyInspector,
+  classHierarchyInspector: Pick<ECSchemaProvider, "classDerivesFrom">,
 ): Promise<GroupingHandlerResult> {
   const releaseMainThread = createMainThreadReleaseOnTimePassedHandler();
   const groupedNodes = new Array<ProcessedInstanceHierarchyNode>();
@@ -141,7 +141,7 @@ function sortByBaseClass(classes: EC.Class[]): EC.Class[] {
 
 /** @internal */
 export async function createBaseClassGroupingHandlers(
-  imodelAccess: ECSchemaProvider & ECClassHierarchyInspector,
+  imodelAccess: ECSchemaProvider,
   parentNode: ParentHierarchyNode | undefined,
   nodes: ProcessedInstanceHierarchyNode[],
 ): Promise<GroupingHandler[]> {

--- a/packages/hierarchies/src/hierarchies/imodel/operators/grouping/PropertiesGrouping.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/operators/grouping/PropertiesGrouping.ts
@@ -13,13 +13,7 @@ import {
 import { HierarchyNode } from "../../../HierarchyNode.js";
 import { HierarchyNodeKey } from "../../../HierarchyNodeKey.js";
 
-import type {
-  ArrayElement,
-  EC,
-  ECClassHierarchyInspector,
-  ECSchemaProvider,
-  IPrimitiveValueFormatter,
-} from "@itwin/presentation-shared";
+import type { ArrayElement, EC, ECSchemaProvider, IPrimitiveValueFormatter } from "@itwin/presentation-shared";
 import type { ParentHierarchyNode } from "../../../HierarchyNode.js";
 import type { PropertyGroupingNodeKey } from "../../../HierarchyNodeKey.js";
 import type {
@@ -70,7 +64,7 @@ export async function createPropertyGroups(
   handlerGroupingParams: PropertyGroupInfo,
   valueFormatter: IPrimitiveValueFormatter,
   localizedStrings: PropertiesGroupingLocalizedStrings,
-  classHierarchyInspector: ECClassHierarchyInspector,
+  classHierarchyInspector: Pick<ECSchemaProvider, "classDerivesFrom">,
 ): Promise<GroupingHandlerResult> {
   let otherValuesGrouping: { node: ProcessedInstancesGroupingHierarchyNode; new: boolean } | undefined;
   const getOtherValuesGroupingNode = () => {
@@ -397,7 +391,7 @@ async function shouldCreatePropertyGroup(
   handlerGroupingParams: PropertyGroupInfo,
   nodePropertyGroupingParams: HierarchyNodePropertiesGroupingParams,
   nodeFullClassName: EC.FullClassNameDotNotation,
-  classHierarchyInspector: ECClassHierarchyInspector,
+  classHierarchyInspector: Pick<ECSchemaProvider, "classDerivesFrom">,
 ): Promise<boolean> {
   if (
     nodePropertyGroupingParams.propertiesClassName.toLocaleLowerCase() !==
@@ -477,7 +471,7 @@ export function doRangesMatch(
 
 /** @internal */
 export async function createPropertiesGroupingHandlers(
-  imodelAccess: ECSchemaProvider & ECClassHierarchyInspector,
+  imodelAccess: ECSchemaProvider,
   parentNode: ParentHierarchyNode | undefined,
   nodes: ProcessedInstanceHierarchyNode[],
   valueFormatter: IPrimitiveValueFormatter,

--- a/packages/hierarchies/src/test/Utils.ts
+++ b/packages/hierarchies/src/test/Utils.ts
@@ -9,7 +9,7 @@ import { getClass } from "@itwin/presentation-shared";
 
 import type { Mock } from "vitest";
 import type { LogLevel } from "@itwin/core-bentley";
-import type { EC, ECClassHierarchyInspector } from "@itwin/presentation-shared";
+import type { EC } from "@itwin/presentation-shared";
 import type { GroupingHierarchyNode, NonGroupingHierarchyNode } from "../hierarchies/HierarchyNode.js";
 import type {
   ClassGroupingNodeKey,
@@ -288,37 +288,26 @@ export function createECSchemaProviderStub() {
     props.baseClass && props.baseClass.addDerivedClass(res);
     return res;
   };
-  return {
+  const stubProvider = {
     stubEntityClass,
     stubRelationshipClass,
     stubOtherClass,
     getSchema: async (name: string) => getSchemaImpl(name),
-  };
-}
-
-export function createClassHierarchyInspectorStub(
-  schemaProvider = createECSchemaProviderStub(),
-): {
-  stubEntityClass: TStubEntityClassFunc;
-  stubRelationshipClass: TStubRelationshipClassFunc;
-  stubOtherClass: TStubClassFunc;
-} & ECClassHierarchyInspector {
-  return {
-    stubEntityClass: schemaProvider.stubEntityClass,
-    stubRelationshipClass: schemaProvider.stubRelationshipClass,
-    stubOtherClass: schemaProvider.stubOtherClass,
-    classDerivesFrom: async (derived: EC.FullClassNameDotNotation, base: EC.FullClassNameDotNotation) => {
-      const derivedClass = await getClass(schemaProvider, derived);
-      const baseClass = await getClass(schemaProvider, base);
+    classDerivesFrom: async (
+      derived: EC.FullClassNameDotNotation,
+      base: EC.FullClassNameDotNotation,
+    ): Promise<boolean> => {
+      const derivedClass = await getClass(stubProvider, derived);
+      const baseClass = await getClass(stubProvider, base);
       return derivedClass.is(baseClass);
     },
   };
+  return stubProvider;
 }
 
 export function createIModelAccessStub() {
   const createQueryReader: Mock<LimitingECSqlQueryExecutor["createQueryReader"]> = vi.fn();
-  const schemaProvider = createECSchemaProviderStub();
-  return { ...schemaProvider, ...createClassHierarchyInspectorStub(schemaProvider), createQueryReader };
+  return { ...createECSchemaProviderStub(), createQueryReader };
 }
 
 export function createInstanceLabelSelectClauseFactoryStub() {

--- a/packages/hierarchies/src/test/imodel/PredicateBasedHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/PredicateBasedHierarchyDefinition.test.ts
@@ -41,7 +41,7 @@ describe("createPredicateBasedHierarchyDefinition", () => {
       createInstanceNodesQueryDefinition(),
     ];
     const factory = createPredicateBasedHierarchyDefinition({
-      classHierarchyInspector: imodelAccess,
+      imodelAccess,
       hierarchy: { rootNodes: async () => rootHierarchyLevel, childNodes: [] },
     });
     const result = await factory.defineHierarchyLevel({ ...constProps(), parentNode: undefined });
@@ -65,7 +65,7 @@ describe("createPredicateBasedHierarchyDefinition", () => {
     ];
 
     const factory = createPredicateBasedHierarchyDefinition({
-      classHierarchyInspector: imodelAccess,
+      imodelAccess,
       hierarchy: {
         rootNodes: async () => [],
         childNodes: [
@@ -114,7 +114,7 @@ describe("createPredicateBasedHierarchyDefinition", () => {
     ];
 
     const factory = createPredicateBasedHierarchyDefinition({
-      classHierarchyInspector: imodelAccess,
+      imodelAccess,
       hierarchy: {
         rootNodes: async () => [],
         childNodes: [
@@ -153,7 +153,7 @@ describe("createPredicateBasedHierarchyDefinition", () => {
 
     const spy = vi.fn().mockResolvedValue([]);
     const factory = createPredicateBasedHierarchyDefinition({
-      classHierarchyInspector: imodelAccess,
+      imodelAccess,
       hierarchy: {
         rootNodes: async () => [],
         childNodes: [{ parentInstancesNodePredicate: "TestSchema.ClassX", definitions: spy }],
@@ -187,7 +187,7 @@ describe("createPredicateBasedHierarchyDefinition", () => {
     const derivedClassDefs = vi.fn().mockResolvedValue([]);
     const baseClassDefs = vi.fn().mockResolvedValue([]);
     let factory = createPredicateBasedHierarchyDefinition({
-      classHierarchyInspector: imodelAccess,
+      imodelAccess,
       hierarchy: {
         rootNodes: async () => [],
         childNodes: [
@@ -207,7 +207,7 @@ describe("createPredicateBasedHierarchyDefinition", () => {
     expect(baseClassDefs).not.toHaveBeenCalled();
 
     factory = createPredicateBasedHierarchyDefinition({
-      classHierarchyInspector: imodelAccess,
+      imodelAccess,
       hierarchy: {
         rootNodes: async () => [],
         childNodes: [
@@ -229,7 +229,7 @@ describe("createPredicateBasedHierarchyDefinition", () => {
   it("uses provided node parser", () => {
     const parseNode = vi.fn();
     const factory = createPredicateBasedHierarchyDefinition({
-      classHierarchyInspector: imodelAccess,
+      imodelAccess,
       parseNode,
       hierarchy: { rootNodes: async () => [], childNodes: [] },
     });
@@ -239,7 +239,7 @@ describe("createPredicateBasedHierarchyDefinition", () => {
   it("uses provided node pre-processor", () => {
     const preprocessor = vi.fn();
     const factory = createPredicateBasedHierarchyDefinition({
-      classHierarchyInspector: imodelAccess,
+      imodelAccess,
       preProcessNode: preprocessor,
       hierarchy: { rootNodes: async () => [], childNodes: [] },
     });
@@ -249,7 +249,7 @@ describe("createPredicateBasedHierarchyDefinition", () => {
   it("uses provided node post-processor", () => {
     const postprocessor = vi.fn();
     const factory = createPredicateBasedHierarchyDefinition({
-      classHierarchyInspector: imodelAccess,
+      imodelAccess,
       postProcessNode: postprocessor,
       hierarchy: { rootNodes: async () => [], childNodes: [] },
     });

--- a/packages/hierarchies/src/test/imodel/SearchHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/SearchHierarchyDefinition.test.ts
@@ -22,7 +22,7 @@ import {
   createTestProcessedInstanceNode,
 } from "../Utils.js";
 
-import type { ECClassHierarchyInspector } from "@itwin/presentation-shared";
+import type { ECSchemaProvider } from "@itwin/presentation-shared";
 import type { HierarchyNodeIdentifier } from "../../hierarchies/HierarchyNodeIdentifier.js";
 import type { HierarchySearchTree } from "../../hierarchies/HierarchySearch.js";
 import type {
@@ -39,8 +39,8 @@ import type { RxjsHierarchyDefinition } from "../../hierarchies/internal/RxjsHie
 
 describe("SearchHierarchyDefinition", () => {
   function createStubECClassHierarchyInspector(
-    overrides?: Partial<ECClassHierarchyInspector>,
-  ): ECClassHierarchyInspector {
+    overrides?: Partial<Pick<ECSchemaProvider, "classDerivesFrom">>,
+  ): Pick<ECSchemaProvider, "classDerivesFrom"> {
     return { classDerivesFrom: vi.fn().mockResolvedValue(false), ...overrides };
   }
 
@@ -51,7 +51,7 @@ describe("SearchHierarchyDefinition", () => {
   function createSearchHierarchyDefinition(props: {
     targetPaths: HierarchySearchTree[];
     source?: Partial<RxjsHierarchyDefinition>;
-    imodelAccess?: Partial<ECClassHierarchyInspector>;
+    imodelAccess?: Partial<Pick<ECSchemaProvider, "classDerivesFrom">>;
     sourceName?: string;
   }) {
     return new SearchHierarchyDefinition({
@@ -302,7 +302,7 @@ describe("SearchHierarchyDefinition", () => {
     });
 
     it("falls back to classDerivesFrom when class names differ", async () => {
-      const classDerivesFrom = vi.fn<ECClassHierarchyInspector["classDerivesFrom"]>();
+      const classDerivesFrom = vi.fn<ECSchemaProvider["classDerivesFrom"]>();
       classDerivesFrom.mockImplementation(async (derived, candidate) => {
         if (derived === "Schema.Derived" && candidate === "Schema.Base") {
           return true;
@@ -331,7 +331,7 @@ describe("SearchHierarchyDefinition", () => {
     });
 
     it("doesn't match when classDerivesFrom returns false for both directions", async () => {
-      const classDerivesFrom = vi.fn<ECClassHierarchyInspector["classDerivesFrom"]>().mockResolvedValue(false);
+      const classDerivesFrom = vi.fn<ECSchemaProvider["classDerivesFrom"]>().mockResolvedValue(false);
 
       const targetPaths: HierarchySearchTree[] = [{ identifier: { className: "Schema.Unrelated", id: "0x1" } }];
       const parsedNode = createSourceInstanceNode({

--- a/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
+++ b/packages/models-tree/src/models-tree/ModelsTreeDefinition.ts
@@ -47,7 +47,6 @@ import type {
 } from "@itwin/presentation-hierarchies";
 import type {
   EC,
-  ECClassHierarchyInspector,
   ECSchemaProvider,
   ECSqlBinding,
   ECSqlQueryDef,
@@ -81,7 +80,7 @@ export const defaultHierarchyConfiguration: ModelsTreeHierarchyConfiguration = {
 };
 
 interface ModelsTreeDefinitionProps {
-  imodelAccess: ECSchemaProvider & ECClassHierarchyInspector & LimitingECSqlQueryExecutor;
+  imodelAccess: ECSchemaProvider & LimitingECSqlQueryExecutor;
   idsCache?: ModelsTreeIdsCache;
   hierarchyConfig?: ModelsTreeHierarchyConfiguration;
 }
@@ -93,7 +92,7 @@ export interface ElementsGroupInfo {
 }
 
 interface ModelsTreeInstanceKeyPathsBaseProps {
-  imodelAccess: ECClassHierarchyInspector & ECSchemaProvider & LimitingECSqlQueryExecutor;
+  imodelAccess: ECSchemaProvider & LimitingECSqlQueryExecutor;
   idsCache?: ModelsTreeIdsCache;
   hierarchyConfig?: ModelsTreeHierarchyConfiguration;
   limit?: number | "unbounded";
@@ -127,7 +126,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
 
   public constructor(props: ModelsTreeDefinitionProps) {
     this._impl = createPredicateBasedHierarchyDefinition({
-      classHierarchyInspector: props.imodelAccess,
+      imodelAccess: props.imodelAccess,
       hierarchy: {
         rootNodes: async (requestProps) => this.createRootHierarchyLevelDefinition(requestProps),
         childNodes: [
@@ -565,7 +564,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
 }
 
 function createGeometricElementInstanceKeyPaths(
-  imodelAccess: ECClassHierarchyInspector & LimitingECSqlQueryExecutor,
+  imodelAccess: Pick<ECSchemaProvider, "classDerivesFrom"> & LimitingECSqlQueryExecutor,
   idsCache: ModelsTreeIdsCache,
   hierarchyConfig: ModelsTreeHierarchyConfiguration,
   targetItems: Array<Id64String | ElementsGroupInfo>,

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -331,10 +331,7 @@ This label selectors factory doesn't create labels on its own, but allows assign
 Example usage:
 
 ```ts
-import {
-  createClassBasedInstanceLabelSelectClauseFactory,
-  ECSchemaProvider,
-} from "@itwin/presentation-shared";
+import { createClassBasedInstanceLabelSelectClauseFactory, ECSchemaProvider } from "@itwin/presentation-shared";
 
 const imodelAccess: ECSchemaProvider = getSchemaProvider();
 const labelsFactory = createClassBasedInstanceLabelSelectClauseFactory({

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -16,7 +16,7 @@ The namespace defines all the [EC](https://www.itwinjs.org/bis/ec/) types that P
 
 ### `ECSchemaProvider` & `getClass`
 
-- `ECSchemaProvider` is an interface for something that knows how to get an [ECSchema](https://www.itwinjs.org/bis/ec/ec-schema/) from an iModel. The package itself doesn't provide an implementation for this interface and instead relies on `@itwin/presentation-core-interop` to do that.
+- `ECSchemaProvider` is an interface for something that knows how to get an [ECSchema](https://www.itwinjs.org/bis/ec/ec-schema/) from an iModel, or check if one class is the same as, or derives from, another. The package itself doesn't provide an implementation for this interface and instead relies on `@itwin/presentation-core-interop` to do that.
 
 - `getClass` is an utility function that makes it easier to get an `EC.Class`, given an `ECSchemaProvider` and a full class name.
 
@@ -36,30 +36,18 @@ const ecClassFromSchema = ecSchema.getClass("MyClass");
 
 // ... or use the `getClass` utility to get straight to the class
 const ecClassFromUtility = await getClass(schemaProvider, "MySchema.MyClass");
+
+// check whether one class derives from another
+const isGeometricElement = await schemaProvider.classDerivesFrom("MySchema.MyClass", "BisCore.GeometricElement");
 ```
 
-### `ECClassHierarchyInspector` & `createCachingECClassHierarchyInspector`
+### `ECClassHierarchyInspector` & `createCachingECClassHierarchyInspector` (deprecated)
 
-- `ECClassHierarchyInspector` is an interface for something that knows how to check whether one `EC.Class` derives from another. While that can be achieved through `ECSchemaProvider` by getting an `EC.Class` and calling its `is` method, using this interface provides a more streamlined and, possibly, more efficient way to do the check. In addition, the `ECClassHierarchyInspector.classDerivesFrom` returns a `Promise<boolean> | boolean`, which lets the implementation return the result synchronously, if it's already known.
+> **Deprecated:** `ECClassHierarchyInspector` and `createCachingECClassHierarchyInspector` are deprecated. `ECSchemaProvider` now exposes a `classDerivesFrom` method directly, so a separate class hierarchy inspector is no longer needed.
 
-- `createCachingECClassHierarchyInspector` is a factory method that creates `ECClassHierarchyInspector` instance that uses a LRU cache to store the check results. In Presentation library use cases, class inheritance checks are done very frequently to warrant caching these results.
+- `ECClassHierarchyInspector` is an interface for something that knows how to check whether one `EC.Class` derives from another. The same capability is now available directly on `ECSchemaProvider` via its `classDerivesFrom` method. Like the inspector, `ECSchemaProvider.classDerivesFrom` returns a `Promise<boolean> | boolean`, which lets the implementation return the result synchronously when it's already known.
 
-Example usage:
-
-```ts
-import { createCachingECClassHierarchyInspector, ECClassHierarchyInspector } from "@itwin/presentation-shared";
-
-const classHierarchyInspector: ECClassHierarchyInspector = createCachingECClassHierarchyInspector({
-  // provide `ECSchemaProvider` that will be used to access iModels schemas
-  schemaProvider: getMetadataProvider(),
-  // tell how many entries should be cached in LRU cache (0 or `undefined` stand for "no caching")
-  cacheSize: 100,
-});
-const isGeometricElement = await classHierarchyInspector.classDerivesFrom(
-  "MySchema.MyClass",
-  "BisCore.GeometricElement",
-);
-```
+- `createCachingECClassHierarchyInspector` is a factory method that creates an `ECClassHierarchyInspector` instance that uses a LRU cache to store the check results. It is no longer needed - use `ECSchemaProvider.classDerivesFrom` instead.
 
 ## ECSql
 
@@ -345,12 +333,12 @@ Example usage:
 ```ts
 import {
   createClassBasedInstanceLabelSelectClauseFactory,
-  ECClassHierarchyInspector,
+  ECSchemaProvider,
 } from "@itwin/presentation-shared";
 
-const classHierarchyInspector: ECClassHierarchyInspector = getClassHierarchyInspector();
+const imodelAccess: ECSchemaProvider = getSchemaProvider();
 const labelsFactory = createClassBasedInstanceLabelSelectClauseFactory({
-  classHierarchyInspector,
+  imodelAccess,
   clauses: [
     {
       className: "MySchema.MyClass",
@@ -377,10 +365,10 @@ This label selectors factory creates labels according to [BIS instance label rul
 Example usage:
 
 ```ts
-import { createBisInstanceLabelSelectClauseFactory, ECClassHierarchyInspector } from "@itwin/presentation-shared";
+import { createBisInstanceLabelSelectClauseFactory, ECSchemaProvider } from "@itwin/presentation-shared";
 
-const classHierarchyInspector: ECClassHierarchyInspector = getClassHierarchyInspector();
-const labelsFactory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector });
+const imodelAccess: ECSchemaProvider = getSchemaProvider();
+const labelsFactory = createBisInstanceLabelSelectClauseFactory({ imodelAccess });
 const ecsql = `SELECT ${await labelsFactory.createSelectClause({ classAlias: "element" })} AS [Label] FROM [BisCore].[Element] AS [element]`;
 // ...
 ```
@@ -397,7 +385,7 @@ Example usage:
 ```ts
 import { createIModelInstanceLabelSelectClauseFactory } from "@itwin/presentation-shared";
 
-// `imodelAccess` must satisfy `ECSqlQueryExecutor & ECClassHierarchyInspector & ECSchemaProvider`
+// `imodelAccess` must satisfy `ECSqlQueryExecutor & ECSchemaProvider`
 const labelsFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
 const ecsql = `SELECT ${await labelsFactory.createSelectClause({ classAlias: "element" })} AS [Label] FROM [BisCore].[Element] AS [element]`;
 // ...

--- a/packages/shared/api/presentation-shared.api.md
+++ b/packages/shared/api/presentation-shared.api.md
@@ -22,14 +22,14 @@ export interface ArrayValueDescriptor {
 // @public
 interface BisInstanceLabelSelectClauseFactoryProps {
     // (undocumented)
-    classHierarchyInspector: ECClassHierarchyInspector;
+    imodelAccess: Pick<ECSchemaProvider, "classDerivesFrom">;
 }
 
 // @public
 interface ClassBasedInstanceLabelSelectClauseFactoryProps {
-    classHierarchyInspector: ECClassHierarchyInspector;
     clauses: ClassBasedLabelSelectClause[];
     defaultClauseFactory?: IInstanceLabelSelectClauseFactory;
+    imodelAccess: Pick<ECSchemaProvider, "classDerivesFrom">;
 }
 
 // @public
@@ -66,7 +66,7 @@ export namespace ConcatenatedValuePart {
 // @public
 export function createBisInstanceLabelSelectClauseFactory(props: BisInstanceLabelSelectClauseFactoryProps): IInstanceLabelSelectClauseFactory;
 
-// @public
+// @public @deprecated
 export function createCachingECClassHierarchyInspector(props: {
     schemaProvider: ECSchemaProvider;
     cacheSize?: number;
@@ -320,7 +320,7 @@ export namespace EC {
     }
 }
 
-// @public
+// @public @deprecated
 export interface ECClassHierarchyInspector {
     // (undocumented)
     classDerivesFrom(derivedClassFullName: EC.FullClassNameDotNotation, candidateBaseClassFullName: EC.FullClassNameDotNotation): Promise<boolean> | boolean;
@@ -328,6 +328,7 @@ export interface ECClassHierarchyInspector {
 
 // @public
 export interface ECSchemaProvider {
+    classDerivesFrom(derivedClassFullName: EC.FullClassNameDotNotation, candidateBaseClassFullName: EC.FullClassNameDotNotation): Promise<boolean> | boolean;
     // (undocumented)
     getSchema(schemaName: string): Promise<EC.Schema | undefined>;
 }
@@ -479,7 +480,7 @@ export interface ILogger {
 // @public
 interface IModelInstanceLabelSelectClauseFactoryProps {
     defaultClauseFactory?: IInstanceLabelSelectClauseFactory;
-    imodelAccess: ECSqlQueryExecutor & ECClassHierarchyInspector & ECSchemaProvider;
+    imodelAccess: ECSqlQueryExecutor & ECSchemaProvider;
 }
 
 // @public

--- a/packages/shared/api/presentation-shared.exports.csv
+++ b/packages/shared/api/presentation-shared.exports.csv
@@ -9,6 +9,7 @@ public;type;ConcatenatedValuePart
 public;namespace;ConcatenatedValuePart
 public;function;createBisInstanceLabelSelectClauseFactory
 public;function;createCachingECClassHierarchyInspector
+deprecated;function;createCachingECClassHierarchyInspector
 public;function;createClassBasedInstanceLabelSelectClauseFactory
 public;function;createDefaultInstanceLabelSelectClauseFactory
 public;function;createDefaultValueFormatter
@@ -16,6 +17,7 @@ public;function;createIModelInstanceLabelSelectClauseFactory
 public;function;createMainThreadReleaseOnTimePassedHandler
 public;namespace;EC
 public;interface;ECClassHierarchyInspector
+deprecated;interface;ECClassHierarchyInspector
 public;interface;ECSchemaProvider
 public;type;ECSqlBinding
 public;namespace;ECSqlBinding

--- a/packages/shared/src/presentation-shared.ts
+++ b/packages/shared/src/presentation-shared.ts
@@ -22,6 +22,7 @@ export type { ArrayElement, OmitOverUnion, Props } from "./shared/MappedTypes.js
 export type {
   ArrayValueDescriptor,
   EC,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   ECClassHierarchyInspector,
   ECSchemaProvider,
   NavigationValueDescriptor,
@@ -31,7 +32,11 @@ export type {
   StructValueDescriptor,
   ValueDescriptor,
 } from "./shared/Metadata.js";
-export { createCachingECClassHierarchyInspector, getClass } from "./shared/Metadata.js";
+export {
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  createCachingECClassHierarchyInspector,
+  getClass,
+} from "./shared/Metadata.js";
 export {
   createMainThreadReleaseOnTimePassedHandler,
   julianToDateTime,

--- a/packages/shared/src/shared/Metadata.ts
+++ b/packages/shared/src/shared/Metadata.ts
@@ -16,11 +16,24 @@ import type { ECSqlBinding } from "./ECSqlCore.js";
  */
 export interface ECSchemaProvider {
   getSchema(schemaName: string): Promise<EC.Schema | undefined>;
+
+  /**
+   * Checks whether the class identified by `derivedClassFullName` is the same as, or derives from, the class
+   * identified by `candidateBaseClassFullName`. A class is considered to derive from itself.
+   *
+   * The result may be returned synchronously when the class hierarchy information is already available, or as a
+   * promise otherwise.
+   */
+  classDerivesFrom(
+    derivedClassFullName: EC.FullClassNameDotNotation,
+    candidateBaseClassFullName: EC.FullClassNameDotNotation,
+  ): Promise<boolean> | boolean;
 }
 
 /**
  * An interface for a class hierarchy inspector that can be used to determine if one class derives from another.
  * @see `createCachingECClassHierarchyInspector`
+ * @deprecated in 2.0. Use `ECSchemaProvider` instead - it now exposes `classDerivesFrom` directly.
  * @public
  */
 export interface ECClassHierarchyInspector {
@@ -32,13 +45,17 @@ export interface ECClassHierarchyInspector {
 
 /**
  * Creates a new `ECClassHierarchyInspector` that caches results of `derivesFrom` calls.
+ *
  * @public
+ * @deprecated in 2.0. Use `createECSchemaProvider` from `@itwin/presentation-core-interop` instead - the created
+ * `ECSchemaProvider` exposes `classDerivesFrom` directly, without the need for a separate class hierarchy inspector.
  */
 export function createCachingECClassHierarchyInspector(props: {
   /** Schema provider used to load schemas and their classes. */
   schemaProvider: ECSchemaProvider;
   /** Optional cache size, describing the number of derived/base class combinations to store in cache. Defaults to `0`, which means no caching. */
   cacheSize?: number;
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
 }): ECClassHierarchyInspector {
   const map = new LRUMap<string, Promise<boolean> | boolean>(props.cacheSize ?? 0);
   function createCacheKey(derivedClassName: EC.FullClassNameDotNotation, baseClassName: EC.FullClassNameDotNotation) {

--- a/packages/shared/src/shared/instance-label-factory-impls/BisInstanceLabelSelectClauseFactory.ts
+++ b/packages/shared/src/shared/instance-label-factory-impls/BisInstanceLabelSelectClauseFactory.ts
@@ -8,7 +8,7 @@ import { createClassBasedInstanceLabelSelectClauseFactory } from "./ClassBasedIn
 import { ALIAS_PREFIX, concatenate, createECInstanceIdSuffixSelectors } from "./Utils.js";
 
 import type { IInstanceLabelSelectClauseFactory } from "../InstanceLabelSelectClauseFactory.js";
-import type { ECClassHierarchyInspector } from "../Metadata.js";
+import type { ECSchemaProvider } from "../Metadata.js";
 import type { ClassBasedLabelSelectClause } from "./ClassBasedInstanceLabelSelectClauseFactory.js";
 
 /**
@@ -16,7 +16,7 @@ import type { ClassBasedLabelSelectClause } from "./ClassBasedInstanceLabelSelec
  * @public
  */
 interface BisInstanceLabelSelectClauseFactoryProps {
-  classHierarchyInspector: ECClassHierarchyInspector;
+  imodelAccess: Pick<ECSchemaProvider, "classDerivesFrom">;
 }
 
 /**
@@ -28,10 +28,7 @@ export function createBisInstanceLabelSelectClauseFactory(
   props: BisInstanceLabelSelectClauseFactoryProps,
 ): IInstanceLabelSelectClauseFactory {
   const clauses: ClassBasedLabelSelectClause[] = [];
-  const factory = createClassBasedInstanceLabelSelectClauseFactory({
-    classHierarchyInspector: props.classHierarchyInspector,
-    clauses,
-  });
+  const factory = createClassBasedInstanceLabelSelectClauseFactory({ imodelAccess: props.imodelAccess, clauses });
   clauses.push(
     {
       className: "BisCore.GeometricElement",

--- a/packages/shared/src/shared/instance-label-factory-impls/ClassBasedInstanceLabelSelectClauseFactory.ts
+++ b/packages/shared/src/shared/instance-label-factory-impls/ClassBasedInstanceLabelSelectClauseFactory.ts
@@ -10,7 +10,7 @@ import type {
   CreateInstanceLabelSelectClauseProps,
   IInstanceLabelSelectClauseFactory,
 } from "../InstanceLabelSelectClauseFactory.js";
-import type { EC, ECClassHierarchyInspector } from "../Metadata.js";
+import type { EC, ECSchemaProvider } from "../Metadata.js";
 
 /**
  * An association of a class and an instance label select clause factory method.
@@ -29,7 +29,7 @@ export interface ClassBasedLabelSelectClause {
  */
 export interface ClassBasedInstanceLabelSelectClauseFactoryProps {
   /** Access to ECClass hierarchy in the iModel. */
-  classHierarchyInspector: ECClassHierarchyInspector;
+  imodelAccess: Pick<ECSchemaProvider, "classDerivesFrom">;
 
   /**
    * A prioritized list of instance label selectors associated to classes they should be applied to.
@@ -54,17 +54,17 @@ export interface ClassBasedInstanceLabelSelectClauseFactoryProps {
 export function createClassBasedInstanceLabelSelectClauseFactory(
   props: ClassBasedInstanceLabelSelectClauseFactoryProps,
 ): IInstanceLabelSelectClauseFactory {
-  const { classHierarchyInspector, clauses: labelClausesByClass } = props;
+  const { imodelAccess, clauses: labelClausesByClass } = props;
   const defaultClauseFactory = props.defaultClauseFactory ?? createDefaultInstanceLabelSelectClauseFactory();
   async function getLabelClausesForClass(queryClassName: EC.FullClassNameDotNotation) {
     const matchingLabelClauses = await Promise.all(
       labelClausesByClass.map(async (entry) => {
-        if (await classHierarchyInspector.classDerivesFrom(entry.className, queryClassName)) {
+        if (await imodelAccess.classDerivesFrom(entry.className, queryClassName)) {
           // label selector is intended for a more specific class than we're selecting from - need to include it
           // as query results (on polymorphic select) are going to include more specific class instances too
           return entry;
         }
-        if (await classHierarchyInspector.classDerivesFrom(queryClassName, entry.className)) {
+        if (await imodelAccess.classDerivesFrom(queryClassName, entry.className)) {
           // label selector is intended for a base class of what query is selecting - need to include it as
           // we want base class label selectors to apply to subclass instances
           return entry;

--- a/packages/shared/src/shared/instance-label-factory-impls/IModelInstanceLabelSelectClauseFactory.ts
+++ b/packages/shared/src/shared/instance-label-factory-impls/IModelInstanceLabelSelectClauseFactory.ts
@@ -23,7 +23,7 @@ import type {
   CreateInstanceLabelSelectClauseProps,
   IInstanceLabelSelectClauseFactory,
 } from "../InstanceLabelSelectClauseFactory.js";
-import type { EC, ECClassHierarchyInspector, ECSchemaProvider } from "../Metadata.js";
+import type { EC, ECSchemaProvider } from "../Metadata.js";
 import type { ClassBasedLabelSelectClause } from "./ClassBasedInstanceLabelSelectClauseFactory.js";
 import type {
   InstanceLabelOverride,
@@ -43,7 +43,7 @@ interface IModelInstanceLabelSelectClauseFactoryProps {
    * Combined access to the iModel for querying PresentationRules rulesets and inspecting class hierarchy.
    * Follows the same combined-access pattern as other iModel-backed factories in this package.
    */
-  imodelAccess: ECSqlQueryExecutor & ECClassHierarchyInspector & ECSchemaProvider;
+  imodelAccess: ECSqlQueryExecutor & ECSchemaProvider;
 
   /**
    * A fallback label clause factory used when no applicable `InstanceLabelOverride` rules are found
@@ -87,8 +87,7 @@ async function createIModelInstanceLabelSelectClauseFactoryImpl(
   props: IModelInstanceLabelSelectClauseFactoryProps,
 ): Promise<IInstanceLabelSelectClauseFactory> {
   const defaultClauseFactory =
-    props.defaultClauseFactory ??
-    createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector: props.imodelAccess });
+    props.defaultClauseFactory ?? createBisInstanceLabelSelectClauseFactory({ imodelAccess: props.imodelAccess });
 
   const rules = await loadOverrideRules(props.imodelAccess);
   if (rules.length === 0) {
@@ -108,7 +107,7 @@ async function createIModelInstanceLabelSelectClauseFactoryImpl(
       }),
   }));
   const innerFactory = createClassBasedInstanceLabelSelectClauseFactory({
-    classHierarchyInspector: props.imodelAccess,
+    imodelAccess: props.imodelAccess,
     clauses,
     defaultClauseFactory,
   });

--- a/packages/shared/src/test/Metadata.test.ts
+++ b/packages/shared/src/test/Metadata.test.ts
@@ -6,11 +6,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createCachingECClassHierarchyInspector, getClass } from "../shared/Metadata.js";
 
+/* eslint-disable @typescript-eslint/no-deprecated */
 describe("createCachingECClassHierarchyInspector", () => {
-  const schemaProvider = { getSchema: vi.fn() };
+  const schemaProvider = { getSchema: vi.fn(), classDerivesFrom: vi.fn() };
 
   beforeEach(() => {
     schemaProvider.getSchema.mockReset();
+    schemaProvider.classDerivesFrom.mockReset();
   });
 
   it("returns `true` when candidate is base class", async () => {
@@ -86,12 +88,14 @@ describe("createCachingECClassHierarchyInspector", () => {
     expect(getClassStub).toHaveBeenCalledWith("b");
   });
 });
+/* eslint-enable @typescript-eslint/no-deprecated */
 
 describe("getClass", () => {
-  const schemaProvider = { getSchema: vi.fn() };
+  const schemaProvider = { getSchema: vi.fn(), classDerivesFrom: vi.fn() };
 
   beforeEach(() => {
     schemaProvider.getSchema.mockReset();
+    schemaProvider.classDerivesFrom.mockReset();
   });
 
   it("throws when schema does not exist", async () => {

--- a/packages/shared/src/test/MetadataProviderStub.ts
+++ b/packages/shared/src/test/MetadataProviderStub.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { vi } from "vitest";
+import { parseFullClassName } from "../shared/Utils.js";
 
 import type { Mock } from "vitest";
 import type { EC } from "../shared/Metadata.js";
@@ -36,6 +37,30 @@ export function createECSchemaProviderStub() {
     getSchema: vi.fn(async (schemaName: string): Promise<EC.Schema | undefined> => {
       return schemaStubs.get(schemaName);
     }),
+    classDerivesFrom: vi.fn(
+      (
+        derivedClassFullName: EC.FullClassNameDotNotation,
+        candidateBaseClassFullName: EC.FullClassNameDotNotation,
+      ): boolean => {
+        if (derivedClassFullName === candidateBaseClassFullName) {
+          return true;
+        }
+        const { schemaName: derivedSchemaName, className: derivedClassName } = parseFullClassName(derivedClassFullName);
+        const derivedClass = schemaStubs.get(derivedSchemaName)?.classes.get(derivedClassName);
+        if (!derivedClass) {
+          return false;
+        }
+
+        const { schemaName: baseSchemaName, className: baseClassName } = parseFullClassName(candidateBaseClassFullName);
+        const baseClass = schemaStubs.get(baseSchemaName)?.classes.get(baseClassName);
+
+        if (!baseClass) {
+          return false;
+        }
+
+        return derivedClass.is(baseClass);
+      },
+    ),
   };
   const getSchemaStub = (schemaName: string) => {
     let schemaStub = schemaStubs.get(schemaName);

--- a/packages/shared/src/test/instance-label-factory-impls/BisInstanceLabelSelectClauseFactory.test.ts
+++ b/packages/shared/src/test/instance-label-factory-impls/BisInstanceLabelSelectClauseFactory.test.ts
@@ -16,12 +16,12 @@ import { trimWhitespace } from "../../shared/Utils.js";
 import type { IInstanceLabelSelectClauseFactory } from "../../shared/InstanceLabelSelectClauseFactory.js";
 
 describe("createBisInstanceLabelSelectClauseFactory", () => {
-  const classHierarchyInspector = { classDerivesFrom: vi.fn() };
+  const imodelAccess = { classDerivesFrom: vi.fn() };
   let factory: IInstanceLabelSelectClauseFactory;
   beforeEach(() => {
-    factory = createBisInstanceLabelSelectClauseFactory({ classHierarchyInspector });
-    classHierarchyInspector.classDerivesFrom.mockReset();
-    classHierarchyInspector.classDerivesFrom.mockImplementation(async (derived, base) => {
+    factory = createBisInstanceLabelSelectClauseFactory({ imodelAccess });
+    imodelAccess.classDerivesFrom.mockReset();
+    imodelAccess.classDerivesFrom.mockImplementation(async (derived, base) => {
       if (derived === "BisCore.GeometricElement") {
         return base === "BisCore.Element" || base === "BisCore.GeometricElement";
       }

--- a/packages/shared/src/test/instance-label-factory-impls/ClassBasedInstanceLabelSelectClauseFactory.test.ts
+++ b/packages/shared/src/test/instance-label-factory-impls/ClassBasedInstanceLabelSelectClauseFactory.test.ts
@@ -15,14 +15,14 @@ describe("createClassBasedInstanceLabelSelectClauseFactory", () => {
       return "default selector";
     },
   };
-  const classHierarchyInspector = { classDerivesFrom: vi.fn() };
+  const imodelAccess = { classDerivesFrom: vi.fn() };
   beforeEach(() => {
-    classHierarchyInspector.classDerivesFrom.mockReset();
+    imodelAccess.classDerivesFrom.mockReset();
   });
 
   it("returns default clause when given an empty list of clauses", async () => {
     const factory = createClassBasedInstanceLabelSelectClauseFactory({
-      classHierarchyInspector,
+      imodelAccess,
       defaultClauseFactory,
       clauses: [],
     });
@@ -32,21 +32,21 @@ describe("createClassBasedInstanceLabelSelectClauseFactory", () => {
 
   it("returns default clause when none of given clause classes match query class", async () => {
     const factory = createClassBasedInstanceLabelSelectClauseFactory({
-      classHierarchyInspector,
+      imodelAccess,
       defaultClauseFactory,
       clauses: [
         { className: "Schema.ClassA", clause: async () => "a selector" },
         { className: "Schema.ClassB", clause: async () => "b selector" },
       ],
     });
-    classHierarchyInspector.classDerivesFrom.mockResolvedValue(false);
+    imodelAccess.classDerivesFrom.mockResolvedValue(false);
     const result = await factory.createSelectClause({ classAlias: "class-alias", className: "Schema.QueryClass" });
     expect(result).toBe("default selector");
   });
 
   it("returns combination of all clauses if class name prop is not set", async () => {
     const factory = createClassBasedInstanceLabelSelectClauseFactory({
-      classHierarchyInspector,
+      imodelAccess,
       defaultClauseFactory,
       clauses: [
         { className: "Schema.ClassA", clause: async () => "a selector" },
@@ -75,14 +75,14 @@ describe("createClassBasedInstanceLabelSelectClauseFactory", () => {
 
   it("returns clauses for classes that derive from query class", async () => {
     const factory = createClassBasedInstanceLabelSelectClauseFactory({
-      classHierarchyInspector,
+      imodelAccess,
       defaultClauseFactory,
       clauses: [
         { className: "Schema.ClassA", clause: async () => "a selector" },
         { className: "Schema.ClassB", clause: async () => "b selector" },
       ],
     });
-    classHierarchyInspector.classDerivesFrom.mockImplementation(
+    imodelAccess.classDerivesFrom.mockImplementation(
       async (derived, base) => derived === "Schema.ClassA" && base === "Schema.QueryClass",
     );
     const result = await factory.createSelectClause({ classAlias: "class-alias", className: "Schema.QueryClass" });
@@ -102,14 +102,14 @@ describe("createClassBasedInstanceLabelSelectClauseFactory", () => {
 
   it("returns clauses for base classes of query class", async () => {
     const factory = createClassBasedInstanceLabelSelectClauseFactory({
-      classHierarchyInspector,
+      imodelAccess,
       defaultClauseFactory,
       clauses: [
         { className: "Schema.ClassA", clause: async () => "a selector" },
         { className: "Schema.ClassB", clause: async () => "b selector" },
       ],
     });
-    classHierarchyInspector.classDerivesFrom.mockImplementation(
+    imodelAccess.classDerivesFrom.mockImplementation(
       async (derived, base) => derived === "Schema.QueryClass" && base === "Schema.ClassB",
     );
     const result = await factory.createSelectClause({ classAlias: "class-alias", className: "Schema.QueryClass" });

--- a/packages/unified-selection/api/unified-selection.api.md
+++ b/packages/unified-selection/api/unified-selection.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import type { ECClassHierarchyInspector } from '@itwin/presentation-shared';
+import type { ECSchemaProvider } from '@itwin/presentation-shared';
 import type { ECSqlQueryExecutor } from '@itwin/presentation-shared';
 import type { Event as Event_2 } from '@itwin/presentation-shared';
 import type { Id64Arg } from '@itwin/core-bentley';
@@ -24,7 +24,7 @@ export interface CachingHiliteSetProvider {
 // @public @deprecated
 interface CachingHiliteSetProviderProps {
     createHiliteSetProvider?: typeof createHiliteSetProvider;
-    imodelProvider: (imodelKey: string) => ECClassHierarchyInspector & ECSqlQueryExecutor;
+    imodelProvider: (imodelKey: string) => Pick<ECSchemaProvider, "classDerivesFrom"> & ECSqlQueryExecutor;
     selectionStorage: SelectionStorage;
 }
 
@@ -124,7 +124,7 @@ interface EnableUnifiedSelectionSyncWithIModelProps {
     cachingHiliteSetProvider?: CachingHiliteSetProvider | (Omit<CachingHiliteSetProvider, "dispose"> & {
         [Symbol.dispose]: () => void;
     });
-    imodelAccess: ECSqlQueryExecutor & ECClassHierarchyInspector & {
+    imodelAccess: ECSqlQueryExecutor & Pick<ECSchemaProvider, "classDerivesFrom"> & {
         readonly key: string;
         readonly hiliteSet: CoreIModelHiliteSet;
         readonly selectionSet: CoreIModelSelectionSet;
@@ -152,7 +152,7 @@ export interface HiliteSetProvider {
 
 // @public
 interface HiliteSetProviderProps {
-    imodelAccess: ECClassHierarchyInspector & ECSqlQueryExecutor;
+    imodelAccess: Pick<ECSchemaProvider, "classDerivesFrom"> & ECSqlQueryExecutor;
 }
 
 // @public
@@ -169,7 +169,7 @@ export interface IModelHiliteSetProvider {
 // @public
 interface IModelHiliteSetProviderProps {
     createHiliteSetProvider?: typeof createHiliteSetProvider;
-    imodelProvider: (imodelKey: string) => ECClassHierarchyInspector & ECSqlQueryExecutor;
+    imodelProvider: (imodelKey: string) => Pick<ECSchemaProvider, "classDerivesFrom"> & ECSqlQueryExecutor;
     selectionStorage: SelectionStorage;
 }
 

--- a/packages/unified-selection/learning/HiliteSets.md
+++ b/packages/unified-selection/learning/HiliteSets.md
@@ -22,16 +22,11 @@ The `@itwin/unified-selection` package delivers APIs for creating a `HiliteSet` 
 
   ```ts
   import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
-  import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
   import { createHiliteSetProvider } from "@itwin/unified-selection";
 
   const schemaProvider = createECSchemaProvider(getIModelConnection());
   const hiliteProvider = createHiliteSetProvider({
-    imodelAccess: {
-      ...schemaProvider,
-      ...createCachingECClassHierarchyInspector({ schemaProvider }),
-      ...createECSqlQueryExecutor(getIModelConnection()),
-    },
+    imodelAccess: { ...schemaProvider, ...createECSqlQueryExecutor(getIModelConnection()) },
   });
   const hiliteSetIterator = hiliteProvider.getHiliteSet({ selectables });
   ```

--- a/packages/unified-selection/learning/SyncWithIModelConnection.md
+++ b/packages/unified-selection/learning/SyncWithIModelConnection.md
@@ -18,7 +18,6 @@ For example, in a React application this function could be used inside a `useEff
 
 ```ts
 import { createECSchemaProvider, createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
-import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
 import { enableUnifiedSelectionSyncWithIModel, SelectionStorage } from "@itwin/unified-selection";
 
 /** An iModel-based component that handles iModel selection directly, through its `SelectionSet` */
@@ -38,9 +37,7 @@ function IModelComponent({ selectionStorage }: { selectionStorage: SelectionStor
         // selection and hilite sets
         imodelAccess: {
           ...createECSqlQueryExecutor(iModelConnection),
-          ...createCachingECClassHierarchyInspector({
-            schemaProvider: createECSchemaProvider(iModelConnection),
-          }),
+          ...createECSchemaProvider(iModelConnection),
           key: createIModelKey(iModelConnection),
           hiliteSet: iModelConnection.hilited,
           selectionSet: iModelConnection.selectionSet,

--- a/packages/unified-selection/src/test/HiliteSetProvider.test.ts
+++ b/packages/unified-selection/src/test/HiliteSetProvider.test.ts
@@ -406,7 +406,7 @@ describe("HiliteSetProvider", () => {
         expect((await iter.next()).done).toBe(true);
       });
 
-      it("rethrows ECClassHierarchyInspector errors", async () => {
+      it("rethrows classDerivesFrom errors", async () => {
         imodelAccess.classDerivesFrom.mockImplementation((cn, pc) => {
           if (cn === "TestSchema.TestElement" && pc === "BisCore.Element") {
             throw new Error("dummy error");

--- a/packages/unified-selection/src/test/IModelHiliteSetProvider.test.ts
+++ b/packages/unified-selection/src/test/IModelHiliteSetProvider.test.ts
@@ -9,7 +9,7 @@ import { createIModelHiliteSetProvider } from "../unified-selection/IModelHilite
 import { createStorage } from "../unified-selection/SelectionStorage.js";
 import { createSelectableInstanceKey } from "./_helpers/SelectablesCreator.js";
 
-import type { ECClassHierarchyInspector, ECSqlQueryExecutor } from "@itwin/presentation-shared";
+import type { ECSchemaProvider, ECSqlQueryExecutor } from "@itwin/presentation-shared";
 import type { HiliteSet, HiliteSetProvider, HiliteSetProviderProps } from "../unified-selection/HiliteSetProvider.js";
 import type { SelectableInstanceKey } from "../unified-selection/Selectable.js";
 import type { SelectionStorage } from "../unified-selection/SelectionStorage.js";
@@ -23,7 +23,8 @@ describe("createIModelHiliteSetProvider", () => {
   let selectionStorage: SelectionStorage;
   let hiliteSetCache: ReturnType<typeof createIModelHiliteSetProvider>;
   const provider = { getHiliteSet: vi.fn<(props: { imodelKey: string }) => AsyncIterableIterator<HiliteSet>>() };
-  const imodelProvider = vi.fn<(imodelKey: string) => ECClassHierarchyInspector & ECSqlQueryExecutor>();
+  const imodelProvider =
+    vi.fn<(imodelKey: string) => Pick<ECSchemaProvider, "classDerivesFrom"> & ECSqlQueryExecutor>();
   const imodelKey = "iModelKey";
 
   async function loadHiliteSet() {

--- a/packages/unified-selection/src/unified-selection/CachingHiliteSetProvider.ts
+++ b/packages/unified-selection/src/unified-selection/CachingHiliteSetProvider.ts
@@ -8,7 +8,7 @@ import "./DisposePolyfill.js";
 
 import { createIModelHiliteSetProvider } from "./IModelHiliteSetProvider.js";
 
-import type { ECClassHierarchyInspector, ECSqlQueryExecutor } from "@itwin/presentation-shared";
+import type { ECSchemaProvider, ECSqlQueryExecutor } from "@itwin/presentation-shared";
 import type { createHiliteSetProvider, HiliteSet } from "./HiliteSetProvider.js";
 import type { SelectionStorage } from "./SelectionStorage.js";
 
@@ -22,7 +22,7 @@ export interface CachingHiliteSetProviderProps {
   selectionStorage: SelectionStorage;
 
   /** A callback that should return iModel access by iModel key. */
-  imodelProvider: (imodelKey: string) => ECClassHierarchyInspector & ECSqlQueryExecutor;
+  imodelProvider: (imodelKey: string) => Pick<ECSchemaProvider, "classDerivesFrom"> & ECSqlQueryExecutor;
 
   /** An optional hilite set provider factory. If not provided, defaults to `createHiliteSetProvider` from this package. */
   createHiliteSetProvider?: typeof createHiliteSetProvider;

--- a/packages/unified-selection/src/unified-selection/EnableUnifiedSelectionSyncWithIModel.ts
+++ b/packages/unified-selection/src/unified-selection/EnableUnifiedSelectionSyncWithIModel.ts
@@ -15,7 +15,7 @@ import { CoreSelectionSetEventType } from "./types/IModel.js";
 import { safeDispose } from "./Utils.js";
 
 import type { GuidString, Id64Arg, Id64Set } from "@itwin/core-bentley";
-import type { ECClassHierarchyInspector, ECSqlQueryExecutor } from "@itwin/presentation-shared";
+import type { ECSchemaProvider, ECSqlQueryExecutor } from "@itwin/presentation-shared";
 import type { CachingHiliteSetProvider } from "./CachingHiliteSetProvider.js";
 import type { HiliteSet, HiliteSetProvider } from "./HiliteSetProvider.js";
 import type { IModelHiliteSetProvider } from "./IModelHiliteSetProvider.js";
@@ -44,13 +44,12 @@ export interface EnableUnifiedSelectionSyncWithIModelProps {
    *
    * ```ts
    * import { createECSqlQueryExecutor, createECSchemaProvider, createIModelKey } from "@itwin/presentation-core-interop";
-   * import { createCachingECClassHierarchyInspector } from "@itwin/presentation-shared";
    * import { IModelConnection } from "@itwin/core-frontend";
    *
    * const imodel: IModelConnection = ...
    * const imodelAccess = {
    *   ...createECSqlQueryExecutor(imodel),
-   *   ...createCachingECClassHierarchyInspector({ schemaProvider: createECSchemaProvider(imodel) }),
+   *   ...createECSchemaProvider(imodel),
    *   key: createIModelKey(imodel),
    *   hiliteSet: imodel.hilited,
    *   selectionSet: imodel.selectionSet,
@@ -58,7 +57,7 @@ export interface EnableUnifiedSelectionSyncWithIModelProps {
    * ```
    */
   imodelAccess: ECSqlQueryExecutor &
-    ECClassHierarchyInspector & {
+    Pick<ECSchemaProvider, "classDerivesFrom"> & {
       /** Key of the iModel. Generally taken from `IModelConnection.key`. */
       readonly key: string;
       /** The set of currently hilited elements taken from `IModelConnection.hilited`. */

--- a/packages/unified-selection/src/unified-selection/HiliteSetProvider.ts
+++ b/packages/unified-selection/src/unified-selection/HiliteSetProvider.ts
@@ -14,7 +14,7 @@ import type { Observable } from "rxjs";
 import type { GuidString, Id64String } from "@itwin/core-bentley";
 import type {
   EC,
-  ECClassHierarchyInspector,
+  ECSchemaProvider,
   ECSqlBinding,
   ECSqlQueryDef,
   ECSqlQueryExecutor,
@@ -48,7 +48,7 @@ export interface HiliteSet {
  */
 export interface HiliteSetProviderProps {
   /** An object that provides access to iModel's metadata and allows running ECSQL queries on it. */
-  imodelAccess: ECClassHierarchyInspector & ECSqlQueryExecutor;
+  imodelAccess: Pick<ECSchemaProvider, "classDerivesFrom"> & ECSqlQueryExecutor;
 }
 
 /**
@@ -74,7 +74,7 @@ export function createHiliteSetProvider(props: HiliteSetProviderProps): HiliteSe
 }
 
 class HiliteSetProviderImpl implements HiliteSetProvider {
-  private _imodelAccess: ECClassHierarchyInspector & ECSqlQueryExecutor;
+  private _imodelAccess: Pick<ECSchemaProvider, "classDerivesFrom"> & ECSqlQueryExecutor;
   // Map between a class name and its type
   private _classRelationCache: Map<string, InstanceIdType | Promise<InstanceIdType>>;
   #componentId: GuidString;

--- a/packages/unified-selection/src/unified-selection/IModelHiliteSetProvider.ts
+++ b/packages/unified-selection/src/unified-selection/IModelHiliteSetProvider.ts
@@ -11,7 +11,7 @@ import { createHiliteSetProvider } from "./HiliteSetProvider.js";
 import { CLEAR_SELECTION_STORAGE_SOURCE } from "./SelectionStorage.js";
 
 import type { Observable } from "rxjs";
-import type { ECClassHierarchyInspector, ECSqlQueryExecutor } from "@itwin/presentation-shared";
+import type { ECSchemaProvider, ECSqlQueryExecutor } from "@itwin/presentation-shared";
 import type { HiliteSet, HiliteSetProvider } from "./HiliteSetProvider.js";
 import type { StorageSelectionChangeEventArgs } from "./SelectionChangeEvent.js";
 import type { SelectionStorage } from "./SelectionStorage.js";
@@ -25,7 +25,7 @@ export interface IModelHiliteSetProviderProps {
   selectionStorage: SelectionStorage;
 
   /** A callback that should return iModel access by iModel key. */
-  imodelProvider: (imodelKey: string) => ECClassHierarchyInspector & ECSqlQueryExecutor;
+  imodelProvider: (imodelKey: string) => Pick<ECSchemaProvider, "classDerivesFrom"> & ECSqlQueryExecutor;
 
   /** An optional hilite set provider factory. If not provided, defaults to `createHiliteSetProvider` from this package. */
   createHiliteSetProvider?: typeof createHiliteSetProvider;
@@ -76,7 +76,7 @@ class IModelHiliteSetProviderImpl implements IModelHiliteSetProvider {
   private _hiliteSetProviders = new Map<string, HiliteSetProvider>();
   private _cache = new Map<string, Observable<HiliteSet>>();
   private _removeListener: () => void;
-  private _imodelProvider: (imodelKey: string) => ECClassHierarchyInspector & ECSqlQueryExecutor;
+  private _imodelProvider: (imodelKey: string) => Pick<ECSchemaProvider, "classDerivesFrom"> & ECSqlQueryExecutor;
   private _createHiliteSetProvider: typeof createHiliteSetProvider;
 
   constructor(props: IModelHiliteSetProviderProps) {


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/1488