### PR TITLE
`content`: Implement `getInstanceKeys` functionality and associated tests for content provider

### DIFF
--- a/.changeset/fresh-streams-yield.md
+++ b/.changeset/fresh-streams-yield.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-shared": minor
+---
+
+Add `eachValueFrom` for consuming subscribable streams through async iteration.

--- a/apps/full-stack-tests/src/content/GetInstanceKeys.test.ts
+++ b/apps/full-stack-tests/src/content/GetInstanceKeys.test.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createContentProvider, resolveContentSources } from "@itwin/presentation-content";
+import { buildTestECDb } from "../ECDbUtils.js";
+import { initialize, terminate } from "../IntegrationTests.js";
+import { importSchema } from "../SchemaUtils.js";
+import { createContentIModelAccess, getPropertyFieldsByName } from "./Utils.js";
+
+import type { InstanceKey } from "@itwin/presentation-shared";
+
+async function collect<T>(values: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const value of values) {
+    result.push(value);
+  }
+  return result;
+}
+
+function expectKeys(actual: InstanceKey[], expected: InstanceKey[]) {
+  expect(actual).toHaveLength(expected.length);
+  expect(actual).toEqual(expect.arrayContaining(expected));
+}
+
+describe("Content", () => {
+  describe("getInstanceKeys", () => {
+    beforeAll(async () => {
+      await initialize();
+    });
+
+    afterAll(async () => {
+      await terminate();
+    });
+
+    it("gets matching keys across sources and returns concrete polymorphic classes", async () => {
+      using setup = await buildTestECDb(async (builder, testName) => {
+        const schema = await importSchema(
+          testName,
+          builder,
+          `
+            <ECEntityClass typeName="A">
+              <ECProperty propertyName="Score" typeName="int" />
+            </ECEntityClass>
+            <ECEntityClass typeName="B">
+              <ECProperty propertyName="Score" typeName="int" />
+            </ECEntityClass>
+            <ECEntityClass typeName="Base" modifier="Abstract" />
+            <ECEntityClass typeName="Derived">
+              <BaseClass>Base</BaseClass>
+            </ECEntityClass>
+          `,
+        );
+        const a1 = builder.insertInstance(schema.items.A.fullName, { score: 1 });
+        const a2 = builder.insertInstance(schema.items.A.fullName, { score: 2 });
+        const b = builder.insertInstance(schema.items.B.fullName, { score: 3 });
+        const derived = builder.insertInstance(schema.items.Derived.fullName);
+        return { schema, a1, a2, b, derived };
+      });
+      const imodelAccess = createContentIModelAccess(setup.ecdb);
+
+      const aSources = await resolveContentSources({
+        imodelAccess,
+        targets: [{ primaryClass: setup.schema.items.A.fullName }],
+      });
+      const aProvider = createContentProvider({ imodelAccess, sources: aSources });
+      expectKeys(await collect(aProvider.getInstanceKeys()), [setup.a1, setup.a2]);
+
+      const scoreField = getPropertyFieldsByName(await aProvider.getContentDescriptor(), "Score")[0];
+      expectKeys(
+        await collect(aProvider.getInstanceKeys({ filters: [{ field: scoreField, operator: "is-equal", value: 2 }] })),
+        [setup.a2],
+      );
+
+      const separateSources = await resolveContentSources({
+        imodelAccess,
+        targets: [{ primaryClass: setup.schema.items.A.fullName }, { primaryClass: setup.schema.items.B.fullName }],
+      });
+      expectKeys(await collect(createContentProvider({ imodelAccess, sources: separateSources }).getInstanceKeys()), [
+        setup.a1,
+        setup.a2,
+        setup.b,
+      ]);
+
+      const polymorphicSources = await resolveContentSources({
+        imodelAccess,
+        targets: [{ primaryClass: setup.schema.items.Base.fullName }],
+      });
+      expectKeys(
+        await collect(createContentProvider({ imodelAccess, sources: polymorphicSources }).getInstanceKeys()),
+        [setup.derived],
+      );
+    });
+  });
+});

--- a/packages/content/src/content/Content.ts
+++ b/packages/content/src/content/Content.ts
@@ -263,6 +263,8 @@ export interface ContentProvider {
   /**
    * Get instance keys for all items matching the configured sources.
    *
+   * A key may be returned more than once when configured sources overlap.
+   *
    * @param options - Optional filters (affects which keys are returned).
    */
   getInstanceKeys(options?: Pick<ContentRequestOptions, "filters">): AsyncIterable<InstanceKey>;

--- a/packages/content/src/content/CreateContentProvider.ts
+++ b/packages/content/src/content/CreateContentProvider.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { buildContentDescriptor } from "./descriptor-building/BuildDescriptor.js";
+import { getInstanceKeys } from "./query/GetInstanceKeys.js";
 import { getSize } from "./query/GetSize.js";
 
 import type { Props } from "@itwin/presentation-shared";
@@ -30,9 +31,13 @@ export function createContentProviderImpl(props: Props<typeof createContentProvi
     async getSize(options) {
       return getSize({ imodelAccess, sources, queryFilterers: config?.queryFilterers, filters: options?.filters });
     },
-    /* v8 ignore next 3 */
-    getInstanceKeys() {
-      throw new Error("Not implemented");
+    getInstanceKeys(options) {
+      return getInstanceKeys({
+        imodelAccess,
+        sources,
+        queryFilterers: config?.queryFilterers,
+        filters: options?.filters,
+      });
     },
     /* v8 ignore next 3 */
     getItems() {

--- a/packages/content/src/content/query/BaseQuery.ts
+++ b/packages/content/src/content/query/BaseQuery.ts
@@ -41,7 +41,7 @@ interface BaseQueryParts {
   from: string;
   /** IdSet join + merged relationship-path joins + query-filterer joins. */
   joins: string;
-  /** ANDed WHERE conditions (no `WHERE` keyword), or undefined. */
+  /** Complete WHERE clause with ANDed conditions, or undefined. */
   where?: string;
   bindings?: Record<string, ECSqlBinding>;
   /** Alias of the primary class in the FROM clause. Always `"this"`. */
@@ -324,7 +324,9 @@ export async function buildBaseQuery(
       }
     }
 
-    const where = whereConditions.length > 1 ? whereConditions.map((c) => `(${c})`).join(" AND ") : whereConditions[0];
+    const whereConditionsClause =
+      whereConditions.length > 1 ? whereConditions.map((c) => `(${c})`).join(" AND ") : whereConditions[0];
+    const where = whereConditionsClause && `WHERE ${whereConditionsClause}`;
     return {
       from,
       joins: joinFragments.join("\n"),

--- a/packages/content/src/content/query/GetInstanceKeys.ts
+++ b/packages/content/src/content/query/GetInstanceKeys.ts
@@ -41,7 +41,7 @@ export function getInstanceKeys(props: {
               "SELECT [this].[ECInstanceId], ec_classname([this].[ECClassId], 's.c')",
               parts.from,
               parts.joins,
-              parts.where && `WHERE ${parts.where}`,
+              parts.where,
             ]
               .filter((fragment) => fragment)
               .join(" "),

--- a/packages/content/src/content/query/GetInstanceKeys.ts
+++ b/packages/content/src/content/query/GetInstanceKeys.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { finalize, from, map, mergeMap } from "rxjs";
-import { eachValueFrom, normalizeFullClassName } from "@itwin/presentation-shared";
+import { eachValueFrom } from "@itwin/presentation-shared";
 import { buildBaseQuery } from "./BaseQuery.js";
 import { QUERY_CONCURRENCY } from "./QueryConcurrency.js";
 
@@ -50,7 +50,7 @@ export function getInstanceKeys(props: {
           { rowFormat: "Indexes" },
         );
         return from(reader).pipe(
-          map((row) => ({ id: row[0], className: normalizeFullClassName(row[1]) })),
+          map((row): InstanceKey => ({ id: row[0], className: row[1] })),
           // Calling `return()` on the iterator should cancel the query execution on the backend and free up resources
           finalize(() => void reader.return?.(undefined)),
         );

--- a/packages/content/src/content/query/GetInstanceKeys.ts
+++ b/packages/content/src/content/query/GetInstanceKeys.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { finalize, from, map, mergeMap } from "rxjs";
+import { eachValueFrom, normalizeFullClassName } from "@itwin/presentation-shared";
+import { buildBaseQuery } from "./BaseQuery.js";
+import { QUERY_CONCURRENCY } from "./QueryConcurrency.js";
+
+import type { ECSchemaProvider, ECSqlQueryExecutor, InstanceKey } from "@itwin/presentation-shared";
+import type { ContentValueFilter } from "../Content.js";
+import type { ContentSource } from "../ContentTarget.js";
+import type { QueryFilterer } from "../extensions/QueryFilterer.js";
+
+/**
+ * Gets keys of instances matching the supplied sources.
+ *
+ * @internal
+ */
+export function getInstanceKeys(props: {
+  imodelAccess: ECSchemaProvider & ECSqlQueryExecutor;
+  sources: ContentSource[];
+  queryFilterers?: QueryFilterer[];
+  filters?: ContentValueFilter[];
+}): AsyncIterable<InstanceKey> {
+  return eachValueFrom(
+    from(props.sources).pipe(
+      mergeMap(async (source) =>
+        buildBaseQuery({
+          schemaProvider: props.imodelAccess,
+          source,
+          queryFilterers: props.queryFilterers,
+          filters: props.filters,
+        }),
+      ),
+      mergeMap(({ anchor: { parts } }) => {
+        const reader = props.imodelAccess.createQueryReader(
+          {
+            ecsql: [
+              "SELECT [this].[ECInstanceId], ec_classname([this].[ECClassId], 's.c')",
+              parts.from,
+              parts.joins,
+              parts.where && `WHERE ${parts.where}`,
+            ]
+              .filter((fragment) => fragment)
+              .join(" "),
+            bindings: parts.bindings,
+          },
+          { rowFormat: "Indexes" },
+        );
+        return from(reader).pipe(
+          map((row) => ({ id: row[0], className: normalizeFullClassName(row[1]) })),
+          // Calling `return()` on the iterator should cancel the query execution on the backend and free up resources
+          finalize(() => void reader.return?.(undefined)),
+        );
+      }, QUERY_CONCURRENCY),
+    ),
+  );
+}

--- a/packages/content/src/content/query/GetSize.ts
+++ b/packages/content/src/content/query/GetSize.ts
@@ -36,9 +36,7 @@ export async function getSize(props: {
       mergeMap(({ anchor: { parts } }) => {
         const reader = props.imodelAccess.createQueryReader(
           {
-            ecsql: ["SELECT COUNT(*)", parts.from, parts.joins, parts.where && `WHERE ${parts.where}`]
-              .filter((fragment) => fragment)
-              .join(" "),
+            ecsql: ["SELECT COUNT(*)", parts.from, parts.joins, parts.where].filter((fragment) => fragment).join(" "),
             bindings: parts.bindings,
           },
           { rowFormat: "Indexes" },

--- a/packages/content/src/test/CreateContentProvider.test.ts
+++ b/packages/content/src/test/CreateContentProvider.test.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { ResolvablePromise } from "presentation-test-utilities";
+import { collect, ResolvablePromise } from "presentation-test-utilities";
 import { describe, expect, it, vi } from "vitest";
 import { createContentProvider, resolveContentSources } from "../content/Content.js";
 import { createEntityClass, createPrimitiveProperty, createSchemaAccess } from "./MetadataStubs.js";
@@ -54,14 +54,6 @@ function createInstanceKeysIModelAccess(props: {
     ...createSchemaAccess(props.schemaClasses ?? [createEntityClass({ fullName: "Schema.A" })]),
     createQueryReader,
   };
-}
-
-async function collect<T>(values: AsyncIterable<T>): Promise<T[]> {
-  const result: T[] = [];
-  for await (const value of values) {
-    result.push(value);
-  }
-  return result;
 }
 
 describe("createContentProvider", () => {

--- a/packages/content/src/test/CreateContentProvider.test.ts
+++ b/packages/content/src/test/CreateContentProvider.test.ts
@@ -212,9 +212,7 @@ describe("createContentProvider", () => {
 
   describe("getInstanceKeys", () => {
     it("queries a source without building its descriptor", async () => {
-      const keysIModelAccess = createInstanceKeysIModelAccess({
-        keyBatches: [[{ id: "0x1", className: "Schema.A" }]],
-      });
+      const keysIModelAccess = createInstanceKeysIModelAccess({ keyBatches: [[{ id: "0x1", className: "Schema.A" }]] });
       const provider = createContentProvider({ imodelAccess: keysIModelAccess, sources: [createSource("Schema.A")] });
 
       await expect(collect(provider.getInstanceKeys())).resolves.to.deep.equal([{ id: "0x1", className: "Schema.A" }]);
@@ -241,9 +239,7 @@ describe("createContentProvider", () => {
         primaryClassNames: ["Schema.A"],
         selectorId: "Schema.A.Length",
       };
-      const keysIModelAccess = createInstanceKeysIModelAccess({
-        keyBatches: [[{ id: "0x2", className: "Schema.A" }]],
-      });
+      const keysIModelAccess = createInstanceKeysIModelAccess({ keyBatches: [[{ id: "0x2", className: "Schema.A" }]] });
       const provider = createContentProvider({ imodelAccess: keysIModelAccess, sources: [createSource("Schema.A")] });
 
       await expect(
@@ -261,10 +257,7 @@ describe("createContentProvider", () => {
 
     it("yields keys from separate source queries", async () => {
       const keysIModelAccess = createInstanceKeysIModelAccess({
-        keyBatches: [
-          [{ id: "0x1", className: "Schema.A" }],
-          [{ id: "0x2", className: "Schema.B" }],
-        ],
+        keyBatches: [[{ id: "0x1", className: "Schema.A" }], [{ id: "0x2", className: "Schema.B" }]],
       });
       const provider = createContentProvider({
         imodelAccess: keysIModelAccess,
@@ -273,10 +266,12 @@ describe("createContentProvider", () => {
 
       const keys = await collect(provider.getInstanceKeys());
       expect(keys).toHaveLength(2);
-      expect(keys).toEqual(expect.arrayContaining([
-        { id: "0x1", className: "Schema.A" },
-        { id: "0x2", className: "Schema.B" },
-      ]));
+      expect(keys).toEqual(
+        expect.arrayContaining([
+          { id: "0x1", className: "Schema.A" },
+          { id: "0x2", className: "Schema.B" },
+        ]),
+      );
       expect(keysIModelAccess.createQueryReader).toHaveBeenCalledTimes(2);
     });
 

--- a/packages/content/src/test/CreateContentProvider.test.ts
+++ b/packages/content/src/test/CreateContentProvider.test.ts
@@ -37,6 +37,33 @@ function createSizeIModelAccess(props: { schemaClasses?: EC.Class[]; counts: Arr
   };
 }
 
+function createInstanceKeysIModelAccess(props: {
+  schemaClasses?: EC.Class[];
+  keyBatches: Array<Array<{ id: string; className: string }>>;
+}) {
+  const keyBatches = props.keyBatches.map((batch) => [...batch]);
+  const createQueryReader = vi.fn(() => {
+    const sourceKeys = keyBatches.shift() ?? [];
+    return (async function* () {
+      for (const key of sourceKeys) {
+        yield { 0: key.id, 1: key.className };
+      }
+    })();
+  });
+  return {
+    ...createSchemaAccess(props.schemaClasses ?? [createEntityClass({ fullName: "Schema.A" })]),
+    createQueryReader,
+  };
+}
+
+async function collect<T>(values: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const value of values) {
+    result.push(value);
+  }
+  return result;
+}
+
 describe("createContentProvider", () => {
   describe("getContentDescriptor", () => {
     it("builds the descriptor from the configured sources", async () => {
@@ -180,6 +207,85 @@ describe("createContentProvider", () => {
       const provider = createContentProvider({ imodelAccess: sizeIModelAccess, sources: [createSource("Schema.A")] });
 
       await expect(provider.getSize()).resolves.to.equal(0);
+    });
+  });
+
+  describe("getInstanceKeys", () => {
+    it("queries a source without building its descriptor", async () => {
+      const keysIModelAccess = createInstanceKeysIModelAccess({
+        keyBatches: [[{ id: "0x1", className: "Schema.A" }]],
+      });
+      const provider = createContentProvider({ imodelAccess: keysIModelAccess, sources: [createSource("Schema.A")] });
+
+      await expect(collect(provider.getInstanceKeys())).resolves.to.deep.equal([{ id: "0x1", className: "Schema.A" }]);
+      expect(keysIModelAccess.createQueryReader).toHaveBeenCalledOnce();
+      expect(keysIModelAccess.createQueryReader).toHaveBeenCalledWith(
+        {
+          ecsql: "SELECT [this].[ECInstanceId], ec_classname([this].[ECClassId], 's.c') FROM [Schema].[A] [this]",
+          bindings: undefined,
+        },
+        { rowFormat: "Indexes" },
+      );
+    });
+
+    it("includes value filters in an instance-key query", async () => {
+      const length: PropertyField = {
+        kind: "property",
+        id: "Schema.A.Length",
+        label: "Length",
+        type: { kind: "primitive", type: "Double" },
+        propertyClassName: "Schema.A",
+        propertyName: "Length",
+        pathFromTarget: [],
+        valueClassNames: ["Schema.A"],
+        primaryClassNames: ["Schema.A"],
+        selectorId: "Schema.A.Length",
+      };
+      const keysIModelAccess = createInstanceKeysIModelAccess({
+        keyBatches: [[{ id: "0x2", className: "Schema.A" }]],
+      });
+      const provider = createContentProvider({ imodelAccess: keysIModelAccess, sources: [createSource("Schema.A")] });
+
+      await expect(
+        collect(provider.getInstanceKeys({ filters: [{ field: length, operator: "is-equal", value: 10 }] })),
+      ).resolves.to.deep.equal([{ id: "0x2", className: "Schema.A" }]);
+      expect(keysIModelAccess.createQueryReader).toHaveBeenCalledWith(
+        {
+          ecsql:
+            "SELECT [this].[ECInstanceId], ec_classname([this].[ECClassId], 's.c') FROM [Schema].[A] [this] WHERE [this].[Length] = :pres_vf0",
+          bindings: { ["pres_vf0"]: { type: "double", value: 10 } },
+        },
+        { rowFormat: "Indexes" },
+      );
+    });
+
+    it("yields keys from separate source queries", async () => {
+      const keysIModelAccess = createInstanceKeysIModelAccess({
+        keyBatches: [
+          [{ id: "0x1", className: "Schema.A" }],
+          [{ id: "0x2", className: "Schema.B" }],
+        ],
+      });
+      const provider = createContentProvider({
+        imodelAccess: keysIModelAccess,
+        sources: [createSource("Schema.A"), createSource("Schema.B")],
+      });
+
+      const keys = await collect(provider.getInstanceKeys());
+      expect(keys).toHaveLength(2);
+      expect(keys).toEqual(expect.arrayContaining([
+        { id: "0x1", className: "Schema.A" },
+        { id: "0x2", className: "Schema.B" },
+      ]));
+      expect(keysIModelAccess.createQueryReader).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not query when there are no sources", async () => {
+      const keysIModelAccess = createInstanceKeysIModelAccess({ keyBatches: [] });
+      const provider = createContentProvider({ imodelAccess: keysIModelAccess, sources: [] });
+
+      await expect(collect(provider.getInstanceKeys())).resolves.to.deep.equal([]);
+      expect(keysIModelAccess.createQueryReader).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/content/src/test/query/BaseQuery.test.ts
+++ b/packages/content/src/test/query/BaseQuery.test.ts
@@ -345,7 +345,7 @@ describe("buildBaseQuery", () => {
         }),
       });
 
-      expect(result.anchor.parts.where).to.equal("[this].Area > :minArea");
+      expect(result.anchor.parts.where).to.equal("WHERE [this].Area > :minArea");
       expect(result.anchor.parts.bindings).to.deep.equal({ minArea: { type: "double", value: 5 } });
     });
 
@@ -356,7 +356,7 @@ describe("buildBaseQuery", () => {
       });
 
       expect(result.anchor.parts.joins).to.include(`IdSet(:${ECSQL_PREFIX}TargetInstanceIds)`);
-      expect(result.anchor.parts.where).to.equal("[this].Area > 5");
+      expect(result.anchor.parts.where).to.equal("WHERE [this].Area > 5");
     });
   });
 
@@ -373,7 +373,7 @@ describe("buildBaseQuery", () => {
 
       expect(getFilterClauses).toHaveBeenCalledWith({ targetAlias: "this" });
       expect(result.anchor.parts.joins).to.include("JOIN filterer_table ft");
-      expect(result.anchor.parts.where).to.equal("ft.flag = 1");
+      expect(result.anchor.parts.where).to.equal("WHERE ft.flag = 1");
       expect(result.anchor.parts.bindings).to.deep.equal({ fb: { type: "int", value: 7 } });
     });
 
@@ -387,7 +387,7 @@ describe("buildBaseQuery", () => {
         queryFilterers: [filtererA, filtererB],
       });
 
-      expect(result.anchor.parts.where).to.equal("(a = 1) AND (b = 2)");
+      expect(result.anchor.parts.where).to.equal("WHERE (a = 1) AND (b = 2)");
     });
 
     it("handles a filterer contributing no clauses", async () => {
@@ -407,7 +407,7 @@ describe("buildBaseQuery", () => {
 
       const result = await buildBaseQuery({ schemaProvider, source: makeSource([]), filters });
 
-      expect(result.anchor.parts.where).to.equal(`[this].[Length] = :${ECSQL_PREFIX}vf0`);
+      expect(result.anchor.parts.where).to.equal(`WHERE [this].[Length] = :${ECSQL_PREFIX}vf0`);
       expect(result.anchor.parts.bindings).to.deep.equal({ [`${ECSQL_PREFIX}vf0`]: { type: "double", value: 1 } });
     });
 
@@ -418,7 +418,7 @@ describe("buildBaseQuery", () => {
 
       const result = await buildBaseQuery({ schemaProvider, source: makeSource([path]), filters });
 
-      expect(result.anchor.parts.where).to.equal(`[${ECSQL_PREFIX}t0].[Name] = :${ECSQL_PREFIX}vf0`);
+      expect(result.anchor.parts.where).to.equal(`WHERE [${ECSQL_PREFIX}t0].[Name] = :${ECSQL_PREFIX}vf0`);
     });
 
     it("resolves a relationship-class property against the relationship alias", async () => {
@@ -434,7 +434,7 @@ describe("buildBaseQuery", () => {
 
       const result = await buildBaseQuery({ schemaProvider, source: makeSource([path]), filters });
 
-      expect(result.anchor.parts.where).to.equal(`[${ECSQL_PREFIX}r0].[RelProp] = :${ECSQL_PREFIX}vf0`);
+      expect(result.anchor.parts.where).to.equal(`WHERE [${ECSQL_PREFIX}r0].[RelProp] = :${ECSQL_PREFIX}vf0`);
     });
 
     it("resolves an `is-null` filter on a 1:1 related property as a plain join", async () => {
@@ -445,7 +445,7 @@ describe("buildBaseQuery", () => {
       const result = await buildBaseQuery({ schemaProvider, source: makeSource([path]), filters });
 
       // A 1:1 path has at most one related row, so the outer join alone (no EXISTS) is enough.
-      expect(result.anchor.parts.where).to.equal(`[${ECSQL_PREFIX}t0].[Name] IS NULL`);
+      expect(result.anchor.parts.where).to.equal(`WHERE [${ECSQL_PREFIX}t0].[Name] IS NULL`);
     });
 
     it("resolves an `is-not-null` filter on a 1:1 related property as a plain join", async () => {
@@ -455,7 +455,7 @@ describe("buildBaseQuery", () => {
 
       const result = await buildBaseQuery({ schemaProvider, source: makeSource([path]), filters });
 
-      expect(result.anchor.parts.where).to.equal(`[${ECSQL_PREFIX}t0].[Name] IS NOT NULL`);
+      expect(result.anchor.parts.where).to.equal(`WHERE [${ECSQL_PREFIX}t0].[Name] IS NOT NULL`);
     });
 
     it("binds a struct member using the member's declared type", async () => {
@@ -470,7 +470,7 @@ describe("buildBaseQuery", () => {
 
       const result = await buildBaseQuery({ schemaProvider, source: makeSource([]), filters });
 
-      expect(result.anchor.parts.where).to.equal(`[this].[Address].[Street] = :${ECSQL_PREFIX}vf0`);
+      expect(result.anchor.parts.where).to.equal(`WHERE [this].[Address].[Street] = :${ECSQL_PREFIX}vf0`);
       expect(result.anchor.parts.bindings).to.deep.equal({ [`${ECSQL_PREFIX}vf0`]: { type: "string", value: "Main" } });
     });
 
@@ -536,13 +536,13 @@ describe("buildBaseQuery", () => {
       const result = await buildBaseQuery({ schemaProvider, source: makeSource([]), filters });
 
       expect(result.anchor.parts.where).to.equal(
-        [
+        `WHERE ${[
           `([this].[Origin].[x] = :${ECSQL_PREFIX}vf0)`,
           `([this].[Origin].[y] = :${ECSQL_PREFIX}vf1)`,
           `([this].[Location].[x] = :${ECSQL_PREFIX}vf2)`,
           `([this].[Location].[y] = :${ECSQL_PREFIX}vf3)`,
           `([this].[Location].[z] = :${ECSQL_PREFIX}vf4)`,
-        ].join(" AND "),
+        ].join(" AND ")}`,
       );
       expect(result.anchor.parts.bindings).to.deep.equal({
         [`${ECSQL_PREFIX}vf0`]: { type: "double", value: 1 },
@@ -562,7 +562,7 @@ describe("buildBaseQuery", () => {
 
       const result = await buildBaseQuery({ schemaProvider, source: makeSource([]), filters });
 
-      expect(result.anchor.parts.where).to.equal(`[this].[Location].[z] = :${ECSQL_PREFIX}vf0`);
+      expect(result.anchor.parts.where).to.equal(`WHERE [this].[Location].[z] = :${ECSQL_PREFIX}vf0`);
     });
 
     it("validates the coordinate member of a related point property", async () => {
@@ -578,7 +578,7 @@ describe("buildBaseQuery", () => {
 
       const validFilters: ContentValueFilter[] = [{ field, member: "y", operator: "is-equal", value: 1 }];
       const validResult = await buildBaseQuery({ schemaProvider, source: makeSource([path]), filters: validFilters });
-      expect(validResult.anchor.parts.where).to.equal(`[${ECSQL_PREFIX}t0].[Location].[y] = :${ECSQL_PREFIX}vf0`);
+      expect(validResult.anchor.parts.where).to.equal(`WHERE [${ECSQL_PREFIX}t0].[Location].[y] = :${ECSQL_PREFIX}vf0`);
 
       const invalidFilters: ContentValueFilter[] = [{ field, member: "w", operator: "is-equal", value: 1 }];
       await expect(
@@ -631,7 +631,7 @@ describe("buildBaseQuery", () => {
 
       const result = await buildBaseQuery({ schemaProvider, source: makeSource([]), filters });
 
-      expect(result.anchor.parts.where).to.equal(`[this].[Parent].[Id] = :${ECSQL_PREFIX}vf0`);
+      expect(result.anchor.parts.where).to.equal(`WHERE [this].[Parent].[Id] = :${ECSQL_PREFIX}vf0`);
       expect(result.anchor.parts.bindings).to.deep.equal({ [`${ECSQL_PREFIX}vf0`]: { type: "id", value: "0x1" } });
     });
 
@@ -648,7 +648,9 @@ describe("buildBaseQuery", () => {
 
       const result = await buildBaseQuery({ schemaProvider, source: makeSource([]), filters });
 
-      expect(result.anchor.parts.where).to.equal(`([this].CodeValue || [this].UserLabel) LIKE :${ECSQL_PREFIX}vf0`);
+      expect(result.anchor.parts.where).to.equal(
+        `WHERE ([this].CodeValue || [this].UserLabel) LIKE :${ECSQL_PREFIX}vf0`,
+      );
     });
 
     it("substitutes a calculated field's custom target alias", async () => {
@@ -665,7 +667,7 @@ describe("buildBaseQuery", () => {
 
       const result = await buildBaseQuery({ schemaProvider, source: makeSource([]), filters });
 
-      expect(result.anchor.parts.where).to.equal(`([this].CodeValue) LIKE :${ECSQL_PREFIX}vf0`);
+      expect(result.anchor.parts.where).to.equal(`WHERE ([this].CodeValue) LIKE :${ECSQL_PREFIX}vf0`);
     });
 
     it("parenthesizes a compound calculated expression before applying the operator", async () => {
@@ -681,7 +683,7 @@ describe("buildBaseQuery", () => {
 
       const result = await buildBaseQuery({ schemaProvider, source: makeSource([]), filters });
 
-      expect(result.anchor.parts.where).to.equal(`([this].FlagA OR [this].FlagB) = :${ECSQL_PREFIX}vf0`);
+      expect(result.anchor.parts.where).to.equal(`WHERE ([this].FlagA OR [this].FlagB) = :${ECSQL_PREFIX}vf0`);
     });
 
     it("carries a calculated field's own bindings into the base query", async () => {
@@ -698,7 +700,7 @@ describe("buildBaseQuery", () => {
 
       const result = await buildBaseQuery({ schemaProvider, source: makeSource([]), filters });
 
-      expect(result.anchor.parts.where).to.equal(`([this].Length * :scale) > :${ECSQL_PREFIX}vf0`);
+      expect(result.anchor.parts.where).to.equal(`WHERE ([this].Length * :scale) > :${ECSQL_PREFIX}vf0`);
       expect(result.anchor.parts.bindings).to.deep.equal({
         scale: { type: "double", value: 2 },
         [`${ECSQL_PREFIX}vf0`]: { type: "double", value: 10 },
@@ -719,7 +721,7 @@ describe("buildBaseQuery", () => {
       });
 
       expect(result.anchor.parts.where).to.equal(
-        `([this].Area > 5) AND (ft.flag = 1) AND ([this].[Length] = :${ECSQL_PREFIX}vf0)`,
+        `WHERE ([this].Area > 5) AND (ft.flag = 1) AND ([this].[Length] = :${ECSQL_PREFIX}vf0)`,
       );
     });
   });
@@ -780,7 +782,7 @@ describe("buildBaseQuery", () => {
           OUTER JOIN [TestSchema].[Target] [${ECSQL_PREFIX}t0] ON [${ECSQL_PREFIX}t0].[ECInstanceId] = [${ECSQL_PREFIX}r0].[TargetECInstanceId]
         `),
       );
-      expect(result.anchor.parts.where).to.equal(`[${ECSQL_PREFIX}t0].[Name] = :${ECSQL_PREFIX}vf0`);
+      expect(result.anchor.parts.where).to.equal(`WHERE [${ECSQL_PREFIX}t0].[Name] = :${ECSQL_PREFIX}vf0`);
     });
 
     it("de-duplicates filter-referenced paths and ignores direct fields", async () => {
@@ -871,7 +873,7 @@ describe("buildBaseQuery", () => {
       expect(result.anchor.parts.joins).to.include(`IdSet(:${ECSQL_PREFIX}TargetInstanceIds)`);
       expect(result.anchor.parts.joins).to.include("JOIN filterer_table ft");
       expect(result.anchor.parts.joins).to.include("OUTER JOIN [TestSchema].[Target]");
-      expect(result.anchor.parts.where).to.equal("(ft.flag = 1) AND (this.Flag = 1)");
+      expect(result.anchor.parts.where).to.equal("WHERE (ft.flag = 1) AND (this.Flag = 1)");
     });
 
     it("isolates a 1:many path (by schema multiplicity) into its own inner-joined group", async () => {
@@ -1029,7 +1031,7 @@ describe("buildBaseQuery", () => {
 
       expect(trimWhitespace(result.anchor.parts.where!)).to.equal(
         trimWhitespace(`
-          (${joinedPredicates}) AND (
+          WHERE (${joinedPredicates}) AND (
             (
               SELECT COUNT(*) = 0 OR COUNT([${targetAlias(overflowPath)}].[Name]) < COUNT(*)
               FROM [TestSchema].[Rel21] [${relationshipAlias(overflowPath)}]
@@ -1077,7 +1079,7 @@ describe("buildBaseQuery", () => {
         expect(result.anchor.parts.joins).to.equal("");
         expect(trimWhitespace(result.anchor.parts.where!)).to.equal(
           trimWhitespace(`
-            EXISTS (
+            WHERE EXISTS (
               SELECT 1
               FROM [TestSchema].[RelMany] [${ECSQL_PREFIX}r0]
               INNER JOIN [TestSchema].[Many] [${ECSQL_PREFIX}t0] ON [${ECSQL_PREFIX}t0].[ECInstanceId] = [${ECSQL_PREFIX}r0].[TargetECInstanceId]
@@ -1126,7 +1128,7 @@ describe("buildBaseQuery", () => {
         expect(result.anchor.parts.joins).to.equal("");
         expect(trimWhitespace(result.anchor.parts.where!)).to.equal(
           trimWhitespace(`
-          EXISTS (
+          WHERE EXISTS (
             SELECT 1
             FROM [TestSchema].[RelMany] [${ECSQL_PREFIX}r0]
             INNER JOIN [TestSchema].[Many] [${ECSQL_PREFIX}t0] ON [${ECSQL_PREFIX}t0].[ECInstanceId] = [${ECSQL_PREFIX}r0].[TargetECInstanceId]
@@ -1165,7 +1167,7 @@ describe("buildBaseQuery", () => {
 
       expect(trimWhitespace(result.anchor.parts.where!)).to.equal(
         trimWhitespace(`
-          ([${ECSQL_PREFIX}t1].[Name] = :${ECSQL_PREFIX}vf0) AND (
+          WHERE ([${ECSQL_PREFIX}t1].[Name] = :${ECSQL_PREFIX}vf0) AND (
             EXISTS (
               SELECT 1
               FROM [TestSchema].[RelMany] [${ECSQL_PREFIX}r0]
@@ -1237,7 +1239,7 @@ describe("buildBaseQuery", () => {
       expect(result.anchor.parts.joins).to.equal("");
       expect(trimWhitespace(result.anchor.parts.where!)).to.equal(
         trimWhitespace(`
-          EXISTS (
+          WHERE EXISTS (
             SELECT 1
             FROM [TestSchema].[ManyNav] [${ECSQL_PREFIX}t0]
             WHERE [${ECSQL_PREFIX}t0].[Owner].[Id] = [this].[ECInstanceId] AND ([${ECSQL_PREFIX}t0].[Name] = :${ECSQL_PREFIX}vf0)
@@ -1268,7 +1270,7 @@ describe("buildBaseQuery", () => {
       // A relationship-class property resolves against the step's relationship alias, not the target.
       expect(trimWhitespace(result.anchor.parts.where!)).to.equal(
         trimWhitespace(`
-          EXISTS (
+          WHERE EXISTS (
             SELECT 1
             FROM [TestSchema].[RelMany] [${ECSQL_PREFIX}r0]
             INNER JOIN [TestSchema].[Many] [${ECSQL_PREFIX}t0] ON [${ECSQL_PREFIX}t0].[ECInstanceId] = [${ECSQL_PREFIX}r0].[TargetECInstanceId]
@@ -1302,7 +1304,7 @@ describe("buildBaseQuery", () => {
       expect(result.anchor.paths).to.deep.equal([]);
       expect(trimWhitespace(result.anchor.parts.where!)).to.equal(
         trimWhitespace(`
-          EXISTS (
+          WHERE EXISTS (
             SELECT 1
             FROM [TestSchema].[RelOne] [${ECSQL_PREFIX}r0]
             INNER JOIN [TestSchema].[One] [${ECSQL_PREFIX}t0] ON [${ECSQL_PREFIX}t0].[ECInstanceId] = [${ECSQL_PREFIX}r0].[TargetECInstanceId]
@@ -1345,7 +1347,7 @@ describe("buildBaseQuery", () => {
       const key = "TestSchema.Primary-[TestSchema.Rel39]->TestSchema.Target39";
       const aliases = result.anchor.parts.relatedClassAliases.get(key);
       expect(aliases).to.not.be.undefined;
-      expect(result.anchor.parts.where).to.equal(`[${aliases!.target}].[Name] = :${ECSQL_PREFIX}vf0`);
+      expect(result.anchor.parts.where).to.equal(`WHERE [${aliases!.target}].[Name] = :${ECSQL_PREFIX}vf0`);
     });
 
     it("evaluates an `is-null` filter on a 1:many path as no-related-instance-or-null-value, via a single aggregate scan", async () => {
@@ -1366,7 +1368,7 @@ describe("buildBaseQuery", () => {
       expect(result.anchor.parts.joins).to.equal("");
       expect(trimWhitespace(result.anchor.parts.where!)).to.equal(
         trimWhitespace(`
-          (
+          WHERE (
             SELECT COUNT(*) = 0 OR COUNT([${ECSQL_PREFIX}t0].[Name]) < COUNT(*)
             FROM [TestSchema].[RelMany] [${ECSQL_PREFIX}r0]
             INNER JOIN [TestSchema].[Many] [${ECSQL_PREFIX}t0] ON [${ECSQL_PREFIX}t0].[ECInstanceId] = [${ECSQL_PREFIX}r0].[TargetECInstanceId]
@@ -1392,7 +1394,7 @@ describe("buildBaseQuery", () => {
       expect(result.anchor.paths.map((p) => p.path)).to.deep.equal([path]);
       expect(result.additional).to.be.undefined;
       expect(result.anchor.parts.relatedClassAliases.size).to.equal(1);
-      expect(result.anchor.parts.where).to.equal(`[${ECSQL_PREFIX}t0].[Name] = :${ECSQL_PREFIX}vf0`);
+      expect(result.anchor.parts.where).to.equal(`WHERE [${ECSQL_PREFIX}t0].[Name] = :${ECSQL_PREFIX}vf0`);
       // A single link-table path renders exactly two `OUTER JOIN`s; a duplicated join would double that.
       expect(trimWhitespace(result.anchor.parts.joins).split("OUTER JOIN").length - 1).to.equal(2);
     });

--- a/packages/hierarchies/src/hierarchies/HierarchyMerge.ts
+++ b/packages/hierarchies/src/hierarchies/HierarchyMerge.ts
@@ -7,8 +7,8 @@ import "./internal/DisposePolyfill.js";
 
 import { filter, first, from, map, mergeMap, of } from "rxjs";
 import { BeEvent } from "@itwin/core-bentley";
+import { eachValueFrom } from "@itwin/presentation-shared";
 import { safeDispose } from "./internal/Common.js";
-import { eachValueFrom } from "./internal/EachValueFrom.js";
 import { sortNodesByLabelOperator } from "./internal/operators/Sorting.js";
 
 import type { EventArgs } from "@itwin/presentation-shared";

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
@@ -30,6 +30,7 @@ import { assert, BeEvent, Guid, StopWatch } from "@itwin/core-bentley";
 import {
   createDefaultValueFormatter,
   createIModelInstanceLabelSelectClauseFactory,
+  eachValueFrom,
   formatConcatenatedValue,
   InstanceKey,
   normalizeFullClassName,
@@ -45,7 +46,6 @@ import {
   createNodeIdentifierForLogging,
   hasChildren,
 } from "../internal/Common.js";
-import { eachValueFrom } from "../internal/EachValueFrom.js";
 import { doLog, log } from "../internal/LoggingUtils.js";
 import { partition } from "../internal/operators/Partition.js";
 import { reduceToMergeMapList } from "../internal/operators/ReduceToMergeMap.js";

--- a/packages/shared/api/presentation-shared.api.md
+++ b/packages/shared/api/presentation-shared.api.md
@@ -146,6 +146,9 @@ interface CreateRelationshipPathJoinClauseProps {
 function createRelationshipPathJoinInfo(props: CreateRelationshipPathJoinClauseProps): Promise<RelationshipPathJoinInfo>;
 
 // @public
+export function eachValueFrom<T>(source: Subscribable<T>): AsyncIterableIterator<T>;
+
+// @public
 export namespace EC {
     export type ArrayProperty = StructArrayProperty | EnumerationArrayProperty | PrimitiveArrayProperty;
     export interface ArrayPropertyAttributes {
@@ -733,6 +736,17 @@ export interface StructValueDescriptor {
     // (undocumented)
     kind: "struct";
     members: StructMember[];
+}
+
+// @public
+interface Subscribable<T> {
+    subscribe(observer: {
+        next: (value: T) => void;
+        error: (reason: unknown) => void;
+        complete: () => void;
+    }): {
+        unsubscribe: () => void;
+    };
 }
 
 // @public

--- a/packages/shared/api/presentation-shared.exports.csv
+++ b/packages/shared/api/presentation-shared.exports.csv
@@ -15,6 +15,7 @@ public;function;createDefaultInstanceLabelSelectClauseFactory
 public;function;createDefaultValueFormatter
 public;function;createIModelInstanceLabelSelectClauseFactory
 public;function;createMainThreadReleaseOnTimePassedHandler
+public;function;eachValueFrom
 public;namespace;EC
 public;interface;ECClassHierarchyInspector
 deprecated;interface;ECClassHierarchyInspector

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -53,6 +53,7 @@
     "eslint": "catalog:build-tools",
     "presentation-test-utilities": "workspace:*",
     "rimraf": "catalog:build-tools",
+    "rxjs": "catalog:rxjs",
     "@typescript/native": "catalog:build-tools",
     "typescript": "catalog:build-tools",
     "vitest": "catalog:test-tools"

--- a/packages/shared/src/presentation-shared.ts
+++ b/packages/shared/src/presentation-shared.ts
@@ -6,6 +6,7 @@
 export * as ECSql from "./shared/ecsql-snippets/index.js";
 
 export { ConcatenatedValue, ConcatenatedValuePart } from "./shared/ConcatenatedValue.js";
+export { eachValueFrom } from "./shared/EachValueFrom.js";
 export { ECSqlBinding } from "./shared/ECSqlCore.js";
 export type { ECSqlQueryDef, ECSqlQueryExecutor, ECSqlQueryReaderOptions, ECSqlQueryRow } from "./shared/ECSqlCore.js";
 export type { IPrimitiveValueFormatter } from "./shared/Formatting.js";

--- a/packages/shared/src/shared/EachValueFrom.ts
+++ b/packages/shared/src/shared/EachValueFrom.ts
@@ -2,21 +2,36 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
-import type { Observable } from "rxjs";
-
 // cspell:words deferreds
 
 /**
+ * The subscription operations required by `eachValueFrom`.
+ *
+ * @public
+ */
+export interface Subscribable<T> {
+  /**
+   * Subscribes to stream notifications.
+   */
+  subscribe(observer: {
+    next: (value: T) => void;
+    error: (reason: unknown) => void;
+    complete: () => void;
+  }): { unsubscribe: () => void };
+}
+
+/**
+ * Converts a subscribable stream into an async iterator.
+ *
  * This is pretty much a combination of:
  * - https://github.com/benlesh/rxjs-for-await/blob/94f9cf9cb015ac3700dfd1850eb81d36962eb70f/src/index.ts#L33,
  * - https://github.com/ReactiveX/rxjs/blob/2587ee852eb43eeb0883a7787bac2944d823392b/packages/observable/src/observable.ts#L922.
  *
  * Our implementation uses a linked list rather than an array to store values, which is more efficient.
  *
- * @internal
+ * @public
  */
-export async function* eachValueFrom<T>(source: Observable<T>): AsyncIterableIterator<T> {
+export async function* eachValueFrom<T>(source: Subscribable<T>): AsyncIterableIterator<T> {
   const deferreds = new Queue<{ resolve: (value: IteratorResult<T>) => void; reject: (reason: unknown) => void }>();
   const values = new Queue<T>();
   let error;

--- a/packages/shared/src/shared/EachValueFrom.ts
+++ b/packages/shared/src/shared/EachValueFrom.ts
@@ -13,11 +13,9 @@ export interface Subscribable<T> {
   /**
    * Subscribes to stream notifications.
    */
-  subscribe(observer: {
-    next: (value: T) => void;
-    error: (reason: unknown) => void;
-    complete: () => void;
-  }): { unsubscribe: () => void };
+  subscribe(observer: { next: (value: T) => void; error: (reason: unknown) => void; complete: () => void }): {
+    unsubscribe: () => void;
+  };
 }
 
 /**

--- a/packages/shared/src/test/EachValueFrom.test.ts
+++ b/packages/shared/src/test/EachValueFrom.test.ts
@@ -6,7 +6,7 @@
 import { collect } from "presentation-test-utilities";
 import { from, Subject } from "rxjs";
 import { describe, expect, it } from "vitest";
-import { eachValueFrom } from "../../hierarchies/internal/EachValueFrom.js";
+import { eachValueFrom } from "../shared/EachValueFrom.js";
 
 describe("eachValueFrom", () => {
   it("returns observable values when they're emitted quicker than consumed", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1499,6 +1499,9 @@ importers:
       rimraf:
         specifier: catalog:build-tools
         version: 6.1.3
+      rxjs:
+        specifier: catalog:rxjs
+        version: 7.8.2
       typescript:
         specifier: catalog:build-tools
         version: '@typescript/typescript6@6.0.2'


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation/issues/1412.

Moves `eachValueFrom` from `presentation-hierarchies`, where it was an internal utility, to `presentation-shared`, where it becomes `@public`, so we can reuse it in other packages. Note: the API is exposed without `rxjs` dependency (it's still added to `package.json` as a devDependency for tests).