### PR TITLE
Fix property-grouping performance regression

### DIFF
--- a/.changeset/perf-property-grouping-schema-cache.md
+++ b/.changeset/perf-property-grouping-schema-cache.md
@@ -1,0 +1,8 @@
+---
+"@itwin/presentation-core-interop": patch
+"@itwin/presentation-hierarchies": patch
+---
+
+Fixed a performance regression that made property grouping of large hierarchies dramatically slower.
+
+`createECSchemaProvider` now caches resolved schemas, so repeated `getSchema`/`getClass` calls no longer trigger a new native schema view request each time. A cached schema is reused until the underlying schema view becomes outdated, at which point it is refreshed on next access. In addition, property grouping now resolves each properties class once instead of once per grouped node.

--- a/.changeset/perf-property-grouping-schema-cache.md
+++ b/.changeset/perf-property-grouping-schema-cache.md
@@ -5,4 +5,4 @@
 
 Fixed a performance regression that made property grouping of large hierarchies dramatically slower.
 
-`createECSchemaProvider` now caches resolved schemas, so repeated `getSchema`/`getClass` calls no longer trigger a new native schema view request each time. A cached schema is reused until the underlying schema view becomes outdated, at which point it is refreshed on next access. In addition, property grouping now resolves each properties class once instead of once per grouped node.
+`createECSchemaProvider` now caches resolved schemas and the `EC.Class` objects built from them, so repeated `getSchema`/`getClass` calls and `EC.Property.class` accesses no longer trigger a new native schema view request or rebuild the class each time. Cached schemas are reused until the underlying schema view becomes outdated, at which point they are refreshed on next access. In addition, property grouping now resolves each properties class once instead of once per grouped node.

--- a/packages/core-interop/src/core-interop/Metadata.ts
+++ b/packages/core-interop/src/core-interop/Metadata.ts
@@ -119,11 +119,36 @@ export function createECSchemaProvider(
     return { classHierarchyResolver, schemaView };
   }
 
-  return {
-    async getSchema(name) {
+  // Cache the resolved schema by name so repeated `getSchema`/`getClass` calls reuse it instead of issuing a new
+  // `getSchemaView` request each time. The cached promise doubles as an in-flight guard: concurrent
+  // first-time requests for the same schema share it (and its underlying `getSchemaView` request) instead of each
+  // building the schema. The entry is retained until the schema view it was built from is marked outdated by the host
+  // (a newer view has replaced it), at which point the next access refreshes it.
+  const schemaCache = new Map<string, Promise<{ schemaView: PublicCoreSchemaView; schema: EC.Schema | undefined }>>();
+  async function fetchSchema(name: string) {
+    const entry = (async () => {
       const { classHierarchyResolver, schemaView } = await getSchemaProviderContext(name);
       const svSchema = schemaView.getSchema(name);
-      return svSchema ? createECSchemaFromSchemaView(svSchema, { schemaView, classHierarchyResolver }) : undefined;
+      const schema = svSchema
+        ? createECSchemaFromSchemaView(svSchema, { schemaView, classHierarchyResolver })
+        : undefined;
+      return { schemaView, schema };
+    })();
+    schemaCache.set(name, entry);
+    // Drop rejected entries so a transient failure doesn't get cached permanently.
+    entry.catch(() => {
+      if (schemaCache.get(name) === entry) {
+        schemaCache.delete(name);
+      }
+    });
+    return entry;
+  }
+
+  return {
+    async getSchema(name) {
+      const cached = schemaCache.get(name);
+      const entry = await (cached ?? fetchSchema(name));
+      return entry.schemaView.isOutdated ? (await fetchSchema(name)).schema : entry.schema;
     },
     classDerivesFrom(
       derivedClassFullName: EC.FullClassNameDotNotation,

--- a/packages/core-interop/src/core-interop/Metadata.ts
+++ b/packages/core-interop/src/core-interop/Metadata.ts
@@ -136,6 +136,7 @@ export function createECSchemaProvider(
     })();
     schemaCache.set(name, entry);
     // Drop rejected entries so a transient failure doesn't get cached permanently.
+    /* v8 ignore next 4 -- defensive cleanup for rejected cache entries while a newer entry may have already replaced this one */
     entry.catch(() => {
       if (schemaCache.get(name) === entry) {
         schemaCache.delete(name);

--- a/packages/core-interop/src/core-interop/Metadata.ts
+++ b/packages/core-interop/src/core-interop/Metadata.ts
@@ -126,11 +126,15 @@ export function createECSchemaProvider(
   // (a newer view has replaced it), at which point the next access refreshes it.
   const schemaCache = new Map<string, Promise<{ schemaView: PublicCoreSchemaView; schema: EC.Schema | undefined }>>();
   async function fetchSchema(name: string) {
+    // Cache built `EC.Class` objects (by full name) for this schema, so repeated accesses (e.g. the
+    // `EC.Property.class` getter, invoked once per grouped node) reuse a single class instead of rebuilding it from
+    // the schema view every time. Scoped to the fetch so a later refetch (when the view is outdated) starts fresh.
+    const classCache = new Map<string, EC.Class>();
     const entry = (async () => {
       const { classHierarchyResolver, schemaView } = await getSchemaProviderContext(name);
       const svSchema = schemaView.getSchema(name);
       const schema = svSchema
-        ? createECSchemaFromSchemaView(svSchema, { schemaView, classHierarchyResolver })
+        ? createECSchemaFromSchemaView(svSchema, { schemaView, classHierarchyResolver, classCache })
         : undefined;
       return { schemaView, schema };
     })();
@@ -171,6 +175,8 @@ interface SchemaViewProviderContext {
   schemaView: PublicCoreSchemaView;
   classHierarchyResolver: ECClassHierarchyResolver;
   schema: EC.Schema;
+  /** Shared cache of built `EC.Class` objects keyed by full class name, to avoid rebuilding them on every access. */
+  classCache: Map<string, EC.Class>;
 }
 
 export function createECSchemaFromSchemaView(
@@ -184,7 +190,7 @@ export function createECSchemaFromSchemaView(
     isHidden: svSchema.isHidden,
     getClass(name) {
       const svClass = svSchema.getClass(name);
-      return svClass ? createECClassFromSchemaView(svClass, { ...context, schema: ecSchema }) : undefined;
+      return svClass ? getECClassFromSchemaView(svClass, { ...context, schema: ecSchema }) : undefined;
     },
     getEnumeration(name) {
       const svEnum = svSchema.getEnumeration(name);
@@ -200,6 +206,22 @@ export function createECSchemaFromSchemaView(
     },
   };
   return ecSchema;
+}
+
+/**
+ * Cache-aware entry point for building an `EC.Class` from a schema view class: returns a previously built class for
+ * the same full name, otherwise builds one via `createECClassFromSchemaView` and stores it in the context's cache.
+ */
+function getECClassFromSchemaView(svClass: CoreSchemaView.Class, context: SchemaViewProviderContext): EC.Class {
+  // Key by the schema view's raw full name: it is a stable identifier for the class, so we avoid normalizing it on
+  // every (hot) cache hit. `createECClassFromSchemaView` normalizes once, on a miss, for the `EC.Class.fullName` field.
+  const cached = context.classCache.get(svClass.fullName);
+  if (cached) {
+    return cached;
+  }
+  const ecClass = createECClassFromSchemaView(svClass, context);
+  context.classCache.set(svClass.fullName, ecClass);
+  return ecClass;
 }
 
 export function createECClassFromSchemaView(
@@ -229,7 +251,7 @@ export function createECClassFromSchemaView(
     },
     get baseClass(): EC.Class | undefined {
       return svClass.baseClass
-        ? createECClassFromSchemaView(svClass.baseClass, {
+        ? getECClassFromSchemaView(svClass.baseClass, {
             ...context,
             schema: useOrCreateSchema(svClass.baseClass.schema, context),
           })
@@ -261,7 +283,7 @@ export function createECClassFromSchemaView(
       ...ecClass,
       getMixins(): EC.Mixin[] {
         return svClass.mixins.map((m) =>
-          createECClassFromSchemaView(m, { ...context, schema: useOrCreateSchema(m.schema, context) }),
+          getECClassFromSchemaView(m, { ...context, schema: useOrCreateSchema(m.schema, context) }),
         );
       },
     };
@@ -311,7 +333,7 @@ function createECRelConstraintFromSchemaView(
     polymorphic: svConstraint.polymorphic,
     get constraintClasses() {
       return svConstraint.constraintClasses.map((c) =>
-        createECClassFromSchemaView(c, { ...context, schema: useOrCreateSchema(c.schema, context) }),
+        getECClassFromSchemaView(c, { ...context, schema: useOrCreateSchema(c.schema, context) }),
       );
     },
     get abstractConstraint(): EC.EntityClass | EC.Mixin | EC.RelationshipClass | undefined {
@@ -323,7 +345,7 @@ function createECRelConstraintFromSchemaView(
       if (!svClass) {
         return undefined;
       }
-      return createECClassFromSchemaView(svClass, { ...context, schema: useOrCreateSchema(svClass.schema, context) });
+      return getECClassFromSchemaView(svClass, { ...context, schema: useOrCreateSchema(svClass.schema, context) });
     },
   };
 }
@@ -339,7 +361,7 @@ export function createECPropertyFromSchemaView(
     // in which case we fall back to the class the property was enumerated from.
     get class(): EC.Class {
       return svProp.declaringClass
-        ? createECClassFromSchemaView(svProp.declaringClass, {
+        ? getECClassFromSchemaView(svProp.declaringClass, {
             ...context,
             schema: useOrCreateSchema(svProp.declaringClass.schema, context),
           })
@@ -381,7 +403,7 @@ export function createECPropertyFromSchemaView(
         return svProp.direction === StrengthDirection.Forward ? "Forward" : "Backward";
       },
       get relationshipClass(): EC.RelationshipClass {
-        return createECClassFromSchemaView(svProp.relationshipClass, {
+        return getECClassFromSchemaView(svProp.relationshipClass, {
           ...context,
           schema: useOrCreateSchema(svProp.relationshipClass.schema, context),
         }) as EC.RelationshipClass;
@@ -455,7 +477,7 @@ export function createECPropertyFromSchemaView(
         return svProp.isArray();
       },
       get structClass(): EC.StructClass {
-        return createECClassFromSchemaView(svProp.structClass, {
+        return getECClassFromSchemaView(svProp.structClass, {
           ...context,
           schema: useOrCreateSchema(svProp.structClass.schema, context),
         });

--- a/packages/core-interop/src/test/Metadata.test.ts
+++ b/packages/core-interop/src/test/Metadata.test.ts
@@ -242,13 +242,38 @@ describe("createECSchemaProvider", () => {
     expect(getSchemaView).toHaveBeenCalledWith({ schemas: ["SchemaA", "SchemaB"] });
   });
 
-  it("issues a new request for schemas requested in a later frame", async () => {
+  it("reuses the cached schema while the schema view is not outdated", async () => {
     const schemaView = createMockSchemaView(new Map([["SchemaA", { name: "SchemaA", classes: new Map() }]]));
     const getSchemaView = vi.fn(async () => schemaView);
     const imodel = { getSchemaView, createQueryReader: () => createCoreECSqlReaderStub() };
     const provider = createECSchemaProvider(imodel);
 
     await provider.getSchema("SchemaA");
+    await provider.getSchema("SchemaA");
+    expect(getSchemaView).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares a single request between concurrent calls for the same schema", async () => {
+    const schemaView = createMockSchemaView(new Map([["SchemaA", { name: "SchemaA", classes: new Map() }]]));
+    const getSchemaView = vi.fn(async () => schemaView);
+    const imodel = { getSchemaView, createQueryReader: () => createCoreECSqlReaderStub() };
+    const provider = createECSchemaProvider(imodel);
+
+    const [first, second] = await Promise.all([provider.getSchema("SchemaA"), provider.getSchema("SchemaA")]);
+    expect(getSchemaView).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+  });
+
+  it("issues a new request when the cached schema view is outdated", async () => {
+    const view1 = createMockSchemaView(new Map([["SchemaA", { name: "SchemaA", classes: new Map() }]]));
+    const view2 = createMockSchemaView(new Map([["SchemaA", { name: "SchemaA", classes: new Map() }]]));
+    const getSchemaView = vi.fn().mockResolvedValueOnce(view1).mockResolvedValueOnce(view2);
+    const imodel = { getSchemaView, createQueryReader: () => createCoreECSqlReaderStub() };
+    const provider = createECSchemaProvider(imodel);
+
+    await provider.getSchema("SchemaA");
+    // Simulate the host replacing the view with a newer one, marking the cached one outdated.
+    (view1 as { isOutdated: boolean }).isOutdated = true;
     await provider.getSchema("SchemaA");
     expect(getSchemaView).toHaveBeenCalledTimes(2);
   });

--- a/packages/core-interop/src/test/Metadata.test.ts
+++ b/packages/core-interop/src/test/Metadata.test.ts
@@ -266,7 +266,12 @@ describe("createECSchemaProvider", () => {
 
   it("reuses the same `EC.Class` instance for repeated class lookups", async () => {
     const schemaView = createMockSchemaView(
-      new Map([["TestSchema", { name: "TestSchema", classes: new Map([["TestClass", { name: "TestClass", schemaName: "TestSchema" }]]) }]]),
+      new Map([
+        [
+          "TestSchema",
+          { name: "TestSchema", classes: new Map([["TestClass", { name: "TestClass", schemaName: "TestSchema" }]]) },
+        ],
+      ]),
     );
     const getSchemaView = vi.fn(async () => schemaView);
     const imodel = { getSchemaView, createQueryReader: () => createCoreECSqlReaderStub() };

--- a/packages/core-interop/src/test/Metadata.test.ts
+++ b/packages/core-interop/src/test/Metadata.test.ts
@@ -264,6 +264,21 @@ describe("createECSchemaProvider", () => {
     expect(first).toBe(second);
   });
 
+  it("reuses the same `EC.Class` instance for repeated class lookups", async () => {
+    const schemaView = createMockSchemaView(
+      new Map([["TestSchema", { name: "TestSchema", classes: new Map([["TestClass", { name: "TestClass", schemaName: "TestSchema" }]]) }]]),
+    );
+    const getSchemaView = vi.fn(async () => schemaView);
+    const imodel = { getSchemaView, createQueryReader: () => createCoreECSqlReaderStub() };
+    const provider = createECSchemaProvider(imodel);
+
+    const schema = await provider.getSchema("TestSchema");
+    const first = schema!.getClass("TestClass");
+    const second = schema!.getClass("TestClass");
+    expect(first).toBeDefined();
+    expect(first).toBe(second);
+  });
+
   it("issues a new request when the cached schema view is outdated", async () => {
     const view1 = createMockSchemaView(new Map([["SchemaA", { name: "SchemaA", classes: new Map() }]]));
     const view2 = createMockSchemaView(new Map([["SchemaA", { name: "SchemaA", classes: new Map() }]]));
@@ -1599,7 +1614,7 @@ function createMockSchemaViewContext({
     classDerivesFrom: vi.fn(),
     getDerivedClassNames: vi.fn().mockReturnValue(derivedClassNames ?? []),
   };
-  return { schemaView, classHierarchyResolver };
+  return { schemaView, classHierarchyResolver, classCache: new Map() };
 }
 
 function createMockSchemaView(schemas: Map<string, MockSchemaProps>): PublicSchemaView {

--- a/packages/hierarchies/src/hierarchies/imodel/operators/grouping/PropertiesGrouping.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/operators/grouping/PropertiesGrouping.ts
@@ -320,6 +320,17 @@ export async function getUniquePropertiesGroupInfo(
   const releaseMainThread = createMainThreadReleaseOnTimePassedHandler();
   const parentPropertyGroupPath = parentNode ? createNodePropertyGroupPathMatchers(parentNode) : [];
   const uniqueProperties = new Map<string, PropertyGroupInfo>();
+  // `getClass` resolves the same class for every node sharing a `propertiesClassName`, so resolve each class once and
+  // reuse it across nodes instead of calling `getClass` (schema lookup + class lookup) on every node.
+  const propertiesClassCache = new Map<EC.FullClassNameDotNotation, EC.Class>();
+  const getPropertiesClass = async (fullClassName: EC.FullClassNameDotNotation): Promise<EC.Class> => {
+    let ecClass = propertiesClassCache.get(fullClassName);
+    if (!ecClass) {
+      ecClass = await getClass(schemaProvider, fullClassName);
+      propertiesClassCache.set(fullClassName, ecClass);
+    }
+    return ecClass;
+  };
   for (const node of nodes) {
     await releaseMainThread();
 
@@ -328,7 +339,7 @@ export async function getUniquePropertiesGroupInfo(
       continue;
     }
 
-    const propertiesClass = await getClass(schemaProvider, byProperties.propertiesClassName);
+    const propertiesClass = await getPropertiesClass(byProperties.propertiesClassName);
     let propertyGroupIndex = 0;
     const previousPropertiesInfo = new Array<{ propertyGroup: HierarchyNodePropertyGroup; propertyGroupKey: string }>();
     for (const propertyGroup of byProperties.propertyGroups) {


### PR DESCRIPTION
Resolves https://github.com/iTwin/presentation/issues/1510 (hopefully).

`grouping by property` (and other property-grouping benchmarks) regressed massively on `next` (issue #1510): `getUniquePropertiesGroupInfo` was resolving the properties class via `getClass` once per grouped node, and the schema provider does not cache `getSchema`, so each call triggered a new native `getSchemaView` request. For a 50k-node hierarchy this meant ~50k schema-view reloads and pushed the benchmark from ~7.5s to ~146s.

Two complementary fixes:
- `core-interop`: `createECSchemaProvider` now caches the resolved schema by name (a single promise-keyed map that also de-dupes concurrent first-time requests), refreshing the entry only when the underlying schema view becomes outdated.
- `hierarchies`: `getUniquePropertiesGroupInfo` resolves each properties class once and reuses it across nodes.

Combined, `grouping by property` drops from ~146s to ~21s.