### PR TITLE
`createValueFormatter`: Changed to take a `formatsProvider`, a `unitsProvider` and the iModel instead of a `SchemaContext`

### DIFF
--- a/.changeset/quiet-formatters-shift.md
+++ b/.changeset/quiet-formatters-shift.md
@@ -6,6 +6,8 @@
 
 `SchemaContext` is inefficient on iModels with large domain schemas, so the function no longer depends on it. Sourcing formats from a `FormatsProvider` also lets the consuming application register its own formatting overrides (per organization, per iModel, per user, etc.), achieving cohesive formatting across the whole application - something a bare `SchemaContext` couldn't provide.
 
+Additionally, when a kind of quantity can’t be resolved (e.g. missing schema/KoQ or an unsupported persistence unit name), `createValueFormatter` now falls back to the `baseFormatter` instead of throwing.
+
 Migration: the `schemaContext` prop is removed, provide `formatsProvider`, `unitsProvider` and `imodel` instead:
 
 ```ts

--- a/.changeset/quiet-formatters-shift.md
+++ b/.changeset/quiet-formatters-shift.md
@@ -1,0 +1,24 @@
+---
+"@itwin/presentation-core-interop": major
+---
+
+`createValueFormatter`: Changed to take a `formatsProvider`, a `unitsProvider` and the iModel instead of a `SchemaContext`.
+
+`SchemaContext` is inefficient on iModels with large domain schemas, so the function no longer depends on it. Sourcing formats from a `FormatsProvider` also lets the consuming application register its own formatting overrides (per organization, per iModel, per user, etc.), achieving cohesive formatting across the whole application - something a bare `SchemaContext` couldn't provide.
+
+Migration: the `schemaContext` prop is removed, provide `formatsProvider`, `unitsProvider` and `imodel` instead:
+
+```ts
+// previously:
+const formatter = createValueFormatter({ schemaContext: imodel.schemaContext, unitSystem: "metric" });
+
+// now, on the frontend:
+const formatter = createValueFormatter({
+  formatsProvider: IModelApp.formatsProvider,
+  unitsProvider: IModelApp.quantityFormatter,
+  imodel,
+  unitSystem: "metric",
+});
+```
+
+On the backend, where there's no `IModelApp`, construct equivalent providers from the iModel's `SchemaContext`, e.g. `formatsProvider: new SchemaFormatsProvider(schemaContext)` and `unitsProvider: new SchemaUnitProvider(schemaContext)` from `@itwin/ecschema-metadata`, ideally caching them per iModel.

--- a/apps/full-stack-tests/src/core-interop/learning-snippets/CreateValueFormatter.test.ts
+++ b/apps/full-stack-tests/src/core-interop/learning-snippets/CreateValueFormatter.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { SchemaFormatsProvider } from "@itwin/ecschema-metadata";
+import { SchemaFormatsProvider, SchemaUnitProvider } from "@itwin/ecschema-metadata";
 // __PUBLISH_EXTRACT_START__ Presentation.CoreInterop.CreateValueFormatter.Imports
 import { IModelApp } from "@itwin/core-frontend";
 import { createValueFormatter } from "@itwin/presentation-core-interop";
@@ -43,11 +43,14 @@ describe("Core interop", () => {
           return imodelConnection;
         }
 
-        // The end product is responsible for registering a schema-aware `FormatsProvider` - `createValueFormatter` doesn't do this itself.
+        // The end product is responsible for registering schema-aware `FormatsProvider` / `UnitsProvider` instances -
+        // `createValueFormatter` doesn't do this itself.
         IModelApp.formatsProvider = new SchemaFormatsProvider(imodelConnection.schemaContext);
-        using _resetFormatsProvider = {
-          [Symbol.dispose]() {
+        IModelApp.quantityFormatter.unitsProvider = new SchemaUnitProvider(imodelConnection.schemaContext);
+        await using _resetIModelApp = {
+          async [Symbol.asyncDispose]() {
             IModelApp.resetFormatsProvider();
+            await IModelApp.quantityFormatter.resetToUseInternalUnitsProvider();
           },
         };
 

--- a/apps/full-stack-tests/src/core-interop/learning-snippets/CreateValueFormatter.test.ts
+++ b/apps/full-stack-tests/src/core-interop/learning-snippets/CreateValueFormatter.test.ts
@@ -25,11 +25,11 @@ describe("Core interop", () => {
       });
 
       it("creates formatter that formats values with units", async function () {
-        const { imodelConnection, schema } = await buildTestIModel(async (imodel, testName) => {
+        const { imodelConnection, schema } = await buildTestIModel(async (imodelDb, testName) => {
           return {
             schema: await importSchema(
               testName,
-              imodel,
+              imodelDb,
               `
                 <ECSchemaReference name="Formats" version="01.00.00" alias="f"/>
                 <ECSchemaReference name="Units" version="01.00.03" alias="u"/>

--- a/apps/full-stack-tests/src/core-interop/learning-snippets/CreateValueFormatter.test.ts
+++ b/apps/full-stack-tests/src/core-interop/learning-snippets/CreateValueFormatter.test.ts
@@ -45,6 +45,11 @@ describe("Core interop", () => {
 
         // The end product is responsible for registering a schema-aware `FormatsProvider` - `createValueFormatter` doesn't do this itself.
         IModelApp.formatsProvider = new SchemaFormatsProvider(imodelConnection.schemaContext);
+        using _resetFormatsProvider = {
+          [Symbol.dispose]() {
+            IModelApp.resetFormatsProvider();
+          },
+        };
 
         // __PUBLISH_EXTRACT_START__ Presentation.CoreInterop.CreateValueFormatter.Example
         const imodel = getIModelConnection();

--- a/apps/full-stack-tests/src/core-interop/learning-snippets/CreateValueFormatter.test.ts
+++ b/apps/full-stack-tests/src/core-interop/learning-snippets/CreateValueFormatter.test.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { SchemaFormatsProvider } from "@itwin/ecschema-metadata";
 // __PUBLISH_EXTRACT_START__ Presentation.CoreInterop.CreateValueFormatter.Imports
-import { SchemaContext } from "@itwin/ecschema-metadata";
+import { IModelApp } from "@itwin/core-frontend";
 import { createValueFormatter } from "@itwin/presentation-core-interop";
 // __PUBLISH_EXTRACT_END__
 import { buildTestIModel } from "../../IModelUtils.js";
@@ -42,10 +43,23 @@ describe("Core interop", () => {
           return imodelConnection;
         }
 
+        // The end product is responsible for registering a schema-aware `FormatsProvider` - `createValueFormatter` doesn't do this itself.
+        IModelApp.formatsProvider = new SchemaFormatsProvider(imodelConnection.schemaContext);
+
         // __PUBLISH_EXTRACT_START__ Presentation.CoreInterop.CreateValueFormatter.Example
-        const schemaContext: SchemaContext = getIModelConnection().schemaContext;
-        const metricFormatter = createValueFormatter({ schemaContext, unitSystem: "metric" });
-        const imperialFormatter = createValueFormatter({ schemaContext, unitSystem: "imperial" });
+        const imodel = getIModelConnection();
+        const metricFormatter = createValueFormatter({
+          formatsProvider: IModelApp.formatsProvider,
+          unitsProvider: IModelApp.quantityFormatter,
+          imodel,
+          unitSystem: "metric",
+        });
+        const imperialFormatter = createValueFormatter({
+          formatsProvider: IModelApp.formatsProvider,
+          unitsProvider: IModelApp.quantityFormatter,
+          imodel,
+          unitSystem: "imperial",
+        });
 
         // Define the raw value to be formatted
         const value = 1.234;

--- a/apps/full-stack-tests/src/hierarchies/Formatting.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/Formatting.test.ts
@@ -5,6 +5,7 @@
 
 import { afterAll, describe, expect, it, test, vi } from "vitest";
 import { Guid, Id64 } from "@itwin/core-bentley";
+import { SchemaFormatsProvider, SchemaUnitProvider } from "@itwin/ecschema-metadata";
 import { createValueFormatter } from "@itwin/presentation-core-interop";
 import { ECSql } from "@itwin/presentation-shared";
 import { buildTestECDb } from "../ECDbUtils.js";
@@ -142,7 +143,13 @@ describe("Hierarchies", () => {
           provider: createProvider({
             ecdb,
             hierarchy,
-            formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "metric" }),
+            formatterFactory: ({ schemaContext, imodel }) =>
+              createValueFormatter({
+                formatsProvider: new SchemaFormatsProvider(schemaContext),
+                unitsProvider: new SchemaUnitProvider(schemaContext),
+                imodel,
+                unitSystem: "metric",
+              }),
           }),
           expect: [{ node: (node) => expect(node.label).toBe(`[123.5 m]`) }],
         });
@@ -150,7 +157,13 @@ describe("Hierarchies", () => {
           provider: createProvider({
             ecdb,
             hierarchy,
-            formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "imperial" }),
+            formatterFactory: ({ schemaContext, imodel }) =>
+              createValueFormatter({
+                formatsProvider: new SchemaFormatsProvider(schemaContext),
+                unitsProvider: new SchemaUnitProvider(schemaContext),
+                imodel,
+                unitSystem: "imperial",
+              }),
           }),
           expect: [{ node: (node) => expect(node.label).toBe(`[405.0 ft]`) }],
         });
@@ -158,7 +171,13 @@ describe("Hierarchies", () => {
           provider: createProvider({
             ecdb,
             hierarchy,
-            formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "usCustomary" }),
+            formatterFactory: ({ schemaContext, imodel }) =>
+              createValueFormatter({
+                formatsProvider: new SchemaFormatsProvider(schemaContext),
+                unitsProvider: new SchemaUnitProvider(schemaContext),
+                imodel,
+                unitSystem: "usCustomary",
+              }),
           }),
           expect: [{ node: (node) => expect(node.label).toBe(`[405.0 ft]`) }],
         });
@@ -166,7 +185,13 @@ describe("Hierarchies", () => {
           provider: createProvider({
             ecdb,
             hierarchy,
-            formatterFactory: (schemas) => createValueFormatter({ schemaContext: schemas, unitSystem: "usSurvey" }),
+            formatterFactory: ({ schemaContext, imodel }) =>
+              createValueFormatter({
+                formatsProvider: new SchemaFormatsProvider(schemaContext),
+                unitsProvider: new SchemaUnitProvider(schemaContext),
+                imodel,
+                unitSystem: "usSurvey",
+              }),
           }),
           expect: [{ node: (node) => expect(node.label).toBe(`[405.04 ft (US Survey)]`) }],
         });

--- a/apps/full-stack-tests/src/hierarchies/Utils.ts
+++ b/apps/full-stack-tests/src/hierarchies/Utils.ts
@@ -41,8 +41,20 @@ export function createProvider(
         search?: HierarchySearchPaths;
         queryCacheSize?: number;
       }
-    | { imodel: IModelConnection | IModelDb; formatterFactory?: (schemas: SchemaContext) => IPrimitiveValueFormatter }
-    | { ecdb: ECDb; formatterFactory?: (schemas: SchemaContext) => IPrimitiveValueFormatter }
+    | {
+        imodel: IModelConnection | IModelDb;
+        formatterFactory?: (props: {
+          schemaContext: SchemaContext;
+          imodel: ReturnType<typeof unifyIModelAPIs>;
+        }) => IPrimitiveValueFormatter;
+      }
+    | {
+        ecdb: ECDb;
+        formatterFactory?: (props: {
+          schemaContext: SchemaContext;
+          imodel: ReturnType<typeof unifyIModelAPIs>;
+        }) => IPrimitiveValueFormatter;
+      }
   ) & {
     imodelChanged?: Event<() => void>;
     hierarchy: HierarchyDefinition;
@@ -55,7 +67,10 @@ export function createProvider(
   const { imodelChanged, hierarchy, localizedStrings, search, queryCacheSize } = props;
   const formatter =
     "formatterFactory" in props && props.formatterFactory
-      ? props.formatterFactory(createSchemaContext("imodel" in props ? props.imodel : props.ecdb))
+      ? props.formatterFactory({
+          schemaContext: createSchemaContext("imodel" in props ? props.imodel : props.ecdb),
+          imodel: unifyIModelAPIs("imodel" in props ? props.imodel : props.ecdb),
+        })
       : undefined;
   return createIModelHierarchyProvider({
     imodelAccess:

--- a/packages/core-interop/README.md
+++ b/packages/core-interop/README.md
@@ -76,7 +76,7 @@ const schemaProvider = createECSchemaProvider(imodel);
 
 ### `createValueFormatter`
 
-Creates an instance of `IPrimitiveValueFormatter` that knows how to format primitive property values using their units' information. That information is retrieved from an iModel through `itwinjs-core` [SchemaContext](https://www.itwinjs.org/reference/ecschema-metadata/context/schemacontext/).
+Creates an instance of `IPrimitiveValueFormatter` that knows how to format primitive property values using their units' information. The formats and units used come from a `FormatsProvider` and `UnitsProvider` registered by the end product (e.g. `IModelApp.formatsProvider` / `IModelApp.quantityFormatter` on the frontend), while the kind of quantity's persistence unit is resolved from the iModel itself.
 
 Example:
 
@@ -84,12 +84,22 @@ Example:
 <!-- BEGIN EXTRACTION -->
 
 ```ts
-import { SchemaContext } from "@itwin/ecschema-metadata";
+import { IModelApp } from "@itwin/core-frontend";
 import { createValueFormatter } from "@itwin/presentation-core-interop";
 
-const schemaContext: SchemaContext = getIModelConnection().schemaContext;
-const metricFormatter = createValueFormatter({ schemaContext, unitSystem: "metric" });
-const imperialFormatter = createValueFormatter({ schemaContext, unitSystem: "imperial" });
+const imodel = getIModelConnection();
+const metricFormatter = createValueFormatter({
+  formatsProvider: IModelApp.formatsProvider,
+  unitsProvider: IModelApp.quantityFormatter,
+  imodel,
+  unitSystem: "metric",
+});
+const imperialFormatter = createValueFormatter({
+  formatsProvider: IModelApp.formatsProvider,
+  unitsProvider: IModelApp.quantityFormatter,
+  imodel,
+  unitSystem: "imperial",
+});
 
 // Define the raw value to be formatted
 const value = 1.234;

--- a/packages/core-interop/api/presentation-core-interop.api.md
+++ b/packages/core-interop/api/presentation-core-interop.api.md
@@ -7,14 +7,15 @@
 import { ECSchemaProvider } from '@itwin/presentation-shared';
 import type { ECSqlQueryExecutor } from '@itwin/presentation-shared';
 import type { Event as Event_2 } from '@itwin/presentation-shared';
+import type { FormatsProvider } from '@itwin/core-quantity';
 import type { ILogger } from '@itwin/presentation-shared';
 import type { IPrimitiveValueFormatter } from '@itwin/presentation-shared';
 import { LogLevel } from '@itwin/core-bentley';
 import { QueryBinder } from '@itwin/core-common';
 import type { QueryOptions } from '@itwin/core-common';
 import type { QueryRowProxy } from '@itwin/core-common';
-import type { SchemaContext } from '@itwin/ecschema-metadata';
 import type { SchemaView } from '@itwin/ecschema-metadata';
+import type { UnitsProvider } from '@itwin/core-quantity';
 import type { UnitSystemKey } from '@itwin/core-quantity';
 
 // @public
@@ -56,7 +57,13 @@ export function createValueFormatter(props: CreateValueFormatterProps): IPrimiti
 // @public
 interface CreateValueFormatterProps {
     baseFormatter?: IPrimitiveValueFormatter;
-    schemaContext: SchemaContext;
+    formatsProvider: Pick<FormatsProvider, "getFormat">;
+    imodel: {
+        getSchemaView(props?: {
+            schemas?: string[];
+        }): Promise<PersistenceUnitSchemaView>;
+    };
+    unitsProvider: UnitsProvider;
     unitSystem?: UnitSystemKey;
 }
 
@@ -80,6 +87,9 @@ interface ICoreTxnManager {
     onCommit: Event_2;
     onCommitted: Event_2;
 }
+
+// @public
+type PersistenceUnitSchemaView = Pick<SchemaView, "findKindOfQuantity">;
 
 // @public
 type PublicCoreSchemaView = Pick<SchemaView, "schemaToken" | "isOutdated" | "schemaCount" | "classCount" | "getSchema" | "getSchemaByAlias" | "getSchemas" | "findClass" | "findEnumeration" | "findKindOfQuantity" | "findPropertyCategory">;

--- a/packages/core-interop/api/presentation-core-interop.api.md
+++ b/packages/core-interop/api/presentation-core-interop.api.md
@@ -89,7 +89,7 @@ interface ICoreTxnManager {
 }
 
 // @public
-type PersistenceUnitSchemaView = Pick<SchemaView, "findKindOfQuantity">;
+type PersistenceUnitSchemaView = Pick<SchemaView, "findKindOfQuantity" | "getSchemaByAlias">;
 
 // @public
 type PublicCoreSchemaView = Pick<SchemaView, "schemaToken" | "isOutdated" | "schemaCount" | "classCount" | "getSchema" | "getSchemaByAlias" | "getSchemas" | "findClass" | "findEnumeration" | "findKindOfQuantity" | "findPropertyCategory">;

--- a/packages/core-interop/src/core-interop/Formatting.ts
+++ b/packages/core-interop/src/core-interop/Formatting.ts
@@ -4,18 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { FormatterSpec, Format as QuantityFormat } from "@itwin/core-quantity";
-import {
-  KindOfQuantity,
-  OverrideFormat,
-  SchemaKey,
-  SchemaMatchType,
-  SchemaUnitProvider,
-} from "@itwin/ecschema-metadata";
-import { createDefaultValueFormatter, parseFullClassName } from "@itwin/presentation-shared";
+import { createDefaultValueFormatter, normalizeFullClassName, parseFullClassName } from "@itwin/presentation-shared";
+import { createBatchedSchemaViewGetter } from "./Metadata.js";
 
-import type { FormatProps, UnitsProvider, UnitSystemKey } from "@itwin/core-quantity";
-import type { Format, InvertedUnit, LazyLoadedFormat, SchemaContext, Unit } from "@itwin/ecschema-metadata";
+import type { FormatsProvider, UnitsProvider, UnitSystemKey } from "@itwin/core-quantity";
+import type { SchemaView } from "@itwin/ecschema-metadata";
 import type { IPrimitiveValueFormatter, TypedPrimitiveValue } from "@itwin/presentation-shared";
+
+/**
+ * Subset of `SchemaView` used to look up a kind of quantity's persistence unit.
+ * @public
+ */
+type PersistenceUnitSchemaView = Pick<SchemaView, "findKindOfQuantity">;
 
 /**
  * Props for `createValueFormatter` function.
@@ -23,21 +23,34 @@ import type { IPrimitiveValueFormatter, TypedPrimitiveValue } from "@itwin/prese
  */
 interface CreateValueFormatterProps {
   /**
-   * An instance of [SchemaContext](https://www.itwinjs.org/reference/ecschema-metadata/context/schemacontext/) for
-   * getting units information. Generally, retrieved directly from `IModelDb` or `IModelConnection` using the `schemaContext` accessor.
+   * Supplies `FormatProps` for a property's kind of quantity, by its full name. On the frontend, `IModelApp.formatsProvider`
+   * satisfies this. `getFormat` returning `undefined` means no format is registered for the kind of quantity - `baseFormatter`
+   * is used in that case.
    */
-  schemaContext: SchemaContext;
+  formatsProvider: Pick<FormatsProvider, "getFormat">;
 
   /**
-   * An optional unit system to use for formatting property values. If not provided, default presentation units are used. If a property
-   * doesn't have a default presentation unit, then persistence unit is used. Finally, if a property doesn't have a unit assigned at all,
-   * `baseFormatter` is used to format the property value.
+   * Resolves units and is used to build format specs. On the frontend, `IModelApp.quantityFormatter` implements this
+   * interface directly.
+   */
+  unitsProvider: UnitsProvider;
+
+  /**
+   * Supplies [SchemaView](https://www.itwinjs.org/reference/ecschema-metadata/context/schemaview/) instances used to look up
+   * a kind of quantity's persistence unit. `IModelDb` and `IModelConnection` satisfy this shape directly.
+   */
+  imodel: { getSchemaView(props?: { schemas?: string[] }): Promise<PersistenceUnitSchemaView> };
+
+  /**
+   * An optional unit system override, forwarded to `formatsProvider.getFormat`. If not provided, `formatsProvider` formats
+   * using whatever unit system it's configured with.
    */
   unitSystem?: UnitSystemKey;
 
   /**
-   * Base primitive value formatter for cases when a property doesn't have any units' information. Defaults to the result of `createDefaultValueFormatter`
-   * from `@itwin/presentation-shared` package.
+   * Base primitive value formatter used whenever a property's value can't be formatted using unit information - e.g. the
+   * property doesn't have a kind of quantity, no format is registered for it, or its kind of quantity doesn't specify a usable
+   * persistence unit. Defaults to the result of `createDefaultValueFormatter` from `@itwin/presentation-shared` package.
    */
   baseFormatter?: IPrimitiveValueFormatter;
 }
@@ -49,25 +62,39 @@ interface CreateValueFormatterProps {
  * Usage example:
  *
  * ```ts
- * import { IModelConnection } from "@itwin/core-frontend";
+ * import { IModelApp, IModelConnection } from "@itwin/core-frontend";
  * import { createValueFormatter } from "@itwin/presentation-core-interop";
  *
  * const imodel: IModelConnection = getIModel();
- * const formatter = createValueFormatter({ schemaContext: imodel.schemaContext, unitSystem: "metric" });
+ * const formatter = createValueFormatter({
+ *   formatsProvider: IModelApp.formatsProvider,
+ *   unitsProvider: IModelApp.quantityFormatter,
+ *   imodel,
+ *   unitSystem: "metric",
+ * });
  * const formattedValue = await formatter({ type: "Double", value: 1.234, koqName: "MySchema.LengthKindOfQuantity" });
  * ```
+ *
+ * On the backend, where there's no `IModelApp`, construct equivalent `formatsProvider` / `unitsProvider` instances
+ * from the active iModel using `SchemaFormatsProvider` and `SchemaUnitProvider` from `@itwin/ecschema-metadata`,
+ * ideally caching them per iModel.
  *
  * @public
  */
 export function createValueFormatter(props: CreateValueFormatterProps): IPrimitiveValueFormatter {
-  const { schemaContext, unitSystem } = props;
+  const { formatsProvider, unitsProvider, imodel, unitSystem } = props;
   /* v8 ignore next -- @preserve */
   const baseFormatter = props.baseFormatter ?? createDefaultValueFormatter();
-  const unitsProvider = new SchemaUnitProvider(schemaContext);
+  const getSchemaView = createBatchedSchemaViewGetter(imodel);
   return async function (value: TypedPrimitiveValue): Promise<string> {
     if (value.type === "Double" && !!value.koqName) {
-      const koq = await getKindOfQuantity(schemaContext, value.koqName);
-      const spec = await getFormatterSpec(unitsProvider, koq, unitSystem);
+      const spec = await getFormatterSpec({
+        formatsProvider,
+        unitsProvider,
+        getSchemaView,
+        koqName: value.koqName,
+        unitSystem,
+      });
       if (spec) {
         return spec.applyFormatting(value.value);
       }
@@ -76,119 +103,41 @@ export function createValueFormatter(props: CreateValueFormatterProps): IPrimiti
   };
 }
 
-async function getKindOfQuantity(schemas: SchemaContext, fullName: string) {
-  const { schemaName, className: koqName } = parseFullClassName(fullName);
-  const schema = await schemas.getSchema(new SchemaKey(schemaName), SchemaMatchType.Latest);
-  if (!schema) {
-    throw new Error(`Invalid schema "${schemaName}" specified in KoQ full name "${fullName}"`);
-  }
-  const koq = await schema.getItem(koqName, KindOfQuantity);
-  if (!koq) {
-    throw new Error(
-      `Invalid kind of quantity "${koqName}" specified in KoQ full name "${fullName}" - it does not exist in schema "${schemaName}"`,
-    );
-  }
-  return koq;
-}
-
-async function getFormatterSpec(unitsProvider: UnitsProvider, koq: KindOfQuantity, unitSystem?: UnitSystemKey) {
-  const formattingProps = await getFormattingProps(koq, unitSystem);
-  if (!formattingProps) {
+async function getFormatterSpec(props: {
+  formatsProvider: Pick<FormatsProvider, "getFormat">;
+  unitsProvider: UnitsProvider;
+  getSchemaView: (schemaName: string) => Promise<PersistenceUnitSchemaView>;
+  koqName: string;
+  unitSystem?: UnitSystemKey;
+}): Promise<FormatterSpec | undefined> {
+  const { formatsProvider, unitsProvider, getSchemaView, koqName, unitSystem } = props;
+  const formatProps = await formatsProvider.getFormat(koqName, unitSystem);
+  if (!formatProps) {
     return undefined;
   }
-  const { formatProps, persistenceUnitName } = formattingProps;
+  const persistenceUnitName = await getPersistenceUnitName(getSchemaView, koqName);
+  if (!persistenceUnitName) {
+    return undefined;
+  }
   const persistenceUnit = await unitsProvider.findUnitByName(persistenceUnitName);
   const format = await QuantityFormat.createFromJSON("", unitsProvider, formatProps);
   return FormatterSpec.create("", format, unitsProvider, persistenceUnit);
 }
 
-interface FormattingProps {
-  formatProps: FormatProps;
-  persistenceUnitName: string;
-}
-
-async function getFormattingProps(
-  koq: KindOfQuantity,
-  unitSystem?: UnitSystemKey,
-): Promise<FormattingProps | undefined> {
-  const persistenceUnit = await koq.persistenceUnit;
-  if (!persistenceUnit) {
+async function getPersistenceUnitName(
+  getSchemaView: (schemaName: string) => Promise<PersistenceUnitSchemaView>,
+  koqName: string,
+): Promise<string | undefined> {
+  const { schemaName } = parseFullClassName(koqName);
+  const schemaView = await getSchemaView(schemaName);
+  const koq = schemaView.findKindOfQuantity(koqName);
+  if (!koq) {
     return undefined;
   }
-  const formatProps = await getKoqFormatProps(koq, persistenceUnit, unitSystem);
-  if (!formatProps) {
+  try {
+    // Legacy ECDb profiles (pre EC3.2 Units/Formats migration) return persistence units in a format this doesn't understand.
+    return normalizeFullClassName(koq.persistenceUnit);
+  } catch {
     return undefined;
   }
-  return { formatProps, persistenceUnitName: persistenceUnit.fullName };
-}
-
-async function getKoqFormatProps(
-  koq: KindOfQuantity,
-  persistenceUnit: Unit | InvertedUnit,
-  unitSystem?: UnitSystemKey,
-) {
-  const unitSystems = getUnitSystemGroupNames(unitSystem);
-  // use one of KOQ presentation format that matches requested unit system
-  const presentationFormat = await getKoqPresentationFormat(koq, unitSystems);
-  if (presentationFormat) {
-    return getFormatProps(presentationFormat);
-  }
-
-  // use persistence unit format if it matches requested unit system and matching presentation format was not found
-  const persistenceUnitSystem = await persistenceUnit.unitSystem;
-  if (persistenceUnitSystem && unitSystems.includes(persistenceUnitSystem.name.toUpperCase())) {
-    return getPersistenceUnitFormatProps(persistenceUnit);
-  }
-
-  // use default presentation format if persistence unit does not match requested unit system
-  if (koq.defaultPresentationFormat) {
-    return getFormatProps(koq.defaultPresentationFormat);
-  }
-
-  return undefined;
-}
-
-async function getKoqPresentationFormat(koq: KindOfQuantity, unitSystems: string[]) {
-  const presentationFormats = koq.presentationFormats;
-  for (const system of unitSystems) {
-    for (const format of presentationFormats) {
-      const units = format instanceof OverrideFormat ? format.units : (await format).units;
-      const lazyUnit = units && units[0][0];
-      const currentUnitSystem = lazyUnit && (await lazyUnit).unitSystem;
-      if (currentUnitSystem && currentUnitSystem.name.toUpperCase() === system) {
-        return format;
-      }
-    }
-  }
-  return undefined;
-}
-
-async function getFormatProps(format: LazyLoadedFormat | OverrideFormat | Format): Promise<FormatProps> {
-  return format instanceof OverrideFormat ? format.getFormatProps() : (await format).toJSON();
-}
-
-function getPersistenceUnitFormatProps(persistenceUnit: Unit | InvertedUnit): FormatProps {
-  // Same as Format "DefaultRealU" in Formats ecschema
-  return {
-    formatTraits: ["keepSingleZero", "keepDecimalPoint", "showUnitLabel"],
-    precision: 6,
-    type: "Decimal",
-    uomSeparator: " ",
-    decimalSeparator: ".",
-    composite: { units: [{ name: persistenceUnit.fullName, label: persistenceUnit.label }] },
-  };
-}
-
-function getUnitSystemGroupNames(unitSystem?: UnitSystemKey) {
-  switch (unitSystem) {
-    case "imperial":
-      return ["IMPERIAL", "USCUSTOM", "INTERNATIONAL", "FINANCE"];
-    case "metric":
-      return ["SI", "METRIC", "INTERNATIONAL", "FINANCE"];
-    case "usCustomary":
-      return ["USCUSTOM", "INTERNATIONAL", "FINANCE"];
-    case "usSurvey":
-      return ["USSURVEY", "USCUSTOM", "INTERNATIONAL", "FINANCE"];
-  }
-  return [];
 }

--- a/packages/core-interop/src/core-interop/Formatting.ts
+++ b/packages/core-interop/src/core-interop/Formatting.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { FormatterSpec, Format as QuantityFormat } from "@itwin/core-quantity";
-import { createDefaultValueFormatter, normalizeFullClassName, parseFullClassName } from "@itwin/presentation-shared";
+import { createDefaultValueFormatter, parseFullClassName } from "@itwin/presentation-shared";
 import { createBatchedSchemaViewGetter } from "./Metadata.js";
 
 import type { FormatsProvider, UnitsProvider, UnitSystemKey } from "@itwin/core-quantity";
@@ -15,7 +15,7 @@ import type { IPrimitiveValueFormatter, TypedPrimitiveValue } from "@itwin/prese
  * Subset of `SchemaView` used to look up a kind of quantity's persistence unit.
  * @public
  */
-type PersistenceUnitSchemaView = Pick<SchemaView, "findKindOfQuantity">;
+type PersistenceUnitSchemaView = Pick<SchemaView, "findKindOfQuantity" | "getSchemaByAlias">;
 
 /**
  * Props for `createValueFormatter` function.
@@ -124,6 +124,13 @@ async function getFormatterSpec(props: {
   return FormatterSpec.create("", format, unitsProvider, persistenceUnit);
 }
 
+/**
+ * `Units`/`Formats` are excluded from `SchemaView` by design (see class docs), so `SchemaView.getSchemaByAlias` can never
+ * resolve them. Schemas almost universally reference them using these exact aliases, so fall back to them when
+ * `getSchemaByAlias` can't help.
+ */
+const WELL_KNOWN_SCHEMA_ALIASES: Partial<Record<string, string>> = { u: "Units", f: "Formats" };
+
 async function getPersistenceUnitName(
   getSchemaView: (schemaName: string) => Promise<PersistenceUnitSchemaView>,
   koqName: string,
@@ -135,8 +142,14 @@ async function getPersistenceUnitName(
     return undefined;
   }
   try {
-    // Legacy ECDb profiles (pre EC3.2 Units/Formats migration) return persistence units in a format this doesn't understand.
-    return normalizeFullClassName(koq.persistenceUnit);
+    // Despite `persistenceUnit`'s doc comment, it's returned alias-qualified (e.g. "u:M"), not schema-name-qualified.
+    // Legacy ECDb profiles (pre EC3.2 Units/Formats migration) return it in a format this doesn't understand at all.
+    const { schemaName: aliasOrSchemaName, className: unitName } = parseFullClassName(koq.persistenceUnit);
+    const resolvedSchemaName =
+      schemaView.getSchemaByAlias(aliasOrSchemaName)?.name ??
+      WELL_KNOWN_SCHEMA_ALIASES[aliasOrSchemaName.toLowerCase()] ??
+      aliasOrSchemaName;
+    return `${resolvedSchemaName}.${unitName}`;
   } catch {
     return undefined;
   }

--- a/packages/core-interop/src/core-interop/Metadata.ts
+++ b/packages/core-interop/src/core-interop/Metadata.ts
@@ -42,6 +42,38 @@ type PublicCoreSchemaView = Pick<
 type CoreSchemaViewGetter = (props?: { schemas?: string[] }) => Promise<PublicCoreSchemaView>;
 
 /**
+ * Accumulates schema names requested within the same frame and issues a single `getSchemaView` request for all of
+ * them in the next one, returning each caller the batch's result. Used both by `createECSchemaProvider` and by
+ * `createValueFormatter` (which resolves kind of quantity persistence units without needing the class hierarchy).
+ *
+ * @internal
+ */
+export function createBatchedSchemaViewGetter<TSchemaView>(imodel: {
+  getSchemaView: (props?: { schemas?: string[] }) => Promise<TSchemaView>;
+}): (schemaName: string) => Promise<TSchemaView> {
+  const schemaNameSubject = new Subject<string>();
+  const schemaViewBatches = schemaNameSubject.pipe(
+    bufferTime(0),
+    filter((schemaNames) => schemaNames.length > 0),
+    mergeMap(async (schemaNames) => {
+      const schemas = new Set(schemaNames);
+      return { schemas, schemaView: await imodel.getSchemaView({ schemas: [...schemas] }) };
+    }),
+    share(),
+  );
+  return async function getSchemaView(schemaName: string): Promise<TSchemaView> {
+    const schemaView = firstValueFrom(
+      schemaViewBatches.pipe(
+        filter((batch) => batch.schemas.has(schemaName)),
+        map((batch) => batch.schemaView),
+      ),
+    );
+    schemaNameSubject.next(schemaName);
+    return schemaView;
+  };
+}
+
+/**
  * Creates an `ECSchemaProvider` for a given iModel with [SchemaView](https://www.itwinjs.org/reference/ecschema-metadata/context/schemaview/)
  * getter and query reader factory.
  *
@@ -61,27 +93,7 @@ type CoreSchemaViewGetter = (props?: { schemas?: string[] }) => Promise<PublicCo
 export function createECSchemaProvider(
   imodel: { getSchemaView: CoreSchemaViewGetter } & CoreECSqlReaderFactory,
 ): ECSchemaProvider {
-  // Accumulates schema names requested within the same frame and issues a single `getSchemaView` request in the next one.
-  const schemaNameSubject = new Subject<string>();
-  const schemaViewBatches = schemaNameSubject.pipe(
-    bufferTime(0),
-    filter((schemaNames) => schemaNames.length > 0),
-    mergeMap(async (schemaNames) => {
-      const schemas = new Set(schemaNames);
-      return { schemas, schemaView: await imodel.getSchemaView({ schemas: [...schemas] }) };
-    }),
-    share(),
-  );
-  async function getSchemaView(schemaName: string): Promise<PublicCoreSchemaView> {
-    const schemaView = firstValueFrom(
-      schemaViewBatches.pipe(
-        filter((batch) => batch.schemas.has(schemaName)),
-        map((batch) => batch.schemaView),
-      ),
-    );
-    schemaNameSubject.next(schemaName);
-    return schemaView;
-  }
+  const getSchemaView = createBatchedSchemaViewGetter(imodel);
 
   // Ensures we only create a single `ECClassHierarchyResolver` for the iModel, which is used to resolve derived classes for all schemas.
   // Cache the promise (not the resolved value) so concurrent `getSchema` calls share one `createECClassHierarchyResolver` invocation.

--- a/packages/core-interop/src/test/Formatting.test.ts
+++ b/packages/core-interop/src/test/Formatting.test.ts
@@ -5,40 +5,27 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FormatterSpec, Format as QuantityFormat } from "@itwin/core-quantity";
-import {
-  DelayedPromiseWithProps,
-  OverrideFormat,
-  SchemaItemKey,
-  SchemaItemType,
-  SchemaKey,
-  SchemaUnitProvider,
-} from "@itwin/ecschema-metadata";
-import { parseFullClassName } from "@itwin/presentation-shared";
 import { createValueFormatter } from "../core-interop/Formatting.js";
 
-import type { UnitSystemKey } from "@itwin/core-quantity";
-import type {
-  Format,
-  KindOfQuantity,
-  LazyLoadedFormat,
-  LazyLoadedSchemaItem,
-  Schema,
-  SchemaContext,
-  SchemaItem,
-  SchemaItemFormatProps,
-  Unit,
-  UnitSystem,
-} from "@itwin/ecschema-metadata";
+import type { UnitsProvider, UnitSystemKey } from "@itwin/core-quantity";
+import type { SchemaView } from "@itwin/ecschema-metadata";
 import type { IPrimitiveValueFormatter, TypedPrimitiveValue } from "@itwin/presentation-shared";
 
 describe("createValueFormatter", () => {
-  const schemaContext = { getSchema: vi.fn() };
+  const formatsProvider = { getFormat: vi.fn() };
+  const findUnitByName = vi.fn();
+  const unitsProvider = { findUnitByName } as unknown as UnitsProvider;
+  const findKindOfQuantity = vi.fn();
+  const getSchemaView = vi.fn(async (): Promise<Pick<SchemaView, "findKindOfQuantity">> => ({ findKindOfQuantity }));
+  const imodel = { getSchemaView };
   const defaultFormatter = vi.fn(async () => "DEFAULT");
   let formatter: IPrimitiveValueFormatter;
 
   function initFormatter(unitSystem?: UnitSystemKey) {
     formatter = createValueFormatter({
-      schemaContext: schemaContext as unknown as SchemaContext,
+      formatsProvider,
+      unitsProvider,
+      imodel,
       unitSystem,
       baseFormatter: defaultFormatter,
     });
@@ -46,6 +33,10 @@ describe("createValueFormatter", () => {
 
   beforeEach(() => {
     defaultFormatter.mockClear();
+    formatsProvider.getFormat.mockReset();
+    findUnitByName.mockReset();
+    getSchemaView.mockClear();
+    findKindOfQuantity.mockReset();
     initFormatter();
   });
 
@@ -53,91 +44,48 @@ describe("createValueFormatter", () => {
     const prop: TypedPrimitiveValue = { type: "Double", value: 1.23 };
     expect(await formatter(prop)).toBe("DEFAULT");
     expect(defaultFormatter).toHaveBeenCalledExactlyOnceWith(prop);
+    expect(formatsProvider.getFormat).not.toHaveBeenCalled();
   });
 
-  it("throws when property references non-existing schema in KoQ", async () => {
-    schemaContext.getSchema.mockResolvedValue(undefined);
-    const prop: TypedPrimitiveValue = { type: "Double", value: 1.23, koqName: "X.Y" };
-    await expect(formatter(prop)).rejects.toThrow("Invalid schema");
+  it("returns default formatter result for non-Double values", async () => {
+    const prop: TypedPrimitiveValue = { type: "String", value: "abc" };
+    expect(await formatter(prop)).toBe("DEFAULT");
+    expect(defaultFormatter).toHaveBeenCalledExactlyOnceWith(prop);
+    expect(formatsProvider.getFormat).not.toHaveBeenCalled();
   });
 
-  it("throws when property references non-existing KoQ", async () => {
-    schemaContext.getSchema.mockResolvedValue({ name: "X", getItem: async () => undefined });
-    const prop: TypedPrimitiveValue = { type: "Double", value: 1.23, koqName: "X.Y" };
-    await expect(formatter(prop)).rejects.toThrow("Invalid kind of quantity");
+  it("returns default formatter result when no format is registered for the KoQ", async () => {
+    formatsProvider.getFormat.mockResolvedValue(undefined);
+    const prop: TypedPrimitiveValue = { type: "Double", value: 1.23, koqName: "schema.koq" };
+    expect(await formatter(prop)).toBe("DEFAULT");
+    expect(formatsProvider.getFormat).toHaveBeenCalledExactlyOnceWith("schema.koq", undefined);
+    expect(defaultFormatter).toHaveBeenCalledExactlyOnceWith(prop);
   });
 
-  it("returns default formatter result when KoQ doesn't specify persistence unit", async () => {
-    schemaContext.getSchema.mockResolvedValue({
-      name: "X",
-      getItem: async (name: string) => {
-        if (name === "Y") {
-          return { persistenceUnit: undefined } as unknown as KindOfQuantity;
-        }
-        return undefined;
-      },
-    });
-    const prop: TypedPrimitiveValue = { type: "Double", value: 1.23, koqName: "X.Y" };
+  it("returns default formatter result when KoQ is not found in SchemaView", async () => {
+    formatsProvider.getFormat.mockResolvedValue({});
+    findKindOfQuantity.mockReturnValue(undefined);
+    const prop: TypedPrimitiveValue = { type: "Double", value: 1.23, koqName: "schema.koq" };
     expect(await formatter(prop)).toBe("DEFAULT");
     expect(defaultFormatter).toHaveBeenCalledExactlyOnceWith(prop);
   });
 
-  it("returns default formatter result when KoQ doesn't specify presentation format", async () => {
-    schemaContext.getSchema.mockResolvedValue({
-      name: "X",
-      getItem: async (name: string) => {
-        if (name === "Y") {
-          return {
-            persistenceUnit: createLazyLoaded({
-              key: new SchemaItemKey("persistence_unit", new SchemaKey("units_schema")),
-              unitSystem: createLazyLoaded({
-                key: new SchemaItemKey("metric", new SchemaKey("units_schema")),
-                name: "metric",
-              } as UnitSystem),
-            } as Unit),
-            presentationFormats: [],
-            defaultPresentationFormat: undefined,
-          } as unknown as KindOfQuantity;
-        }
-        return undefined;
-      },
-    });
-    const prop: TypedPrimitiveValue = { type: "Double", value: 1.23, koqName: "X.Y" };
+  it("returns default formatter result when KoQ's persistence unit can't be normalized (e.g. legacy FUS format)", async () => {
+    formatsProvider.getFormat.mockResolvedValue({});
+    findKindOfQuantity.mockReturnValue({ persistenceUnit: "not-a-valid-full-name" });
+    const prop: TypedPrimitiveValue = { type: "Double", value: 1.23, koqName: "schema.koq" };
     expect(await formatter(prop)).toBe("DEFAULT");
     expect(defaultFormatter).toHaveBeenCalledExactlyOnceWith(prop);
   });
 
-  it("returns koq formatter result when presentation format is found in koq formats list", async () => {
+  it("formats value using resolved format and persistence unit", async () => {
     initFormatter("metric");
-    const persistenceUnit = createUnit("schema.persistence_unit", "metric");
-    const presentationUnit = createUnit("schema.presentation_unit", "metric");
-    const presentationFormatProps = {} as SchemaItemFormatProps;
-    schemaContext.getSchema.mockResolvedValue({
-      name: "schema",
-      getItem: async (name: string) => {
-        if (name === "koq") {
-          return {
-            schemaItemType: SchemaItemType.KindOfQuantity,
-            persistenceUnit: createLazyLoaded(persistenceUnit),
-            presentationFormats: [
-              {
-                units: [[createLazyLoaded(presentationUnit), "presentation unit"]],
-                toJSON: () => presentationFormatProps,
-              } as unknown as LazyLoadedFormat,
-            ],
-            defaultPresentationFormat: undefined,
-          } as unknown as KindOfQuantity;
-        }
-        if (name === "persistence_unit") {
-          return persistenceUnit;
-        }
-        if (name === "presentation_unit") {
-          return presentationUnit;
-        }
-        return undefined;
-      },
-    });
+    const formatProps = {};
+    formatsProvider.getFormat.mockResolvedValue(formatProps);
+    findKindOfQuantity.mockReturnValue({ persistenceUnit: "Units:M" });
 
+    const persistenceUnit = {};
+    findUnitByName.mockResolvedValue(persistenceUnit);
     const koqFormatterStub = vi.fn().mockReturnValue("KOQ FORMAT");
     const quantityFormat = {} as unknown as QuantityFormat;
     const createQuantityFormatStub = vi.spyOn(QuantityFormat, "createFromJSON").mockResolvedValue(quantityFormat);
@@ -146,231 +94,33 @@ describe("createValueFormatter", () => {
       .mockResolvedValue({ applyFormatting: koqFormatterStub } as unknown as FormatterSpec);
 
     expect(await formatter({ type: "Double", value: 1.23, koqName: "schema.koq" })).toBe("KOQ FORMAT");
-    expect(createQuantityFormatStub).toHaveBeenCalledOnce();
-    expect(createQuantityFormatStub.mock.calls[0][0]).toBe("");
-    expect(createQuantityFormatStub.mock.calls[0][1]).toBeInstanceOf(SchemaUnitProvider);
-    expect(createQuantityFormatStub.mock.calls[0][2]).toBe(presentationFormatProps);
-    expect(createFormatSpecStub).toHaveBeenCalledOnce();
-    expect(createFormatSpecStub.mock.calls[0][0]).toBe("");
-    expect(createFormatSpecStub.mock.calls[0][1]).toBe(quantityFormat);
-    expect(createFormatSpecStub.mock.calls[0][2]).toBeInstanceOf(SchemaUnitProvider);
-    expect(createFormatSpecStub.mock.calls[0][3]!.name).toBe(persistenceUnit.fullName);
+    expect(formatsProvider.getFormat).toHaveBeenCalledExactlyOnceWith("schema.koq", "metric");
+    expect(findUnitByName).toHaveBeenCalledExactlyOnceWith("Units.M");
+    expect(createQuantityFormatStub).toHaveBeenCalledExactlyOnceWith("", unitsProvider, formatProps);
+    expect(createFormatSpecStub).toHaveBeenCalledExactlyOnceWith("", quantityFormat, unitsProvider, persistenceUnit);
     expect(koqFormatterStub).toHaveBeenCalledExactlyOnceWith(1.23);
   });
 
-  it("returns koq formatter result when presentation override format is found in koq formats list", async () => {
-    initFormatter("metric");
-    const persistenceUnit = createUnit("schema.persistence_unit", "metric");
-    const presentationUnit = createUnit("schema.presentation_unit", "metric");
-    // eslint-disable-next-line @itwin/no-internal
-    const overrideFormat = new OverrideFormat(
-      { fullName: "schema.base_format", toJSON: () => ({}) } as Format,
-      undefined,
-      [[createLazyLoaded(presentationUnit), "presentation unit"]],
-    );
-    schemaContext.getSchema.mockResolvedValue({
-      name: "schema",
-      getItem: async (name: string) => {
-        if (name === "koq") {
-          return {
-            schemaItemType: SchemaItemType.KindOfQuantity,
-            persistenceUnit: createLazyLoaded(persistenceUnit),
-            presentationFormats: [overrideFormat],
-            defaultPresentationFormat: undefined,
-          } as unknown as KindOfQuantity;
-        }
-        if (name === "persistence_unit") {
-          return persistenceUnit;
-        }
-        if (name === "presentation_unit") {
-          return presentationUnit;
-        }
-        return undefined;
-      },
-    });
+  it("forwards unitSystem override to formatsProvider.getFormat", async () => {
+    formatsProvider.getFormat.mockResolvedValue(undefined);
+    await formatter({ type: "Double", value: 1.23, koqName: "schema.koq" });
+    expect(formatsProvider.getFormat).toHaveBeenCalledExactlyOnceWith("schema.koq", undefined);
 
-    const koqFormatterStub = vi.fn().mockReturnValue("KOQ FORMAT");
-    const quantityFormat = {} as unknown as QuantityFormat;
-    const createQuantityFormatStub = vi.spyOn(QuantityFormat, "createFromJSON").mockResolvedValue(quantityFormat);
-    const createFormatSpecStub = vi
-      .spyOn(FormatterSpec, "create")
-      .mockResolvedValue({ applyFormatting: koqFormatterStub } as unknown as FormatterSpec);
-
-    expect(await formatter({ type: "Double", value: 1.23, koqName: "schema.koq" })).toBe("KOQ FORMAT");
-    expect(createQuantityFormatStub).toHaveBeenCalledOnce();
-    expect(createQuantityFormatStub.mock.calls[0][0]).toBe("");
-    expect(createQuantityFormatStub.mock.calls[0][1]).toBeInstanceOf(SchemaUnitProvider);
-    expect(createQuantityFormatStub.mock.calls[0][2].composite?.units[0].name).toBe(presentationUnit.fullName);
-    expect(createFormatSpecStub).toHaveBeenCalledOnce();
-    expect(createFormatSpecStub.mock.calls[0][0]).toBe("");
-    expect(createFormatSpecStub.mock.calls[0][1]).toBe(quantityFormat);
-    expect(createFormatSpecStub.mock.calls[0][2]).toBeInstanceOf(SchemaUnitProvider);
-    expect(createFormatSpecStub.mock.calls[0][3]?.name).toBe(persistenceUnit.fullName);
-    expect(koqFormatterStub).toHaveBeenCalledExactlyOnceWith(1.23);
-  });
-
-  it("returns koq formatter result when persistence unit system matches requested unit system", async () => {
     initFormatter("imperial");
-
-    const persistenceUnit = createUnit("schema.persistence_unit", "imperial");
-    schemaContext.getSchema.mockResolvedValue({
-      name: "schema",
-      getItem: async (name: string) => {
-        if (name === "koq") {
-          return {
-            schemaItemType: SchemaItemType.KindOfQuantity,
-            persistenceUnit: createLazyLoaded(persistenceUnit),
-            presentationFormats: [],
-            defaultPresentationFormat: undefined,
-          } as unknown as KindOfQuantity;
-        }
-        if (name === "persistence_unit") {
-          return persistenceUnit;
-        }
-        return undefined;
-      },
-    });
-
-    const koqFormatterStub = vi.fn().mockReturnValue("KOQ FORMAT");
-    const quantityFormat = {} as unknown as QuantityFormat;
-    const createQuantityFormatStub = vi.spyOn(QuantityFormat, "createFromJSON").mockResolvedValue(quantityFormat);
-    const createFormatSpecStub = vi
-      .spyOn(FormatterSpec, "create")
-      .mockResolvedValue({ applyFormatting: koqFormatterStub } as unknown as FormatterSpec);
-
-    expect(await formatter({ type: "Double", value: 1.23, koqName: "schema.koq" })).toBe("KOQ FORMAT");
-    expect(createQuantityFormatStub).toHaveBeenCalledOnce();
-    expect(createQuantityFormatStub.mock.calls[0][0]).toBe("");
-    expect(createQuantityFormatStub.mock.calls[0][1]).toBeInstanceOf(SchemaUnitProvider);
-    expect((createQuantityFormatStub.mock.calls[0][2] as SchemaItemFormatProps).composite!.units[0].name).toBe(
-      persistenceUnit.fullName,
-    );
-    expect(createFormatSpecStub).toHaveBeenCalledOnce();
-    expect(createFormatSpecStub.mock.calls[0][0]).toBe("");
-    expect(createFormatSpecStub.mock.calls[0][1]).toBe(quantityFormat);
-    expect(createFormatSpecStub.mock.calls[0][2]).toBeInstanceOf(SchemaUnitProvider);
-    expect(createFormatSpecStub.mock.calls[0][3]!.name).toBe(persistenceUnit.fullName);
-    expect(koqFormatterStub).toHaveBeenCalledExactlyOnceWith(1.23);
+    formatsProvider.getFormat.mockResolvedValue(undefined);
+    await formatter({ type: "Double", value: 1.23, koqName: "schema.koq" });
+    expect(formatsProvider.getFormat).toHaveBeenCalledWith("schema.koq", "imperial");
   });
 
-  it("returns koq formatter result when default presentation unit is of requested unit system", async () => {
-    initFormatter("usCustomary");
+  it("batches same-frame getSchemaView requests for different KoQs", async () => {
+    formatsProvider.getFormat.mockResolvedValue({});
+    findKindOfQuantity.mockReturnValue(undefined);
 
-    const persistenceUnit = createUnit("schema.persistence_unit", "imperial");
-    const defaultPresentationUnit = createUnit("schema.presentation_unit", "usCustomary");
-    const defaultPresentationFormatProps = {} as SchemaItemFormatProps;
-    schemaContext.getSchema.mockResolvedValue({
-      name: "schema",
-      getItem: async (name: string) => {
-        if (name === "koq") {
-          return {
-            schemaItemType: SchemaItemType.KindOfQuantity,
-            persistenceUnit: createLazyLoaded(persistenceUnit),
-            presentationFormats: [],
-            defaultPresentationFormat: {
-              units: [[createLazyLoaded(defaultPresentationUnit), "presentation unit"]],
-              toJSON: () => defaultPresentationFormatProps,
-            } as unknown as LazyLoadedFormat,
-          } as unknown as KindOfQuantity;
-        }
-        if (name === "persistence_unit") {
-          return persistenceUnit;
-        }
-        if (name === "presentation_unit") {
-          return defaultPresentationUnit;
-        }
-        return undefined;
-      },
-    });
+    await Promise.all([
+      formatter({ type: "Double", value: 1, koqName: "schemaA.koq1" }),
+      formatter({ type: "Double", value: 2, koqName: "schemaA.koq2" }),
+    ]);
 
-    const koqFormatterStub = vi.fn().mockReturnValue("KOQ FORMAT");
-    const quantityFormat = {} as unknown as QuantityFormat;
-    const createQuantityFormatStub = vi.spyOn(QuantityFormat, "createFromJSON").mockResolvedValue(quantityFormat);
-    const createFormatSpecStub = vi
-      .spyOn(FormatterSpec, "create")
-      .mockResolvedValue({ applyFormatting: koqFormatterStub } as unknown as FormatterSpec);
-
-    expect(await formatter({ type: "Double", value: 1.23, koqName: "schema.koq" })).toBe("KOQ FORMAT");
-    expect(createQuantityFormatStub).toHaveBeenCalledOnce();
-    expect(createQuantityFormatStub.mock.calls[0][0]).toBe("");
-    expect(createQuantityFormatStub.mock.calls[0][1]).toBeInstanceOf(SchemaUnitProvider);
-    expect(createQuantityFormatStub.mock.calls[0][2]).toBe(defaultPresentationFormatProps);
-    expect(createFormatSpecStub).toHaveBeenCalledOnce();
-    expect(createFormatSpecStub.mock.calls[0][0]).toBe("");
-    expect(createFormatSpecStub.mock.calls[0][1]).toBe(quantityFormat);
-    expect(createFormatSpecStub.mock.calls[0][2]).toBeInstanceOf(SchemaUnitProvider);
-    expect(createFormatSpecStub.mock.calls[0][3]!.name).toBe(persistenceUnit.fullName);
-    expect(koqFormatterStub).toHaveBeenCalledExactlyOnceWith(1.23);
-  });
-
-  it("returns koq formatter result when koq uses override format as default presentation format", async () => {
-    initFormatter("usSurvey");
-
-    const persistenceUnit = createUnit("schema.persistence_unit", "metric");
-    const presentationUnit = createUnit("schema.presentation_unit", "usSurvey");
-    // eslint-disable-next-line @itwin/no-internal
-    const overrideFormat = new OverrideFormat(
-      { fullName: "schema.base_format", toJSON: () => ({}) } as Format,
-      undefined,
-      [[createLazyLoaded(presentationUnit), "presentation unit"]],
-    );
-    schemaContext.getSchema.mockResolvedValue({
-      name: "schema",
-      getItem: async (name: string) => {
-        if (name === "koq") {
-          return {
-            schemaItemType: SchemaItemType.KindOfQuantity,
-            persistenceUnit: createLazyLoaded(persistenceUnit),
-            presentationFormats: [],
-            defaultPresentationFormat: overrideFormat,
-          } as unknown as KindOfQuantity;
-        }
-        if (name === "persistence_unit") {
-          return persistenceUnit;
-        }
-        if (name === "presentation_unit") {
-          return presentationUnit;
-        }
-        return undefined;
-      },
-    });
-
-    const koqFormatterStub = vi.fn().mockReturnValue("KOQ FORMAT");
-    const quantityFormat = {} as unknown as QuantityFormat;
-    const createQuantityFormatStub = vi.spyOn(QuantityFormat, "createFromJSON").mockResolvedValue(quantityFormat);
-    const createFormatSpecStub = vi
-      .spyOn(FormatterSpec, "create")
-      .mockResolvedValue({ applyFormatting: koqFormatterStub } as unknown as FormatterSpec);
-
-    expect(await formatter({ type: "Double", value: 1.23, koqName: "schema.koq" })).toBe("KOQ FORMAT");
-    expect(createQuantityFormatStub).toHaveBeenCalledOnce();
-    expect(createQuantityFormatStub.mock.calls[0][0]).toBe("");
-    expect(createQuantityFormatStub.mock.calls[0][1]).toBeInstanceOf(SchemaUnitProvider);
-    expect(createQuantityFormatStub.mock.calls[0][2].composite?.units[0].name).toBe(presentationUnit.fullName);
-    expect(createFormatSpecStub).toHaveBeenCalledOnce();
-    expect(createFormatSpecStub.mock.calls[0][0]).toBe("");
-    expect(createFormatSpecStub.mock.calls[0][1]).toBe(quantityFormat);
-    expect(createFormatSpecStub.mock.calls[0][2]).toBeInstanceOf(SchemaUnitProvider);
-    expect(createFormatSpecStub.mock.calls[0][3]?.name).toBe(persistenceUnit.fullName);
-    expect(koqFormatterStub).toHaveBeenCalledExactlyOnceWith(1.23);
+    expect(getSchemaView).toHaveBeenCalledExactlyOnceWith({ schemas: ["schemaA"] });
   });
 });
-
-function createUnit(fullName: string, unitSystem: UnitSystemKey) {
-  const { schemaName, className } = parseFullClassName(fullName);
-  return {
-    schemaItemType: SchemaItemType.Unit,
-    key: new SchemaItemKey(className, new SchemaKey(schemaName)),
-    schema: {} as Schema,
-    fullName,
-    unitSystem: createLazyLoaded({
-      key: new SchemaItemKey(unitSystem, new SchemaKey("units_schema")),
-      name: unitSystem,
-    } as UnitSystem),
-  } as unknown as Unit;
-}
-
-function createLazyLoaded<T extends SchemaItem>(item: T): LazyLoadedSchemaItem<T> {
-  // eslint-disable-next-line @itwin/no-internal
-  return new DelayedPromiseWithProps(item.key, async () => Promise.resolve(item));
-}

--- a/packages/core-interop/src/test/Formatting.test.ts
+++ b/packages/core-interop/src/test/Formatting.test.ts
@@ -16,7 +16,13 @@ describe("createValueFormatter", () => {
   const findUnitByName = vi.fn();
   const unitsProvider = { findUnitByName } as unknown as UnitsProvider;
   const findKindOfQuantity = vi.fn();
-  const getSchemaView = vi.fn(async (): Promise<Pick<SchemaView, "findKindOfQuantity">> => ({ findKindOfQuantity }));
+  const getSchemaByAlias = vi.fn();
+  const getSchemaView = vi.fn(
+    async (): Promise<Pick<SchemaView, "findKindOfQuantity" | "getSchemaByAlias">> => ({
+      findKindOfQuantity,
+      getSchemaByAlias,
+    }),
+  );
   const imodel = { getSchemaView };
   const defaultFormatter = vi.fn(async () => "DEFAULT");
   let formatter: IPrimitiveValueFormatter;
@@ -37,6 +43,7 @@ describe("createValueFormatter", () => {
     findUnitByName.mockReset();
     getSchemaView.mockClear();
     findKindOfQuantity.mockReset();
+    getSchemaByAlias.mockReset().mockReturnValue(undefined);
     initFormatter();
   });
 
@@ -99,6 +106,39 @@ describe("createValueFormatter", () => {
     expect(createQuantityFormatStub).toHaveBeenCalledExactlyOnceWith("", unitsProvider, formatProps);
     expect(createFormatSpecStub).toHaveBeenCalledExactlyOnceWith("", quantityFormat, unitsProvider, persistenceUnit);
     expect(koqFormatterStub).toHaveBeenCalledExactlyOnceWith(1.23);
+  });
+
+  it("resolves an alias-qualified persistence unit via getSchemaByAlias", async () => {
+    initFormatter("metric");
+    const formatProps = {};
+    formatsProvider.getFormat.mockResolvedValue(formatProps);
+    findKindOfQuantity.mockReturnValue({ persistenceUnit: "myAlias:M" });
+    getSchemaByAlias.mockImplementation((alias: string) => (alias === "myAlias" ? { name: "CustomUnits" } : undefined));
+
+    const persistenceUnit = {};
+    findUnitByName.mockResolvedValue(persistenceUnit);
+    vi.spyOn(QuantityFormat, "createFromJSON").mockResolvedValue({} as unknown as QuantityFormat);
+    vi.spyOn(FormatterSpec, "create").mockResolvedValue({ applyFormatting: vi.fn() } as unknown as FormatterSpec);
+
+    await formatter({ type: "Double", value: 1.23, koqName: "schema.koq" });
+    expect(getSchemaByAlias).toHaveBeenCalledExactlyOnceWith("myAlias");
+    expect(findUnitByName).toHaveBeenCalledExactlyOnceWith("CustomUnits.M");
+  });
+
+  it("falls back to well-known aliases for the excluded Units/Formats schemas", async () => {
+    initFormatter("metric");
+    const formatProps = {};
+    formatsProvider.getFormat.mockResolvedValue(formatProps);
+    // `getSchemaByAlias` can never resolve `Units`/`Formats` - they're excluded from `SchemaView`.
+    findKindOfQuantity.mockReturnValue({ persistenceUnit: "u:M" });
+
+    const persistenceUnit = {};
+    findUnitByName.mockResolvedValue(persistenceUnit);
+    vi.spyOn(QuantityFormat, "createFromJSON").mockResolvedValue({} as unknown as QuantityFormat);
+    vi.spyOn(FormatterSpec, "create").mockResolvedValue({ applyFormatting: vi.fn() } as unknown as FormatterSpec);
+
+    await formatter({ type: "Double", value: 1.23, koqName: "schema.koq" });
+    expect(findUnitByName).toHaveBeenCalledExactlyOnceWith("Units.M");
   });
 
   it("forwards unitSystem override to formatsProvider.getFormat", async () => {

--- a/packages/hierarchies/learning/Formatting.md
+++ b/packages/hierarchies/learning/Formatting.md
@@ -37,12 +37,22 @@ In the above example, the formatter customizes boolean values' formatting and re
 <!-- BEGIN EXTRACTION -->
 
 ```ts
-import { SchemaContext } from "@itwin/ecschema-metadata";
+import { IModelApp } from "@itwin/core-frontend";
 import { createValueFormatter } from "@itwin/presentation-core-interop";
 
-const schemaContext: SchemaContext = getIModelConnection().schemaContext;
-const metricFormatter = createValueFormatter({ schemaContext, unitSystem: "metric" });
-const imperialFormatter = createValueFormatter({ schemaContext, unitSystem: "imperial" });
+const imodel = getIModelConnection();
+const metricFormatter = createValueFormatter({
+  formatsProvider: IModelApp.formatsProvider,
+  unitsProvider: IModelApp.quantityFormatter,
+  imodel,
+  unitSystem: "metric",
+});
+const imperialFormatter = createValueFormatter({
+  formatsProvider: IModelApp.formatsProvider,
+  unitsProvider: IModelApp.quantityFormatter,
+  imodel,
+  unitSystem: "imperial",
+});
 
 // Define the raw value to be formatted
 const value = 1.234;


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/1487