### PR TITLE
`shared`: Fix outer join snippets

### DIFF
--- a/.changeset/outer-join-clause-fix.md
+++ b/.changeset/outer-join-clause-fix.md
@@ -1,0 +1,5 @@
+---
+"@itwin/presentation-shared": patch
+---
+
+`createRelationshipPathJoinClause`: fix produced ECSQL being invalid when joining with `joinType: "outer"`. The produced snippet used `OUTER JOIN`, which ECSQL fails to parse - now it uses `LEFT OUTER JOIN`.

--- a/apps/full-stack-tests/src/shared/ECSqlJoinSnippets.test.ts
+++ b/apps/full-stack-tests/src/shared/ECSqlJoinSnippets.test.ts
@@ -1,0 +1,132 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+  insertGroupInformationElement,
+  insertGroupInformationModelWithPartition,
+  insertPhysicalElement,
+  insertPhysicalModelWithPartition,
+  insertPhysicalType,
+  insertSpatialCategory,
+} from "presentation-test-utilities";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { ECSql, ECSqlQueryRow } from "@itwin/presentation-shared";
+import { createIModelAccess } from "../hierarchies/Utils.js";
+import { initialize, terminate } from "../IntegrationTests.js";
+import { buildTestIModel } from "../TestIModelSetup.js";
+
+describe("createRelationshipPathJoinClause", () => {
+  beforeAll(async () => {
+    await initialize();
+  });
+
+  afterAll(async () => {
+    await terminate();
+  });
+
+  it("creates executable outer join through a navigation property relationship", async () => {
+    const { imodel, type, elementWithType, elementWithoutType } = await buildTestIModel(async (builder) => {
+      const model = insertPhysicalModelWithPartition({ builder, codeValue: "test model" });
+      const category = insertSpatialCategory({ builder, codeValue: "test category" });
+      const insertedType = insertPhysicalType({ builder });
+      return {
+        type: insertedType,
+        elementWithType: insertPhysicalElement({
+          builder,
+          modelId: model.id,
+          categoryId: category.id,
+          typeDefinitionId: insertedType.id,
+        }),
+        elementWithoutType: insertPhysicalElement({ builder, modelId: model.id, categoryId: category.id }),
+      };
+    });
+    const imodelAccess = createIModelAccess(imodel);
+
+    const joinClause = await ECSql.createRelationshipPathJoinClause({
+      schemaProvider: imodelAccess,
+      path: [
+        {
+          sourceClassName: "BisCore.PhysicalElement",
+          sourceAlias: "s",
+          relationshipName: "BisCore.GeometricElement3dHasTypeDefinition",
+          relationshipAlias: "r",
+          targetClassName: "BisCore.PhysicalType",
+          targetAlias: "t",
+          joinType: "outer",
+        },
+      ],
+    });
+    const ecsql = `
+      SELECT [s].[ECInstanceId] [sourceId], [t].[ECInstanceId] [targetId]
+      FROM [BisCore].[PhysicalElement] [s]
+      ${joinClause}
+    `;
+
+    const rows = new Array<ECSqlQueryRow>();
+    for await (const row of imodelAccess.createQueryReader({ ecsql }, { rowFormat: "ECSqlPropertyNames" })) {
+      rows.push(row);
+    }
+
+    expect(rows.map((row) => ({ sourceId: row.sourceId, targetId: row.targetId ?? undefined }))).toEqual(
+      expect.arrayContaining([
+        { sourceId: elementWithType.id, targetId: type.id },
+        { sourceId: elementWithoutType.id, targetId: undefined },
+      ]),
+    );
+  });
+
+  it("creates executable outer join through a link table relationship", async () => {
+    const { imodel, groupWithMember, member, emptyGroup } = await buildTestIModel(async (builder) => {
+      const groupModel = insertGroupInformationModelWithPartition({ builder, codeValue: "test group model" });
+      const physicalModel = insertPhysicalModelWithPartition({ builder, codeValue: "test physical model" });
+      const category = insertSpatialCategory({ builder, codeValue: "test category" });
+      const insertedGroup = insertGroupInformationElement({ builder, modelId: groupModel.id });
+      const insertedMember = insertPhysicalElement({ builder, modelId: physicalModel.id, categoryId: category.id });
+      builder.insertRelationship({
+        classFullName: "BisCore.ElementGroupsMembers",
+        sourceId: insertedGroup.id,
+        targetId: insertedMember.id,
+      });
+      return {
+        groupWithMember: insertedGroup,
+        member: insertedMember,
+        emptyGroup: insertGroupInformationElement({ builder, modelId: groupModel.id }),
+      };
+    });
+    const imodelAccess = createIModelAccess(imodel);
+
+    const joinClause = await ECSql.createRelationshipPathJoinClause({
+      schemaProvider: imodelAccess,
+      path: [
+        {
+          sourceClassName: "BisCore.GroupInformationElement",
+          sourceAlias: "s",
+          relationshipName: "BisCore.ElementGroupsMembers",
+          relationshipAlias: "r",
+          targetClassName: "BisCore.PhysicalElement",
+          targetAlias: "t",
+          joinType: "outer",
+        },
+      ],
+    });
+    const ecsql = `
+      SELECT [s].[ECInstanceId] [sourceId], [t].[ECInstanceId] [targetId]
+      FROM [BisCore].[GroupInformationElement] [s]
+      ${joinClause}
+    `;
+
+    const rows = new Array<ECSqlQueryRow>();
+    for await (const row of imodelAccess.createQueryReader({ ecsql }, { rowFormat: "ECSqlPropertyNames" })) {
+      rows.push(row);
+    }
+
+    expect(rows.map((row) => ({ sourceId: row.sourceId, targetId: row.targetId ?? undefined }))).toEqual(
+      expect.arrayContaining([
+        { sourceId: groupWithMember.id, targetId: member.id },
+        { sourceId: emptyGroup.id, targetId: undefined },
+      ]),
+    );
+  });
+});

--- a/packages/shared/src/shared/ecsql-snippets/ECSqlJoinSnippets.ts
+++ b/packages/shared/src/shared/ecsql-snippets/ECSqlJoinSnippets.ts
@@ -42,12 +42,12 @@ interface CreateRelationshipPathJoinClauseProps {
  *   ```
  * - When outer joining through a non-navigation-property relationship:
  *   ```SQL
- *   LEFT JOIN (
+ *   LEFT OUTER JOIN (
  *     SELECT [relationship_alias].*
  *     FROM [relationship_schema_name].[relationship_class_name] [relationship_alias]
  *     INNER JOIN [target_schema_name].[target_class_name] [target_alias] ON [target_alias].[ECInstanceId] = [relationship_alias].[TargetECInstanceId]
  *   ) [relationship_alias]
- *   LEFT JOIN [target_schema_name].[target_class_name] [target_alias] ON [target_alias].[ECInstanceId] = [relationship_alias].[TargetECInstanceId]
+ *   LEFT OUTER JOIN [target_schema_name].[target_class_name] [target_alias] ON [target_alias].[ECInstanceId] = [relationship_alias].[TargetECInstanceId]
  *   ```
  * - When inner joining through a non-navigation-property relationship:
  *   ```SQL
@@ -166,7 +166,7 @@ async function getNavigationProperty(step: ResolvedRelationshipPathStep): Promis
 
 function getJoinClause(type: "inner" | "outer" | undefined) {
   if (type === "outer") {
-    return "OUTER JOIN";
+    return "LEFT OUTER JOIN";
   }
   return "INNER JOIN";
 }

--- a/packages/shared/src/test/ecsql-snippets/ECSqlJoinSnippets.test.ts
+++ b/packages/shared/src/test/ecsql-snippets/ECSqlJoinSnippets.test.ts
@@ -308,12 +308,12 @@ describe("createRelationshipPathJoinClause", () => {
         ),
       ).toBe(
         trimWhitespace(`
-          OUTER JOIN (
+          LEFT OUTER JOIN (
             SELECT [r].*
             FROM [${schemaName}].[${relationship.name}] [r]
             INNER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId]
           ) [r] ON [r].[SourceECInstanceId] = [s].[ECInstanceId]
-          OUTER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId]
+          LEFT OUTER JOIN [${schemaName}].[${targetClass.name}] [t] ON [t].[ECInstanceId] = [r].[TargetECInstanceId]
         `),
       );
     });


### PR DESCRIPTION
Fixed generated OUTER JOIN snippets. `OUTER JOIN` is not a valid ECSQL syntax. Updated to use `LEFT OUTER JOIN`.