### PR TITLE
Memoize hidden-classes tree to fix models tree load regression

### DIFF
--- a/.changeset/memoize-hidden-classes-tree.md
+++ b/.changeset/memoize-hidden-classes-tree.md
@@ -1,0 +1,7 @@
+---
+"@itwin/presentation-hierarchies": patch
+---
+
+`createNodesQueryClauseFactory`: Memoize the hidden-classes tree computed for each select class, significantly speeding up hierarchies that repeatedly select broad base classes (e.g. the models tree).
+
+Previously the hidden-classes tree (introduced with hidden classes/properties support) was recomputed on every `createFilterClauses` call, which recursively walks the whole derived-class subtree of the select class and rebuilds class metadata. The result now persists for the lifetime of the query factory. The factory therefore caches schema-derived metadata and must be re-created when the iModel's schemas may have changed - `createIModelHierarchyProvider` does this automatically by re-creating its factories in response to the `imodelChanged` event.

--- a/.changeset/memoize-hidden-classes-tree.md
+++ b/.changeset/memoize-hidden-classes-tree.md
@@ -2,6 +2,6 @@
 "@itwin/presentation-hierarchies": patch
 ---
 
-`createNodesQueryClauseFactory`: Memoize the hidden-classes tree computed for each select class, significantly speeding up hierarchies that repeatedly select broad base classes (e.g. the models tree).
+Improved hierarchy load performance by memoizing the hidden-classes tree per selected class, avoiding repeated traversal of large derived-class hierarchies (notably improving the models tree).
 
-Previously the hidden-classes tree (introduced with hidden classes/properties support) was recomputed on every `createFilterClauses` call, which recursively walks the whole derived-class subtree of the select class and rebuilds class metadata. The result now persists for the lifetime of the query factory. The factory therefore caches schema-derived metadata and must be re-created when the iModel's schemas may have changed - `createIModelHierarchyProvider` does this automatically by re-creating its factories in response to the `imodelChanged` event.
+The memoization persists for the lifetime of the hierarchy provider's query factories. When iModel schemas may have changed, `createIModelHierarchyProvider` now re-creates its per-iModel factories in response to the `imodelChanged` event.

--- a/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/IModelHierarchyProvider.ts
@@ -264,9 +264,12 @@ interface RequestContextProp {
 type WithSourceNameOverride<T> = T & { sourceName?: string };
 
 class IModelHierarchyProviderImpl implements HierarchyProvider {
-  private _imodels: Array<
-    MergedIModelHierarchyProviderProps["imodels"][number] & { nodeSelectClauseFactory: NodesQueryClauseFactory }
-  >;
+  private readonly _imodelProps: MergedIModelHierarchyProviderProps["imodels"];
+  private _imodels: Array<{
+    imodelAccess: IModelAccess;
+    imodelChanged?: Event<() => void>;
+    nodeSelectClauseFactory: NodesQueryClauseFactory;
+  }>;
   private _hierarchyChanged: BeEvent<(args: EventArgs<HierarchyProvider["hierarchyChanged"]>) => void>;
   private _valuesFormatter: IPrimitiveValueFormatter;
   private _sourceHierarchyDefinition: RxjsHierarchyDefinition;
@@ -289,13 +292,8 @@ class IModelHierarchyProviderImpl implements HierarchyProvider {
     this.#componentId = Guid.createValue();
     this.#componentName = "IModelHierarchyProviderImpl";
     this.#sourceName = props.sourceName ?? `${this.#componentName}:${this.#componentId}`;
-    this._imodels = props.imodels.map(({ imodelAccess, imodelChanged, instanceLabelSelectClauseFactory }) => {
-      if (!instanceLabelSelectClauseFactory) {
-        instanceLabelSelectClauseFactory = createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
-      }
-      const nodeSelectClauseFactory = createNodesQueryClauseFactory({ imodelAccess, instanceLabelSelectClauseFactory });
-      return { imodelAccess, imodelChanged, nodeSelectClauseFactory };
-    });
+    this._imodelProps = props.imodels;
+    this._imodels = props.imodels.map((imodelProps) => this.#createIModelState(imodelProps));
     this._hierarchyChanged = new BeEvent();
     this._activeHierarchyDefinition = this._sourceHierarchyDefinition = getRxjsHierarchyDefinition(
       props.hierarchyDefinition,
@@ -317,24 +315,34 @@ class IModelHierarchyProviderImpl implements HierarchyProvider {
 
     const imodelChangeSubscription = from(this._imodels)
       .pipe(
-        mergeMap(({ imodelAccess, imodelChanged }) =>
+        mergeMap(({ imodelAccess, imodelChanged }, index) =>
           imodelChanged
             ? fromEventPattern(
                 (handler) => imodelChanged.addListener(handler),
                 (handler) => imodelChanged.removeListener(handler),
-                () => imodelAccess,
+                () => ({ imodelKey: imodelAccess.imodelKey, index }),
               )
             : EMPTY,
         ),
       )
-      .subscribe(({ imodelKey }) => {
+      .subscribe(({ imodelKey, index }) => {
         this.invalidateHierarchyCache(`Data source changed: "${imodelKey}"`);
         this._dispose.next();
+        // The iModel's schemas may have changed, so re-create the query factories to drop their schema-derived caches.
+        this._imodels[index] = this.#createIModelState(this._imodelProps[index]);
         this._hierarchyChanged.raiseEvent({});
       });
     this._unsubscribe = () => {
       imodelChangeSubscription.unsubscribe();
     };
+  }
+
+  #createIModelState(imodelProps: MergedIModelHierarchyProviderProps["imodels"][number]) {
+    const { imodelAccess, imodelChanged } = imodelProps;
+    const instanceLabelSelectClauseFactory =
+      imodelProps.instanceLabelSelectClauseFactory ?? createIModelInstanceLabelSelectClauseFactory({ imodelAccess });
+    const nodeSelectClauseFactory = createNodesQueryClauseFactory({ imodelAccess, instanceLabelSelectClauseFactory });
+    return { imodelAccess, imodelChanged, nodeSelectClauseFactory };
   }
 
   public [Symbol.dispose]() {

--- a/packages/hierarchies/src/hierarchies/imodel/NodeSelectQueryFactory.ts
+++ b/packages/hierarchies/src/hierarchies/imodel/NodeSelectQueryFactory.ts
@@ -253,6 +253,10 @@ export interface NodesQueryClauseFactory {
 
 /**
  * Creates an instance of `NodeSelectQueryFactory`.
+ *
+ * The created factory caches metadata derived from the iModel's schemas (e.g. the tree of hidden classes for a
+ * given select class). The cache lives for the lifetime of the factory and is not invalidated automatically, so
+ * the factory must be re-created when the iModel's schemas may have changed.
  */
 export function createNodesQueryClauseFactory(props: {
   imodelAccess: ECSchemaProvider;
@@ -265,6 +269,7 @@ export function createNodesQueryClauseFactory(props: {
 class NodeSelectQueryFactory {
   private _imodelAccess: ECSchemaProvider;
   private _instanceLabelSelectClauseFactory: IInstanceLabelSelectClauseFactory;
+  private _hiddenClassesTreeCache = new Map<string, Promise<HiddenClassNode[]>>();
 
   public constructor(props: {
     imodelAccess: ECSchemaProvider;
@@ -322,8 +327,20 @@ class NodeSelectQueryFactory {
       ? await createInstanceFilterClauses({ imodelAccess: this._imodelAccess, contentClass, filter })
       : { from: contentClass.fullName, joins: [], where: [] };
 
-    const fromClass = await getClass(this._imodelAccess, normalizeFullClassName(from));
-    const hiddenClasses = await getHiddenClassesTree(this._imodelAccess, fromClass);
+    const normalizedFrom = normalizeFullClassName(from);
+    const fromClass = await getClass(this._imodelAccess, normalizedFrom);
+    // The hidden-classes tree depends only on the select class and the (static) schema metadata, but it is
+    // expensive to compute (it recursively walks the whole derived-class subtree). The same select classes
+    // recur across every hierarchy level, so memoize the result per class for the lifetime of this factory.
+    let hiddenClassesPromise = this._hiddenClassesTreeCache.get(normalizedFrom);
+    if (!hiddenClassesPromise) {
+      hiddenClassesPromise = getHiddenClassesTree(this._imodelAccess, fromClass);
+      // Don't keep a rejected result cached - drop it so a later call can retry. Until this handler runs, the
+      // entry stays this same promise (concurrent calls get a cache hit), so an unconditional delete is safe.
+      hiddenClassesPromise.catch(() => this._hiddenClassesTreeCache.delete(normalizedFrom));
+      this._hiddenClassesTreeCache.set(normalizedFrom, hiddenClassesPromise);
+    }
+    const hiddenClasses = await hiddenClassesPromise;
     const hiddenClassesWhereClause = createWhereClauseForHiddenClasses(hiddenClasses, contentClass.alias);
     hiddenClassesWhereClause.hideClause && where.push(hiddenClassesWhereClause.hideClause);
     assert(!hiddenClassesWhereClause.showClause, "`showClause` is expected to always be empty here");

--- a/packages/hierarchies/src/test/imodel/IModelHierarchyProvider.test.ts
+++ b/packages/hierarchies/src/test/imodel/IModelHierarchyProvider.test.ts
@@ -249,6 +249,38 @@ describe("createIModelHierarchyProvider", () => {
       evt.raiseEvent();
       expect(spy).toHaveBeenCalledOnce();
     });
+
+    it("re-creates query clause factory to drop schema-derived caches on `imodelChanged` event", async () => {
+      const selectClass = imodelAccess.stubEntityClass({ schemaName: "s", className: "x" });
+      imodelAccess.stubEntityClass({ schemaName: "s", className: "y1", baseClass: selectClass, isHidden: true });
+      const imodelChanged = new BeEvent();
+
+      let lastFilterClauses: { where?: string } | undefined;
+      using provider = createIModelHierarchyProvider({
+        imodelAccess,
+        imodelChanged,
+        hierarchyDefinition: {
+          async defineHierarchyLevel({ createFilterClauses }) {
+            lastFilterClauses = await createFilterClauses({
+              contentClass: { fullName: selectClass.fullName, alias: "this" },
+            });
+            return [];
+          },
+        },
+      });
+
+      await collect(provider.getNodes({ parentNode: undefined }));
+      expect(lastFilterClauses?.where).toEqual("[this].[ECClassId] IS NOT ([s].[y1])");
+
+      // Add another hidden class to schema
+      imodelAccess.stubEntityClass({ schemaName: "s", className: "y2", baseClass: selectClass, isHidden: true });
+
+      // Without imodelChanged event, cached hidden classes tree would be reused if the factory wasn't recreated
+      imodelChanged.raiseEvent();
+
+      await collect(provider.getNodes({ parentNode: undefined }));
+      expect(lastFilterClauses?.where).toEqual("[this].[ECClassId] IS NOT ([s].[y1], [s].[y2])");
+    });
   });
 
   describe("Custom parsing", async () => {

--- a/packages/hierarchies/src/test/imodel/NodeSelectQueryFactory.test.ts
+++ b/packages/hierarchies/src/test/imodel/NodeSelectQueryFactory.test.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { trimWhitespace } from "@itwin/presentation-shared";
 import {
   createNodesQueryClauseFactory,
@@ -1418,6 +1418,83 @@ describe("createNodesQueryClauseFactory", () => {
             joins: "",
             where: `[content-class].[ECClassId] IS NOT (${hideClass1.ecsqlSelector}, ${hideClass2.ecsqlSelector})`,
           });
+        });
+      });
+
+      describe("hidden classes tree caching", () => {
+        function stubHiddenClassesTree() {
+          const selectClass = imodelAccess.stubEntityClass({ schemaName: "s", className: "x" });
+          const hideClass = imodelAccess.stubEntityClass({
+            schemaName: "s",
+            className: "y",
+            baseClass: selectClass,
+            isHidden: true,
+          });
+          // Add a couple more levels so computing the tree walks several classes (and calls `getSchema` repeatedly).
+          imodelAccess.stubEntityClass({ schemaName: "s", className: "z", baseClass: hideClass, isHidden: false });
+          return { selectClass, hideClass };
+        }
+
+        it("computes the hidden classes tree only once per select class across multiple calls", async () => {
+          const { selectClass } = stubHiddenClassesTree();
+          const getSchemaSpy = vi.spyOn(imodelAccess, "getSchema");
+
+          const first = await factory.createFilterClauses({
+            contentClass: { fullName: selectClass.fullName, alias: "content-class" },
+          });
+          const callsAfterFirst = getSchemaSpy.mock.calls.length;
+          expect(callsAfterFirst).toBeGreaterThan(1);
+
+          const second = await factory.createFilterClauses({
+            contentClass: { fullName: selectClass.fullName, alias: "content-class" },
+          });
+          // The second call reuses the cached tree, so it must not walk the derived-class hierarchy again.
+          expect(getSchemaSpy.mock.calls.length - callsAfterFirst).toBeLessThan(callsAfterFirst);
+          expect(second.where).toEqual(first.where);
+        });
+
+        it("computes the hidden classes tree again for a newly created factory", async () => {
+          const { selectClass } = stubHiddenClassesTree();
+          const getSchemaSpy = vi.spyOn(imodelAccess, "getSchema");
+
+          await factory.createFilterClauses({
+            contentClass: { fullName: selectClass.fullName, alias: "content-class" },
+          });
+          const callsAfterFirst = getSchemaSpy.mock.calls.length;
+
+          // The cache is scoped to the factory instance, so re-creating the factory (as the provider does when
+          // the iModel changes) rebuilds the tree from the current metadata.
+          const newFactory = createNodesQueryClauseFactory({ imodelAccess, instanceLabelSelectClauseFactory });
+          await newFactory.createFilterClauses({
+            contentClass: { fullName: selectClass.fullName, alias: "content-class" },
+          });
+          expect(getSchemaSpy.mock.calls.length - callsAfterFirst).toBeGreaterThanOrEqual(callsAfterFirst);
+        });
+
+        it("does not cache a failed computation, allowing a later call to retry", async () => {
+          const selectClass = imodelAccess.stubEntityClass({ schemaName: "s1", className: "x" });
+          imodelAccess.stubEntityClass({ schemaName: "s2", className: "y", baseClass: selectClass, isHidden: true });
+
+          const originalGetSchema = imodelAccess.getSchema.bind(imodelAccess);
+          let failForHiddenSchema = true;
+          vi.spyOn(imodelAccess, "getSchema").mockImplementation(async (name: string) => {
+            if (name === "s2" && failForHiddenSchema) {
+              failForHiddenSchema = false;
+              throw new Error("transient failure");
+            }
+            return originalGetSchema(name);
+          });
+
+          // First call fails while computing the hidden-classes tree, so nothing should be cached.
+          await expect(
+            factory.createFilterClauses({ contentClass: { fullName: selectClass.fullName, alias: "content-class" } }),
+          ).rejects.toThrow("transient failure");
+
+          // The retry recomputes the tree (this time successfully) instead of replaying the cached rejection.
+          const clauses = await factory.createFilterClauses({
+            contentClass: { fullName: selectClass.fullName, alias: "content-class" },
+          });
+          expect(trimWhitespace(clauses.where)).toEqual(`[content-class].[ECClassId] IS NOT ([s2].[y])`);
         });
       });
     });


### PR DESCRIPTION
`createFilterClauses` recomputed the hidden-classes tree on every call, which recursively walks the whole derived-class subtree of the select class and rebuilds class metadata. For hierarchies that repeatedly select broad base classes (e.g. the models tree) this dominated load time and allocation.

Memoize the tree per select class for the lifetime of the query factory. The factory now caches schema-derived metadata, so it must be re-created when the iModel's schemas may have changed; `createIModelHierarchyProvider` does this by re-creating its per-iModel factories in response to the `imodelChanged` event. Follow-up improvement: https://github.com/iTwin/presentation/issues/1519.

Local Baytown 'models tree full' load: ~9,000ms -> ~5,900ms (matching master), with ~9x fewer minor GCs.