### PR TITLE
Enforce case-sensitive comparisons for class and property names across the codebase

### DIFF
--- a/.changeset/quiet-windows-compare.md
+++ b/.changeset/quiet-windows-compare.md
@@ -1,0 +1,6 @@
+---
+"@itwin/presentation-hierarchies": major
+"@itwin/presentation-shared": major
+---
+
+Full class and property names are now compared case-sensitively. Provide names using the casing defined by their EC schemas.

--- a/apps/full-stack-tests/src/hierarchies/learning-snippets/CustomHierarchyProvider.test.ts
+++ b/apps/full-stack-tests/src/hierarchies/learning-snippets/CustomHierarchyProvider.test.ts
@@ -695,7 +695,7 @@ function createBooksService() {
   }
   async function getAuthors(query?: BooksServiceFilter<(typeof authors)[0]>) {
     return filterEntries(authors, query, (entry, { key, name, hasBooks }) => {
-      if (key && !entry.key.toLocaleLowerCase().includes(key.toLocaleLowerCase())) {
+      if (key && !entry.key.includes(key)) {
         return false;
       }
       if (name && !entry.name.toLocaleLowerCase().includes(name.toLocaleLowerCase())) {
@@ -709,13 +709,13 @@ function createBooksService() {
   }
   async function getBooks(query?: BooksServiceFilter<(typeof books)[0]>) {
     return filterEntries(books, query, (entry, { key, authorKey, title }) => {
-      if (key && !entry.key.toLocaleLowerCase().includes(key.toLocaleLowerCase())) {
+      if (authorKey && !entry.authorKey.includes(authorKey)) {
+        return false;
+      }
+      if (key && !entry.key.includes(key)) {
         return false;
       }
       if (title && !entry.title.toLocaleLowerCase().includes(title.toLocaleLowerCase())) {
-        return false;
-      }
-      if (authorKey && !entry.authorKey.toLocaleLowerCase().includes(authorKey.toLocaleLowerCase())) {
         return false;
       }
       return true;

--- a/packages/content/src/content/query/BaseQuery.ts
+++ b/packages/content/src/content/query/BaseQuery.ts
@@ -595,10 +595,7 @@ function getSelectorValueType(
           `Value filters directly on struct fields are not supported. Provide a member to filter on instead.`,
         );
       }
-      const memberLowercase = member.toLocaleLowerCase();
-      const memberType = type.members.find(
-        (structMember) => structMember.name.toLocaleLowerCase() === memberLowercase,
-      )?.type;
+      const memberType = type.members.find((structMember) => structMember.name === member)?.type;
       if (!memberType) {
         throw new Error(`Value filter references member "${member}" that is not a member of the struct field.`);
       }

--- a/packages/content/src/test/query/BaseQuery.test.ts
+++ b/packages/content/src/test/query/BaseQuery.test.ts
@@ -441,6 +441,21 @@ describe("buildBaseQuery", () => {
       );
     });
 
+    it("throws for a struct member with different casing", async () => {
+      const field = makePropertyField({
+        propertyName: "Address",
+        type: {
+          kind: "struct",
+          members: [{ name: "Street", label: "Street", type: { kind: "primitive", type: "String" } }],
+        },
+      });
+      const filters: ContentValueFilter[] = [{ field, member: "street", operator: "is-equal", value: "Main" }];
+
+      await expect(buildBaseQuery({ schemaProvider, source: makeSource([]), filters })).rejects.toThrow(
+        'member "street" that is not a member of the struct field',
+      );
+    });
+
     it("throws for a struct field filtered without a member", async () => {
       const field = makePropertyField({ propertyName: "Address", type: { kind: "struct", members: [] } });
       const filters: ContentValueFilter[] = [{ field, operator: "is-equal", value: "x" }];

--- a/packages/hierarchies/learning/CustomHierarchyProviders.md
+++ b/packages/hierarchies/learning/CustomHierarchyProviders.md
@@ -207,7 +207,7 @@ function createBooksService() {
   }
   async function getAuthors(query?: BooksServiceFilter<(typeof authors)[0]>) {
     return filterEntries(authors, query, (entry, { key, name, hasBooks }) => {
-      if (key && !entry.key.toLocaleLowerCase().includes(key.toLocaleLowerCase())) {
+      if (key && !entry.key.includes(key)) {
         return false;
       }
       if (name && !entry.name.toLocaleLowerCase().includes(name.toLocaleLowerCase())) {
@@ -221,13 +221,13 @@ function createBooksService() {
   }
   async function getBooks(query?: BooksServiceFilter<(typeof books)[0]>) {
     return filterEntries(books, query, (entry, { key, authorKey, title }) => {
-      if (key && !entry.key.toLocaleLowerCase().includes(key.toLocaleLowerCase())) {
+      if (authorKey && !entry.authorKey.includes(authorKey)) {
+        return false;
+      }
+      if (key && !entry.key.includes(key)) {
         return false;
       }
       if (title && !entry.title.toLocaleLowerCase().includes(title.toLocaleLowerCase())) {
-        return false;
-      }
-      if (authorKey && !entry.authorKey.toLocaleLowerCase().includes(authorKey.toLocaleLowerCase())) {
         return false;
       }
       return true;

--- a/packages/hierarchies/src/hierarchies/HierarchyNodeKey.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyNodeKey.ts
@@ -255,7 +255,7 @@ export namespace HierarchyNodeKey {
       }
       case "class-grouping": {
         assert(rhs.type === "class-grouping");
-        return compareStrings(lhs.className.toLocaleLowerCase(), rhs.className.toLocaleLowerCase());
+        return compareStrings(lhs.className, rhs.className);
       }
       case "label-grouping": {
         assert(rhs.type === "label-grouping");
@@ -271,17 +271,11 @@ export namespace HierarchyNodeKey {
           return lhs.properties.length - rhs.properties.length;
         }
         for (let i = 0; i < lhs.properties.length; ++i) {
-          const classCompareResult = compareStrings(
-            lhs.properties[i].className.toLocaleLowerCase(),
-            rhs.properties[i].className.toLocaleLowerCase(),
-          );
+          const classCompareResult = compareStrings(lhs.properties[i].className, rhs.properties[i].className);
           if (classCompareResult !== 0) {
             return classCompareResult;
           }
-          const nameCompareResult = compareStrings(
-            lhs.properties[i].propertyName.toLocaleLowerCase(),
-            rhs.properties[i].propertyName.toLocaleLowerCase(),
-          );
+          const nameCompareResult = compareStrings(lhs.properties[i].propertyName, rhs.properties[i].propertyName);
           if (nameCompareResult !== 0) {
             return nameCompareResult;
           }
@@ -290,17 +284,11 @@ export namespace HierarchyNodeKey {
       }
       case "property-grouping:value": {
         assert(rhs.type === "property-grouping:value");
-        const propertyClassNameCompareResult = compareStrings(
-          lhs.propertyClassName.toLocaleLowerCase(),
-          rhs.propertyClassName.toLocaleLowerCase(),
-        );
+        const propertyClassNameCompareResult = compareStrings(lhs.propertyClassName, rhs.propertyClassName);
         if (propertyClassNameCompareResult !== 0) {
           return propertyClassNameCompareResult;
         }
-        const propertyNameCompareResult = compareStrings(
-          lhs.propertyName.toLocaleLowerCase(),
-          rhs.propertyName.toLocaleLowerCase(),
-        );
+        const propertyNameCompareResult = compareStrings(lhs.propertyName, rhs.propertyName);
         if (propertyNameCompareResult !== 0) {
           return propertyNameCompareResult;
         }
@@ -308,17 +296,11 @@ export namespace HierarchyNodeKey {
       }
       case "property-grouping:range": {
         assert(rhs.type === "property-grouping:range");
-        const propertyClassNameCompareResult = compareStrings(
-          lhs.propertyClassName.toLocaleLowerCase(),
-          rhs.propertyClassName.toLocaleLowerCase(),
-        );
+        const propertyClassNameCompareResult = compareStrings(lhs.propertyClassName, rhs.propertyClassName);
         if (propertyClassNameCompareResult !== 0) {
           return propertyClassNameCompareResult;
         }
-        const propertyNameCompareResult = compareStrings(
-          lhs.propertyName.toLocaleLowerCase(),
-          rhs.propertyName.toLocaleLowerCase(),
-        );
+        const propertyNameCompareResult = compareStrings(lhs.propertyName, rhs.propertyName);
         if (propertyNameCompareResult !== 0) {
           return propertyNameCompareResult;
         }

--- a/packages/hierarchies/src/hierarchies/imodel/SearchHierarchyDefinition.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/SearchHierarchyDefinition.ts
@@ -114,7 +114,7 @@ export class SearchHierarchyDefinition implements RxjsHierarchyDefinition {
                 if (identifier.imodelKey && identifier.imodelKey !== imodelKey) {
                   return false;
                 }
-                if (identifier.className.toLocaleLowerCase() === rowInstanceKey.className.toLocaleLowerCase()) {
+                if (identifier.className === rowInstanceKey.className) {
                   return true;
                 }
                 return firstValueFrom(
@@ -212,7 +212,7 @@ export class SearchHierarchyDefinition implements RxjsHierarchyDefinition {
               for (const entry of entries) {
                 /* v8 ignore else -- @preserve */
                 if (
-                  entry.className.toLocaleLowerCase() === x.className.toLocaleLowerCase() ||
+                  entry.className === x.className ||
                   (await imodelAccess.classDerivesFrom(entry.className, x.className)) ||
                   (await imodelAccess.classDerivesFrom(x.className, entry.className))
                 ) {
@@ -230,7 +230,7 @@ export class SearchHierarchyDefinition implements RxjsHierarchyDefinition {
                 continue;
               }
               if (
-                id.className.toLocaleLowerCase() !== definition.fullClassName.toLocaleLowerCase() &&
+                id.className !== definition.fullClassName &&
                 !(await Promise.all([
                   imodelAccess.classDerivesFrom(id.className, definition.fullClassName),
                   imodelAccess.classDerivesFrom(definition.fullClassName, id.className),

--- a/packages/hierarchies/src/hierarchies/imodel/operators/grouping/BaseClassGrouping.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/operators/grouping/BaseClassGrouping.ts
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { SortedArray } from "@itwin/core-bentley";
 import { createMainThreadReleaseOnTimePassedHandler, getClass } from "@itwin/presentation-shared";
 import { HierarchyNode } from "../../../HierarchyNode.js";
 
@@ -37,9 +36,7 @@ export async function getBaseClassGroupingECClasses(
 
   if (parentNode && HierarchyNode.isClassGroupingNode(parentNode)) {
     // if we have a class grouping node, we can cut the front of sortedClasses up to a point where our grouping class is
-    const cutPosition = sortedClasses.findIndex(
-      (c) => c.fullName.toLocaleLowerCase() === parentNode.key.className.toLocaleLowerCase(),
-    );
+    const cutPosition = sortedClasses.findIndex((c) => c.fullName === parentNode.key.className);
     if (cutPosition >= 0) {
       return sortedClasses.slice(cutPosition + 1);
     }
@@ -63,9 +60,7 @@ export async function createBaseClassGroupsForSingleBaseClass(
     await releaseMainThread();
     if (
       !node.processingParams?.grouping?.byBaseClasses ||
-      !node.processingParams.grouping.byBaseClasses.fullClassNames.some(
-        (className) => className.toLocaleLowerCase() === baseClassFullName.toLocaleLowerCase(),
-      )
+      !node.processingParams.grouping.byBaseClasses.fullClassNames.includes(baseClassFullName)
     ) {
       ungroupedNodes.push(node);
       continue;
@@ -102,19 +97,16 @@ export async function createBaseClassGroupsForSingleBaseClass(
 
 async function getGroupingBaseClassNames(nodes: ProcessedInstanceHierarchyNode[]) {
   const releaseMainThread = createMainThreadReleaseOnTimePassedHandler();
-  const baseClasses = new SortedArray<EC.FullClassNameDotNotation>(
-    (a, b) => a.toLocaleLowerCase().localeCompare(b.toLocaleLowerCase()),
-    false,
-  );
+  const baseClasses = new Set<EC.FullClassNameDotNotation>();
   for (const node of nodes) {
     await releaseMainThread();
     if (node.processingParams?.grouping?.byBaseClasses) {
       for (const className of node.processingParams.grouping.byBaseClasses.fullClassNames) {
-        baseClasses.insert(className);
+        baseClasses.add(className);
       }
     }
   }
-  return baseClasses;
+  return [...baseClasses];
 }
 
 function sortByBaseClass(classes: EC.Class[]): EC.Class[] {

--- a/packages/hierarchies/src/hierarchies/imodel/operators/grouping/ClassGrouping.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/operators/grouping/ClassGrouping.ts
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { Dictionary } from "@itwin/core-bentley";
 import { createMainThreadReleaseOnTimePassedHandler, getClass } from "@itwin/presentation-shared";
 import { HierarchyNode } from "../../../HierarchyNode.js";
 
@@ -21,10 +20,7 @@ interface ClassInfo {
 
 interface ClassGroupingInformation {
   ungrouped: ProcessedInstanceHierarchyNode[];
-  grouped: Dictionary<
-    EC.FullClassNameDotNotation,
-    { class: ClassInfo; groupedNodes: ProcessedInstanceHierarchyNode[] }
-  >;
+  grouped: Map<EC.FullClassNameDotNotation, { class: ClassInfo; groupedNodes: ProcessedInstanceHierarchyNode[] }>;
 }
 
 /** @internal */
@@ -37,19 +33,16 @@ export async function createClassGroups(
     parentNode && HierarchyNode.isClassGroupingNode(parentNode) ? parentNode.key.className : undefined;
   const groupings: ClassGroupingInformation = {
     ungrouped: [],
-    grouped: new Dictionary<
+    grouped: new Map<
       EC.FullClassNameDotNotation,
       { class: ClassInfo; groupedNodes: ProcessedInstanceHierarchyNode[] }
-    >((a, b) => a.toLocaleLowerCase().localeCompare(b.toLocaleLowerCase())),
+    >(),
   };
   const releaseMainThread = createMainThreadReleaseOnTimePassedHandler();
   for (const node of nodes) {
     await releaseMainThread();
     const nodeClassName = node.key.instanceKeys[0].className;
-    if (
-      node.processingParams?.grouping?.byClass &&
-      (!parentNodeClass || nodeClassName.toLocaleLowerCase() !== parentNodeClass.toLocaleLowerCase())
-    ) {
+    if (node.processingParams?.grouping?.byClass && (!parentNodeClass || nodeClassName !== parentNodeClass)) {
       let groupingInfo = groupings.grouped.get(nodeClassName);
       if (!groupingInfo) {
         const nodeClass = await getClass(schemaProvider, nodeClassName);
@@ -67,7 +60,7 @@ export async function createClassGroups(
 async function createGroupingNodes(groupings: ClassGroupingInformation): Promise<GroupingHandlerResult> {
   const groupedNodes = new Array<ProcessedInstancesGroupingHierarchyNode>();
   const releaseMainThread = createMainThreadReleaseOnTimePassedHandler();
-  for (const { value: entry } of groupings.grouped) {
+  for (const entry of groupings.grouped.values()) {
     await releaseMainThread();
     const groupingNodeKey: ClassGroupingNodeKey = { type: "class-grouping", className: entry.class.fullName };
     const groupedNodeParentKeys = entry.groupedNodes[0].parentKeys;

--- a/packages/hierarchies/src/hierarchies/imodel/operators/grouping/PropertiesGrouping.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/operators/grouping/PropertiesGrouping.ts
@@ -129,7 +129,7 @@ export async function createPropertyGroups(
       if (byProperties.createGroupForUnspecifiedValues) {
         addGroupingToMap(
           groupings.grouped,
-          `${currentProperty.propertyName.toLocaleLowerCase()}:Unspecified`,
+          `${propertyIdentifier.propertyName}:Unspecified`,
           {
             label: localizedStrings.unspecified,
             propertyGroupingNodeKey: {
@@ -173,7 +173,7 @@ export async function createPropertyGroups(
             `${await valueFormatter(fromValueTypedPrimitive)} - ${await valueFormatter(toValueTypedPrimitive)}`;
           addGroupingToMap(
             groupings.grouped,
-            `${currentProperty.propertyName.toLocaleLowerCase()}:[${matchingRange.fromValue}-${matchingRange.toValue}]${matchingRange.rangeLabel ? `(${matchingRange.rangeLabel})` : ""}`,
+            `${propertyIdentifier.propertyName}:[${matchingRange.fromValue}-${matchingRange.toValue}]${matchingRange.rangeLabel ? `(${matchingRange.rangeLabel})` : ""}`,
             {
               label: rangeLabel,
               propertyGroupingNodeKey: {
@@ -197,8 +197,7 @@ export async function createPropertyGroups(
         };
         const hasPropertyIdentifier = groupingNode.key.properties.find(
           (x) =>
-            x.className.toLocaleLowerCase() === thisPropertyIdentifier.className.toLocaleLowerCase() &&
-            x.propertyName.toLocaleLowerCase() === thisPropertyIdentifier.propertyName.toLocaleLowerCase(),
+            x.className === thisPropertyIdentifier.className && x.propertyName === thisPropertyIdentifier.propertyName,
         );
         if (!hasPropertyIdentifier) {
           groupingNode.key.properties.push(thisPropertyIdentifier);
@@ -221,7 +220,7 @@ export async function createPropertyGroups(
 
     addGroupingToMap(
       groupings.grouped,
-      `${currentProperty.propertyName.toLocaleLowerCase()}:${formattedValue}`,
+      `${propertyIdentifier.propertyName}:${formattedValue}`,
       {
         label: formattedValue,
         propertyGroupingNodeKey: {
@@ -302,19 +301,12 @@ function createNodePropertyGroupPathMatchers(
       case "property-grouping:other":
         return (x) =>
           key.properties.some(
-            (p) =>
-              p.className.toLocaleLowerCase() === x.propertiesClassName.toLocaleLowerCase() &&
-              p.propertyName.toLocaleLowerCase() === x.propertyName.toLocaleLowerCase() &&
-              !!x.isRange,
+            (p) => p.className === x.propertiesClassName && p.propertyName === x.propertyName && !!x.isRange,
           );
       case "property-grouping:range":
-        return (x) =>
-          key.propertyClassName.toLocaleLowerCase() === x.propertiesClassName.toLocaleLowerCase() &&
-          key.propertyName.toLocaleLowerCase() === x.propertyName.toLocaleLowerCase();
+        return (x) => key.propertyClassName === x.propertiesClassName && key.propertyName === x.propertyName;
       case "property-grouping:value":
-        return (x) =>
-          key.propertyClassName.toLocaleLowerCase() === x.propertiesClassName.toLocaleLowerCase() &&
-          key.propertyName.toLocaleLowerCase() === x.propertyName.toLocaleLowerCase();
+        return (x) => key.propertyClassName === x.propertiesClassName && key.propertyName === x.propertyName;
     }
   });
 }
@@ -340,40 +332,41 @@ export async function getUniquePropertiesGroupInfo(
     let propertyGroupIndex = 0;
     const previousPropertiesInfo = new Array<{ propertyGroup: HierarchyNodePropertyGroup; propertyGroupKey: string }>();
     for (const propertyGroup of byProperties.propertyGroups) {
+      const property = propertiesClass.getProperty(propertyGroup.propertyName);
+      const propertyName = property?.name ?? propertyGroup.propertyName;
+      const propertyClassName = property?.class.fullName ?? propertiesClass.fullName;
       const mapKeyRanges = getRangesAsString(propertyGroup.ranges);
       const lastKey =
         previousPropertiesInfo.length > 0
           ? previousPropertiesInfo[previousPropertiesInfo.length - 1].propertyGroupKey
           : "";
-      const propertyGroupKey = `${lastKey}:${propertyGroup.propertyName}(${mapKeyRanges})`;
-      const mapKey = `${byProperties.propertiesClassName}:${propertyGroupKey}`.toLocaleLowerCase();
+      const propertyGroupKey = `${lastKey}:${propertyName}(${mapKeyRanges})`;
+      const mapKey = `${propertiesClass.fullName}:${propertyGroupKey}`;
 
       let isAlreadyGrouped = false;
       if (parentPropertyGroupPath.length > 0 && propertyGroupIndex < parentPropertyGroupPath.length) {
         const groupMatcher = parentPropertyGroupPath[propertyGroupIndex];
-        const propertyClassName =
-          propertiesClass.getProperty(propertyGroup.propertyName)?.class.fullName ?? byProperties.propertiesClassName;
         isAlreadyGrouped = groupMatcher({
           propertiesClassName: propertyClassName,
-          propertyName: propertyGroup.propertyName,
+          propertyName,
           isRange: !!propertyGroup.ranges,
         });
       }
       if (!isAlreadyGrouped && !uniqueProperties.get(mapKey)) {
         uniqueProperties.set(mapKey, {
           ecClass: propertiesClass,
-          propertyGroup: { propertyName: propertyGroup.propertyName, ranges: propertyGroup.ranges },
+          propertyGroup: { propertyName, ranges: propertyGroup.ranges },
           previousPropertiesGroupingInfo: previousPropertiesInfo.map((groupingInfo) => ({
             propertiesClassName:
               propertiesClass.getProperty(groupingInfo.propertyGroup.propertyName)?.class.fullName ??
-              byProperties.propertiesClassName,
+              propertiesClass.fullName,
             propertyName: groupingInfo.propertyGroup.propertyName,
             isRange: !!groupingInfo.propertyGroup.ranges,
           })),
         });
       }
 
-      previousPropertiesInfo.push({ propertyGroup, propertyGroupKey });
+      previousPropertiesInfo.push({ propertyGroup: { ...propertyGroup, propertyName }, propertyGroupKey });
       ++propertyGroupIndex;
     }
   }
@@ -399,8 +392,7 @@ async function shouldCreatePropertyGroup(
   classHierarchyInspector: Pick<ECSchemaProvider, "classDerivesFrom">,
 ): Promise<boolean> {
   if (
-    nodePropertyGroupingParams.propertiesClassName.toLocaleLowerCase() !==
-      handlerGroupingParams.ecClass.fullName.toLocaleLowerCase() ||
+    nodePropertyGroupingParams.propertiesClassName !== handlerGroupingParams.ecClass.fullName ||
     nodePropertyGroupingParams.propertyGroups.length < handlerGroupingParams.previousPropertiesGroupingInfo.length + 1
   ) {
     return false;
@@ -408,8 +400,7 @@ async function shouldCreatePropertyGroup(
   const currentProperty =
     nodePropertyGroupingParams.propertyGroups[handlerGroupingParams.previousPropertiesGroupingInfo.length];
   if (
-    currentProperty.propertyName.toLocaleLowerCase() !==
-      handlerGroupingParams.propertyGroup.propertyName.toLocaleLowerCase() ||
+    currentProperty.propertyName !== handlerGroupingParams.propertyGroup.propertyName ||
     !doRangesMatch(currentProperty.ranges, handlerGroupingParams.propertyGroup.ranges)
   ) {
     return false;
@@ -429,10 +420,8 @@ export function doPreviousPropertiesMatch(
     previousPropertiesGroupingInfo.length <= nodesProperties.propertyGroups.length &&
     previousPropertiesGroupingInfo.every(
       (groupingInfo, index) =>
-        groupingInfo.propertiesClassName.toLocaleLowerCase() ===
-          nodesProperties.propertiesClassName.toLocaleLowerCase() &&
-        groupingInfo.propertyName.toLocaleLowerCase() ===
-          nodesProperties.propertyGroups[index].propertyName.toLocaleLowerCase() &&
+        groupingInfo.propertiesClassName === nodesProperties.propertiesClassName &&
+        groupingInfo.propertyName === nodesProperties.propertyGroups[index].propertyName &&
         !!groupingInfo.isRange === !!nodesProperties.propertyGroups[index].ranges,
     )
   );

--- a/packages/hierarchies/src/test/HierarchyNodeIdentifier.test.ts
+++ b/packages/hierarchies/src/test/HierarchyNodeIdentifier.test.ts
@@ -146,8 +146,10 @@ describe("HierarchyNodeIdentifier", () => {
       ).toBeGreaterThan(0);
     });
 
-    it("compares instance identifiers case-insensitively by className", () => {
-      expect(HierarchyNodeIdentifier.compare({ className: "S.A", id: "0x1" }, { className: "s.a", id: "0x1" })).toBe(0);
+    it("compares instance identifiers case-sensitively by className", () => {
+      expect(
+        HierarchyNodeIdentifier.compare({ className: "S.A", id: "0x1" }, { className: "s.a", id: "0x1" }),
+      ).not.toBe(0);
     });
   });
 });

--- a/packages/hierarchies/src/test/HierarchyNodeKey.test.ts
+++ b/packages/hierarchies/src/test/HierarchyNodeKey.test.ts
@@ -80,7 +80,7 @@ describe("HierarchyNodeKey", () => {
           { type: "instances", instanceKeys: [{ className: "s.a", id: "0" }] },
           { type: "instances", instanceKeys: [{ className: "S.A", id: "0" }] },
         ),
-      ).toBe(true);
+      ).toBe(false);
       expect(
         HierarchyNodeKey.equals(
           { type: "instances", instanceKeys: [] },
@@ -113,7 +113,7 @@ describe("HierarchyNodeKey", () => {
           { type: "class-grouping", className: "s.x" },
           { type: "class-grouping", className: "S.X" },
         ),
-      ).toBe(true);
+      ).toBe(false);
       expect(
         HierarchyNodeKey.equals(
           { type: "class-grouping", className: "s.x" },
@@ -155,7 +155,13 @@ describe("HierarchyNodeKey", () => {
           { type: "property-grouping:other", properties: [{ className: "s.x", propertyName: "y" }] },
           { type: "property-grouping:other", properties: [{ className: "S.X", propertyName: "Y" }] },
         ),
-      ).toBe(true);
+      ).toBe(false);
+      expect(
+        HierarchyNodeKey.equals(
+          { type: "property-grouping:other", properties: [{ className: "s.x", propertyName: "y" }] },
+          { type: "property-grouping:other", properties: [{ className: "s.x", propertyName: "Y" }] },
+        ),
+      ).toBe(false);
       expect(
         HierarchyNodeKey.equals(
           { type: "property-grouping:other", properties: [] },
@@ -172,7 +178,8 @@ describe("HierarchyNodeKey", () => {
         formattedPropertyValue: "value",
       };
       expect(HierarchyNodeKey.equals(baseValue, baseValue)).toBe(true);
-      expect(HierarchyNodeKey.equals(baseValue, { ...baseValue, propertyClassName: "schema.classname" })).toBe(true);
+      expect(HierarchyNodeKey.equals(baseValue, { ...baseValue, propertyClassName: "schema.classname" })).toBe(false);
+      expect(HierarchyNodeKey.equals(baseValue, { ...baseValue, propertyName: "PROPERTY NAME" })).toBe(false);
       expect(HierarchyNodeKey.equals(baseValue, { ...baseValue, formattedPropertyValue: "value2" })).toBe(false);
       expect(HierarchyNodeKey.equals(baseValue, { ...baseValue, propertyName: "other name" })).toBe(false);
       expect(HierarchyNodeKey.equals(baseValue, { ...baseValue, propertyClassName: "Schema.Other" })).toBe(false);
@@ -189,7 +196,8 @@ describe("HierarchyNodeKey", () => {
       expect(HierarchyNodeKey.equals(baseValueRange, baseValueRange)).toBe(true);
       expect(
         HierarchyNodeKey.equals(baseValueRange, { ...baseValueRange, propertyClassName: "schema.classname" }),
-      ).toBe(true);
+      ).toBe(false);
+      expect(HierarchyNodeKey.equals(baseValueRange, { ...baseValueRange, propertyName: "PROPERTY NAME" })).toBe(false);
       expect(HierarchyNodeKey.equals(baseValueRange, { ...baseValueRange, toValue: 3 })).toBe(false);
       expect(HierarchyNodeKey.equals(baseValueRange, { ...baseValueRange, fromValue: 2 })).toBe(false);
       expect(HierarchyNodeKey.equals(baseValueRange, { ...baseValueRange, propertyName: "other name" })).toBe(false);

--- a/packages/hierarchies/src/test/Utils.ts
+++ b/packages/hierarchies/src/test/Utils.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { vi } from "vitest";
-import { Dictionary, Logger } from "@itwin/core-bentley";
+import { Logger } from "@itwin/core-bentley";
 import { getClass } from "@itwin/presentation-shared";
 
 import type { Mock } from "vitest";
@@ -179,12 +179,8 @@ export type TStubRelationshipClassFunc = (
 
 export function createECSchemaProviderStub() {
   const schemaStubs = new Map<string, StubbedSchema>();
-  const classes = new Dictionary<EC.FullClassNameDotNotation, EC.Class>((a, b) =>
-    a.toLocaleLowerCase().localeCompare(b.toLocaleLowerCase()),
-  ); // className -> class
-  const classHierarchy = new Dictionary<EC.FullClassNameDotNotation, EC.FullClassNameDotNotation>((a, b) =>
-    a.toLocaleLowerCase().localeCompare(b.toLocaleLowerCase()),
-  ); // className -> baseClassName
+  const classes = new Map<EC.FullClassNameDotNotation, EC.Class>(); // className -> class
+  const classHierarchy = new Map<EC.FullClassNameDotNotation, EC.FullClassNameDotNotation>(); // className -> baseClassName
   const getSchemaImpl = (schemaName: string) => {
     let schemaStub = schemaStubs.get(schemaName);
     if (!schemaStub) {
@@ -206,8 +202,8 @@ export function createECSchemaProviderStub() {
     options?: { onlyDirect?: boolean },
   ): EC.FullClassNameDotNotation[] => {
     const derivedClasses = new Array<EC.FullClassNameDotNotation>();
-    for (const { key: derivedClassName, value: baseClassName } of classHierarchy) {
-      if (baseClassName.toLocaleLowerCase() === classFullName.toLocaleLowerCase()) {
+    for (const [derivedClassName, baseClassName] of classHierarchy) {
+      if (baseClassName === classFullName) {
         derivedClasses.push(derivedClassName);
         if (!options?.onlyDirect) {
           derivedClasses.push(...getDerivedClassNames(derivedClassName, options));
@@ -249,16 +245,11 @@ export function createECSchemaProviderStub() {
         typeof targetClassOrClassName === "string"
           ? `${schemaName!}.${targetClassOrClassName}`
           : targetClassOrClassName.fullName;
-      return (
-        targetName.toLocaleLowerCase() === myName.toLocaleLowerCase() ||
-        getBaseClasses(myName).some(
-          (baseClass) => baseClass.fullName.toLocaleLowerCase() === targetName.toLocaleLowerCase(),
-        )
-      );
+      return targetName === myName || getBaseClasses(myName).some((baseClass) => baseClass.fullName === targetName);
     },
     isHidden: props.isHidden,
     getProperty(this, propertyName: string): EC.Property | undefined {
-      const prop = props.properties?.find((p) => p.name.toLocaleLowerCase() === propertyName.toLocaleLowerCase());
+      const prop = props.properties?.find((p) => p.name === propertyName);
       return prop ? { ...prop, class: this as unknown as EC.Class } : undefined;
     },
     getProperties(this): Array<EC.Property> {

--- a/packages/hierarchies/src/test/imodel/SearchHierarchyDefinition.test.ts
+++ b/packages/hierarchies/src/test/imodel/SearchHierarchyDefinition.test.ts
@@ -250,6 +250,22 @@ describe("SearchHierarchyDefinition", () => {
       expect(result.search).toBeUndefined();
     });
 
+    it("doesn't match when identifier class name casing differs from row class name", async () => {
+      const targetPaths: HierarchySearchTree[] = [{ identifier: { className: "schema.class", id: "0x1" } }];
+      const parsedNode = createSourceInstanceNode({
+        key: createTestInstanceNodeKey({ instanceKeys: [{ className: "Schema.Class", id: "0x1" }] }),
+      });
+      const def = createSearchHierarchyDefinition({ targetPaths, source: { parseNode: () => of(parsedNode) } });
+      const result = await firstValueFrom(
+        def.parseNode({
+          row: { [ECSQL_COLUMN_NAME_SearchECInstanceId]: "0x1", [ECSQL_COLUMN_NAME_SearchClassName]: "Schema.Class" },
+          parentNode: undefined,
+          imodelKey: "imodel",
+        }),
+      );
+      expect(result.search).toBeUndefined();
+    });
+
     it("doesn't match generic node identifier", async () => {
       const targetPaths: HierarchySearchTree[] = [{ identifier: { type: "generic", id: "0x1" } }];
       const parsedNode = createSourceInstanceNode({

--- a/packages/hierarchies/src/test/imodel/operators/grouping/BaseClassGrouping.test.ts
+++ b/packages/hierarchies/src/test/imodel/operators/grouping/BaseClassGrouping.test.ts
@@ -222,6 +222,22 @@ describe("BaseClassGrouping", () => {
       });
     });
 
+    it("doesn't group nodes when configured base class casing differs", async () => {
+      const node = createTestProcessedInstanceNode({
+        key: { type: "instances", instanceKeys: [{ className: "TestSchema.A", id: "0x1" }] },
+        // cspell:disable-next-line
+        processingParams: { grouping: { byBaseClasses: { fullClassNames: ["testschema.parentclass"] } } },
+      });
+      const baseClass = imodelAccess.stubEntityClass({ schemaName: "TestSchema", className: "ParentClass" });
+      imodelAccess.stubEntityClass({ schemaName: "TestSchema", className: "A", baseClass });
+
+      expect(await baseClassGrouping.createBaseClassGroupsForSingleBaseClass([node], baseClass, imodelAccess)).toEqual({
+        groupingType: "base-class",
+        grouped: [],
+        ungrouped: [node],
+      });
+    });
+
     it("groups only nodes for which ECClass is base", async () => {
       const nodes = [
         createTestProcessedInstanceNode({

--- a/packages/hierarchies/src/test/imodel/operators/grouping/BaseClassGrouping.test.ts
+++ b/packages/hierarchies/src/test/imodel/operators/grouping/BaseClassGrouping.test.ts
@@ -172,7 +172,6 @@ describe("BaseClassGrouping", () => {
     });
 
     it("groups multiple instance nodes", async () => {
-      // note: class names are intentionally in different casing & format to ensure we support that
       const nodes = [
         createTestProcessedInstanceNode({
           key: { type: "instances", instanceKeys: [{ className: "TestSchema.A", id: "0x1" }] },
@@ -182,16 +181,16 @@ describe("BaseClassGrouping", () => {
             grouping: {
               byBaseClasses: {
                 /* cspell:disable-next-line */
-                fullClassNames: ["testschema.parentclass"],
+                fullClassNames: ["TestSchema.ParentClass"],
               },
             },
           },
         }),
         createTestProcessedInstanceNode({
-          key: { type: "instances", instanceKeys: [{ className: "testSchema.b", id: "0x2" }] },
+          key: { type: "instances", instanceKeys: [{ className: "TestSchema.B", id: "0x2" }] },
           parentKeys: [createTestGenericNodeKey({ id: "x" })],
           label: "2",
-          processingParams: { grouping: { byBaseClasses: { fullClassNames: ["testSchema.parentClass"] } } },
+          processingParams: { grouping: { byBaseClasses: { fullClassNames: ["TestSchema.ParentClass"] } } },
         }),
       ];
 

--- a/packages/hierarchies/src/test/imodel/operators/grouping/ClassGrouping.test.ts
+++ b/packages/hierarchies/src/test/imodel/operators/grouping/ClassGrouping.test.ts
@@ -84,6 +84,21 @@ describe("ClassGrouping", () => {
     });
   });
 
+  it("creates a class group when parent class casing differs", async () => {
+    const node = createTestProcessedInstanceNode({
+      key: { type: "instances", instanceKeys: [{ className: "TestSchema.A", id: "0x1" }] },
+      parentKeys: [createTestGenericNodeKey({ id: "x" })],
+      processingParams: { grouping: { byClass: true } },
+    });
+    schemaProvider.stubEntityClass({ schemaName: "TestSchema", className: "A" });
+    const parentNode = createTestProcessedGroupingNode({ key: { type: "class-grouping", className: "testschema.a" } });
+
+    const result = await createClassGroups(schemaProvider, parentNode, [node]);
+
+    expect(result.grouped).toHaveLength(1);
+    expect(result.ungrouped).toEqual([]);
+  });
+
   it("creates different groups for nodes of different classes", async () => {
     const nodes = [
       createTestProcessedInstanceNode({

--- a/packages/hierarchies/src/test/imodel/operators/grouping/ClassGrouping.test.ts
+++ b/packages/hierarchies/src/test/imodel/operators/grouping/ClassGrouping.test.ts
@@ -91,7 +91,7 @@ describe("ClassGrouping", () => {
       processingParams: { grouping: { byClass: true } },
     });
     schemaProvider.stubEntityClass({ schemaName: "TestSchema", className: "A" });
-    const parentNode = createTestProcessedGroupingNode({ key: { type: "class-grouping", className: "testschema.a" } });
+    const parentNode = createTestProcessedGroupingNode({ key: { type: "class-grouping", className: "TestSchema.a" } });
 
     const result = await createClassGroups(schemaProvider, parentNode, [node]);
 

--- a/packages/hierarchies/src/test/imodel/operators/grouping/ClassGrouping.test.ts
+++ b/packages/hierarchies/src/test/imodel/operators/grouping/ClassGrouping.test.ts
@@ -50,7 +50,6 @@ describe("ClassGrouping", () => {
   });
 
   it("groups multiple instance nodes", async () => {
-    // note: class names are intentionally in different casing & format to ensure we support that
     const nodes = [
       createTestProcessedInstanceNode({
         key: { type: "instances", instanceKeys: [{ className: "TestSchema.A", id: "0x1" }] },
@@ -59,7 +58,7 @@ describe("ClassGrouping", () => {
         processingParams: { grouping: { byClass: true } },
       }),
       createTestProcessedInstanceNode({
-        key: { type: "instances", instanceKeys: [{ className: "testSchema.a", id: "0x2" }] },
+        key: { type: "instances", instanceKeys: [{ className: "TestSchema.A", id: "0x2" }] },
         parentKeys: [createTestGenericNodeKey({ id: "x" })],
         label: "2",
         processingParams: { grouping: { byClass: true } },

--- a/packages/hierarchies/src/test/imodel/operators/grouping/PropertiesGrouping.test.ts
+++ b/packages/hierarchies/src/test/imodel/operators/grouping/PropertiesGrouping.test.ts
@@ -1093,27 +1093,25 @@ describe("PropertiesGrouping", () => {
       });
 
       it("groups multiple nodes when they have the same property value into property value grouping node", async () => {
-        // note: class and property names are intentionally in different casing & format to ensure we support that
         const nodes = [
           createTestProcessedInstanceNode({
             key: { type: "instances", instanceKeys: [{ className: "TestSchema.Class", id: "0x1" }] },
             processingParams: {
               grouping: {
                 byProperties: {
-                  propertiesClassName: "testSchema.class",
-                  propertyGroups: [{ propertyName: "propertyName", propertyValue: "PropertyValue" }],
+                  propertiesClassName: "TestSchema.Class",
+                  propertyGroups: [{ propertyName: "PropertyName", propertyValue: "PropertyValue" }],
                 },
               },
             },
           }),
           createTestProcessedInstanceNode({
-            key: { type: "instances", instanceKeys: [{ className: "testSchema.Class", id: "0x2" }] },
+            key: { type: "instances", instanceKeys: [{ className: "TestSchema.Class", id: "0x2" }] },
             processingParams: {
               grouping: {
                 byProperties: {
-                  propertiesClassName: "testSchema.Class",
-                  /* cspell:disable-next-line */
-                  propertyGroups: [{ propertyName: "propertyname", propertyValue: "PropertyValue" }],
+                  propertiesClassName: "TestSchema.Class",
+                  propertyGroups: [{ propertyName: "PropertyName", propertyValue: "PropertyValue" }],
                 },
               },
             },
@@ -1549,33 +1547,30 @@ describe("PropertiesGrouping", () => {
       });
 
       it('groups nodes with different property grouping parameters into a single "other" property grouping node', async () => {
-        // note: class and property names are intentionally in different casing & format to ensure we support that
         const nodes = [
           createTestProcessedInstanceNode({
             key: { type: "instances", instanceKeys: [{ className: "TestSchema.Class1", id: "0x1" }] },
             processingParams: {
               grouping: {
                 byProperties: {
-                  propertiesClassName: "testSchema.class1",
+                  propertiesClassName: "TestSchema.Class1",
                   createGroupForOutOfRangeValues: true,
                   propertyGroups: [
-                    { propertyName: "propertyName1", propertyValue: 6, ranges: [{ fromValue: 1, toValue: 5 }] },
+                    { propertyName: "PropertyName1", propertyValue: 6, ranges: [{ fromValue: 1, toValue: 5 }] },
                   ],
                 },
               },
             },
           }),
           createTestProcessedInstanceNode({
-            key: { type: "instances", instanceKeys: [{ className: "testSchema.Class2", id: "0x2" }] },
+            key: { type: "instances", instanceKeys: [{ className: "TestSchema.Class2", id: "0x2" }] },
             processingParams: {
               grouping: {
                 byProperties: {
-                  /* cspell:disable-next-line */
-                  propertiesClassName: "testschema.class2",
+                  propertiesClassName: "TestSchema.Class2",
                   createGroupForOutOfRangeValues: true,
                   propertyGroups: [
-                    /* cspell:disable-next-line */
-                    { propertyName: "propertyname2", propertyValue: 6, ranges: [{ fromValue: 7, toValue: 10 }] },
+                    { propertyName: "PropertyName2", propertyValue: 6, ranges: [{ fromValue: 7, toValue: 10 }] },
                   ],
                 },
               },
@@ -1874,17 +1869,16 @@ describe("PropertiesGrouping", () => {
       });
 
       it("groups multiple nodes, when property values fit into range", async () => {
-        // note: class and property names are intentionally in different casing & format to ensure we support that
         const nodes = [
           createTestProcessedInstanceNode({
             key: { type: "instances", instanceKeys: [{ className: "TestSchema.Class", id: "0x1" }] },
             processingParams: {
               grouping: {
                 byProperties: {
-                  propertiesClassName: "testSchema.class",
+                  propertiesClassName: "TestSchema.Class",
                   propertyGroups: [
                     {
-                      propertyName: "propertyName",
+                      propertyName: "PropertyName",
                       propertyValue: 5,
                       ranges: [{ fromValue: 1, toValue: 5, rangeLabel: "rangeLabel" }],
                     },
@@ -1894,15 +1888,14 @@ describe("PropertiesGrouping", () => {
             },
           }),
           createTestProcessedInstanceNode({
-            key: { type: "instances", instanceKeys: [{ className: "testSchema.class", id: "0x2" }] },
+            key: { type: "instances", instanceKeys: [{ className: "TestSchema.Class", id: "0x2" }] },
             processingParams: {
               grouping: {
                 byProperties: {
-                  propertiesClassName: "testSchema.Class",
+                  propertiesClassName: "TestSchema.Class",
                   propertyGroups: [
                     {
-                      /* cspell:disable-next-line */
-                      propertyName: "propertyname",
+                      propertyName: "PropertyName",
                       propertyValue: 2,
                       ranges: [{ fromValue: 1, toValue: 5, rangeLabel: "rangeLabel" }],
                     },

--- a/packages/hierarchies/src/test/imodel/operators/grouping/PropertiesGrouping.test.ts
+++ b/packages/hierarchies/src/test/imodel/operators/grouping/PropertiesGrouping.test.ts
@@ -1162,6 +1162,44 @@ describe("PropertiesGrouping", () => {
         });
       });
 
+      it("doesn't group nodes when configured class or property name casing differs", async () => {
+        const node = createTestProcessedInstanceNode({
+          key: { type: "instances", instanceKeys: [{ className: "TestSchema.Class", id: "0x1" }] },
+          processingParams: {
+            grouping: {
+              byProperties: {
+                // cspell:disable-next-line
+                propertiesClassName: "testschema.class",
+                // cspell:disable-next-line
+                propertyGroups: [{ propertyName: "propertyname", propertyValue: "PropertyValue" }],
+              },
+            },
+          },
+        });
+        const property = {
+          name: "PropertyName",
+          isPrimitive: () => true,
+          isNavigation: () => false,
+          primitiveType: "String",
+        } as unknown as EC.Property;
+        const ecClass = imodelAccess.stubEntityClass({
+          schemaName: "TestSchema",
+          className: "Class",
+          properties: [property],
+        });
+
+        expect(
+          await propertiesGrouping.createPropertyGroups(
+            [node],
+            [],
+            { ecClass, previousPropertiesGroupingInfo: [], propertyGroup: { propertyName: "PropertyName" } },
+            formatter,
+            testLocalizedStrings,
+            imodelAccess,
+          ),
+        ).toEqual({ groupingType: "property", grouped: [], ungrouped: [node] });
+      });
+
       it("creates different property value groups for nodes with different property values", async () => {
         const nodes = [
           createTestProcessedInstanceNode({

--- a/packages/shared/src/shared/Values.ts
+++ b/packages/shared/src/shared/Values.ts
@@ -36,7 +36,7 @@ export namespace InstanceKey {
    *- `positive value` if lhs key is more than rhs key
    */
   export function compare(lhs: InstanceKey, rhs: InstanceKey): number {
-    const classNameCompareResult = compareStrings(lhs.className.toLocaleLowerCase(), rhs.className.toLocaleLowerCase());
+    const classNameCompareResult = compareStrings(lhs.className, rhs.className);
     if (classNameCompareResult !== 0) {
       return classNameCompareResult;
     }

--- a/packages/shared/src/test/Values.test.ts
+++ b/packages/shared/src/test/Values.test.ts
@@ -17,7 +17,7 @@ describe("InstanceKey", () => {
   describe("compare", () => {
     it("compares two keys", () => {
       expect(InstanceKey.compare({ className: "s.a", id: "1" }, { className: "s.a", id: "1" })).toBe(0);
-      expect(InstanceKey.compare({ className: "s.a", id: "1" }, { className: "S.A", id: "1" })).toBe(0);
+      expect(InstanceKey.compare({ className: "s.a", id: "1" }, { className: "S.A", id: "1" })).not.toBe(0);
       expect(InstanceKey.compare({ className: "s.a", id: "1" }, { className: "s.b", id: "2" })).toBeLessThan(0);
       expect(InstanceKey.compare({ className: "s.a", id: "1" }, { className: "s.b", id: "1" })).toBeLessThan(0);
       expect(InstanceKey.compare({ className: "s.a", id: "1" }, { className: "s.a", id: "2" })).toBeLessThan(0);


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/1492