### PR TITLE
Stabilize performance benchmarks by forcing GC before each measurement

### DIFF
--- a/.github/workflows/benchmark-hierarchies.yml
+++ b/.github/workflows/benchmark-hierarchies.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - apps/performance-tests/hierarchies/**
       - apps/performance-tests/util/**
+      - apps/performance-tests/package.json
       - packages/core-interop/**
       - packages/hierarchies/**
       - packages/models-tree/**

--- a/.github/workflows/benchmark-hierarchies.yml
+++ b/.github/workflows/benchmark-hierarchies.yml
@@ -6,8 +6,8 @@ on:
     branches:
       - master
     paths:
-      - apps/performance-tests/hierarchies/**
-      - apps/performance-tests/util/**
+      - apps/performance-tests/src/hierarchies/**
+      - apps/performance-tests/src/util/**
       - apps/performance-tests/package.json
       - packages/core-interop/**
       - packages/hierarchies/**

--- a/.github/workflows/benchmark-pr-hierarchies.yml
+++ b/.github/workflows/benchmark-pr-hierarchies.yml
@@ -3,8 +3,8 @@ name: PR hierarchies performance benchmark
 on:
   pull_request:
     paths:
-      - apps/performance-tests/hierarchies/**
-      - apps/performance-tests/util/**
+      - apps/performance-tests/src/hierarchies/**
+      - apps/performance-tests/src/util/**
       - apps/performance-tests/package.json
       - packages/core-interop/**
       - packages/hierarchies/**

--- a/.github/workflows/benchmark-pr-hierarchies.yml
+++ b/.github/workflows/benchmark-pr-hierarchies.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - apps/performance-tests/hierarchies/**
       - apps/performance-tests/util/**
+      - apps/performance-tests/package.json
       - packages/core-interop/**
       - packages/hierarchies/**
       - packages/models-tree/**

--- a/.github/workflows/benchmark-pr-unified-selection.yml
+++ b/.github/workflows/benchmark-pr-unified-selection.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - apps/performance-tests/unified-selection/**
       - apps/performance-tests/util/**
+      - apps/performance-tests/package.json
       - packages/unified-selection/**
       - packages/shared/**
       - pnpm-lock.yaml

--- a/.github/workflows/benchmark-pr-unified-selection.yml
+++ b/.github/workflows/benchmark-pr-unified-selection.yml
@@ -3,8 +3,8 @@ name: PR unified-selection performance benchmark
 on:
   pull_request:
     paths:
-      - apps/performance-tests/unified-selection/**
-      - apps/performance-tests/util/**
+      - apps/performance-tests/src/unified-selection/**
+      - apps/performance-tests/src/util/**
       - apps/performance-tests/package.json
       - packages/unified-selection/**
       - packages/shared/**

--- a/.github/workflows/benchmark-unified-selection.yml
+++ b/.github/workflows/benchmark-unified-selection.yml
@@ -6,8 +6,8 @@ on:
     branches:
       - master
     paths:
-      - apps/performance-tests/unified-selection/**
-      - apps/performance-tests/util/**
+      - apps/performance-tests/src/unified-selection/**
+      - apps/performance-tests/src/util/**
       - apps/performance-tests/package.json
       - packages/unified-selection/**
       - packages/shared/**

--- a/.github/workflows/benchmark-unified-selection.yml
+++ b/.github/workflows/benchmark-unified-selection.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - apps/performance-tests/unified-selection/**
       - apps/performance-tests/util/**
+      - apps/performance-tests/package.json
       - packages/unified-selection/**
       - packages/shared/**
 

--- a/apps/performance-tests/package.json
+++ b/apps/performance-tests/package.json
@@ -10,9 +10,9 @@
     "clean": "rimraf lib temp",
     "docs": "betools extract --fileExt=ts --extractFrom=./src --recursive --out=./build/docs/extract",
     "lint": "eslint \"./src/**/*.ts\"",
-    "test": "vitest run",
-    "test:hierarchies": "vitest run src/hierarchies",
-    "test:unified-selection": "vitest run src/unified-selection",
+    "test": "cross-env NODE_OPTIONS=--expose-gc vitest run",
+    "test:hierarchies": "cross-env NODE_OPTIONS=--expose-gc vitest run src/hierarchies",
+    "test:unified-selection": "cross-env NODE_OPTIONS=--expose-gc vitest run src/unified-selection",
     "test:recreate": "cross-env RECREATE=true pnpm test"
   },
   "devDependencies": {

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -42,7 +42,7 @@ export function run<T>(props: RunOptions<T>): void {
   const testFunc = async ({ task }: { task: { meta: TaskMeta } }) => {
     const blockHandler = new MainThreadBlocksDetector();
     const value = await props.setup();
-// Force a full GC after setup so every measured section starts from a clean heap.
+    // Force a full GC after setup so every measured section starts from a clean heap.
     // Otherwise leftover setup/module-eval garbage lingering in the young generation occasionally gets
     // promoted to old space once the load starts churning through short-lived per-node objects. That
     // bloats old space, enlarges the old-to-young remembered set, and makes every subsequent Scavenge

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -42,6 +42,14 @@ export function run<T>(props: RunOptions<T>): void {
   const testFunc = async ({ task }: { task: { meta: TaskMeta } }) => {
     const blockHandler = new MainThreadBlocksDetector();
     const value = await props.setup();
+    // Force a full GC after setup so every measured section starts from a compacted, empty heap.
+    // Otherwise leftover setup/module-eval garbage lingering in the young generation occasionally gets
+    // promoted to old space once the load starts churning through short-lived per-node objects. That
+    // bloats old space, enlarges the old-to-young remembered set, and makes every subsequent Scavenge
+    // an order of magnitude costlier, producing a bimodal ~1.5-2x run-to-run variance. Starting from a
+    // clean heap keeps measurements stable. Requires running node with `--expose-gc` (wired up via the
+    // package.json test scripts); `global.gc` is left undefined otherwise, so this is a no-op.
+    global.gc?.();
     const start = Date.now();
     try {
       blockHandler.start();

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -42,7 +42,7 @@ export function run<T>(props: RunOptions<T>): void {
   const testFunc = async ({ task }: { task: { meta: TaskMeta } }) => {
     const blockHandler = new MainThreadBlocksDetector();
     const value = await props.setup();
-    // Force a full GC after setup so every measured section starts from a compacted, empty heap.
+// Force a full GC after setup so every measured section starts from a clean heap.
     // Otherwise leftover setup/module-eval garbage lingering in the young generation occasionally gets
     // promoted to old space once the load starts churning through short-lived per-node objects. That
     // bloats old space, enlarges the old-to-young remembered set, and makes every subsequent Scavenge


### PR DESCRIPTION
The hierarchy benchmarks showed a bimodal ~1.5-2x run-to-run variance. Its cause is a V8 GC promotion cascade: leftover setup garbage in the young generation occasionally gets promoted to old space when the measured load starts churning short-lived per-node objects, bloating old space and making every subsequent Scavenge an order of magnitude costlier.

Force a full GC after setup (before the timed section) so each measurement starts from a compacted, empty heap, and run the test scripts with `--expose-gc` so `global.gc` is available.